### PR TITLE
Fix float formatting issues

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"os"
 	"regexp"
@@ -544,13 +545,13 @@ var g = &grammar{
 			pos:  position{line: 529, col: 1, offset: 14941},
 			expr: &choiceExpr{
 				pos: position{line: 529, col: 10, offset: 14950},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 529, col: 10, offset: 14950},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
 							pos: position{line: 529, col: 10, offset: 14950},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 529, col: 10, offset: 14950},
 									label: "indexBlock",
@@ -618,7 +619,7 @@ var g = &grammar{
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
 							pos: position{line: 595, col: 3, offset: 17014},
-							exprs: []any{
+							exprs: []interface{}{
 								&zeroOrOneExpr{
 									pos: position{line: 595, col: 3, offset: 17014},
 									expr: &ruleRefExpr{
@@ -676,7 +677,7 @@ var g = &grammar{
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
 							pos: position{line: 614, col: 3, offset: 17640},
-							exprs: []any{
+							exprs: []interface{}{
 								&zeroOrOneExpr{
 									pos: position{line: 614, col: 3, offset: 17640},
 									expr: &ruleRefExpr{
@@ -728,7 +729,7 @@ var g = &grammar{
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
 					pos: position{line: 630, col: 16, offset: 18119},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 630, col: 16, offset: 18119},
 							label: "index",
@@ -763,7 +764,7 @@ var g = &grammar{
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
 					pos: position{line: 635, col: 20, offset: 18360},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 635, col: 20, offset: 18360},
 							label: "first",
@@ -779,7 +780,7 @@ var g = &grammar{
 								pos: position{line: 635, col: 45, offset: 18385},
 								expr: &seqExpr{
 									pos: position{line: 635, col: 46, offset: 18386},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 635, col: 46, offset: 18386},
 											name: "OR",
@@ -804,7 +805,7 @@ var g = &grammar{
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
 					pos: position{line: 660, col: 15, offset: 18984},
-					exprs: []any{
+					exprs: []interface{}{
 						&zeroOrOneExpr{
 							pos: position{line: 660, col: 15, offset: 18984},
 							expr: &ruleRefExpr{
@@ -839,7 +840,7 @@ var g = &grammar{
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
 					pos: position{line: 664, col: 21, offset: 19076},
-					exprs: []any{
+					exprs: []interface{}{
 						&charClassMatcher{
 							pos:        position{line: 664, col: 21, offset: 19076},
 							val:        "[0-9]",
@@ -939,7 +940,7 @@ var g = &grammar{
 					label: "timeStamp",
 					expr: &choiceExpr{
 						pos: position{line: 689, col: 37, offset: 19978},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 689, col: 37, offset: 19978},
 								name: "FullTimeStamp",
@@ -964,7 +965,7 @@ var g = &grammar{
 					label: "epochInMilli",
 					expr: &choiceExpr{
 						pos: position{line: 698, col: 31, offset: 20282},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 698, col: 31, offset: 20282},
 								name: "DateTimeToUnixEpochMs",
@@ -986,7 +987,7 @@ var g = &grammar{
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
 					pos: position{line: 702, col: 22, offset: 20389},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 702, col: 22, offset: 20389},
 							val:        "end",
@@ -1017,7 +1018,7 @@ var g = &grammar{
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
 					pos: position{line: 711, col: 24, offset: 20625},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 711, col: 24, offset: 20625},
 							val:        "start",
@@ -1048,7 +1049,7 @@ var g = &grammar{
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
 					pos: position{line: 720, col: 28, offset: 20871},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 720, col: 28, offset: 20871},
 							val:        "increment",
@@ -1074,7 +1075,7 @@ var g = &grammar{
 								pos: position{line: 720, col: 77, offset: 20920},
 								expr: &choiceExpr{
 									pos: position{line: 720, col: 78, offset: 20921},
-									alternatives: []any{
+									alternatives: []interface{}{
 										&litMatcher{
 											pos:        position{line: 720, col: 78, offset: 20921},
 											val:        "s",
@@ -1118,7 +1119,7 @@ var g = &grammar{
 					label: "genTimesOption",
 					expr: &choiceExpr{
 						pos: position{line: 761, col: 35, offset: 22125},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 761, col: 35, offset: 22125},
 								name: "GenTimesOptionEnd",
@@ -1144,7 +1145,7 @@ var g = &grammar{
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
 					pos: position{line: 765, col: 23, offset: 22250},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 765, col: 23, offset: 22250},
 							label: "first",
@@ -1160,7 +1161,7 @@ var g = &grammar{
 								pos: position{line: 765, col: 49, offset: 22276},
 								expr: &seqExpr{
 									pos: position{line: 765, col: 50, offset: 22277},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 765, col: 50, offset: 22277},
 											name: "SPACE",
@@ -1185,7 +1186,7 @@ var g = &grammar{
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
 					pos: position{line: 817, col: 23, offset: 24058},
-					exprs: []any{
+					exprs: []interface{}{
 						&zeroOrOneExpr{
 							pos: position{line: 817, col: 23, offset: 24058},
 							expr: &ruleRefExpr{
@@ -1213,7 +1214,7 @@ var g = &grammar{
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
 					pos: position{line: 821, col: 16, offset: 24133},
-					exprs: []any{
+					exprs: []interface{}{
 						&notExpr{
 							pos: position{line: 821, col: 16, offset: 24133},
 							expr: &ruleRefExpr{
@@ -1248,7 +1249,7 @@ var g = &grammar{
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
 					pos: position{line: 825, col: 16, offset: 24218},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 825, col: 16, offset: 24218},
 							name: "PIPE",
@@ -1258,7 +1259,7 @@ var g = &grammar{
 							label: "block",
 							expr: &choiceExpr{
 								pos: position{line: 825, col: 28, offset: 24230},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 825, col: 28, offset: 24230},
 										name: "SearchBlock",
@@ -1289,7 +1290,7 @@ var g = &grammar{
 					label: "block",
 					expr: &choiceExpr{
 						pos: position{line: 830, col: 32, offset: 24367},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 830, col: 32, offset: 24367},
 								name: "FieldSelectBlock",
@@ -1403,7 +1404,7 @@ var g = &grammar{
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
 					pos: position{line: 835, col: 21, offset: 24846},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 835, col: 21, offset: 24846},
 							name: "PIPE",
@@ -1419,7 +1420,7 @@ var g = &grammar{
 								pos: position{line: 835, col: 40, offset: 24865},
 								expr: &choiceExpr{
 									pos: position{line: 835, col: 41, offset: 24866},
-									alternatives: []any{
+									alternatives: []interface{}{
 										&litMatcher{
 											pos:        position{line: 835, col: 41, offset: 24866},
 											val:        "-",
@@ -1460,7 +1461,7 @@ var g = &grammar{
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
 					pos: position{line: 854, col: 26, offset: 25465},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 854, col: 26, offset: 25465},
 							label: "aggs",
@@ -1492,7 +1493,7 @@ var g = &grammar{
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
 					pos: position{line: 918, col: 20, offset: 27808},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 918, col: 20, offset: 27808},
 							name: "PIPE",
@@ -1551,7 +1552,7 @@ var g = &grammar{
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
 					pos: position{line: 970, col: 16, offset: 29674},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 970, col: 16, offset: 29674},
 							name: "SPACE",
@@ -1573,7 +1574,7 @@ var g = &grammar{
 							label: "str",
 							expr: &choiceExpr{
 								pos: position{line: 970, col: 58, offset: 29716},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 970, col: 58, offset: 29716},
 										name: "IntegerAsString",
@@ -1604,7 +1605,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 975, col: 27, offset: 29883},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&litMatcher{
 								pos:        position{line: 975, col: 27, offset: 29883},
 								val:        "allnum",
@@ -1642,7 +1643,7 @@ var g = &grammar{
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
 					pos: position{line: 983, col: 17, offset: 30130},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 983, col: 17, offset: 30130},
 							name: "BY",
@@ -1667,7 +1668,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
 					pos: position{line: 995, col: 35, offset: 30524},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 995, col: 35, offset: 30524},
 							val:        "reset_on_change",
@@ -1698,7 +1699,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
 					pos: position{line: 1007, col: 29, offset: 30845},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1007, col: 29, offset: 30845},
 							val:        "current",
@@ -1729,7 +1730,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
 					pos: position{line: 1019, col: 28, offset: 31143},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1019, col: 28, offset: 31143},
 							val:        "global",
@@ -1760,7 +1761,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
 					pos: position{line: 1032, col: 28, offset: 31527},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1032, col: 28, offset: 31527},
 							val:        "allnum",
@@ -1791,7 +1792,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
 					pos: position{line: 1045, col: 28, offset: 31911},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1045, col: 28, offset: 31911},
 							val:        "window",
@@ -1822,7 +1823,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
 					pos: position{line: 1065, col: 33, offset: 32573},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1065, col: 33, offset: 32573},
 							val:        "reset_before",
@@ -1861,7 +1862,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
 					pos: position{line: 1077, col: 32, offset: 32921},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1077, col: 32, offset: 32921},
 							val:        "reset_after",
@@ -1900,7 +1901,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
 					pos: position{line: 1089, col: 32, offset: 33266},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1089, col: 32, offset: 33266},
 							val:        "time_window",
@@ -1934,7 +1935,7 @@ var g = &grammar{
 					label: "ssOption",
 					expr: &choiceExpr{
 						pos: position{line: 1105, col: 32, offset: 33791},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1105, col: 32, offset: 33791},
 								name: "StreamStatsOptionResetOnChange",
@@ -1980,7 +1981,7 @@ var g = &grammar{
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
 					pos: position{line: 1109, col: 26, offset: 34074},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1109, col: 26, offset: 34074},
 							label: "first",
@@ -1996,7 +1997,7 @@ var g = &grammar{
 								pos: position{line: 1109, col: 55, offset: 34103},
 								expr: &seqExpr{
 									pos: position{line: 1109, col: 56, offset: 34104},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 1109, col: 56, offset: 34104},
 											name: "SPACE",
@@ -2018,13 +2019,13 @@ var g = &grammar{
 			pos:  position{line: 1168, col: 1, offset: 36299},
 			expr: &choiceExpr{
 				pos: position{line: 1168, col: 21, offset: 36319},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1168, col: 21, offset: 36319},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
 							pos: position{line: 1168, col: 21, offset: 36319},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1168, col: 21, offset: 36319},
 									name: "PIPE",
@@ -2061,7 +2062,7 @@ var g = &grammar{
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
 							pos: position{line: 1179, col: 3, offset: 36774},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1179, col: 3, offset: 36774},
 									name: "PIPE",
@@ -2092,7 +2093,7 @@ var g = &grammar{
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
 					pos: position{line: 1191, col: 15, offset: 37187},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1191, col: 15, offset: 37187},
 							name: "CMD_REGEX",
@@ -2104,7 +2105,7 @@ var g = &grammar{
 								pos: position{line: 1191, col: 34, offset: 37206},
 								expr: &seqExpr{
 									pos: position{line: 1191, col: 35, offset: 37207},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 1191, col: 35, offset: 37207},
 											name: "FieldName",
@@ -2137,7 +2138,7 @@ var g = &grammar{
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
 					pos: position{line: 1219, col: 18, offset: 37836},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1219, col: 18, offset: 37836},
 							name: "PIPE",
@@ -2162,7 +2163,7 @@ var g = &grammar{
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
 					pos: position{line: 1247, col: 17, offset: 38644},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1247, col: 17, offset: 38644},
 							label: "first",
@@ -2178,10 +2179,10 @@ var g = &grammar{
 								pos: position{line: 1247, col: 41, offset: 38668},
 								expr: &seqExpr{
 									pos: position{line: 1247, col: 42, offset: 38669},
-									exprs: []any{
+									exprs: []interface{}{
 										&choiceExpr{
 											pos: position{line: 1247, col: 43, offset: 38670},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 1247, col: 43, offset: 38670},
 													name: "AND",
@@ -2212,7 +2213,7 @@ var g = &grammar{
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
 					pos: position{line: 1265, col: 17, offset: 39076},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1265, col: 17, offset: 39076},
 							label: "first",
@@ -2228,7 +2229,7 @@ var g = &grammar{
 								pos: position{line: 1265, col: 41, offset: 39100},
 								expr: &seqExpr{
 									pos: position{line: 1265, col: 42, offset: 39101},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 1265, col: 42, offset: 39101},
 											name: "OR",
@@ -2250,13 +2251,13 @@ var g = &grammar{
 			pos:  position{line: 1283, col: 1, offset: 39469},
 			expr: &choiceExpr{
 				pos: position{line: 1283, col: 17, offset: 39485},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1283, col: 17, offset: 39485},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
 							pos: position{line: 1283, col: 17, offset: 39485},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 1283, col: 17, offset: 39485},
 									label: "notList",
@@ -2299,13 +2300,13 @@ var g = &grammar{
 			pos:  position{line: 1298, col: 1, offset: 39848},
 			expr: &choiceExpr{
 				pos: position{line: 1298, col: 17, offset: 39864},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1298, col: 17, offset: 39864},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
 							pos: position{line: 1298, col: 17, offset: 39864},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1298, col: 17, offset: 39864},
 									name: "L_PAREN",
@@ -2351,7 +2352,7 @@ var g = &grammar{
 					label: "term",
 					expr: &choiceExpr{
 						pos: position{line: 1306, col: 21, offset: 40112},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1306, col: 21, offset: 40112},
 								name: "FieldWithNumberValue",
@@ -2377,7 +2378,7 @@ var g = &grammar{
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
 					pos: position{line: 1311, col: 19, offset: 40318},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1311, col: 19, offset: 40318},
 							name: "PIPE",
@@ -2417,7 +2418,7 @@ var g = &grammar{
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
 					pos: position{line: 1404, col: 27, offset: 43375},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1404, col: 27, offset: 43375},
 							label: "first",
@@ -2433,7 +2434,7 @@ var g = &grammar{
 								pos: position{line: 1404, col: 56, offset: 43404},
 								expr: &seqExpr{
 									pos: position{line: 1404, col: 57, offset: 43405},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 1404, col: 57, offset: 43405},
 											name: "SPACE",
@@ -2461,7 +2462,7 @@ var g = &grammar{
 					label: "tcArg",
 					expr: &choiceExpr{
 						pos: position{line: 1433, col: 29, offset: 44173},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1433, col: 29, offset: 44173},
 								name: "SingleAggExpr",
@@ -2483,7 +2484,7 @@ var g = &grammar{
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
 					pos: position{line: 1437, col: 18, offset: 44244},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1437, col: 18, offset: 44244},
 							label: "aggs",
@@ -2515,7 +2516,7 @@ var g = &grammar{
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
 					pos: position{line: 1451, col: 18, offset: 44635},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1451, col: 18, offset: 44635},
 							name: "BY",
@@ -2543,7 +2544,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 1459, col: 22, offset: 44794},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1459, col: 22, offset: 44794},
 								name: "BinOptions",
@@ -2568,7 +2569,7 @@ var g = &grammar{
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
 					pos: position{line: 1501, col: 13, offset: 46340},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1501, col: 13, offset: 46340},
 							name: "SPACE",
@@ -2608,7 +2609,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 1506, col: 24, offset: 46516},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&litMatcher{
 								pos:        position{line: 1506, col: 24, offset: 46516},
 								val:        "usenull",
@@ -2649,7 +2650,7 @@ var g = &grammar{
 					label: "timeUnit",
 					expr: &choiceExpr{
 						pos: position{line: 1514, col: 27, offset: 46775},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1514, col: 27, offset: 46775},
 								name: "Second",
@@ -2699,13 +2700,13 @@ var g = &grammar{
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
 					pos: position{line: 1518, col: 21, offset: 46900},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1518, col: 21, offset: 46900},
 							label: "number",
 							expr: &choiceExpr{
 								pos: position{line: 1518, col: 29, offset: 46908},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 1518, col: 29, offset: 46908},
 										name: "FloatAsString",
@@ -2740,7 +2741,7 @@ var g = &grammar{
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
 					pos: position{line: 1577, col: 21, offset: 49663},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1577, col: 21, offset: 49663},
 							val:        "minspan",
@@ -2771,7 +2772,7 @@ var g = &grammar{
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
 					pos: position{line: 1588, col: 21, offset: 49951},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1588, col: 21, offset: 49951},
 							val:        "bins",
@@ -2799,13 +2800,13 @@ var g = &grammar{
 			pos:  position{line: 1609, col: 1, offset: 50552},
 			expr: &choiceExpr{
 				pos: position{line: 1609, col: 23, offset: 50574},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1609, col: 23, offset: 50574},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
 							pos: position{line: 1609, col: 23, offset: 50574},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 1609, col: 23, offset: 50574},
 									val:        "aligntime",
@@ -2832,7 +2833,7 @@ var g = &grammar{
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
 							pos: position{line: 1623, col: 3, offset: 51021},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 1623, col: 3, offset: 51021},
 									val:        "aligntime",
@@ -2848,7 +2849,7 @@ var g = &grammar{
 									label: "timestamp",
 									expr: &choiceExpr{
 										pos: position{line: 1623, col: 32, offset: 51050},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&ruleRefExpr{
 												pos:  position{line: 1623, col: 32, offset: 51050},
 												name: "AbsoluteTimestamp",
@@ -2874,7 +2875,7 @@ var g = &grammar{
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
 					pos: position{line: 1643, col: 19, offset: 51557},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1643, col: 19, offset: 51557},
 							val:        "start",
@@ -2890,7 +2891,7 @@ var g = &grammar{
 							label: "number",
 							expr: &choiceExpr{
 								pos: position{line: 1643, col: 41, offset: 51579},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 1643, col: 41, offset: 51579},
 										name: "FloatAsString",
@@ -2914,7 +2915,7 @@ var g = &grammar{
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
 					pos: position{line: 1658, col: 17, offset: 51990},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 1658, col: 17, offset: 51990},
 							val:        "end",
@@ -2930,7 +2931,7 @@ var g = &grammar{
 							label: "number",
 							expr: &choiceExpr{
 								pos: position{line: 1658, col: 37, offset: 52010},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 1658, col: 37, offset: 52010},
 										name: "FloatAsString",
@@ -2951,13 +2952,13 @@ var g = &grammar{
 			pos:  position{line: 1673, col: 1, offset: 52397},
 			expr: &choiceExpr{
 				pos: position{line: 1673, col: 18, offset: 52414},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1673, col: 18, offset: 52414},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
 							pos: position{line: 1673, col: 18, offset: 52414},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 1673, col: 18, offset: 52414},
 									val:        "span",
@@ -2975,7 +2976,7 @@ var g = &grammar{
 										pos: position{line: 1673, col: 36, offset: 52432},
 										expr: &choiceExpr{
 											pos: position{line: 1673, col: 37, offset: 52433},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 1673, col: 37, offset: 52433},
 													name: "FloatAsString",
@@ -3001,7 +3002,7 @@ var g = &grammar{
 										pos: position{line: 1673, col: 82, offset: 52478},
 										expr: &choiceExpr{
 											pos: position{line: 1673, col: 83, offset: 52479},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 1673, col: 83, offset: 52479},
 													name: "FloatAsString",
@@ -3022,7 +3023,7 @@ var g = &grammar{
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
 							pos: position{line: 1716, col: 3, offset: 53931},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 1716, col: 3, offset: 53931},
 									val:        "span",
@@ -3058,7 +3059,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 1731, col: 25, offset: 54307},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 1731, col: 25, offset: 54307},
 								name: "BinOptionAlignTime",
@@ -3096,7 +3097,7 @@ var g = &grammar{
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
 					pos: position{line: 1735, col: 22, offset: 54462},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1735, col: 22, offset: 54462},
 							label: "first",
@@ -3112,7 +3113,7 @@ var g = &grammar{
 								pos: position{line: 1735, col: 48, offset: 54488},
 								expr: &seqExpr{
 									pos: position{line: 1735, col: 49, offset: 54489},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 1735, col: 49, offset: 54489},
 											name: "SPACE",
@@ -3134,13 +3135,13 @@ var g = &grammar{
 			pos:  position{line: 1781, col: 1, offset: 55979},
 			expr: &choiceExpr{
 				pos: position{line: 1781, col: 13, offset: 55991},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1781, col: 13, offset: 55991},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
 							pos: position{line: 1781, col: 13, offset: 55991},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1781, col: 13, offset: 55991},
 									name: "PIPE",
@@ -3188,7 +3189,7 @@ var g = &grammar{
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
 							pos: position{line: 1808, col: 3, offset: 56899},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1808, col: 3, offset: 56899},
 									name: "PIPE",
@@ -3246,7 +3247,7 @@ var g = &grammar{
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
 					pos: position{line: 1847, col: 16, offset: 58065},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1847, col: 16, offset: 58065},
 							name: "CMD_SPAN",
@@ -3275,7 +3276,7 @@ var g = &grammar{
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
 					pos: position{line: 1854, col: 15, offset: 58251},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1854, col: 15, offset: 58251},
 							label: "intAsStr",
@@ -3304,7 +3305,7 @@ var g = &grammar{
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
 					pos: position{line: 1871, col: 14, offset: 58848},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1871, col: 14, offset: 58848},
 							name: "SPACE",
@@ -3326,7 +3327,7 @@ var g = &grammar{
 								pos: position{line: 1871, col: 41, offset: 58875},
 								expr: &choiceExpr{
 									pos: position{line: 1871, col: 42, offset: 58876},
-									alternatives: []any{
+									alternatives: []interface{}{
 										&litMatcher{
 											pos:        position{line: 1871, col: 42, offset: 58876},
 											val:        "top",
@@ -3367,7 +3368,7 @@ var g = &grammar{
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
 					pos: position{line: 1895, col: 19, offset: 59519},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 1895, col: 19, offset: 59519},
 							name: "PIPE",
@@ -3392,13 +3393,13 @@ var g = &grammar{
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
 					pos: position{line: 1932, col: 18, offset: 60693},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 1932, col: 18, offset: 60693},
 							label: "cmd",
 							expr: &choiceExpr{
 								pos: position{line: 1932, col: 23, offset: 60698},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 1932, col: 23, offset: 60698},
 										name: "CMD_TOP",
@@ -3426,7 +3427,7 @@ var g = &grammar{
 							label: "fieldList",
 							expr: &seqExpr{
 								pos: position{line: 1932, col: 78, offset: 60753},
-								exprs: []any{
+								exprs: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 1932, col: 78, offset: 60753},
 										name: "SPACE",
@@ -3469,13 +3470,13 @@ var g = &grammar{
 			pos:  position{line: 1974, col: 1, offset: 61889},
 			expr: &choiceExpr{
 				pos: position{line: 1974, col: 19, offset: 61907},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 1974, col: 19, offset: 61907},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
 							pos: position{line: 1974, col: 19, offset: 61907},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1974, col: 19, offset: 61907},
 									name: "SPACE",
@@ -3496,7 +3497,7 @@ var g = &grammar{
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
 							pos: position{line: 1977, col: 3, offset: 61974},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 1977, col: 3, offset: 61974},
 									name: "SPACE",
@@ -3552,7 +3553,7 @@ var g = &grammar{
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
 					pos: position{line: 2031, col: 20, offset: 63708},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2031, col: 20, offset: 63708},
 							name: "SPACE",
@@ -3592,7 +3593,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 2036, col: 31, offset: 63894},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&litMatcher{
 								pos:        position{line: 2036, col: 31, offset: 63894},
 								val:        "countfield",
@@ -3639,13 +3640,13 @@ var g = &grammar{
 			pos:  position{line: 2044, col: 1, offset: 64152},
 			expr: &choiceExpr{
 				pos: position{line: 2044, col: 13, offset: 64164},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 2044, col: 13, offset: 64164},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
 							pos: position{line: 2044, col: 13, offset: 64164},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 2044, col: 13, offset: 64164},
 									name: "BY",
@@ -3684,7 +3685,7 @@ var g = &grammar{
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
 					pos: position{line: 2051, col: 15, offset: 64319},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2051, col: 15, offset: 64319},
 							name: "PIPE",
@@ -3713,7 +3714,7 @@ var g = &grammar{
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
 					pos: position{line: 2097, col: 14, offset: 65686},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2097, col: 14, offset: 65686},
 							label: "limitArr",
@@ -3721,7 +3722,7 @@ var g = &grammar{
 								pos: position{line: 2097, col: 23, offset: 65695},
 								expr: &seqExpr{
 									pos: position{line: 2097, col: 24, offset: 65696},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 2097, col: 24, offset: 65696},
 											name: "SPACE",
@@ -3790,7 +3791,7 @@ var g = &grammar{
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
 					pos: position{line: 2154, col: 19, offset: 67568},
-					exprs: []any{
+					exprs: []interface{}{
 						&notExpr{
 							pos: position{line: 2154, col: 19, offset: 67568},
 							expr: &litMatcher{
@@ -3820,7 +3821,7 @@ var g = &grammar{
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
 					pos: position{line: 2160, col: 32, offset: 67756},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2160, col: 32, offset: 67756},
 							label: "first",
@@ -3843,7 +3844,7 @@ var g = &grammar{
 								pos: position{line: 2160, col: 62, offset: 67786},
 								expr: &seqExpr{
 									pos: position{line: 2160, col: 63, offset: 67787},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 2160, col: 63, offset: 67787},
 											name: "SPACE",
@@ -3875,7 +3876,7 @@ var g = &grammar{
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
 					pos: position{line: 2171, col: 19, offset: 68098},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2171, col: 19, offset: 68098},
 							name: "SPACE",
@@ -3895,7 +3896,7 @@ var g = &grammar{
 								pos: position{line: 2171, col: 51, offset: 68130},
 								expr: &seqExpr{
 									pos: position{line: 2171, col: 52, offset: 68131},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 2171, col: 52, offset: 68131},
 											name: "SPACE",
@@ -3946,7 +3947,7 @@ var g = &grammar{
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
 					pos: position{line: 2229, col: 16, offset: 69986},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2229, col: 16, offset: 69986},
 							name: "SPACE",
@@ -3988,7 +3989,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 2234, col: 27, offset: 70162},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&litMatcher{
 								pos:        position{line: 2234, col: 27, offset: 70162},
 								val:        "consecutive",
@@ -4020,7 +4021,7 @@ var g = &grammar{
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
 					pos: position{line: 2242, col: 22, offset: 70398},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2242, col: 22, offset: 70398},
 							name: "CMD_DEDUP_SORTBY",
@@ -4045,7 +4046,7 @@ var g = &grammar{
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
 					pos: position{line: 2247, col: 17, offset: 70553},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2247, col: 17, offset: 70553},
 							label: "first",
@@ -4061,7 +4062,7 @@ var g = &grammar{
 								pos: position{line: 2247, col: 46, offset: 70582},
 								expr: &seqExpr{
 									pos: position{line: 2247, col: 47, offset: 70583},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 2247, col: 47, offset: 70583},
 											name: "SPACE_OR_COMMA",
@@ -4089,7 +4090,7 @@ var g = &grammar{
 					label: "element",
 					expr: &choiceExpr{
 						pos: position{line: 2262, col: 31, offset: 70986},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 2262, col: 31, offset: 70986},
 								name: "SingleSortElementWithCast",
@@ -4111,13 +4112,13 @@ var g = &grammar{
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
 					pos: position{line: 2266, col: 33, offset: 71105},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2266, col: 33, offset: 71105},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
 								pos: position{line: 2266, col: 47, offset: 71119},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&litMatcher{
 										pos:        position{line: 2266, col: 47, offset: 71119},
 										val:        "+",
@@ -4159,13 +4160,13 @@ var g = &grammar{
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
 					pos: position{line: 2281, col: 30, offset: 71445},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2281, col: 30, offset: 71445},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
 								pos: position{line: 2281, col: 44, offset: 71459},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&litMatcher{
 										pos:        position{line: 2281, col: 44, offset: 71459},
 										val:        "+",
@@ -4192,7 +4193,7 @@ var g = &grammar{
 							label: "op",
 							expr: &choiceExpr{
 								pos: position{line: 2281, col: 64, offset: 71479},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&litMatcher{
 										pos:        position{line: 2281, col: 64, offset: 71479},
 										val:        "auto",
@@ -4248,7 +4249,7 @@ var g = &grammar{
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
 					pos: position{line: 2301, col: 16, offset: 71974},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2301, col: 16, offset: 71974},
 							name: "PIPE",
@@ -4274,13 +4275,13 @@ var g = &grammar{
 			pos:  position{line: 2324, col: 1, offset: 72665},
 			expr: &choiceExpr{
 				pos: position{line: 2324, col: 15, offset: 72679},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 2324, col: 15, offset: 72679},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
 							pos: position{line: 2324, col: 15, offset: 72679},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2324, col: 15, offset: 72679},
 									label: "originalPattern",
@@ -4309,7 +4310,7 @@ var g = &grammar{
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
 							pos: position{line: 2335, col: 3, offset: 73038},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2335, col: 3, offset: 73038},
 									label: "originalPattern",
@@ -4344,7 +4345,7 @@ var g = &grammar{
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
 					pos: position{line: 2357, col: 13, offset: 73656},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2357, col: 13, offset: 73656},
 							name: "PIPE",
@@ -4395,7 +4396,7 @@ var g = &grammar{
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
 					pos: position{line: 2386, col: 14, offset: 74457},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2386, col: 14, offset: 74457},
 							name: "PIPE",
@@ -4435,12 +4436,12 @@ var g = &grammar{
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
 					pos: position{line: 2424, col: 14, offset: 75393},
-					exprs: []any{
+					exprs: []interface{}{
 						&zeroOrOneExpr{
 							pos: position{line: 2424, col: 14, offset: 75393},
 							expr: &seqExpr{
 								pos: position{line: 2424, col: 15, offset: 75394},
-								exprs: []any{
+								exprs: []interface{}{
 									&litMatcher{
 										pos:        position{line: 2424, col: 15, offset: 75394},
 										val:        "limit",
@@ -4478,7 +4479,7 @@ var g = &grammar{
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
 					pos: position{line: 2438, col: 14, offset: 75747},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 2438, col: 14, offset: 75747},
 							name: "PIPE",
@@ -4502,7 +4503,7 @@ var g = &grammar{
 								pos: position{line: 2438, col: 50, offset: 75783},
 								expr: &seqExpr{
 									pos: position{line: 2438, col: 51, offset: 75784},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 2438, col: 51, offset: 75784},
 											name: "COMMA",
@@ -4527,7 +4528,7 @@ var g = &grammar{
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
 					pos: position{line: 2473, col: 15, offset: 77037},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2473, col: 15, offset: 77037},
 							label: "field",
@@ -4573,13 +4574,13 @@ var g = &grammar{
 			pos:  position{line: 2498, col: 1, offset: 77877},
 			expr: &choiceExpr{
 				pos: position{line: 2498, col: 18, offset: 77894},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 2498, col: 18, offset: 77894},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
 							pos: position{line: 2498, col: 18, offset: 77894},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2498, col: 18, offset: 77894},
 									val:        "if",
@@ -4634,13 +4635,13 @@ var g = &grammar{
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
 							pos: position{line: 2509, col: 3, offset: 78230},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2509, col: 3, offset: 78230},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 2509, col: 11, offset: 78238},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 2509, col: 11, offset: 78238},
 												val:        "case",
@@ -4675,7 +4676,7 @@ var g = &grammar{
 										pos: position{line: 2509, col: 69, offset: 78296},
 										expr: &seqExpr{
 											pos: position{line: 2509, col: 70, offset: 78297},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2509, col: 70, offset: 78297},
 													name: "COMMA",
@@ -4700,7 +4701,7 @@ var g = &grammar{
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
 							pos: position{line: 2532, col: 3, offset: 78928},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2532, col: 3, offset: 78928},
 									val:        "coalesce",
@@ -4726,7 +4727,7 @@ var g = &grammar{
 										pos: position{line: 2532, col: 47, offset: 78972},
 										expr: &seqExpr{
 											pos: position{line: 2532, col: 48, offset: 78973},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2532, col: 48, offset: 78973},
 													name: "COMMA",
@@ -4751,7 +4752,7 @@ var g = &grammar{
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
 							pos: position{line: 2549, col: 3, offset: 79410},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2549, col: 3, offset: 79410},
 									val:        "nullif",
@@ -4794,7 +4795,7 @@ var g = &grammar{
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
 							pos: position{line: 2561, col: 3, offset: 79754},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2561, col: 3, offset: 79754},
 									val:        "null",
@@ -4823,7 +4824,7 @@ var g = &grammar{
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
 					pos: position{line: 2568, col: 23, offset: 79888},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 2568, col: 23, offset: 79888},
 							label: "condition",
@@ -4891,7 +4892,7 @@ var g = &grammar{
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
 						pos: position{line: 2595, col: 40, offset: 80658},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 2595, col: 40, offset: 80658},
 								name: "MultiValueExprAsValueExpr",
@@ -4910,13 +4911,13 @@ var g = &grammar{
 			pos:  position{line: 2599, col: 1, offset: 80763},
 			expr: &choiceExpr{
 				pos: position{line: 2599, col: 19, offset: 80781},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 2599, col: 19, offset: 80781},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
 							pos: position{line: 2599, col: 20, offset: 80782},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2599, col: 20, offset: 80782},
 									label: "opName",
@@ -4963,7 +4964,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
 							pos: position{line: 2611, col: 4, offset: 81214},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2611, col: 4, offset: 81214},
 									label: "opName",
@@ -5010,7 +5011,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
 							pos: position{line: 2623, col: 4, offset: 81634},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2623, col: 4, offset: 81634},
 									label: "opName",
@@ -5068,13 +5069,13 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
 							pos: position{line: 2639, col: 4, offset: 82312},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2639, col: 4, offset: 82312},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 2639, col: 12, offset: 82320},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 2639, col: 12, offset: 82320},
 												val:        "mvdedup",
@@ -5114,7 +5115,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
 							pos: position{line: 2651, col: 4, offset: 82729},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2651, col: 4, offset: 82729},
 									label: "opName",
@@ -5149,7 +5150,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
 							pos: position{line: 2664, col: 4, offset: 83124},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2664, col: 4, offset: 83124},
 									label: "opName",
@@ -5196,7 +5197,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
 							pos: position{line: 2677, col: 4, offset: 83623},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2677, col: 4, offset: 83623},
 									label: "opName",
@@ -5258,7 +5259,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
 							pos: position{line: 2690, col: 4, offset: 84183},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2690, col: 4, offset: 84183},
 									label: "opName",
@@ -5300,7 +5301,7 @@ var g = &grammar{
 										pos: position{line: 2690, col: 85, offset: 84264},
 										expr: &seqExpr{
 											pos: position{line: 2690, col: 86, offset: 84265},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2690, col: 86, offset: 84265},
 													name: "COMMA",
@@ -5325,7 +5326,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
 							pos: position{line: 2707, col: 4, offset: 84813},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2707, col: 4, offset: 84813},
 									label: "opName",
@@ -5355,14 +5356,14 @@ var g = &grammar{
 										pos: position{line: 2707, col: 75, offset: 84884},
 										expr: &seqExpr{
 											pos: position{line: 2707, col: 76, offset: 84885},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2707, col: 76, offset: 84885},
 													name: "COMMA",
 												},
 												&choiceExpr{
 													pos: position{line: 2707, col: 83, offset: 84892},
-													alternatives: []any{
+													alternatives: []interface{}{
 														&litMatcher{
 															pos:        position{line: 2707, col: 83, offset: 84892},
 															val:        "true",
@@ -5399,7 +5400,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
 							pos: position{line: 2732, col: 4, offset: 85621},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2732, col: 4, offset: 85621},
 									label: "opName",
@@ -5429,7 +5430,7 @@ var g = &grammar{
 										pos: position{line: 2732, col: 69, offset: 85686},
 										expr: &seqExpr{
 											pos: position{line: 2732, col: 70, offset: 85687},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2732, col: 70, offset: 85687},
 													name: "COMMA",
@@ -5454,7 +5455,7 @@ var g = &grammar{
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
 							pos: position{line: 2752, col: 3, offset: 86306},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2752, col: 3, offset: 86306},
 									label: "field",
@@ -5467,7 +5468,7 @@ var g = &grammar{
 									pos: position{line: 2752, col: 25, offset: 86328},
 									expr: &choiceExpr{
 										pos: position{line: 2752, col: 27, offset: 86330},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&ruleRefExpr{
 												pos:  position{line: 2752, col: 27, offset: 86330},
 												name: "OpPlus",
@@ -5512,19 +5513,19 @@ var g = &grammar{
 			pos:  position{line: 2764, col: 1, offset: 86782},
 			expr: &choiceExpr{
 				pos: position{line: 2764, col: 13, offset: 86794},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 2764, col: 13, offset: 86794},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
 							pos: position{line: 2764, col: 14, offset: 86795},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2764, col: 14, offset: 86795},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 2764, col: 22, offset: 86803},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 2764, col: 22, offset: 86803},
 												val:        "lower",
@@ -5570,13 +5571,13 @@ var g = &grammar{
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
 							pos: position{line: 2776, col: 4, offset: 87181},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2776, col: 4, offset: 87181},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 2776, col: 12, offset: 87189},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 2776, col: 12, offset: 87189},
 												val:        "max",
@@ -5611,7 +5612,7 @@ var g = &grammar{
 										pos: position{line: 2776, col: 60, offset: 87237},
 										expr: &seqExpr{
 											pos: position{line: 2776, col: 61, offset: 87238},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2776, col: 61, offset: 87238},
 													name: "COMMA",
@@ -5636,7 +5637,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
 							pos: position{line: 2798, col: 4, offset: 87858},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2798, col: 4, offset: 87858},
 									label: "opName",
@@ -5671,7 +5672,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
 							pos: position{line: 2809, col: 4, offset: 88218},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2809, col: 4, offset: 88218},
 									label: "opName",
@@ -5718,7 +5719,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
 							pos: position{line: 2821, col: 4, offset: 88648},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2821, col: 4, offset: 88648},
 									label: "opName",
@@ -5765,7 +5766,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
 							pos: position{line: 2845, col: 4, offset: 89401},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2845, col: 4, offset: 89401},
 									label: "opName",
@@ -5807,7 +5808,7 @@ var g = &grammar{
 										pos: position{line: 2845, col: 93, offset: 89490},
 										expr: &seqExpr{
 											pos: position{line: 2845, col: 94, offset: 89491},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2845, col: 94, offset: 89491},
 													name: "COMMA",
@@ -5832,7 +5833,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
 							pos: position{line: 2870, col: 3, offset: 90341},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2870, col: 3, offset: 90341},
 									val:        "tostring",
@@ -5858,7 +5859,7 @@ var g = &grammar{
 										pos: position{line: 2870, col: 45, offset: 90383},
 										expr: &seqExpr{
 											pos: position{line: 2870, col: 46, offset: 90384},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2870, col: 46, offset: 90384},
 													name: "COMMA",
@@ -5883,13 +5884,13 @@ var g = &grammar{
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
 							pos: position{line: 2883, col: 4, offset: 90772},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 2883, col: 4, offset: 90772},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 2883, col: 12, offset: 90780},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 2883, col: 12, offset: 90780},
 												val:        "ltrim",
@@ -5946,7 +5947,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
 							pos: position{line: 2902, col: 3, offset: 91309},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2902, col: 3, offset: 91309},
 									val:        "ipmask",
@@ -5989,7 +5990,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
 							pos: position{line: 2909, col: 3, offset: 91519},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2909, col: 3, offset: 91519},
 									val:        "object_to_array",
@@ -6044,7 +6045,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
 							pos: position{line: 2920, col: 3, offset: 91915},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2920, col: 3, offset: 91915},
 									val:        "printf",
@@ -6070,7 +6071,7 @@ var g = &grammar{
 										pos: position{line: 2920, col: 43, offset: 91955},
 										expr: &seqExpr{
 											pos: position{line: 2920, col: 44, offset: 91956},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2920, col: 44, offset: 91956},
 													name: "COMMA",
@@ -6095,7 +6096,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
 							pos: position{line: 2938, col: 3, offset: 92442},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2938, col: 3, offset: 92442},
 									val:        "tojson",
@@ -6113,10 +6114,10 @@ var g = &grammar{
 										pos: position{line: 2938, col: 42, offset: 92481},
 										expr: &seqExpr{
 											pos: position{line: 2938, col: 43, offset: 92482},
-											exprs: []any{
+											exprs: []interface{}{
 												&choiceExpr{
 													pos: position{line: 2938, col: 44, offset: 92483},
-													alternatives: []any{
+													alternatives: []interface{}{
 														&litMatcher{
 															pos:        position{line: 2938, col: 44, offset: 92483},
 															val:        "true",
@@ -6153,7 +6154,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
 							pos: position{line: 2960, col: 3, offset: 93105},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 2960, col: 3, offset: 93105},
 									val:        "cluster",
@@ -6179,7 +6180,7 @@ var g = &grammar{
 										pos: position{line: 2960, col: 53, offset: 93155},
 										expr: &seqExpr{
 											pos: position{line: 2960, col: 54, offset: 93156},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2960, col: 54, offset: 93156},
 													name: "COMMA",
@@ -6205,7 +6206,7 @@ var g = &grammar{
 										pos: position{line: 2960, col: 95, offset: 93197},
 										expr: &seqExpr{
 											pos: position{line: 2960, col: 96, offset: 93198},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2960, col: 96, offset: 93198},
 													name: "COMMA",
@@ -6218,7 +6219,7 @@ var g = &grammar{
 												},
 												&choiceExpr{
 													pos: position{line: 2960, col: 112, offset: 93214},
-													alternatives: []any{
+													alternatives: []interface{}{
 														&litMatcher{
 															pos:        position{line: 2960, col: 112, offset: 93214},
 															val:        "termlist",
@@ -6250,7 +6251,7 @@ var g = &grammar{
 										pos: position{line: 2960, col: 158, offset: 93260},
 										expr: &seqExpr{
 											pos: position{line: 2960, col: 159, offset: 93261},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 2960, col: 159, offset: 93261},
 													name: "COMMA",
@@ -6281,7 +6282,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
 							pos: position{line: 3000, col: 3, offset: 94287},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3000, col: 3, offset: 94287},
 									val:        "getfields",
@@ -6315,7 +6316,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
 							pos: position{line: 3011, col: 3, offset: 94519},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3011, col: 3, offset: 94519},
 									val:        "typeof",
@@ -6346,7 +6347,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
 							pos: position{line: 3017, col: 3, offset: 94679},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3017, col: 3, offset: 94679},
 									val:        "replace",
@@ -6401,7 +6402,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
 							pos: position{line: 3024, col: 3, offset: 94987},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3024, col: 3, offset: 94987},
 									val:        "strftime",
@@ -6444,7 +6445,7 @@ var g = &grammar{
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
 							pos: position{line: 3032, col: 3, offset: 95208},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3032, col: 3, offset: 95208},
 									val:        "strptime",
@@ -6525,7 +6526,7 @@ var g = &grammar{
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
 					pos: position{line: 3054, col: 20, offset: 95750},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 3054, col: 20, offset: 95750},
 							name: "COMMA",
@@ -6547,13 +6548,13 @@ var g = &grammar{
 			pos:  position{line: 3060, col: 1, offset: 95953},
 			expr: &choiceExpr{
 				pos: position{line: 3060, col: 20, offset: 95972},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3060, col: 20, offset: 95972},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
 							pos: position{line: 3060, col: 20, offset: 95972},
-							exprs: []any{
+							exprs: []interface{}{
 								&charClassMatcher{
 									pos:        position{line: 3060, col: 20, offset: 95972},
 									val:        "[a-zA-Z]",
@@ -6589,7 +6590,7 @@ var g = &grammar{
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
 							pos: position{line: 3063, col: 3, offset: 96038},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3063, col: 3, offset: 96038},
 									val:        "'",
@@ -6624,7 +6625,7 @@ var g = &grammar{
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
 					pos: position{line: 3068, col: 15, offset: 96140},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 3068, col: 15, offset: 96140},
 							name: "PIPE",
@@ -6669,7 +6670,7 @@ var g = &grammar{
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
 					pos: position{line: 3086, col: 19, offset: 96613},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3086, col: 19, offset: 96613},
 							label: "first",
@@ -6685,7 +6686,7 @@ var g = &grammar{
 								pos: position{line: 3086, col: 45, offset: 96639},
 								expr: &seqExpr{
 									pos: position{line: 3086, col: 46, offset: 96640},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 3086, col: 46, offset: 96640},
 											name: "OR",
@@ -6710,7 +6711,7 @@ var g = &grammar{
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
 					pos: position{line: 3106, col: 19, offset: 97099},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3106, col: 19, offset: 97099},
 							label: "first",
@@ -6726,7 +6727,7 @@ var g = &grammar{
 								pos: position{line: 3106, col: 45, offset: 97125},
 								expr: &seqExpr{
 									pos: position{line: 3106, col: 46, offset: 97126},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 3106, col: 46, offset: 97126},
 											name: "AND",
@@ -6748,13 +6749,13 @@ var g = &grammar{
 			pos:  position{line: 3126, col: 1, offset: 97569},
 			expr: &choiceExpr{
 				pos: position{line: 3126, col: 19, offset: 97587},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3126, col: 19, offset: 97587},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
 							pos: position{line: 3126, col: 19, offset: 97587},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3126, col: 19, offset: 97587},
 									name: "NOT",
@@ -6798,13 +6799,13 @@ var g = &grammar{
 			pos:  position{line: 3141, col: 1, offset: 97900},
 			expr: &choiceExpr{
 				pos: position{line: 3141, col: 19, offset: 97918},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3141, col: 19, offset: 97918},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
 							pos: position{line: 3141, col: 19, offset: 97918},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3141, col: 19, offset: 97918},
 									name: "L_PAREN",
@@ -6832,7 +6833,7 @@ var g = &grammar{
 							label: "expr",
 							expr: &choiceExpr{
 								pos: position{line: 3144, col: 10, offset: 97990},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 3144, col: 10, offset: 97990},
 										name: "EvalComparisonExpr",
@@ -6853,19 +6854,19 @@ var g = &grammar{
 			pos:  position{line: 3149, col: 1, offset: 98131},
 			expr: &choiceExpr{
 				pos: position{line: 3149, col: 23, offset: 98153},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3149, col: 23, offset: 98153},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
 							pos: position{line: 3149, col: 24, offset: 98154},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3149, col: 24, offset: 98154},
 									label: "op",
 									expr: &choiceExpr{
 										pos: position{line: 3149, col: 28, offset: 98158},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 3149, col: 28, offset: 98158},
 												val:        "isbool",
@@ -6947,13 +6948,13 @@ var g = &grammar{
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
 							pos: position{line: 3179, col: 3, offset: 99156},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3179, col: 3, offset: 99156},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 3179, col: 11, offset: 99164},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 3179, col: 11, offset: 99164},
 												val:        "like",
@@ -7017,7 +7018,7 @@ var g = &grammar{
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
 							pos: position{line: 3192, col: 3, offset: 99630},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3192, col: 3, offset: 99630},
 									label: "left",
@@ -7055,7 +7056,7 @@ var g = &grammar{
 										pos: position{line: 3192, col: 65, offset: 99692},
 										expr: &seqExpr{
 											pos: position{line: 3192, col: 66, offset: 99693},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3192, col: 66, offset: 99693},
 													name: "COMMA",
@@ -7080,7 +7081,7 @@ var g = &grammar{
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
 							pos: position{line: 3211, col: 3, offset: 100262},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3211, col: 3, offset: 100262},
 									val:        "in",
@@ -7106,7 +7107,7 @@ var g = &grammar{
 										pos: position{line: 3211, col: 44, offset: 100303},
 										expr: &seqExpr{
 											pos: position{line: 3211, col: 45, offset: 100304},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3211, col: 45, offset: 100304},
 													name: "COMMA",
@@ -7137,7 +7138,7 @@ var g = &grammar{
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
 					pos: position{line: 3229, col: 23, offset: 100765},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3229, col: 23, offset: 100765},
 							label: "left",
@@ -7171,7 +7172,7 @@ var g = &grammar{
 			pos:  position{line: 3247, col: 1, offset: 101404},
 			expr: &choiceExpr{
 				pos: position{line: 3247, col: 14, offset: 101417},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3247, col: 14, offset: 101417},
 						run: (*parser).callonValueExpr2,
@@ -7189,7 +7190,7 @@ var g = &grammar{
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
 							pos: position{line: 3256, col: 3, offset: 101617},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3256, col: 3, offset: 101617},
 									name: "L_PAREN",
@@ -7238,7 +7239,7 @@ var g = &grammar{
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
 							pos: position{line: 3283, col: 3, offset: 102199},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3283, col: 3, offset: 102199},
 									name: "L_PAREN",
@@ -7263,7 +7264,7 @@ var g = &grammar{
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
 							pos: position{line: 3292, col: 3, offset: 102393},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3292, col: 3, offset: 102393},
 									name: "L_PAREN",
@@ -7303,13 +7304,13 @@ var g = &grammar{
 			pos:  position{line: 3311, col: 1, offset: 102802},
 			expr: &choiceExpr{
 				pos: position{line: 3311, col: 15, offset: 102816},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3311, col: 15, offset: 102816},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
 							pos: position{line: 3311, col: 15, offset: 102816},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3311, col: 15, offset: 102816},
 									label: "text",
@@ -7333,7 +7334,7 @@ var g = &grammar{
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
 							pos: position{line: 3319, col: 3, offset: 103002},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3319, col: 3, offset: 103002},
 									label: "str",
@@ -7357,7 +7358,7 @@ var g = &grammar{
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
 							pos: position{line: 3327, col: 3, offset: 103186},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3327, col: 3, offset: 103186},
 									label: "field",
@@ -7370,7 +7371,7 @@ var g = &grammar{
 									pos: position{line: 3327, col: 25, offset: 103208},
 									expr: &choiceExpr{
 										pos: position{line: 3327, col: 27, offset: 103210},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&ruleRefExpr{
 												pos:  position{line: 3327, col: 27, offset: 103210},
 												name: "OpPlus",
@@ -7430,7 +7431,7 @@ var g = &grammar{
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
 					pos: position{line: 3345, col: 15, offset: 103644},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3345, col: 15, offset: 103644},
 							label: "first",
@@ -7446,7 +7447,7 @@ var g = &grammar{
 								pos: position{line: 3345, col: 37, offset: 103666},
 								expr: &seqExpr{
 									pos: position{line: 3345, col: 38, offset: 103667},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 3345, col: 38, offset: 103667},
 											name: "EVAL_CONCAT",
@@ -7463,7 +7464,7 @@ var g = &grammar{
 							pos: position{line: 3345, col: 63, offset: 103692},
 							expr: &choiceExpr{
 								pos: position{line: 3345, col: 65, offset: 103694},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 3345, col: 65, offset: 103694},
 										name: "OpPlus",
@@ -7498,7 +7499,7 @@ var g = &grammar{
 			pos:  position{line: 3363, col: 1, offset: 104135},
 			expr: &choiceExpr{
 				pos: position{line: 3363, col: 15, offset: 104149},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3363, col: 15, offset: 104149},
 						run: (*parser).callonConcatAtom2,
@@ -7558,7 +7559,7 @@ var g = &grammar{
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
 					pos: position{line: 3398, col: 16, offset: 104797},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3398, col: 16, offset: 104797},
 							label: "expr",
@@ -7571,7 +7572,7 @@ var g = &grammar{
 							pos: position{line: 3398, col: 39, offset: 104820},
 							expr: &choiceExpr{
 								pos: position{line: 3398, col: 41, offset: 104822},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 3398, col: 41, offset: 104822},
 										name: "EVAL_CONCAT",
@@ -7597,7 +7598,7 @@ var g = &grammar{
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
 					pos: position{line: 3403, col: 22, offset: 104922},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3403, col: 22, offset: 104922},
 							label: "first",
@@ -7613,10 +7614,10 @@ var g = &grammar{
 								pos: position{line: 3403, col: 51, offset: 104951},
 								expr: &seqExpr{
 									pos: position{line: 3403, col: 52, offset: 104952},
-									exprs: []any{
+									exprs: []interface{}{
 										&choiceExpr{
 											pos: position{line: 3403, col: 53, offset: 104953},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3403, col: 53, offset: 104953},
 													name: "OpPlus",
@@ -7647,7 +7648,7 @@ var g = &grammar{
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
 					pos: position{line: 3424, col: 22, offset: 105493},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3424, col: 22, offset: 105493},
 							label: "first",
@@ -7663,10 +7664,10 @@ var g = &grammar{
 								pos: position{line: 3424, col: 51, offset: 105522},
 								expr: &seqExpr{
 									pos: position{line: 3424, col: 52, offset: 105523},
-									exprs: []any{
+									exprs: []interface{}{
 										&choiceExpr{
 											pos: position{line: 3424, col: 53, offset: 105524},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3424, col: 53, offset: 105524},
 													name: "OpMul",
@@ -7701,7 +7702,7 @@ var g = &grammar{
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
 					pos: position{line: 3444, col: 21, offset: 106036},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 3444, col: 21, offset: 106036},
 							name: "COMMA",
@@ -7723,13 +7724,13 @@ var g = &grammar{
 			pos:  position{line: 3454, col: 1, offset: 106291},
 			expr: &choiceExpr{
 				pos: position{line: 3454, col: 22, offset: 106312},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3454, col: 22, offset: 106312},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
 							pos: position{line: 3454, col: 22, offset: 106312},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3454, col: 22, offset: 106312},
 									name: "L_PAREN",
@@ -7793,19 +7794,19 @@ var g = &grammar{
 			pos:  position{line: 3483, col: 1, offset: 107059},
 			expr: &choiceExpr{
 				pos: position{line: 3483, col: 20, offset: 107078},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3483, col: 20, offset: 107078},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
 							pos: position{line: 3483, col: 21, offset: 107079},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3483, col: 21, offset: 107079},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 3483, col: 29, offset: 107087},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 3483, col: 29, offset: 107087},
 												val:        "abs",
@@ -7959,7 +7960,7 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
 							pos: position{line: 3503, col: 3, offset: 107823},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3503, col: 3, offset: 107823},
 									label: "roundExpr",
@@ -8005,13 +8006,13 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
 							pos: position{line: 3524, col: 4, offset: 108528},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3524, col: 4, offset: 108528},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 3524, col: 12, offset: 108536},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 3524, col: 12, offset: 108536},
 												val:        "now",
@@ -8055,7 +8056,7 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
 							pos: position{line: 3537, col: 3, offset: 108864},
-							exprs: []any{
+							exprs: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3537, col: 3, offset: 108864},
 									val:        "tonumber",
@@ -8081,7 +8082,7 @@ var g = &grammar{
 										pos: position{line: 3537, col: 53, offset: 108914},
 										expr: &seqExpr{
 											pos: position{line: 3537, col: 54, offset: 108915},
-											exprs: []any{
+											exprs: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3537, col: 54, offset: 108915},
 													name: "COMMA",
@@ -8106,7 +8107,7 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
 							pos: position{line: 3565, col: 3, offset: 109783},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3565, col: 3, offset: 109783},
 									label: "lenExpr",
@@ -8141,13 +8142,13 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr72,
 						expr: &seqExpr{
 							pos: position{line: 3568, col: 4, offset: 109855},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3568, col: 4, offset: 109855},
 									label: "opName",
 									expr: &choiceExpr{
 										pos: position{line: 3568, col: 12, offset: 109863},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&litMatcher{
 												pos:        position{line: 3568, col: 12, offset: 109863},
 												val:        "pow",
@@ -8201,7 +8202,7 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr85,
 						expr: &seqExpr{
 							pos: position{line: 3598, col: 4, offset: 110788},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3598, col: 4, offset: 110788},
 									label: "opName",
@@ -8247,7 +8248,7 @@ var g = &grammar{
 						run: (*parser).callonNumericEvalExpr96,
 						expr: &seqExpr{
 							pos: position{line: 3627, col: 3, offset: 111633},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3627, col: 3, offset: 111633},
 									label: "opName",
@@ -8305,13 +8306,13 @@ var g = &grammar{
 			pos:  position{line: 3644, col: 1, offset: 112286},
 			expr: &choiceExpr{
 				pos: position{line: 3644, col: 12, offset: 112297},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3644, col: 12, offset: 112297},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
 							pos: position{line: 3644, col: 12, offset: 112297},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3644, col: 12, offset: 112297},
 									label: "str",
@@ -8335,7 +8336,7 @@ var g = &grammar{
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
 							pos: position{line: 3660, col: 3, offset: 112691},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3660, col: 3, offset: 112691},
 									label: "field",
@@ -8348,7 +8349,7 @@ var g = &grammar{
 									pos: position{line: 3660, col: 25, offset: 112713},
 									expr: &choiceExpr{
 										pos: position{line: 3660, col: 27, offset: 112715},
-										alternatives: []any{
+										alternatives: []interface{}{
 											&ruleRefExpr{
 												pos:  position{line: 3660, col: 27, offset: 112715},
 												name: "OpPlus",
@@ -8396,7 +8397,7 @@ var g = &grammar{
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
 					pos: position{line: 3677, col: 19, offset: 113141},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 3677, col: 19, offset: 113141},
 							val:        "null",
@@ -8427,7 +8428,7 @@ var g = &grammar{
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
 					pos: position{line: 3688, col: 23, offset: 113373},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 3688, col: 23, offset: 113373},
 							val:        "keeplast",
@@ -8458,7 +8459,7 @@ var g = &grammar{
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
 					pos: position{line: 3699, col: 20, offset: 113614},
-					exprs: []any{
+					exprs: []interface{}{
 						&litMatcher{
 							pos:        position{line: 3699, col: 20, offset: 113614},
 							val:        "limit",
@@ -8508,7 +8509,7 @@ var g = &grammar{
 					label: "option",
 					expr: &choiceExpr{
 						pos: position{line: 3725, col: 23, offset: 114260},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 3725, col: 23, offset: 114260},
 								name: "HeadOptionKeeplast",
@@ -8538,7 +8539,7 @@ var g = &grammar{
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
 					pos: position{line: 3729, col: 19, offset: 114378},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3729, col: 19, offset: 114378},
 							label: "first",
@@ -8554,7 +8555,7 @@ var g = &grammar{
 								pos: position{line: 3729, col: 43, offset: 114402},
 								expr: &seqExpr{
 									pos: position{line: 3729, col: 44, offset: 114403},
-									exprs: []any{
+									exprs: []interface{}{
 										&ruleRefExpr{
 											pos:  position{line: 3729, col: 44, offset: 114403},
 											name: "SPACE",
@@ -8576,13 +8577,13 @@ var g = &grammar{
 			pos:  position{line: 3786, col: 1, offset: 116209},
 			expr: &choiceExpr{
 				pos: position{line: 3786, col: 14, offset: 116222},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3786, col: 14, offset: 116222},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
 							pos: position{line: 3786, col: 14, offset: 116222},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3786, col: 14, offset: 116222},
 									name: "PIPE",
@@ -8607,7 +8608,7 @@ var g = &grammar{
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
 							pos: position{line: 3797, col: 3, offset: 116564},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3797, col: 3, offset: 116564},
 									name: "PIPE",
@@ -8632,7 +8633,7 @@ var g = &grammar{
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
 							pos: position{line: 3817, col: 3, offset: 117104},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3817, col: 3, offset: 117104},
 									name: "PIPE",
@@ -8652,13 +8653,13 @@ var g = &grammar{
 			pos:  position{line: 3835, col: 1, offset: 117579},
 			expr: &choiceExpr{
 				pos: position{line: 3835, col: 14, offset: 117592},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3835, col: 14, offset: 117592},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
 							pos: position{line: 3835, col: 14, offset: 117592},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3835, col: 14, offset: 117592},
 									name: "PIPE",
@@ -8683,7 +8684,7 @@ var g = &grammar{
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
 							pos: position{line: 3856, col: 3, offset: 118189},
-							exprs: []any{
+							exprs: []interface{}{
 								&ruleRefExpr{
 									pos:  position{line: 3856, col: 3, offset: 118189},
 									name: "PIPE",
@@ -8706,7 +8707,7 @@ var g = &grammar{
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
 					pos: position{line: 3877, col: 20, offset: 118831},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3877, col: 20, offset: 118831},
 							label: "first",
@@ -8722,10 +8723,10 @@ var g = &grammar{
 								pos: position{line: 3877, col: 42, offset: 118853},
 								expr: &seqExpr{
 									pos: position{line: 3877, col: 43, offset: 118854},
-									exprs: []any{
+									exprs: []interface{}{
 										&choiceExpr{
 											pos: position{line: 3877, col: 44, offset: 118855},
-											alternatives: []any{
+											alternatives: []interface{}{
 												&ruleRefExpr{
 													pos:  position{line: 3877, col: 44, offset: 118855},
 													name: "COMMA",
@@ -8756,7 +8757,7 @@ var g = &grammar{
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
 					pos: position{line: 3894, col: 15, offset: 119387},
-					exprs: []any{
+					exprs: []interface{}{
 						&labeledExpr{
 							pos:   position{line: 3894, col: 15, offset: 119387},
 							label: "aggFunc",
@@ -8791,7 +8792,7 @@ var g = &grammar{
 					label: "agg",
 					expr: &choiceExpr{
 						pos: position{line: 3910, col: 21, offset: 120276},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 3910, col: 21, offset: 120276},
 								name: "AggCount",
@@ -8817,7 +8818,7 @@ var g = &grammar{
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
 					pos: position{line: 3915, col: 19, offset: 120509},
-					alternatives: []any{
+					alternatives: []interface{}{
 						&litMatcher{
 							pos:        position{line: 3915, col: 19, offset: 120509},
 							val:        "values",
@@ -8986,7 +8987,7 @@ var g = &grammar{
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
 					pos: position{line: 3920, col: 23, offset: 120844},
-					alternatives: []any{
+					alternatives: []interface{}{
 						&litMatcher{
 							pos:        position{line: 3920, col: 23, offset: 120844},
 							val:        "upperperc",
@@ -9023,7 +9024,7 @@ var g = &grammar{
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
 					pos: position{line: 3924, col: 12, offset: 120933},
-					exprs: []any{
+					exprs: []interface{}{
 						&ruleRefExpr{
 							pos:  position{line: 3924, col: 12, offset: 120933},
 							name: "AS",
@@ -9033,7 +9034,7 @@ var g = &grammar{
 							label: "field",
 							expr: &choiceExpr{
 								pos: position{line: 3924, col: 23, offset: 120944},
-								alternatives: []any{
+								alternatives: []interface{}{
 									&ruleRefExpr{
 										pos:  position{line: 3924, col: 23, offset: 120944},
 										name: "FieldName",
@@ -9054,16 +9055,16 @@ var g = &grammar{
 			pos:  position{line: 3938, col: 1, offset: 121285},
 			expr: &choiceExpr{
 				pos: position{line: 3938, col: 13, offset: 121297},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3938, col: 13, offset: 121297},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
 							pos: position{line: 3938, col: 13, offset: 121297},
-							exprs: []any{
+							exprs: []interface{}{
 								&choiceExpr{
 									pos: position{line: 3938, col: 14, offset: 121298},
-									alternatives: []any{
+									alternatives: []interface{}{
 										&litMatcher{
 											pos:        position{line: 3938, col: 14, offset: 121298},
 											val:        "count",
@@ -9108,10 +9109,10 @@ var g = &grammar{
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
 							pos: position{line: 3948, col: 3, offset: 121577},
-							exprs: []any{
+							exprs: []interface{}{
 								&choiceExpr{
 									pos: position{line: 3948, col: 4, offset: 121578},
-									alternatives: []any{
+									alternatives: []interface{}{
 										&litMatcher{
 											pos:        position{line: 3948, col: 4, offset: 121578},
 											val:        "count",
@@ -9150,7 +9151,7 @@ var g = &grammar{
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
 							pos: position{line: 3955, col: 6, offset: 121770},
-							alternatives: []any{
+							alternatives: []interface{}{
 								&litMatcher{
 									pos:        position{line: 3955, col: 6, offset: 121770},
 									val:        "count",
@@ -9174,13 +9175,13 @@ var g = &grammar{
 			pos:  position{line: 3964, col: 1, offset: 121917},
 			expr: &choiceExpr{
 				pos: position{line: 3964, col: 14, offset: 121930},
-				alternatives: []any{
+				alternatives: []interface{}{
 					&actionExpr{
 						pos: position{line: 3964, col: 14, offset: 121930},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
 							pos: position{line: 3964, col: 14, offset: 121930},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3964, col: 14, offset: 121930},
 									label: "aggName",
@@ -9219,7 +9220,7 @@ var g = &grammar{
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
 							pos: position{line: 3979, col: 3, offset: 122398},
-							exprs: []any{
+							exprs: []interface{}{
 								&labeledExpr{
 									pos:   position{line: 3979, col: 3, offset: 122398},
 									label: "aggName",
@@ -9261,7 +9262,7 @@ var g = &grammar{
 					label: "numStr",
 					expr: &choiceExpr{
 						pos: position{line: 4009, col: 26, offset: 123450},
-						alternatives: []any{
+						alternatives: []interface{}{
 							&ruleRefExpr{
 								pos:  position{line: 4009, col: 26, offset: 123450},
 								name: "FloatAsString",
@@ -9277,161 +9278,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4021, col: 1, offset: 123839},
+			pos:  position{line: 4022, col: 1, offset: 123903},
 			expr: &choiceExpr{
-				pos: position{line: 4021, col: 18, offset: 123856},
-				alternatives: []any{
+				pos: position{line: 4022, col: 18, offset: 123920},
+				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 4021, col: 18, offset: 123856},
+						pos: position{line: 4022, col: 18, offset: 123920},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4021, col: 18, offset: 123856},
-							exprs: []any{
+							pos: position{line: 4022, col: 18, offset: 123920},
+							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 4021, col: 18, offset: 123856},
+									pos:   position{line: 4022, col: 18, offset: 123920},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4021, col: 26, offset: 123864},
+										pos:  position{line: 4022, col: 26, offset: 123928},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4021, col: 44, offset: 123882},
+									pos:   position{line: 4022, col: 44, offset: 123946},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4021, col: 58, offset: 123896},
+										pos:  position{line: 4022, col: 58, offset: 123960},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4021, col: 72, offset: 123910},
+									pos:  position{line: 4022, col: 72, offset: 123974},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4021, col: 80, offset: 123918},
+									pos:        position{line: 4022, col: 80, offset: 123982},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4021, col: 87, offset: 123925},
+									pos:   position{line: 4022, col: 87, offset: 123989},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4021, col: 97, offset: 123935},
+										pos:  position{line: 4022, col: 97, offset: 123999},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4021, col: 107, offset: 123945},
+									pos:  position{line: 4022, col: 107, offset: 124009},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4037, col: 3, offset: 124469},
+						pos: position{line: 4038, col: 3, offset: 124533},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4037, col: 3, offset: 124469},
-							exprs: []any{
+							pos: position{line: 4038, col: 3, offset: 124533},
+							exprs: []interface{}{
 								&labeledExpr{
-									pos:   position{line: 4037, col: 3, offset: 124469},
+									pos:   position{line: 4038, col: 3, offset: 124533},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4037, col: 11, offset: 124477},
+										pos:  position{line: 4038, col: 11, offset: 124541},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4037, col: 29, offset: 124495},
+									pos:   position{line: 4038, col: 29, offset: 124559},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4037, col: 43, offset: 124509},
+										pos:  position{line: 4038, col: 43, offset: 124573},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4037, col: 57, offset: 124523},
+									pos:  position{line: 4038, col: 57, offset: 124587},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4037, col: 65, offset: 124531},
+									pos:   position{line: 4038, col: 65, offset: 124595},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4037, col: 71, offset: 124537},
+										pos:  position{line: 4038, col: 71, offset: 124601},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4037, col: 81, offset: 124547},
+									pos:  position{line: 4038, col: 81, offset: 124611},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4052, col: 3, offset: 125027},
+						pos: position{line: 4053, col: 3, offset: 125091},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4052, col: 3, offset: 125027},
-							exprs: []any{
+							pos: position{line: 4053, col: 3, offset: 125091},
+							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 4052, col: 4, offset: 125028},
+									pos:        position{line: 4053, col: 4, offset: 125092},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4052, col: 14, offset: 125038},
+									pos:  position{line: 4053, col: 14, offset: 125102},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4052, col: 22, offset: 125046},
+									pos:   position{line: 4053, col: 22, offset: 125110},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4052, col: 28, offset: 125052},
+										pos:  position{line: 4053, col: 28, offset: 125116},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4052, col: 38, offset: 125062},
+									pos:  position{line: 4053, col: 38, offset: 125126},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4067, col: 3, offset: 125449},
+						pos: position{line: 4068, col: 3, offset: 125513},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4067, col: 3, offset: 125449},
-							exprs: []any{
+							pos: position{line: 4068, col: 3, offset: 125513},
+							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 4067, col: 4, offset: 125450},
+									pos:        position{line: 4068, col: 4, offset: 125514},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4067, col: 14, offset: 125460},
+									pos:  position{line: 4068, col: 14, offset: 125524},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4067, col: 22, offset: 125468},
+									pos:        position{line: 4068, col: 22, offset: 125532},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4067, col: 29, offset: 125475},
+									pos:   position{line: 4068, col: 29, offset: 125539},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4067, col: 39, offset: 125485},
+										pos:  position{line: 4068, col: 39, offset: 125549},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4067, col: 49, offset: 125495},
+									pos:  position{line: 4068, col: 49, offset: 125559},
 									name: "R_PAREN",
 								},
 							},
@@ -9442,22 +9443,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4085, col: 1, offset: 125926},
+			pos:  position{line: 4086, col: 1, offset: 125990},
 			expr: &actionExpr{
-				pos: position{line: 4085, col: 25, offset: 125950},
+				pos: position{line: 4086, col: 25, offset: 126014},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4085, col: 25, offset: 125950},
+					pos:   position{line: 4086, col: 25, offset: 126014},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4085, col: 39, offset: 125964},
-						alternatives: []any{
+						pos: position{line: 4086, col: 39, offset: 126028},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4085, col: 39, offset: 125964},
+								pos:  position{line: 4086, col: 39, offset: 126028},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4085, col: 67, offset: 125992},
+								pos:  position{line: 4086, col: 67, offset: 126056},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9467,43 +9468,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4089, col: 1, offset: 126055},
+			pos:  position{line: 4090, col: 1, offset: 126119},
 			expr: &actionExpr{
-				pos: position{line: 4089, col: 30, offset: 126084},
+				pos: position{line: 4090, col: 30, offset: 126148},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4089, col: 30, offset: 126084},
-					exprs: []any{
+					pos: position{line: 4090, col: 30, offset: 126148},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4089, col: 30, offset: 126084},
+							pos:   position{line: 4090, col: 30, offset: 126148},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4089, col: 34, offset: 126088},
+								pos:  position{line: 4090, col: 34, offset: 126152},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4089, col: 44, offset: 126098},
+							pos:   position{line: 4090, col: 44, offset: 126162},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4089, col: 48, offset: 126102},
-								alternatives: []any{
+								pos: position{line: 4090, col: 48, offset: 126166},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 48, offset: 126102},
+										pos:  position{line: 4090, col: 48, offset: 126166},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4089, col: 67, offset: 126121},
+										pos:  position{line: 4090, col: 67, offset: 126185},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4089, col: 87, offset: 126141},
+							pos:   position{line: 4090, col: 87, offset: 126205},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4089, col: 93, offset: 126147},
+								pos:  position{line: 4090, col: 93, offset: 126211},
 								name: "Number",
 							},
 						},
@@ -9513,15 +9514,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4102, col: 1, offset: 126381},
+			pos:  position{line: 4103, col: 1, offset: 126445},
 			expr: &actionExpr{
-				pos: position{line: 4102, col: 32, offset: 126412},
+				pos: position{line: 4103, col: 32, offset: 126476},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4102, col: 32, offset: 126412},
+					pos:   position{line: 4103, col: 32, offset: 126476},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4102, col: 38, offset: 126418},
+						pos:  position{line: 4103, col: 38, offset: 126482},
 						name: "Number",
 					},
 				},
@@ -9529,34 +9530,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4115, col: 1, offset: 126635},
+			pos:  position{line: 4116, col: 1, offset: 126699},
 			expr: &actionExpr{
-				pos: position{line: 4115, col: 26, offset: 126660},
+				pos: position{line: 4116, col: 26, offset: 126724},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4115, col: 26, offset: 126660},
-					exprs: []any{
+					pos: position{line: 4116, col: 26, offset: 126724},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4115, col: 26, offset: 126660},
+							pos:   position{line: 4116, col: 26, offset: 126724},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4115, col: 30, offset: 126664},
+								pos:  position{line: 4116, col: 30, offset: 126728},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4115, col: 40, offset: 126674},
+							pos:   position{line: 4116, col: 40, offset: 126738},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4115, col: 43, offset: 126677},
+								pos:  position{line: 4116, col: 43, offset: 126741},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4115, col: 60, offset: 126694},
+							pos:   position{line: 4116, col: 60, offset: 126758},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4115, col: 66, offset: 126700},
+								pos:  position{line: 4116, col: 66, offset: 126764},
 								name: "Boolean",
 							},
 						},
@@ -9566,22 +9567,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4128, col: 1, offset: 126935},
+			pos:  position{line: 4129, col: 1, offset: 126999},
 			expr: &actionExpr{
-				pos: position{line: 4128, col: 25, offset: 126959},
+				pos: position{line: 4129, col: 25, offset: 127023},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4128, col: 25, offset: 126959},
+					pos:   position{line: 4129, col: 25, offset: 127023},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4128, col: 39, offset: 126973},
-						alternatives: []any{
+						pos: position{line: 4129, col: 39, offset: 127037},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4128, col: 39, offset: 126973},
+								pos:  position{line: 4129, col: 39, offset: 127037},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4128, col: 67, offset: 127001},
+								pos:  position{line: 4129, col: 67, offset: 127065},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9591,41 +9592,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4132, col: 1, offset: 127064},
+			pos:  position{line: 4133, col: 1, offset: 127128},
 			expr: &actionExpr{
-				pos: position{line: 4132, col: 30, offset: 127093},
+				pos: position{line: 4133, col: 30, offset: 127157},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4132, col: 30, offset: 127093},
-					exprs: []any{
+					pos: position{line: 4133, col: 30, offset: 127157},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4132, col: 30, offset: 127093},
+							pos:   position{line: 4133, col: 30, offset: 127157},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4132, col: 34, offset: 127097},
+								pos:  position{line: 4133, col: 34, offset: 127161},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4132, col: 44, offset: 127107},
+							pos:   position{line: 4133, col: 44, offset: 127171},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4132, col: 47, offset: 127110},
+								pos:  position{line: 4133, col: 47, offset: 127174},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4132, col: 64, offset: 127127},
+							pos:   position{line: 4133, col: 64, offset: 127191},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4132, col: 81, offset: 127144},
-								alternatives: []any{
+								pos: position{line: 4133, col: 81, offset: 127208},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4132, col: 81, offset: 127144},
+										pos:  position{line: 4133, col: 81, offset: 127208},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4132, col: 103, offset: 127166},
+										pos:  position{line: 4133, col: 103, offset: 127230},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9637,22 +9638,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4148, col: 1, offset: 127598},
+			pos:  position{line: 4149, col: 1, offset: 127662},
 			expr: &actionExpr{
-				pos: position{line: 4148, col: 32, offset: 127629},
+				pos: position{line: 4149, col: 32, offset: 127693},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4148, col: 32, offset: 127629},
+					pos:   position{line: 4149, col: 32, offset: 127693},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4148, col: 49, offset: 127646},
-						alternatives: []any{
+						pos: position{line: 4149, col: 49, offset: 127710},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4148, col: 49, offset: 127646},
+								pos:  position{line: 4149, col: 49, offset: 127710},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4148, col: 71, offset: 127668},
+								pos:  position{line: 4149, col: 71, offset: 127732},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9662,33 +9663,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4165, col: 1, offset: 128179},
+			pos:  position{line: 4166, col: 1, offset: 128243},
 			expr: &actionExpr{
-				pos: position{line: 4165, col: 24, offset: 128202},
+				pos: position{line: 4166, col: 24, offset: 128266},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4165, col: 24, offset: 128202},
-					exprs: []any{
+					pos: position{line: 4166, col: 24, offset: 128266},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4165, col: 24, offset: 128202},
+							pos:        position{line: 4166, col: 24, offset: 128266},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4165, col: 31, offset: 128209},
+							pos:  position{line: 4166, col: 31, offset: 128273},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4165, col: 39, offset: 128217},
+							pos:   position{line: 4166, col: 39, offset: 128281},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4165, col: 45, offset: 128223},
+								pos:  position{line: 4166, col: 45, offset: 128287},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4165, col: 52, offset: 128230},
+							pos:  position{line: 4166, col: 52, offset: 128294},
 							name: "R_PAREN",
 						},
 					},
@@ -9697,49 +9698,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4174, col: 1, offset: 128467},
+			pos:  position{line: 4175, col: 1, offset: 128531},
 			expr: &choiceExpr{
-				pos: position{line: 4174, col: 26, offset: 128492},
-				alternatives: []any{
+				pos: position{line: 4175, col: 26, offset: 128556},
+				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 4174, col: 26, offset: 128492},
+						pos: position{line: 4175, col: 26, offset: 128556},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4174, col: 26, offset: 128492},
-							exprs: []any{
+							pos: position{line: 4175, col: 26, offset: 128556},
+							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 4174, col: 26, offset: 128492},
+									pos:        position{line: 4175, col: 26, offset: 128556},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4174, col: 33, offset: 128499},
+									pos:  position{line: 4175, col: 33, offset: 128563},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4174, col: 41, offset: 128507},
+									pos:   position{line: 4175, col: 41, offset: 128571},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4174, col: 47, offset: 128513},
+										pos:  position{line: 4175, col: 47, offset: 128577},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4174, col: 54, offset: 128520},
+									pos:  position{line: 4175, col: 54, offset: 128584},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4183, col: 3, offset: 128710},
+						pos: position{line: 4184, col: 3, offset: 128774},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4183, col: 3, offset: 128710},
+							pos:   position{line: 4184, col: 3, offset: 128774},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4183, col: 9, offset: 128716},
+								pos:  position{line: 4184, col: 9, offset: 128780},
 								name: "String",
 							},
 						},
@@ -9749,35 +9750,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4193, col: 1, offset: 128996},
+			pos:  position{line: 4194, col: 1, offset: 129060},
 			expr: &actionExpr{
-				pos: position{line: 4193, col: 18, offset: 129013},
+				pos: position{line: 4194, col: 18, offset: 129077},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4193, col: 18, offset: 129013},
-					exprs: []any{
+					pos: position{line: 4194, col: 18, offset: 129077},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4193, col: 18, offset: 129013},
+							pos:   position{line: 4194, col: 18, offset: 129077},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4193, col: 24, offset: 129019},
+								pos:  position{line: 4194, col: 24, offset: 129083},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4193, col: 34, offset: 129029},
+							pos:   position{line: 4194, col: 34, offset: 129093},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4193, col: 39, offset: 129034},
+								pos: position{line: 4194, col: 39, offset: 129098},
 								expr: &seqExpr{
-									pos: position{line: 4193, col: 40, offset: 129035},
-									exprs: []any{
+									pos: position{line: 4194, col: 40, offset: 129099},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4193, col: 40, offset: 129035},
+											pos:  position{line: 4194, col: 40, offset: 129099},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4193, col: 46, offset: 129041},
+											pos:  position{line: 4194, col: 46, offset: 129105},
 											name: "FieldName",
 										},
 									},
@@ -9790,16 +9791,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4210, col: 1, offset: 129536},
+			pos:  position{line: 4211, col: 1, offset: 129600},
 			expr: &choiceExpr{
-				pos: position{line: 4210, col: 18, offset: 129553},
-				alternatives: []any{
+				pos: position{line: 4211, col: 18, offset: 129617},
+				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 4210, col: 18, offset: 129553},
+						pos:  position{line: 4211, col: 18, offset: 129617},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4210, col: 38, offset: 129573},
+						pos:  position{line: 4211, col: 38, offset: 129637},
 						name: "EarliestOnly",
 					},
 				},
@@ -9807,62 +9808,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4212, col: 1, offset: 129587},
+			pos:  position{line: 4213, col: 1, offset: 129651},
 			expr: &actionExpr{
-				pos: position{line: 4212, col: 22, offset: 129608},
+				pos: position{line: 4213, col: 22, offset: 129672},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4212, col: 22, offset: 129608},
-					exprs: []any{
+					pos: position{line: 4213, col: 22, offset: 129672},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4212, col: 22, offset: 129608},
+							pos:  position{line: 4213, col: 22, offset: 129672},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4212, col: 35, offset: 129621},
+							pos:  position{line: 4213, col: 35, offset: 129685},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4212, col: 41, offset: 129627},
+							pos:   position{line: 4213, col: 41, offset: 129691},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4212, col: 55, offset: 129641},
-								alternatives: []any{
+								pos: position{line: 4213, col: 55, offset: 129705},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4212, col: 55, offset: 129641},
+										pos:  position{line: 4213, col: 55, offset: 129705},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4212, col: 75, offset: 129661},
+										pos:  position{line: 4213, col: 75, offset: 129725},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4212, col: 94, offset: 129680},
+							pos:  position{line: 4213, col: 94, offset: 129744},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4212, col: 100, offset: 129686},
+							pos:  position{line: 4213, col: 100, offset: 129750},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4212, col: 111, offset: 129697},
+							pos:  position{line: 4213, col: 111, offset: 129761},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4212, col: 117, offset: 129703},
+							pos:   position{line: 4213, col: 117, offset: 129767},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4212, col: 129, offset: 129715},
-								alternatives: []any{
+								pos: position{line: 4213, col: 129, offset: 129779},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4212, col: 129, offset: 129715},
+										pos:  position{line: 4213, col: 129, offset: 129779},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4212, col: 149, offset: 129735},
+										pos:  position{line: 4213, col: 149, offset: 129799},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9874,33 +9875,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4253, col: 1, offset: 130874},
+			pos:  position{line: 4254, col: 1, offset: 130938},
 			expr: &actionExpr{
-				pos: position{line: 4253, col: 17, offset: 130890},
+				pos: position{line: 4254, col: 17, offset: 130954},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4253, col: 17, offset: 130890},
-					exprs: []any{
+					pos: position{line: 4254, col: 17, offset: 130954},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4253, col: 17, offset: 130890},
+							pos:  position{line: 4254, col: 17, offset: 130954},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4253, col: 30, offset: 130903},
+							pos:  position{line: 4254, col: 30, offset: 130967},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4253, col: 36, offset: 130909},
+							pos:   position{line: 4254, col: 36, offset: 130973},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4253, col: 50, offset: 130923},
-								alternatives: []any{
+								pos: position{line: 4254, col: 50, offset: 130987},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4253, col: 50, offset: 130923},
+										pos:  position{line: 4254, col: 50, offset: 130987},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4253, col: 70, offset: 130943},
+										pos:  position{line: 4254, col: 70, offset: 131007},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -9912,24 +9913,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4281, col: 1, offset: 131651},
+			pos:  position{line: 4282, col: 1, offset: 131715},
 			expr: &actionExpr{
-				pos: position{line: 4281, col: 23, offset: 131673},
+				pos: position{line: 4282, col: 23, offset: 131737},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4281, col: 23, offset: 131673},
-					exprs: []any{
+					pos: position{line: 4282, col: 23, offset: 131737},
+					exprs: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 4281, col: 23, offset: 131673},
+							pos:        position{line: 4282, col: 23, offset: 131737},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4281, col: 27, offset: 131677},
+							pos: position{line: 4282, col: 27, offset: 131741},
 							expr: &charClassMatcher{
-								pos:        position{line: 4281, col: 27, offset: 131677},
+								pos:        position{line: 4282, col: 27, offset: 131741},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -9942,21 +9943,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4285, col: 1, offset: 131720},
+			pos:  position{line: 4286, col: 1, offset: 131784},
 			expr: &actionExpr{
-				pos: position{line: 4285, col: 13, offset: 131732},
+				pos: position{line: 4286, col: 13, offset: 131796},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4285, col: 14, offset: 131733},
-					exprs: []any{
+					pos: position{line: 4286, col: 14, offset: 131797},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4285, col: 14, offset: 131733},
+							pos:        position{line: 4286, col: 14, offset: 131797},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4285, col: 17, offset: 131736},
+							pos:        position{line: 4286, col: 17, offset: 131800},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -9968,15 +9969,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4289, col: 1, offset: 131779},
+			pos:  position{line: 4290, col: 1, offset: 131843},
 			expr: &actionExpr{
-				pos: position{line: 4289, col: 16, offset: 131794},
+				pos: position{line: 4290, col: 16, offset: 131858},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4289, col: 16, offset: 131794},
+					pos:   position{line: 4290, col: 16, offset: 131858},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4289, col: 26, offset: 131804},
+						pos:  position{line: 4290, col: 26, offset: 131868},
 						name: "AllTimeScale",
 					},
 				},
@@ -9984,31 +9985,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4296, col: 1, offset: 132031},
+			pos:  position{line: 4297, col: 1, offset: 132095},
 			expr: &actionExpr{
-				pos: position{line: 4296, col: 9, offset: 132039},
+				pos: position{line: 4297, col: 9, offset: 132103},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4296, col: 9, offset: 132039},
-					exprs: []any{
+					pos: position{line: 4297, col: 9, offset: 132103},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4296, col: 9, offset: 132039},
+							pos:        position{line: 4297, col: 9, offset: 132103},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4296, col: 13, offset: 132043},
+							pos:   position{line: 4297, col: 13, offset: 132107},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4296, col: 19, offset: 132049},
-								alternatives: []any{
+								pos: position{line: 4297, col: 19, offset: 132113},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4296, col: 19, offset: 132049},
+										pos:  position{line: 4297, col: 19, offset: 132113},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4296, col: 30, offset: 132060},
+										pos:  position{line: 4297, col: 30, offset: 132124},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10020,26 +10021,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4300, col: 1, offset: 132108},
+			pos:  position{line: 4301, col: 1, offset: 132172},
 			expr: &actionExpr{
-				pos: position{line: 4300, col: 11, offset: 132118},
+				pos: position{line: 4301, col: 11, offset: 132182},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4300, col: 11, offset: 132118},
-					exprs: []any{
+					pos: position{line: 4301, col: 11, offset: 132182},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4300, col: 11, offset: 132118},
+							pos:   position{line: 4301, col: 11, offset: 132182},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4300, col: 16, offset: 132123},
+								pos:  position{line: 4301, col: 16, offset: 132187},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4300, col: 36, offset: 132143},
+							pos:   position{line: 4301, col: 36, offset: 132207},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4300, col: 43, offset: 132150},
+								pos:  position{line: 4301, col: 43, offset: 132214},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10049,44 +10050,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4328, col: 1, offset: 132889},
+			pos:  position{line: 4329, col: 1, offset: 132953},
 			expr: &actionExpr{
-				pos: position{line: 4328, col: 29, offset: 132917},
+				pos: position{line: 4329, col: 29, offset: 132981},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4328, col: 29, offset: 132917},
-					exprs: []any{
+					pos: position{line: 4329, col: 29, offset: 132981},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4328, col: 29, offset: 132917},
+							pos:   position{line: 4329, col: 29, offset: 132981},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4328, col: 36, offset: 132924},
-								alternatives: []any{
+								pos: position{line: 4329, col: 36, offset: 132988},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4328, col: 36, offset: 132924},
+										pos:  position{line: 4329, col: 36, offset: 132988},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4328, col: 45, offset: 132933},
+										pos:  position{line: 4329, col: 45, offset: 132997},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4328, col: 51, offset: 132939},
+							pos:   position{line: 4329, col: 51, offset: 133003},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4328, col: 57, offset: 132945},
+								pos: position{line: 4329, col: 57, offset: 133009},
 								expr: &choiceExpr{
-									pos: position{line: 4328, col: 58, offset: 132946},
-									alternatives: []any{
+									pos: position{line: 4329, col: 58, offset: 133010},
+									alternatives: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4328, col: 58, offset: 132946},
+											pos:  position{line: 4329, col: 58, offset: 133010},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4328, col: 67, offset: 132955},
+											pos:  position{line: 4329, col: 67, offset: 133019},
 											name: "Snap",
 										},
 									},
@@ -10099,29 +10100,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4375, col: 1, offset: 134387},
+			pos:  position{line: 4376, col: 1, offset: 134451},
 			expr: &actionExpr{
-				pos: position{line: 4375, col: 22, offset: 134408},
+				pos: position{line: 4376, col: 22, offset: 134472},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4375, col: 22, offset: 134408},
-					exprs: []any{
+					pos: position{line: 4376, col: 22, offset: 134472},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4375, col: 22, offset: 134408},
+							pos:   position{line: 4376, col: 22, offset: 134472},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4375, col: 34, offset: 134420},
+								pos: position{line: 4376, col: 34, offset: 134484},
 								expr: &choiceExpr{
-									pos: position{line: 4375, col: 35, offset: 134421},
-									alternatives: []any{
+									pos: position{line: 4376, col: 35, offset: 134485},
+									alternatives: []interface{}{
 										&litMatcher{
-											pos:        position{line: 4375, col: 35, offset: 134421},
+											pos:        position{line: 4376, col: 35, offset: 134485},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4375, col: 43, offset: 134429},
+											pos:        position{line: 4376, col: 43, offset: 134493},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10131,12 +10132,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4375, col: 49, offset: 134435},
+							pos:   position{line: 4376, col: 49, offset: 134499},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4375, col: 57, offset: 134443},
+								pos: position{line: 4376, col: 57, offset: 134507},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4375, col: 58, offset: 134444},
+									pos:  position{line: 4376, col: 58, offset: 134508},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10147,31 +10148,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4400, col: 1, offset: 135127},
+			pos:  position{line: 4401, col: 1, offset: 135191},
 			expr: &actionExpr{
-				pos: position{line: 4400, col: 39, offset: 135165},
+				pos: position{line: 4401, col: 39, offset: 135229},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4400, col: 39, offset: 135165},
-					exprs: []any{
+					pos: position{line: 4401, col: 39, offset: 135229},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4400, col: 39, offset: 135165},
+							pos:   position{line: 4401, col: 39, offset: 135229},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4400, col: 46, offset: 135172},
+								pos: position{line: 4401, col: 46, offset: 135236},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4400, col: 47, offset: 135173},
+									pos:  position{line: 4401, col: 47, offset: 135237},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4400, col: 56, offset: 135182},
+							pos:   position{line: 4401, col: 56, offset: 135246},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4400, col: 66, offset: 135192},
+								pos: position{line: 4401, col: 66, offset: 135256},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4400, col: 67, offset: 135193},
+									pos:  position{line: 4401, col: 67, offset: 135257},
 									name: "Snap",
 								},
 							},
@@ -10182,136 +10183,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4427, col: 1, offset: 135823},
+			pos:  position{line: 4428, col: 1, offset: 135887},
 			expr: &actionExpr{
-				pos: position{line: 4427, col: 18, offset: 135840},
+				pos: position{line: 4428, col: 18, offset: 135904},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4427, col: 18, offset: 135840},
-					exprs: []any{
+					pos: position{line: 4428, col: 18, offset: 135904},
+					exprs: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 18, offset: 135840},
+							pos:        position{line: 4428, col: 18, offset: 135904},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 23, offset: 135845},
+							pos:        position{line: 4428, col: 23, offset: 135909},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 29, offset: 135851},
+							pos:        position{line: 4428, col: 29, offset: 135915},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 33, offset: 135855},
+							pos:        position{line: 4428, col: 33, offset: 135919},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 38, offset: 135860},
+							pos:        position{line: 4428, col: 38, offset: 135924},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 44, offset: 135866},
+							pos:        position{line: 4428, col: 44, offset: 135930},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 48, offset: 135870},
+							pos:        position{line: 4428, col: 48, offset: 135934},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 53, offset: 135875},
+							pos:        position{line: 4428, col: 53, offset: 135939},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 58, offset: 135880},
+							pos:        position{line: 4428, col: 58, offset: 135944},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 63, offset: 135885},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4427, col: 69, offset: 135891},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4427, col: 73, offset: 135895},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4427, col: 78, offset: 135900},
+							pos:        position{line: 4428, col: 63, offset: 135949},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 84, offset: 135906},
+							pos:        position{line: 4428, col: 69, offset: 135955},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 88, offset: 135910},
+							pos:        position{line: 4428, col: 73, offset: 135959},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 93, offset: 135915},
+							pos:        position{line: 4428, col: 78, offset: 135964},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4427, col: 99, offset: 135921},
+							pos:        position{line: 4428, col: 84, offset: 135970},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 103, offset: 135925},
+							pos:        position{line: 4428, col: 88, offset: 135974},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4427, col: 108, offset: 135930},
+							pos:        position{line: 4428, col: 93, offset: 135979},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4428, col: 99, offset: 135985},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4428, col: 103, offset: 135989},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4428, col: 108, offset: 135994},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10323,15 +10324,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4431, col: 1, offset: 135972},
+			pos:  position{line: 4432, col: 1, offset: 136036},
 			expr: &actionExpr{
-				pos: position{line: 4431, col: 22, offset: 135993},
+				pos: position{line: 4432, col: 22, offset: 136057},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4431, col: 22, offset: 135993},
+					pos:   position{line: 4432, col: 22, offset: 136057},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4431, col: 32, offset: 136003},
+						pos:  position{line: 4432, col: 32, offset: 136067},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10339,18 +10340,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4442, col: 1, offset: 136446},
+			pos:  position{line: 4443, col: 1, offset: 136510},
 			expr: &choiceExpr{
-				pos: position{line: 4442, col: 14, offset: 136459},
-				alternatives: []any{
+				pos: position{line: 4443, col: 14, offset: 136523},
+				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 4442, col: 14, offset: 136459},
+						pos: position{line: 4443, col: 14, offset: 136523},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4442, col: 14, offset: 136459},
-							exprs: []any{
+							pos: position{line: 4443, col: 14, offset: 136523},
+							exprs: []interface{}{
 								&charClassMatcher{
-									pos:        position{line: 4442, col: 14, offset: 136459},
+									pos:        position{line: 4443, col: 14, offset: 136523},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10358,9 +10359,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4442, col: 29, offset: 136474},
+									pos: position{line: 4443, col: 29, offset: 136538},
 									expr: &charClassMatcher{
-										pos:        position{line: 4442, col: 29, offset: 136474},
+										pos:        position{line: 4443, col: 29, offset: 136538},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10372,10 +10373,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4445, col: 3, offset: 136530},
+						pos: position{line: 4446, col: 3, offset: 136594},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4445, col: 3, offset: 136530},
+							pos:  position{line: 4446, col: 3, offset: 136594},
 							name: "QuotedString",
 						},
 					},
@@ -10384,15 +10385,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4449, col: 1, offset: 136593},
+			pos:  position{line: 4450, col: 1, offset: 136657},
 			expr: &actionExpr{
-				pos: position{line: 4449, col: 24, offset: 136616},
+				pos: position{line: 4450, col: 24, offset: 136680},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4449, col: 24, offset: 136616},
-					exprs: []any{
+					pos: position{line: 4450, col: 24, offset: 136680},
+					exprs: []interface{}{
 						&charClassMatcher{
-							pos:        position{line: 4449, col: 24, offset: 136616},
+							pos:        position{line: 4450, col: 24, offset: 136680},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10400,9 +10401,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4449, col: 39, offset: 136631},
+							pos: position{line: 4450, col: 39, offset: 136695},
 							expr: &charClassMatcher{
-								pos:        position{line: 4449, col: 39, offset: 136631},
+								pos:        position{line: 4450, col: 39, offset: 136695},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10416,22 +10417,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4453, col: 1, offset: 136684},
+			pos:  position{line: 4454, col: 1, offset: 136748},
 			expr: &actionExpr{
-				pos: position{line: 4453, col: 11, offset: 136694},
+				pos: position{line: 4454, col: 11, offset: 136758},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4453, col: 11, offset: 136694},
+					pos:   position{line: 4454, col: 11, offset: 136758},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4453, col: 16, offset: 136699},
-						alternatives: []any{
+						pos: position{line: 4454, col: 16, offset: 136763},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4453, col: 16, offset: 136699},
+								pos:  position{line: 4454, col: 16, offset: 136763},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4453, col: 31, offset: 136714},
+								pos:  position{line: 4454, col: 31, offset: 136778},
 								name: "UnquotedString",
 							},
 						},
@@ -10441,38 +10442,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4457, col: 1, offset: 136755},
+			pos:  position{line: 4458, col: 1, offset: 136819},
 			expr: &actionExpr{
-				pos: position{line: 4457, col: 17, offset: 136771},
+				pos: position{line: 4458, col: 17, offset: 136835},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4457, col: 17, offset: 136771},
-					exprs: []any{
+					pos: position{line: 4458, col: 17, offset: 136835},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4457, col: 17, offset: 136771},
+							pos:        position{line: 4458, col: 17, offset: 136835},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4457, col: 21, offset: 136775},
+							pos: position{line: 4458, col: 21, offset: 136839},
 							expr: &choiceExpr{
-								pos: position{line: 4457, col: 22, offset: 136776},
-								alternatives: []any{
+								pos: position{line: 4458, col: 22, offset: 136840},
+								alternatives: []interface{}{
 									&seqExpr{
-										pos: position{line: 4457, col: 22, offset: 136776},
-										exprs: []any{
+										pos: position{line: 4458, col: 22, offset: 136840},
+										exprs: []interface{}{
 											&notExpr{
-												pos: position{line: 4457, col: 22, offset: 136776},
+												pos: position{line: 4458, col: 22, offset: 136840},
 												expr: &litMatcher{
-													pos:        position{line: 4457, col: 23, offset: 136777},
+													pos:        position{line: 4458, col: 23, offset: 136841},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4457, col: 28, offset: 136782},
+												pos:        position{line: 4458, col: 28, offset: 136846},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -10481,16 +10482,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4457, col: 35, offset: 136789},
-										exprs: []any{
+										pos: position{line: 4458, col: 35, offset: 136853},
+										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 4457, col: 35, offset: 136789},
+												pos:        position{line: 4458, col: 35, offset: 136853},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4457, col: 40, offset: 136794,
+												line: 4458, col: 40, offset: 136858,
 											},
 										},
 									},
@@ -10498,7 +10499,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4457, col: 44, offset: 136798},
+							pos:        position{line: 4458, col: 44, offset: 136862},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10509,48 +10510,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4462, col: 1, offset: 136909},
+			pos:  position{line: 4463, col: 1, offset: 136973},
 			expr: &actionExpr{
-				pos: position{line: 4462, col: 19, offset: 136927},
+				pos: position{line: 4463, col: 19, offset: 136991},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4462, col: 19, offset: 136927},
+					pos: position{line: 4463, col: 19, offset: 136991},
 					expr: &choiceExpr{
-						pos: position{line: 4462, col: 20, offset: 136928},
-						alternatives: []any{
+						pos: position{line: 4463, col: 20, offset: 136992},
+						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 4462, col: 20, offset: 136928},
+								pos:        position{line: 4463, col: 20, offset: 136992},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4462, col: 27, offset: 136935},
-								exprs: []any{
+								pos: position{line: 4463, col: 27, offset: 136999},
+								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 4462, col: 27, offset: 136935},
+										pos: position{line: 4463, col: 27, offset: 136999},
 										expr: &choiceExpr{
-											pos: position{line: 4462, col: 29, offset: 136937},
-											alternatives: []any{
+											pos: position{line: 4463, col: 29, offset: 137001},
+											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 4462, col: 29, offset: 136937},
+													pos:  position{line: 4463, col: 29, offset: 137001},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4462, col: 43, offset: 136951},
+													pos:        position{line: 4463, col: 43, offset: 137015},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4462, col: 49, offset: 136957},
+													pos:  position{line: 4463, col: 49, offset: 137021},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4462, col: 54, offset: 136962,
+										line: 4463, col: 54, offset: 137026,
 									},
 								},
 							},
@@ -10561,12 +10562,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4469, col: 1, offset: 137077},
+			pos:  position{line: 4470, col: 1, offset: 137141},
 			expr: &choiceExpr{
-				pos: position{line: 4469, col: 16, offset: 137092},
-				alternatives: []any{
+				pos: position{line: 4470, col: 16, offset: 137156},
+				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 4469, col: 16, offset: 137092},
+						pos:        position{line: 4470, col: 16, offset: 137156},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10574,18 +10575,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4469, col: 37, offset: 137113},
-						exprs: []any{
+						pos: position{line: 4470, col: 37, offset: 137177},
+						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 4469, col: 37, offset: 137113},
+								pos:        position{line: 4470, col: 37, offset: 137177},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4469, col: 41, offset: 137117},
+								pos: position{line: 4470, col: 41, offset: 137181},
 								expr: &charClassMatcher{
-									pos:        position{line: 4469, col: 41, offset: 137117},
+									pos:        position{line: 4470, col: 41, offset: 137181},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10593,7 +10594,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4469, col: 48, offset: 137124},
+								pos:        position{line: 4470, col: 48, offset: 137188},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10605,46 +10606,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4471, col: 1, offset: 137130},
+			pos:  position{line: 4472, col: 1, offset: 137194},
 			expr: &actionExpr{
-				pos: position{line: 4471, col: 39, offset: 137168},
+				pos: position{line: 4472, col: 39, offset: 137232},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4471, col: 39, offset: 137168},
+					pos: position{line: 4472, col: 39, offset: 137232},
 					expr: &choiceExpr{
-						pos: position{line: 4471, col: 40, offset: 137169},
-						alternatives: []any{
+						pos: position{line: 4472, col: 40, offset: 137233},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4471, col: 40, offset: 137169},
+								pos:  position{line: 4472, col: 40, offset: 137233},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4471, col: 54, offset: 137183},
-								exprs: []any{
+								pos: position{line: 4472, col: 54, offset: 137247},
+								exprs: []interface{}{
 									&notExpr{
-										pos: position{line: 4471, col: 54, offset: 137183},
+										pos: position{line: 4472, col: 54, offset: 137247},
 										expr: &choiceExpr{
-											pos: position{line: 4471, col: 56, offset: 137185},
-											alternatives: []any{
+											pos: position{line: 4472, col: 56, offset: 137249},
+											alternatives: []interface{}{
 												&ruleRefExpr{
-													pos:  position{line: 4471, col: 56, offset: 137185},
+													pos:  position{line: 4472, col: 56, offset: 137249},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4471, col: 70, offset: 137199},
+													pos:        position{line: 4472, col: 70, offset: 137263},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4471, col: 76, offset: 137205},
+													pos:  position{line: 4472, col: 76, offset: 137269},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4471, col: 81, offset: 137210,
+										line: 4472, col: 81, offset: 137274,
 									},
 								},
 							},
@@ -10655,21 +10656,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4475, col: 1, offset: 137250},
+			pos:  position{line: 4476, col: 1, offset: 137314},
 			expr: &actionExpr{
-				pos: position{line: 4475, col: 12, offset: 137261},
+				pos: position{line: 4476, col: 12, offset: 137325},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4475, col: 13, offset: 137262},
-					alternatives: []any{
+					pos: position{line: 4476, col: 13, offset: 137326},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4475, col: 13, offset: 137262},
+							pos:        position{line: 4476, col: 13, offset: 137326},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4475, col: 22, offset: 137271},
+							pos:        position{line: 4476, col: 22, offset: 137335},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10680,14 +10681,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4481, col: 1, offset: 137425},
+			pos:  position{line: 4482, col: 1, offset: 137489},
 			expr: &actionExpr{
-				pos: position{line: 4481, col: 18, offset: 137442},
+				pos: position{line: 4482, col: 18, offset: 137506},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4481, col: 18, offset: 137442},
+					pos: position{line: 4482, col: 18, offset: 137506},
 					expr: &charClassMatcher{
-						pos:        position{line: 4481, col: 18, offset: 137442},
+						pos:        position{line: 4482, col: 18, offset: 137506},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10699,15 +10700,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4485, col: 1, offset: 137493},
+			pos:  position{line: 4486, col: 1, offset: 137557},
 			expr: &actionExpr{
-				pos: position{line: 4485, col: 11, offset: 137503},
+				pos: position{line: 4486, col: 11, offset: 137567},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4485, col: 11, offset: 137503},
+					pos:   position{line: 4486, col: 11, offset: 137567},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4485, col: 18, offset: 137510},
+						pos:  position{line: 4486, col: 18, offset: 137574},
 						name: "NumberAsString",
 					},
 				},
@@ -10715,59 +10716,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4491, col: 1, offset: 137699},
+			pos:  position{line: 4492, col: 1, offset: 137763},
 			expr: &actionExpr{
-				pos: position{line: 4491, col: 19, offset: 137717},
+				pos: position{line: 4492, col: 19, offset: 137781},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4491, col: 19, offset: 137717},
-					exprs: []any{
+					pos: position{line: 4492, col: 19, offset: 137781},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4491, col: 19, offset: 137717},
+							pos:   position{line: 4492, col: 19, offset: 137781},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4491, col: 27, offset: 137725},
-								alternatives: []any{
+								pos: position{line: 4492, col: 27, offset: 137789},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4491, col: 27, offset: 137725},
+										pos:  position{line: 4492, col: 27, offset: 137789},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4491, col: 43, offset: 137741},
+										pos:  position{line: 4492, col: 43, offset: 137805},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4491, col: 60, offset: 137758},
+							pos: position{line: 4492, col: 60, offset: 137822},
 							expr: &choiceExpr{
-								pos: position{line: 4491, col: 62, offset: 137760},
-								alternatives: []any{
+								pos: position{line: 4492, col: 62, offset: 137824},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 4491, col: 62, offset: 137760},
+										pos:  position{line: 4492, col: 62, offset: 137824},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4491, col: 70, offset: 137768},
+										pos:        position{line: 4492, col: 70, offset: 137832},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4491, col: 76, offset: 137774},
+										pos:        position{line: 4492, col: 76, offset: 137838},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4491, col: 82, offset: 137780},
+										pos:        position{line: 4492, col: 82, offset: 137844},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4491, col: 88, offset: 137786},
+										pos:  position{line: 4492, col: 88, offset: 137850},
 										name: "EOF",
 									},
 								},
@@ -10779,17 +10780,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4497, col: 1, offset: 137915},
+			pos:  position{line: 4498, col: 1, offset: 137979},
 			expr: &actionExpr{
-				pos: position{line: 4497, col: 18, offset: 137932},
+				pos: position{line: 4498, col: 18, offset: 137996},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4497, col: 18, offset: 137932},
-					exprs: []any{
+					pos: position{line: 4498, col: 18, offset: 137996},
+					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 4497, col: 18, offset: 137932},
+							pos: position{line: 4498, col: 18, offset: 137996},
 							expr: &charClassMatcher{
-								pos:        position{line: 4497, col: 18, offset: 137932},
+								pos:        position{line: 4498, col: 18, offset: 137996},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10797,9 +10798,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4497, col: 24, offset: 137938},
+							pos: position{line: 4498, col: 24, offset: 138002},
 							expr: &charClassMatcher{
-								pos:        position{line: 4497, col: 24, offset: 137938},
+								pos:        position{line: 4498, col: 24, offset: 138002},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10807,15 +10808,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4497, col: 31, offset: 137945},
+							pos:        position{line: 4498, col: 31, offset: 138009},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4497, col: 35, offset: 137949},
+							pos: position{line: 4498, col: 35, offset: 138013},
 							expr: &charClassMatcher{
-								pos:        position{line: 4497, col: 35, offset: 137949},
+								pos:        position{line: 4498, col: 35, offset: 138013},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10828,17 +10829,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4502, col: 1, offset: 138044},
+			pos:  position{line: 4503, col: 1, offset: 138108},
 			expr: &actionExpr{
-				pos: position{line: 4502, col: 20, offset: 138063},
+				pos: position{line: 4503, col: 20, offset: 138127},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4502, col: 20, offset: 138063},
-					exprs: []any{
+					pos: position{line: 4503, col: 20, offset: 138127},
+					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 4502, col: 20, offset: 138063},
+							pos: position{line: 4503, col: 20, offset: 138127},
 							expr: &charClassMatcher{
-								pos:        position{line: 4502, col: 20, offset: 138063},
+								pos:        position{line: 4503, col: 20, offset: 138127},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10846,9 +10847,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4502, col: 26, offset: 138069},
+							pos: position{line: 4503, col: 26, offset: 138133},
 							expr: &charClassMatcher{
-								pos:        position{line: 4502, col: 26, offset: 138069},
+								pos:        position{line: 4503, col: 26, offset: 138133},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10861,14 +10862,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4506, col: 1, offset: 138112},
+			pos:  position{line: 4507, col: 1, offset: 138176},
 			expr: &actionExpr{
-				pos: position{line: 4506, col: 28, offset: 138139},
+				pos: position{line: 4507, col: 28, offset: 138203},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4506, col: 28, offset: 138139},
+					pos: position{line: 4507, col: 28, offset: 138203},
 					expr: &charClassMatcher{
-						pos:        position{line: 4506, col: 28, offset: 138139},
+						pos:        position{line: 4507, col: 28, offset: 138203},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -10879,15 +10880,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4510, col: 1, offset: 138182},
+			pos:  position{line: 4511, col: 1, offset: 138246},
 			expr: &actionExpr{
-				pos: position{line: 4510, col: 20, offset: 138201},
+				pos: position{line: 4511, col: 20, offset: 138265},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4510, col: 20, offset: 138201},
+					pos:   position{line: 4511, col: 20, offset: 138265},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4510, col: 27, offset: 138208},
+						pos:  position{line: 4511, col: 27, offset: 138272},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -10895,37 +10896,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4518, col: 1, offset: 138455},
+			pos:  position{line: 4519, col: 1, offset: 138519},
 			expr: &actionExpr{
-				pos: position{line: 4518, col: 21, offset: 138475},
+				pos: position{line: 4519, col: 21, offset: 138539},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4518, col: 21, offset: 138475},
-					exprs: []any{
+					pos: position{line: 4519, col: 21, offset: 138539},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4518, col: 21, offset: 138475},
+							pos:  position{line: 4519, col: 21, offset: 138539},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4518, col: 36, offset: 138490},
+							pos:   position{line: 4519, col: 36, offset: 138554},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4518, col: 40, offset: 138494},
-								alternatives: []any{
+								pos: position{line: 4519, col: 40, offset: 138558},
+								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 4518, col: 40, offset: 138494},
+										pos:        position{line: 4519, col: 40, offset: 138558},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4518, col: 47, offset: 138501},
+										pos:        position{line: 4519, col: 47, offset: 138565},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4518, col: 53, offset: 138507},
+										pos:        position{line: 4519, col: 53, offset: 138571},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -10934,7 +10935,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4518, col: 59, offset: 138513},
+							pos:  position{line: 4519, col: 59, offset: 138577},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10943,43 +10944,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4529, col: 1, offset: 138743},
+			pos:  position{line: 4530, col: 1, offset: 138807},
 			expr: &actionExpr{
-				pos: position{line: 4529, col: 23, offset: 138765},
+				pos: position{line: 4530, col: 23, offset: 138829},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4529, col: 23, offset: 138765},
-					exprs: []any{
+					pos: position{line: 4530, col: 23, offset: 138829},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4529, col: 23, offset: 138765},
+							pos:  position{line: 4530, col: 23, offset: 138829},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4529, col: 38, offset: 138780},
+							pos:   position{line: 4530, col: 38, offset: 138844},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4529, col: 42, offset: 138784},
-								alternatives: []any{
+								pos: position{line: 4530, col: 42, offset: 138848},
+								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 4529, col: 42, offset: 138784},
+										pos:        position{line: 4530, col: 42, offset: 138848},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4529, col: 49, offset: 138791},
+										pos:        position{line: 4530, col: 49, offset: 138855},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4529, col: 55, offset: 138797},
+										pos:        position{line: 4530, col: 55, offset: 138861},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4529, col: 62, offset: 138804},
+										pos:        position{line: 4530, col: 62, offset: 138868},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -10988,7 +10989,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4529, col: 67, offset: 138809},
+							pos:  position{line: 4530, col: 67, offset: 138873},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -10997,30 +10998,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4537, col: 1, offset: 138992},
+			pos:  position{line: 4538, col: 1, offset: 139056},
 			expr: &choiceExpr{
-				pos: position{line: 4537, col: 25, offset: 139016},
-				alternatives: []any{
+				pos: position{line: 4538, col: 25, offset: 139080},
+				alternatives: []interface{}{
 					&actionExpr{
-						pos: position{line: 4537, col: 25, offset: 139016},
+						pos: position{line: 4538, col: 25, offset: 139080},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4537, col: 25, offset: 139016},
+							pos:   position{line: 4538, col: 25, offset: 139080},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4537, col: 28, offset: 139019},
+								pos:  position{line: 4538, col: 28, offset: 139083},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4540, col: 3, offset: 139061},
+						pos: position{line: 4541, col: 3, offset: 139125},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4540, col: 3, offset: 139061},
+							pos:   position{line: 4541, col: 3, offset: 139125},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4540, col: 6, offset: 139064},
+								pos:  position{line: 4541, col: 6, offset: 139128},
 								name: "InequalityOperator",
 							},
 						},
@@ -11030,25 +11031,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4544, col: 1, offset: 139107},
+			pos:  position{line: 4545, col: 1, offset: 139171},
 			expr: &actionExpr{
-				pos: position{line: 4544, col: 11, offset: 139117},
+				pos: position{line: 4545, col: 11, offset: 139181},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4544, col: 11, offset: 139117},
-					exprs: []any{
+					pos: position{line: 4545, col: 11, offset: 139181},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4544, col: 11, offset: 139117},
+							pos:  position{line: 4545, col: 11, offset: 139181},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4544, col: 26, offset: 139132},
+							pos:        position{line: 4545, col: 26, offset: 139196},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4544, col: 30, offset: 139136},
+							pos:  position{line: 4545, col: 30, offset: 139200},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11057,25 +11058,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4548, col: 1, offset: 139176},
+			pos:  position{line: 4549, col: 1, offset: 139240},
 			expr: &actionExpr{
-				pos: position{line: 4548, col: 12, offset: 139187},
+				pos: position{line: 4549, col: 12, offset: 139251},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4548, col: 12, offset: 139187},
-					exprs: []any{
+					pos: position{line: 4549, col: 12, offset: 139251},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4548, col: 12, offset: 139187},
+							pos:  position{line: 4549, col: 12, offset: 139251},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4548, col: 27, offset: 139202},
+							pos:        position{line: 4549, col: 27, offset: 139266},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4548, col: 31, offset: 139206},
+							pos:  position{line: 4549, col: 31, offset: 139270},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11084,25 +11085,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4552, col: 1, offset: 139246},
+			pos:  position{line: 4553, col: 1, offset: 139310},
 			expr: &actionExpr{
-				pos: position{line: 4552, col: 10, offset: 139255},
+				pos: position{line: 4553, col: 10, offset: 139319},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4552, col: 10, offset: 139255},
-					exprs: []any{
+					pos: position{line: 4553, col: 10, offset: 139319},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4552, col: 10, offset: 139255},
+							pos:  position{line: 4553, col: 10, offset: 139319},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4552, col: 25, offset: 139270},
+							pos:        position{line: 4553, col: 25, offset: 139334},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4552, col: 29, offset: 139274},
+							pos:  position{line: 4553, col: 29, offset: 139338},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11111,25 +11112,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4556, col: 1, offset: 139314},
+			pos:  position{line: 4557, col: 1, offset: 139378},
 			expr: &actionExpr{
-				pos: position{line: 4556, col: 10, offset: 139323},
+				pos: position{line: 4557, col: 10, offset: 139387},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4556, col: 10, offset: 139323},
-					exprs: []any{
+					pos: position{line: 4557, col: 10, offset: 139387},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4556, col: 10, offset: 139323},
+							pos:  position{line: 4557, col: 10, offset: 139387},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4556, col: 25, offset: 139338},
+							pos:        position{line: 4557, col: 25, offset: 139402},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4556, col: 29, offset: 139342},
+							pos:  position{line: 4557, col: 29, offset: 139406},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11138,25 +11139,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4560, col: 1, offset: 139382},
+			pos:  position{line: 4561, col: 1, offset: 139446},
 			expr: &actionExpr{
-				pos: position{line: 4560, col: 10, offset: 139391},
+				pos: position{line: 4561, col: 10, offset: 139455},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4560, col: 10, offset: 139391},
-					exprs: []any{
+					pos: position{line: 4561, col: 10, offset: 139455},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4560, col: 10, offset: 139391},
+							pos:  position{line: 4561, col: 10, offset: 139455},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4560, col: 25, offset: 139406},
+							pos:        position{line: 4561, col: 25, offset: 139470},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4560, col: 29, offset: 139410},
+							pos:  position{line: 4561, col: 29, offset: 139474},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11165,39 +11166,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4565, col: 1, offset: 139474},
+			pos:  position{line: 4566, col: 1, offset: 139538},
 			expr: &actionExpr{
-				pos: position{line: 4565, col: 11, offset: 139484},
+				pos: position{line: 4566, col: 11, offset: 139548},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4565, col: 12, offset: 139485},
-					alternatives: []any{
+					pos: position{line: 4566, col: 12, offset: 139549},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4565, col: 12, offset: 139485},
+							pos:        position{line: 4566, col: 12, offset: 139549},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4565, col: 24, offset: 139497},
+							pos:        position{line: 4566, col: 24, offset: 139561},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4565, col: 35, offset: 139508},
+							pos:        position{line: 4566, col: 35, offset: 139572},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4565, col: 44, offset: 139517},
+							pos:        position{line: 4566, col: 44, offset: 139581},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4565, col: 52, offset: 139525},
+							pos:        position{line: 4566, col: 52, offset: 139589},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11208,39 +11209,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4569, col: 1, offset: 139567},
+			pos:  position{line: 4570, col: 1, offset: 139631},
 			expr: &actionExpr{
-				pos: position{line: 4569, col: 11, offset: 139577},
+				pos: position{line: 4570, col: 11, offset: 139641},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4569, col: 12, offset: 139578},
-					alternatives: []any{
+					pos: position{line: 4570, col: 12, offset: 139642},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4569, col: 12, offset: 139578},
+							pos:        position{line: 4570, col: 12, offset: 139642},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4569, col: 24, offset: 139590},
+							pos:        position{line: 4570, col: 24, offset: 139654},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4569, col: 35, offset: 139601},
+							pos:        position{line: 4570, col: 35, offset: 139665},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4569, col: 44, offset: 139610},
+							pos:        position{line: 4570, col: 44, offset: 139674},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4569, col: 52, offset: 139618},
+							pos:        position{line: 4570, col: 52, offset: 139682},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11251,39 +11252,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4573, col: 1, offset: 139660},
+			pos:  position{line: 4574, col: 1, offset: 139724},
 			expr: &actionExpr{
-				pos: position{line: 4573, col: 9, offset: 139668},
+				pos: position{line: 4574, col: 9, offset: 139732},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4573, col: 10, offset: 139669},
-					alternatives: []any{
+					pos: position{line: 4574, col: 10, offset: 139733},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4573, col: 10, offset: 139669},
+							pos:        position{line: 4574, col: 10, offset: 139733},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4573, col: 20, offset: 139679},
+							pos:        position{line: 4574, col: 20, offset: 139743},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4573, col: 29, offset: 139688},
+							pos:        position{line: 4574, col: 29, offset: 139752},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4573, col: 37, offset: 139696},
+							pos:        position{line: 4574, col: 37, offset: 139760},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4573, col: 44, offset: 139703},
+							pos:        position{line: 4574, col: 44, offset: 139767},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11294,27 +11295,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4577, col: 1, offset: 139743},
+			pos:  position{line: 4578, col: 1, offset: 139807},
 			expr: &actionExpr{
-				pos: position{line: 4577, col: 8, offset: 139750},
+				pos: position{line: 4578, col: 8, offset: 139814},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4577, col: 9, offset: 139751},
-					alternatives: []any{
+					pos: position{line: 4578, col: 9, offset: 139815},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4577, col: 9, offset: 139751},
+							pos:        position{line: 4578, col: 9, offset: 139815},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4577, col: 18, offset: 139760},
+							pos:        position{line: 4578, col: 18, offset: 139824},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4577, col: 26, offset: 139768},
+							pos:        position{line: 4578, col: 26, offset: 139832},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11325,27 +11326,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4581, col: 1, offset: 139807},
+			pos:  position{line: 4582, col: 1, offset: 139871},
 			expr: &actionExpr{
-				pos: position{line: 4581, col: 9, offset: 139815},
+				pos: position{line: 4582, col: 9, offset: 139879},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4581, col: 10, offset: 139816},
-					alternatives: []any{
+					pos: position{line: 4582, col: 10, offset: 139880},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4581, col: 10, offset: 139816},
+							pos:        position{line: 4582, col: 10, offset: 139880},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4581, col: 20, offset: 139826},
+							pos:        position{line: 4582, col: 20, offset: 139890},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4581, col: 29, offset: 139835},
+							pos:        position{line: 4582, col: 29, offset: 139899},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11356,27 +11357,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4585, col: 1, offset: 139875},
+			pos:  position{line: 4586, col: 1, offset: 139939},
 			expr: &actionExpr{
-				pos: position{line: 4585, col: 10, offset: 139884},
+				pos: position{line: 4586, col: 10, offset: 139948},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4585, col: 11, offset: 139885},
-					alternatives: []any{
+					pos: position{line: 4586, col: 11, offset: 139949},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4585, col: 11, offset: 139885},
+							pos:        position{line: 4586, col: 11, offset: 139949},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4585, col: 22, offset: 139896},
+							pos:        position{line: 4586, col: 22, offset: 139960},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4585, col: 32, offset: 139906},
+							pos:        position{line: 4586, col: 32, offset: 139970},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11387,39 +11388,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4589, col: 1, offset: 139949},
+			pos:  position{line: 4590, col: 1, offset: 140013},
 			expr: &actionExpr{
-				pos: position{line: 4589, col: 12, offset: 139960},
+				pos: position{line: 4590, col: 12, offset: 140024},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4589, col: 13, offset: 139961},
-					alternatives: []any{
+					pos: position{line: 4590, col: 13, offset: 140025},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4589, col: 13, offset: 139961},
+							pos:        position{line: 4590, col: 13, offset: 140025},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4589, col: 26, offset: 139974},
+							pos:        position{line: 4590, col: 26, offset: 140038},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4589, col: 38, offset: 139986},
+							pos:        position{line: 4590, col: 38, offset: 140050},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4589, col: 47, offset: 139995},
+							pos:        position{line: 4590, col: 47, offset: 140059},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4589, col: 55, offset: 140003},
+							pos:        position{line: 4590, col: 55, offset: 140067},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11430,39 +11431,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4593, col: 1, offset: 140046},
+			pos:  position{line: 4594, col: 1, offset: 140110},
 			expr: &actionExpr{
-				pos: position{line: 4593, col: 9, offset: 140054},
+				pos: position{line: 4594, col: 9, offset: 140118},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4593, col: 10, offset: 140055},
-					alternatives: []any{
+					pos: position{line: 4594, col: 10, offset: 140119},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4593, col: 10, offset: 140055},
+							pos:        position{line: 4594, col: 10, offset: 140119},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4593, col: 20, offset: 140065},
+							pos:        position{line: 4594, col: 20, offset: 140129},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4593, col: 29, offset: 140074},
+							pos:        position{line: 4594, col: 29, offset: 140138},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4593, col: 37, offset: 140082},
+							pos:        position{line: 4594, col: 37, offset: 140146},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4593, col: 44, offset: 140089},
+							pos:        position{line: 4594, col: 44, offset: 140153},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11473,33 +11474,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4598, col: 1, offset: 140221},
+			pos:  position{line: 4599, col: 1, offset: 140285},
 			expr: &actionExpr{
-				pos: position{line: 4598, col: 15, offset: 140235},
+				pos: position{line: 4599, col: 15, offset: 140299},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4598, col: 16, offset: 140236},
-					alternatives: []any{
+					pos: position{line: 4599, col: 16, offset: 140300},
+					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4598, col: 16, offset: 140236},
+							pos:        position{line: 4599, col: 16, offset: 140300},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4598, col: 23, offset: 140243},
+							pos:        position{line: 4599, col: 23, offset: 140307},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4598, col: 30, offset: 140250},
+							pos:        position{line: 4599, col: 30, offset: 140314},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4598, col: 37, offset: 140257},
+							pos:        position{line: 4599, col: 37, offset: 140321},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11510,26 +11511,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4607, col: 1, offset: 140481},
+			pos:  position{line: 4608, col: 1, offset: 140545},
 			expr: &actionExpr{
-				pos: position{line: 4607, col: 21, offset: 140501},
+				pos: position{line: 4608, col: 21, offset: 140565},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4607, col: 21, offset: 140501},
-					exprs: []any{
+					pos: position{line: 4608, col: 21, offset: 140565},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4607, col: 21, offset: 140501},
+							pos:  position{line: 4608, col: 21, offset: 140565},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4607, col: 26, offset: 140506},
+							pos:  position{line: 4608, col: 26, offset: 140570},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4607, col: 42, offset: 140522},
+							pos:   position{line: 4608, col: 42, offset: 140586},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4607, col: 53, offset: 140533},
+								pos:  position{line: 4608, col: 53, offset: 140597},
 								name: "TransactionOptions",
 							},
 						},
@@ -11539,17 +11540,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4617, col: 1, offset: 140908},
+			pos:  position{line: 4618, col: 1, offset: 140972},
 			expr: &actionExpr{
-				pos: position{line: 4617, col: 23, offset: 140930},
+				pos: position{line: 4618, col: 23, offset: 140994},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4617, col: 23, offset: 140930},
+					pos:   position{line: 4618, col: 23, offset: 140994},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4617, col: 34, offset: 140941},
+						pos: position{line: 4618, col: 34, offset: 141005},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4617, col: 34, offset: 140941},
+							pos:  position{line: 4618, col: 34, offset: 141005},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11558,35 +11559,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4632, col: 1, offset: 141332},
+			pos:  position{line: 4633, col: 1, offset: 141396},
 			expr: &actionExpr{
-				pos: position{line: 4632, col: 37, offset: 141368},
+				pos: position{line: 4633, col: 37, offset: 141432},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4632, col: 37, offset: 141368},
-					exprs: []any{
+					pos: position{line: 4633, col: 37, offset: 141432},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4632, col: 37, offset: 141368},
+							pos:   position{line: 4633, col: 37, offset: 141432},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4632, col: 43, offset: 141374},
+								pos:  position{line: 4633, col: 43, offset: 141438},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4632, col: 71, offset: 141402},
+							pos:   position{line: 4633, col: 71, offset: 141466},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4632, col: 76, offset: 141407},
+								pos: position{line: 4633, col: 76, offset: 141471},
 								expr: &seqExpr{
-									pos: position{line: 4632, col: 77, offset: 141408},
-									exprs: []any{
+									pos: position{line: 4633, col: 77, offset: 141472},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4632, col: 77, offset: 141408},
+											pos:  position{line: 4633, col: 77, offset: 141472},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4632, col: 83, offset: 141414},
+											pos:  position{line: 4633, col: 83, offset: 141478},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11599,26 +11600,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4667, col: 1, offset: 142403},
+			pos:  position{line: 4668, col: 1, offset: 142467},
 			expr: &actionExpr{
-				pos: position{line: 4667, col: 32, offset: 142434},
+				pos: position{line: 4668, col: 32, offset: 142498},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4667, col: 32, offset: 142434},
+					pos:   position{line: 4668, col: 32, offset: 142498},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4667, col: 40, offset: 142442},
-						alternatives: []any{
+						pos: position{line: 4668, col: 40, offset: 142506},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4667, col: 40, offset: 142442},
+								pos:  position{line: 4668, col: 40, offset: 142506},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4667, col: 77, offset: 142479},
+								pos:  position{line: 4668, col: 77, offset: 142543},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4667, col: 96, offset: 142498},
+								pos:  position{line: 4668, col: 96, offset: 142562},
 								name: "EndsWithOption",
 							},
 						},
@@ -11628,15 +11629,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4671, col: 1, offset: 142542},
+			pos:  position{line: 4672, col: 1, offset: 142606},
 			expr: &actionExpr{
-				pos: position{line: 4671, col: 39, offset: 142580},
+				pos: position{line: 4672, col: 39, offset: 142644},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4671, col: 39, offset: 142580},
+					pos:   position{line: 4672, col: 39, offset: 142644},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4671, col: 46, offset: 142587},
+						pos:  position{line: 4672, col: 46, offset: 142651},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11644,28 +11645,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4682, col: 1, offset: 142803},
+			pos:  position{line: 4683, col: 1, offset: 142867},
 			expr: &actionExpr{
-				pos: position{line: 4682, col: 21, offset: 142823},
+				pos: position{line: 4683, col: 21, offset: 142887},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4682, col: 21, offset: 142823},
-					exprs: []any{
+					pos: position{line: 4683, col: 21, offset: 142887},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4682, col: 21, offset: 142823},
+							pos:        position{line: 4683, col: 21, offset: 142887},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4682, col: 34, offset: 142836},
+							pos:  position{line: 4683, col: 34, offset: 142900},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4682, col: 40, offset: 142842},
+							pos:   position{line: 4683, col: 40, offset: 142906},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4682, col: 48, offset: 142850},
+								pos:  position{line: 4683, col: 48, offset: 142914},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11675,28 +11676,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4692, col: 1, offset: 143088},
+			pos:  position{line: 4693, col: 1, offset: 143152},
 			expr: &actionExpr{
-				pos: position{line: 4692, col: 19, offset: 143106},
+				pos: position{line: 4693, col: 19, offset: 143170},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4692, col: 19, offset: 143106},
-					exprs: []any{
+					pos: position{line: 4693, col: 19, offset: 143170},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4692, col: 19, offset: 143106},
+							pos:        position{line: 4693, col: 19, offset: 143170},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4692, col: 30, offset: 143117},
+							pos:  position{line: 4693, col: 30, offset: 143181},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4692, col: 36, offset: 143123},
+							pos:   position{line: 4693, col: 36, offset: 143187},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4692, col: 44, offset: 143131},
+								pos:  position{line: 4693, col: 44, offset: 143195},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11706,26 +11707,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4703, col: 1, offset: 143400},
+			pos:  position{line: 4704, col: 1, offset: 143464},
 			expr: &actionExpr{
-				pos: position{line: 4703, col: 28, offset: 143427},
+				pos: position{line: 4704, col: 28, offset: 143491},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4703, col: 28, offset: 143427},
+					pos:   position{line: 4704, col: 28, offset: 143491},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4703, col: 37, offset: 143436},
-						alternatives: []any{
+						pos: position{line: 4704, col: 37, offset: 143500},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4703, col: 37, offset: 143436},
+								pos:  position{line: 4704, col: 37, offset: 143500},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4703, col: 63, offset: 143462},
+								pos:  position{line: 4704, col: 63, offset: 143526},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4703, col: 81, offset: 143480},
+								pos:  position{line: 4704, col: 81, offset: 143544},
 								name: "TransactionSearch",
 							},
 						},
@@ -11735,22 +11736,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4707, col: 1, offset: 143528},
+			pos:  position{line: 4708, col: 1, offset: 143592},
 			expr: &actionExpr{
-				pos: position{line: 4707, col: 28, offset: 143555},
+				pos: position{line: 4708, col: 28, offset: 143619},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4707, col: 28, offset: 143555},
+					pos:   position{line: 4708, col: 28, offset: 143619},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4707, col: 33, offset: 143560},
-						alternatives: []any{
+						pos: position{line: 4708, col: 33, offset: 143624},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4707, col: 33, offset: 143560},
+								pos:  position{line: 4708, col: 33, offset: 143624},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4707, col: 64, offset: 143591},
+								pos:  position{line: 4708, col: 64, offset: 143655},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11760,29 +11761,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4711, col: 1, offset: 143651},
+			pos:  position{line: 4712, col: 1, offset: 143715},
 			expr: &actionExpr{
-				pos: position{line: 4711, col: 38, offset: 143688},
+				pos: position{line: 4712, col: 38, offset: 143752},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4711, col: 38, offset: 143688},
-					exprs: []any{
+					pos: position{line: 4712, col: 38, offset: 143752},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4711, col: 38, offset: 143688},
+							pos:        position{line: 4712, col: 38, offset: 143752},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4711, col: 42, offset: 143692},
+							pos:   position{line: 4712, col: 42, offset: 143756},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4711, col: 55, offset: 143705},
+								pos:  position{line: 4712, col: 55, offset: 143769},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4711, col: 68, offset: 143718},
+							pos:        position{line: 4712, col: 68, offset: 143782},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11793,23 +11794,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4719, col: 1, offset: 143857},
+			pos:  position{line: 4720, col: 1, offset: 143921},
 			expr: &actionExpr{
-				pos: position{line: 4719, col: 21, offset: 143877},
+				pos: position{line: 4720, col: 21, offset: 143941},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4719, col: 21, offset: 143877},
-					exprs: []any{
+					pos: position{line: 4720, col: 21, offset: 143941},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4719, col: 21, offset: 143877},
+							pos:        position{line: 4720, col: 21, offset: 143941},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4719, col: 25, offset: 143881},
+							pos: position{line: 4720, col: 25, offset: 143945},
 							expr: &charClassMatcher{
-								pos:        position{line: 4719, col: 25, offset: 143881},
+								pos:        position{line: 4720, col: 25, offset: 143945},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11817,7 +11818,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4719, col: 44, offset: 143900},
+							pos:        position{line: 4720, col: 44, offset: 143964},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11828,15 +11829,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4724, col: 1, offset: 144011},
+			pos:  position{line: 4725, col: 1, offset: 144075},
 			expr: &actionExpr{
-				pos: position{line: 4724, col: 33, offset: 144043},
+				pos: position{line: 4725, col: 33, offset: 144107},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4724, col: 33, offset: 144043},
+					pos:   position{line: 4725, col: 33, offset: 144107},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4724, col: 37, offset: 144047},
+						pos:  position{line: 4725, col: 37, offset: 144111},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11844,15 +11845,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4732, col: 1, offset: 144202},
+			pos:  position{line: 4733, col: 1, offset: 144266},
 			expr: &actionExpr{
-				pos: position{line: 4732, col: 22, offset: 144223},
+				pos: position{line: 4733, col: 22, offset: 144287},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4732, col: 22, offset: 144223},
+					pos:   position{line: 4733, col: 22, offset: 144287},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4732, col: 27, offset: 144228},
+						pos:  position{line: 4733, col: 27, offset: 144292},
 						name: "ClauseLevel1",
 					},
 				},
@@ -11860,37 +11861,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4742, col: 1, offset: 144400},
+			pos:  position{line: 4743, col: 1, offset: 144464},
 			expr: &actionExpr{
-				pos: position{line: 4742, col: 20, offset: 144419},
+				pos: position{line: 4743, col: 20, offset: 144483},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4742, col: 20, offset: 144419},
-					exprs: []any{
+					pos: position{line: 4743, col: 20, offset: 144483},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4742, col: 20, offset: 144419},
+							pos:        position{line: 4743, col: 20, offset: 144483},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4742, col: 27, offset: 144426},
+							pos:  position{line: 4743, col: 27, offset: 144490},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4742, col: 42, offset: 144441},
+							pos:  position{line: 4743, col: 42, offset: 144505},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4742, col: 50, offset: 144449},
+							pos:   position{line: 4743, col: 50, offset: 144513},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4742, col: 60, offset: 144459},
+								pos:  position{line: 4743, col: 60, offset: 144523},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4742, col: 69, offset: 144468},
+							pos:  position{line: 4743, col: 69, offset: 144532},
 							name: "R_PAREN",
 						},
 					},
@@ -11899,22 +11900,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4752, col: 1, offset: 144771},
+			pos:  position{line: 4753, col: 1, offset: 144835},
 			expr: &actionExpr{
-				pos: position{line: 4752, col: 20, offset: 144790},
+				pos: position{line: 4753, col: 20, offset: 144854},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4752, col: 20, offset: 144790},
-					exprs: []any{
+					pos: position{line: 4753, col: 20, offset: 144854},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4752, col: 20, offset: 144790},
+							pos:  position{line: 4753, col: 20, offset: 144854},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4752, col: 25, offset: 144795},
+							pos:   position{line: 4753, col: 25, offset: 144859},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4752, col: 42, offset: 144812},
+								pos:  position{line: 4753, col: 42, offset: 144876},
 								name: "MakeMVBlock",
 							},
 						},
@@ -11924,41 +11925,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4756, col: 1, offset: 144861},
+			pos:  position{line: 4757, col: 1, offset: 144925},
 			expr: &actionExpr{
-				pos: position{line: 4756, col: 16, offset: 144876},
+				pos: position{line: 4757, col: 16, offset: 144940},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4756, col: 16, offset: 144876},
-					exprs: []any{
+					pos: position{line: 4757, col: 16, offset: 144940},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4756, col: 16, offset: 144876},
+							pos:  position{line: 4757, col: 16, offset: 144940},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4756, col: 27, offset: 144887},
+							pos:  position{line: 4757, col: 27, offset: 144951},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4756, col: 33, offset: 144893},
+							pos:   position{line: 4757, col: 33, offset: 144957},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4756, col: 50, offset: 144910},
+								pos: position{line: 4757, col: 50, offset: 144974},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4756, col: 50, offset: 144910},
+									pos:  position{line: 4757, col: 50, offset: 144974},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4756, col: 70, offset: 144930},
+							pos:  position{line: 4757, col: 70, offset: 144994},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4756, col: 85, offset: 144945},
+							pos:   position{line: 4757, col: 85, offset: 145009},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4756, col: 91, offset: 144951},
+								pos:  position{line: 4757, col: 91, offset: 145015},
 								name: "FieldName",
 							},
 						},
@@ -11968,35 +11969,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4785, col: 1, offset: 145722},
+			pos:  position{line: 4786, col: 1, offset: 145786},
 			expr: &actionExpr{
-				pos: position{line: 4785, col: 23, offset: 145744},
+				pos: position{line: 4786, col: 23, offset: 145808},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4785, col: 23, offset: 145744},
-					exprs: []any{
+					pos: position{line: 4786, col: 23, offset: 145808},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 4785, col: 23, offset: 145744},
+							pos:   position{line: 4786, col: 23, offset: 145808},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4785, col: 31, offset: 145752},
+								pos:  position{line: 4786, col: 31, offset: 145816},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4785, col: 46, offset: 145767},
+							pos:   position{line: 4786, col: 46, offset: 145831},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4785, col: 52, offset: 145773},
+								pos: position{line: 4786, col: 52, offset: 145837},
 								expr: &seqExpr{
-									pos: position{line: 4785, col: 53, offset: 145774},
-									exprs: []any{
+									pos: position{line: 4786, col: 53, offset: 145838},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4785, col: 53, offset: 145774},
+											pos:  position{line: 4786, col: 53, offset: 145838},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4785, col: 59, offset: 145780},
+											pos:  position{line: 4786, col: 59, offset: 145844},
 											name: "MVBlockOption",
 										},
 									},
@@ -12009,26 +12010,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4819, col: 1, offset: 146836},
+			pos:  position{line: 4820, col: 1, offset: 146900},
 			expr: &actionExpr{
-				pos: position{line: 4819, col: 18, offset: 146853},
+				pos: position{line: 4820, col: 18, offset: 146917},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4819, col: 18, offset: 146853},
+					pos:   position{line: 4820, col: 18, offset: 146917},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4819, col: 27, offset: 146862},
-						alternatives: []any{
+						pos: position{line: 4820, col: 27, offset: 146926},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4819, col: 27, offset: 146862},
+								pos:  position{line: 4820, col: 27, offset: 146926},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4819, col: 41, offset: 146876},
+								pos:  position{line: 4820, col: 41, offset: 146940},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4819, col: 60, offset: 146895},
+								pos:  position{line: 4820, col: 60, offset: 146959},
 								name: "SetSvOption",
 							},
 						},
@@ -12038,22 +12039,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4823, col: 1, offset: 146936},
+			pos:  position{line: 4824, col: 1, offset: 147000},
 			expr: &actionExpr{
-				pos: position{line: 4823, col: 16, offset: 146951},
+				pos: position{line: 4824, col: 16, offset: 147015},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4823, col: 16, offset: 146951},
+					pos:   position{line: 4824, col: 16, offset: 147015},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4823, col: 28, offset: 146963},
-						alternatives: []any{
+						pos: position{line: 4824, col: 28, offset: 147027},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4823, col: 28, offset: 146963},
+								pos:  position{line: 4824, col: 28, offset: 147027},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4823, col: 46, offset: 146981},
+								pos:  position{line: 4824, col: 46, offset: 147045},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12063,28 +12064,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4827, col: 1, offset: 147028},
+			pos:  position{line: 4828, col: 1, offset: 147092},
 			expr: &actionExpr{
-				pos: position{line: 4827, col: 20, offset: 147047},
+				pos: position{line: 4828, col: 20, offset: 147111},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4827, col: 20, offset: 147047},
-					exprs: []any{
+					pos: position{line: 4828, col: 20, offset: 147111},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4827, col: 20, offset: 147047},
+							pos:        position{line: 4828, col: 20, offset: 147111},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4827, col: 28, offset: 147055},
+							pos:  position{line: 4828, col: 28, offset: 147119},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4827, col: 34, offset: 147061},
+							pos:   position{line: 4828, col: 34, offset: 147125},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4827, col: 38, offset: 147065},
+								pos:  position{line: 4828, col: 38, offset: 147129},
 								name: "QuotedString",
 							},
 						},
@@ -12094,28 +12095,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4838, col: 1, offset: 147316},
+			pos:  position{line: 4839, col: 1, offset: 147380},
 			expr: &actionExpr{
-				pos: position{line: 4838, col: 19, offset: 147334},
+				pos: position{line: 4839, col: 19, offset: 147398},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4838, col: 19, offset: 147334},
-					exprs: []any{
+					pos: position{line: 4839, col: 19, offset: 147398},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4838, col: 19, offset: 147334},
+							pos:        position{line: 4839, col: 19, offset: 147398},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4838, col: 31, offset: 147346},
+							pos:  position{line: 4839, col: 31, offset: 147410},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4838, col: 37, offset: 147352},
+							pos:   position{line: 4839, col: 37, offset: 147416},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4838, col: 41, offset: 147356},
+								pos:  position{line: 4839, col: 41, offset: 147420},
 								name: "QuotedString",
 							},
 						},
@@ -12125,28 +12126,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4856, col: 1, offset: 147827},
+			pos:  position{line: 4857, col: 1, offset: 147891},
 			expr: &actionExpr{
-				pos: position{line: 4856, col: 21, offset: 147847},
+				pos: position{line: 4857, col: 21, offset: 147911},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4856, col: 21, offset: 147847},
-					exprs: []any{
+					pos: position{line: 4857, col: 21, offset: 147911},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4856, col: 21, offset: 147847},
+							pos:        position{line: 4857, col: 21, offset: 147911},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4856, col: 34, offset: 147860},
+							pos:  position{line: 4857, col: 34, offset: 147924},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4856, col: 40, offset: 147866},
+							pos:   position{line: 4857, col: 40, offset: 147930},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4856, col: 48, offset: 147874},
+								pos:  position{line: 4857, col: 48, offset: 147938},
 								name: "Boolean",
 							},
 						},
@@ -12156,28 +12157,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4868, col: 1, offset: 148114},
+			pos:  position{line: 4869, col: 1, offset: 148178},
 			expr: &actionExpr{
-				pos: position{line: 4868, col: 16, offset: 148129},
+				pos: position{line: 4869, col: 16, offset: 148193},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4868, col: 16, offset: 148129},
-					exprs: []any{
+					pos: position{line: 4869, col: 16, offset: 148193},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4868, col: 16, offset: 148129},
+							pos:        position{line: 4869, col: 16, offset: 148193},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4868, col: 24, offset: 148137},
+							pos:  position{line: 4869, col: 24, offset: 148201},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4868, col: 30, offset: 148143},
+							pos:   position{line: 4869, col: 30, offset: 148207},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4868, col: 38, offset: 148151},
+								pos:  position{line: 4869, col: 38, offset: 148215},
 								name: "Boolean",
 							},
 						},
@@ -12187,28 +12188,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4880, col: 1, offset: 148416},
+			pos:  position{line: 4881, col: 1, offset: 148480},
 			expr: &actionExpr{
-				pos: position{line: 4880, col: 15, offset: 148430},
+				pos: position{line: 4881, col: 15, offset: 148494},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4880, col: 15, offset: 148430},
-					exprs: []any{
+					pos: position{line: 4881, col: 15, offset: 148494},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4880, col: 15, offset: 148430},
+							pos:  position{line: 4881, col: 15, offset: 148494},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4880, col: 20, offset: 148435},
+							pos:  position{line: 4881, col: 20, offset: 148499},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4880, col: 30, offset: 148445},
+							pos:   position{line: 4881, col: 30, offset: 148509},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4880, col: 40, offset: 148455},
+								pos: position{line: 4881, col: 40, offset: 148519},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4880, col: 40, offset: 148455},
+									pos:  position{line: 4881, col: 40, offset: 148519},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12219,39 +12220,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4887, col: 1, offset: 148581},
+			pos:  position{line: 4888, col: 1, offset: 148645},
 			expr: &actionExpr{
-				pos: position{line: 4887, col: 23, offset: 148603},
+				pos: position{line: 4888, col: 23, offset: 148667},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4887, col: 23, offset: 148603},
-					exprs: []any{
+					pos: position{line: 4888, col: 23, offset: 148667},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4887, col: 23, offset: 148603},
+							pos:  position{line: 4888, col: 23, offset: 148667},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4887, col: 29, offset: 148609},
+							pos:   position{line: 4888, col: 29, offset: 148673},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4887, col: 35, offset: 148615},
+								pos:  position{line: 4888, col: 35, offset: 148679},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4887, col: 49, offset: 148629},
+							pos:   position{line: 4888, col: 49, offset: 148693},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4887, col: 54, offset: 148634},
+								pos: position{line: 4888, col: 54, offset: 148698},
 								expr: &seqExpr{
-									pos: position{line: 4887, col: 55, offset: 148635},
-									exprs: []any{
+									pos: position{line: 4888, col: 55, offset: 148699},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4887, col: 55, offset: 148635},
+											pos:  position{line: 4888, col: 55, offset: 148699},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4887, col: 61, offset: 148641},
+											pos:  position{line: 4888, col: 61, offset: 148705},
 											name: "SPathArgument",
 										},
 									},
@@ -12264,26 +12265,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4919, col: 1, offset: 149534},
+			pos:  position{line: 4920, col: 1, offset: 149598},
 			expr: &actionExpr{
-				pos: position{line: 4919, col: 18, offset: 149551},
+				pos: position{line: 4920, col: 18, offset: 149615},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4919, col: 18, offset: 149551},
+					pos:   position{line: 4920, col: 18, offset: 149615},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4919, col: 23, offset: 149556},
-						alternatives: []any{
+						pos: position{line: 4920, col: 23, offset: 149620},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 4919, col: 23, offset: 149556},
+								pos:  position{line: 4920, col: 23, offset: 149620},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4919, col: 36, offset: 149569},
+								pos:  position{line: 4920, col: 36, offset: 149633},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4919, col: 50, offset: 149583},
+								pos:  position{line: 4920, col: 50, offset: 149647},
 								name: "PathField",
 							},
 						},
@@ -12293,28 +12294,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4923, col: 1, offset: 149619},
+			pos:  position{line: 4924, col: 1, offset: 149683},
 			expr: &actionExpr{
-				pos: position{line: 4923, col: 15, offset: 149633},
+				pos: position{line: 4924, col: 15, offset: 149697},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4923, col: 15, offset: 149633},
-					exprs: []any{
+					pos: position{line: 4924, col: 15, offset: 149697},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4923, col: 15, offset: 149633},
+							pos:        position{line: 4924, col: 15, offset: 149697},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4923, col: 23, offset: 149641},
+							pos:  position{line: 4924, col: 23, offset: 149705},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4923, col: 29, offset: 149647},
+							pos:   position{line: 4924, col: 29, offset: 149711},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4923, col: 35, offset: 149653},
+								pos:  position{line: 4924, col: 35, offset: 149717},
 								name: "FieldName",
 							},
 						},
@@ -12324,28 +12325,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4926, col: 1, offset: 149709},
+			pos:  position{line: 4927, col: 1, offset: 149773},
 			expr: &actionExpr{
-				pos: position{line: 4926, col: 16, offset: 149724},
+				pos: position{line: 4927, col: 16, offset: 149788},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4926, col: 16, offset: 149724},
-					exprs: []any{
+					pos: position{line: 4927, col: 16, offset: 149788},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 4926, col: 16, offset: 149724},
+							pos:        position{line: 4927, col: 16, offset: 149788},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4926, col: 25, offset: 149733},
+							pos:  position{line: 4927, col: 25, offset: 149797},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4926, col: 31, offset: 149739},
+							pos:   position{line: 4927, col: 31, offset: 149803},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4926, col: 37, offset: 149745},
+								pos:  position{line: 4927, col: 37, offset: 149809},
 								name: "FieldName",
 							},
 						},
@@ -12355,34 +12356,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4929, col: 1, offset: 149802},
+			pos:  position{line: 4930, col: 1, offset: 149866},
 			expr: &actionExpr{
-				pos: position{line: 4929, col: 14, offset: 149815},
+				pos: position{line: 4930, col: 14, offset: 149879},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4929, col: 15, offset: 149816},
-					alternatives: []any{
+					pos: position{line: 4930, col: 15, offset: 149880},
+					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 4929, col: 15, offset: 149816},
-							exprs: []any{
+							pos: position{line: 4930, col: 15, offset: 149880},
+							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 4929, col: 15, offset: 149816},
+									pos:        position{line: 4930, col: 15, offset: 149880},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4929, col: 22, offset: 149823},
+									pos:  position{line: 4930, col: 22, offset: 149887},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4929, col: 28, offset: 149829},
+									pos:  position{line: 4930, col: 28, offset: 149893},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4929, col: 47, offset: 149848},
+							pos:  position{line: 4930, col: 47, offset: 149912},
 							name: "SPathFieldString",
 						},
 					},
@@ -12391,16 +12392,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 4941, col: 1, offset: 150260},
+			pos:  position{line: 4942, col: 1, offset: 150324},
 			expr: &choiceExpr{
-				pos: position{line: 4941, col: 21, offset: 150280},
-				alternatives: []any{
+				pos: position{line: 4942, col: 21, offset: 150344},
+				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 4941, col: 21, offset: 150280},
+						pos:  position{line: 4942, col: 21, offset: 150344},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4941, col: 36, offset: 150295},
+						pos:  position{line: 4942, col: 36, offset: 150359},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12408,28 +12409,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 4944, col: 1, offset: 150368},
+			pos:  position{line: 4945, col: 1, offset: 150432},
 			expr: &actionExpr{
-				pos: position{line: 4944, col: 16, offset: 150383},
+				pos: position{line: 4945, col: 16, offset: 150447},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4944, col: 16, offset: 150383},
-					exprs: []any{
+					pos: position{line: 4945, col: 16, offset: 150447},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4944, col: 16, offset: 150383},
+							pos:  position{line: 4945, col: 16, offset: 150447},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4944, col: 21, offset: 150388},
+							pos:  position{line: 4945, col: 21, offset: 150452},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 4944, col: 32, offset: 150399},
+							pos:   position{line: 4945, col: 32, offset: 150463},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4944, col: 46, offset: 150413},
+								pos: position{line: 4945, col: 46, offset: 150477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4944, col: 46, offset: 150413},
+									pos:  position{line: 4945, col: 46, offset: 150477},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12440,39 +12441,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 4966, col: 1, offset: 151022},
+			pos:  position{line: 4967, col: 1, offset: 151086},
 			expr: &actionExpr{
-				pos: position{line: 4966, col: 24, offset: 151045},
+				pos: position{line: 4967, col: 24, offset: 151109},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4966, col: 24, offset: 151045},
-					exprs: []any{
+					pos: position{line: 4967, col: 24, offset: 151109},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 4966, col: 24, offset: 151045},
+							pos:  position{line: 4967, col: 24, offset: 151109},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4966, col: 30, offset: 151051},
+							pos:   position{line: 4967, col: 30, offset: 151115},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4966, col: 37, offset: 151058},
+								pos:  position{line: 4967, col: 37, offset: 151122},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4966, col: 52, offset: 151073},
+							pos:   position{line: 4967, col: 52, offset: 151137},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4966, col: 57, offset: 151078},
+								pos: position{line: 4967, col: 57, offset: 151142},
 								expr: &seqExpr{
-									pos: position{line: 4966, col: 58, offset: 151079},
-									exprs: []any{
+									pos: position{line: 4967, col: 58, offset: 151143},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 4966, col: 58, offset: 151079},
+											pos:  position{line: 4967, col: 58, offset: 151143},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4966, col: 64, offset: 151085},
+											pos:  position{line: 4967, col: 64, offset: 151149},
 											name: "FormatArgument",
 										},
 									},
@@ -12485,30 +12486,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5000, col: 1, offset: 152274},
+			pos:  position{line: 5001, col: 1, offset: 152338},
 			expr: &actionExpr{
-				pos: position{line: 5000, col: 19, offset: 152292},
+				pos: position{line: 5001, col: 19, offset: 152356},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5000, col: 19, offset: 152292},
+					pos:   position{line: 5001, col: 19, offset: 152356},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5000, col: 28, offset: 152301},
-						alternatives: []any{
+						pos: position{line: 5001, col: 28, offset: 152365},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 5000, col: 28, offset: 152301},
+								pos:  position{line: 5001, col: 28, offset: 152365},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5000, col: 46, offset: 152319},
+								pos:  position{line: 5001, col: 46, offset: 152383},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5000, col: 65, offset: 152338},
+								pos:  position{line: 5001, col: 65, offset: 152402},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5000, col: 82, offset: 152355},
+								pos:  position{line: 5001, col: 82, offset: 152419},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12518,28 +12519,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5004, col: 1, offset: 152405},
+			pos:  position{line: 5005, col: 1, offset: 152469},
 			expr: &actionExpr{
-				pos: position{line: 5004, col: 20, offset: 152424},
+				pos: position{line: 5005, col: 20, offset: 152488},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5004, col: 20, offset: 152424},
-					exprs: []any{
+					pos: position{line: 5005, col: 20, offset: 152488},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5004, col: 20, offset: 152424},
+							pos:        position{line: 5005, col: 20, offset: 152488},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5004, col: 28, offset: 152432},
+							pos:  position{line: 5005, col: 28, offset: 152496},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5004, col: 34, offset: 152438},
+							pos:   position{line: 5005, col: 34, offset: 152502},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5004, col: 38, offset: 152442},
+								pos:  position{line: 5005, col: 38, offset: 152506},
 								name: "QuotedString",
 							},
 						},
@@ -12549,28 +12550,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5013, col: 1, offset: 152654},
+			pos:  position{line: 5014, col: 1, offset: 152718},
 			expr: &actionExpr{
-				pos: position{line: 5013, col: 21, offset: 152674},
+				pos: position{line: 5014, col: 21, offset: 152738},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5013, col: 21, offset: 152674},
-					exprs: []any{
+					pos: position{line: 5014, col: 21, offset: 152738},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5013, col: 21, offset: 152674},
+							pos:        position{line: 5014, col: 21, offset: 152738},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5013, col: 34, offset: 152687},
+							pos:  position{line: 5014, col: 34, offset: 152751},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5013, col: 40, offset: 152693},
+							pos:   position{line: 5014, col: 40, offset: 152757},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5013, col: 47, offset: 152700},
+								pos:  position{line: 5014, col: 47, offset: 152764},
 								name: "IntegerAsString",
 							},
 						},
@@ -12580,28 +12581,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5026, col: 1, offset: 153106},
+			pos:  position{line: 5027, col: 1, offset: 153170},
 			expr: &actionExpr{
-				pos: position{line: 5026, col: 19, offset: 153124},
+				pos: position{line: 5027, col: 19, offset: 153188},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5026, col: 19, offset: 153124},
-					exprs: []any{
+					pos: position{line: 5027, col: 19, offset: 153188},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5026, col: 19, offset: 153124},
+							pos:        position{line: 5027, col: 19, offset: 153188},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5026, col: 30, offset: 153135},
+							pos:  position{line: 5027, col: 30, offset: 153199},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5026, col: 36, offset: 153141},
+							pos:   position{line: 5027, col: 36, offset: 153205},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5026, col: 40, offset: 153145},
+								pos:  position{line: 5027, col: 40, offset: 153209},
 								name: "QuotedString",
 							},
 						},
@@ -12611,78 +12612,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5035, col: 1, offset: 153360},
+			pos:  position{line: 5036, col: 1, offset: 153424},
 			expr: &actionExpr{
-				pos: position{line: 5035, col: 24, offset: 153383},
+				pos: position{line: 5036, col: 24, offset: 153447},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5035, col: 24, offset: 153383},
-					exprs: []any{
+					pos: position{line: 5036, col: 24, offset: 153447},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 5035, col: 24, offset: 153383},
+							pos:   position{line: 5036, col: 24, offset: 153447},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 34, offset: 153393},
+								pos:  position{line: 5036, col: 34, offset: 153457},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 47, offset: 153406},
+							pos:  position{line: 5036, col: 47, offset: 153470},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 53, offset: 153412},
+							pos:   position{line: 5036, col: 53, offset: 153476},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 63, offset: 153422},
+								pos:  position{line: 5036, col: 63, offset: 153486},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 76, offset: 153435},
+							pos:  position{line: 5036, col: 76, offset: 153499},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 82, offset: 153441},
+							pos:   position{line: 5036, col: 82, offset: 153505},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 95, offset: 153454},
+								pos:  position{line: 5036, col: 95, offset: 153518},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 108, offset: 153467},
+							pos:  position{line: 5036, col: 108, offset: 153531},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 114, offset: 153473},
+							pos:   position{line: 5036, col: 114, offset: 153537},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 121, offset: 153480},
+								pos:  position{line: 5036, col: 121, offset: 153544},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 134, offset: 153493},
+							pos:  position{line: 5036, col: 134, offset: 153557},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 140, offset: 153499},
+							pos:   position{line: 5036, col: 140, offset: 153563},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 153, offset: 153512},
+								pos:  position{line: 5036, col: 153, offset: 153576},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 166, offset: 153525},
+							pos:  position{line: 5036, col: 166, offset: 153589},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 172, offset: 153531},
+							pos:   position{line: 5036, col: 172, offset: 153595},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 179, offset: 153538},
+								pos:  position{line: 5036, col: 179, offset: 153602},
 								name: "QuotedString",
 							},
 						},
@@ -12692,28 +12693,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5053, col: 1, offset: 154114},
+			pos:  position{line: 5054, col: 1, offset: 154178},
 			expr: &actionExpr{
-				pos: position{line: 5053, col: 20, offset: 154133},
+				pos: position{line: 5054, col: 20, offset: 154197},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5053, col: 20, offset: 154133},
-					exprs: []any{
+					pos: position{line: 5054, col: 20, offset: 154197},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5053, col: 20, offset: 154133},
+							pos:  position{line: 5054, col: 20, offset: 154197},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5053, col: 25, offset: 154138},
+							pos:  position{line: 5054, col: 25, offset: 154202},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5053, col: 40, offset: 154153},
+							pos:   position{line: 5054, col: 40, offset: 154217},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5053, col: 55, offset: 154168},
+								pos: position{line: 5054, col: 55, offset: 154232},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5053, col: 55, offset: 154168},
+									pos:  position{line: 5054, col: 55, offset: 154232},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12724,42 +12725,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5060, col: 1, offset: 154321},
+			pos:  position{line: 5061, col: 1, offset: 154385},
 			expr: &actionExpr{
-				pos: position{line: 5060, col: 28, offset: 154348},
+				pos: position{line: 5061, col: 28, offset: 154412},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5060, col: 28, offset: 154348},
-					exprs: []any{
+					pos: position{line: 5061, col: 28, offset: 154412},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5060, col: 28, offset: 154348},
+							pos:  position{line: 5061, col: 28, offset: 154412},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5060, col: 34, offset: 154354},
+							pos:   position{line: 5061, col: 34, offset: 154418},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5060, col: 40, offset: 154360},
+								pos: position{line: 5061, col: 40, offset: 154424},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5060, col: 40, offset: 154360},
+									pos:  position{line: 5061, col: 40, offset: 154424},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5060, col: 60, offset: 154380},
+							pos:   position{line: 5061, col: 60, offset: 154444},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5060, col: 65, offset: 154385},
+								pos: position{line: 5061, col: 65, offset: 154449},
 								expr: &seqExpr{
-									pos: position{line: 5060, col: 66, offset: 154386},
-									exprs: []any{
+									pos: position{line: 5061, col: 66, offset: 154450},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 5060, col: 66, offset: 154386},
+											pos:  position{line: 5061, col: 66, offset: 154450},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5060, col: 72, offset: 154392},
+											pos:  position{line: 5061, col: 72, offset: 154456},
 											name: "EventCountArgument",
 										},
 									},
@@ -12772,30 +12773,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5116, col: 1, offset: 156269},
+			pos:  position{line: 5117, col: 1, offset: 156333},
 			expr: &actionExpr{
-				pos: position{line: 5116, col: 23, offset: 156291},
+				pos: position{line: 5117, col: 23, offset: 156355},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5116, col: 23, offset: 156291},
+					pos:   position{line: 5117, col: 23, offset: 156355},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5116, col: 28, offset: 156296},
-						alternatives: []any{
+						pos: position{line: 5117, col: 28, offset: 156360},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 5116, col: 28, offset: 156296},
+								pos:  position{line: 5117, col: 28, offset: 156360},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5116, col: 41, offset: 156309},
+								pos:  position{line: 5117, col: 41, offset: 156373},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5116, col: 58, offset: 156326},
+								pos:  position{line: 5117, col: 58, offset: 156390},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5116, col: 76, offset: 156344},
+								pos:  position{line: 5117, col: 76, offset: 156408},
 								name: "ListVixField",
 							},
 						},
@@ -12805,28 +12806,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5120, col: 1, offset: 156383},
+			pos:  position{line: 5121, col: 1, offset: 156447},
 			expr: &actionExpr{
-				pos: position{line: 5120, col: 15, offset: 156397},
+				pos: position{line: 5121, col: 15, offset: 156461},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5120, col: 15, offset: 156397},
-					exprs: []any{
+					pos: position{line: 5121, col: 15, offset: 156461},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5120, col: 15, offset: 156397},
+							pos:        position{line: 5121, col: 15, offset: 156461},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5120, col: 23, offset: 156405},
+							pos:  position{line: 5121, col: 23, offset: 156469},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5120, col: 29, offset: 156411},
+							pos:   position{line: 5121, col: 29, offset: 156475},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5120, col: 35, offset: 156417},
+								pos:  position{line: 5121, col: 35, offset: 156481},
 								name: "IndexName",
 							},
 						},
@@ -12836,28 +12837,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5123, col: 1, offset: 156473},
+			pos:  position{line: 5124, col: 1, offset: 156537},
 			expr: &actionExpr{
-				pos: position{line: 5123, col: 19, offset: 156491},
+				pos: position{line: 5124, col: 19, offset: 156555},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5123, col: 19, offset: 156491},
-					exprs: []any{
+					pos: position{line: 5124, col: 19, offset: 156555},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5123, col: 19, offset: 156491},
+							pos:        position{line: 5124, col: 19, offset: 156555},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5123, col: 31, offset: 156503},
+							pos:  position{line: 5124, col: 31, offset: 156567},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5123, col: 37, offset: 156509},
+							pos:   position{line: 5124, col: 37, offset: 156573},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5123, col: 43, offset: 156515},
+								pos:  position{line: 5124, col: 43, offset: 156579},
 								name: "Boolean",
 							},
 						},
@@ -12867,28 +12868,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5126, col: 1, offset: 156591},
+			pos:  position{line: 5127, col: 1, offset: 156655},
 			expr: &actionExpr{
-				pos: position{line: 5126, col: 20, offset: 156610},
+				pos: position{line: 5127, col: 20, offset: 156674},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5126, col: 20, offset: 156610},
-					exprs: []any{
+					pos: position{line: 5127, col: 20, offset: 156674},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5126, col: 20, offset: 156610},
+							pos:        position{line: 5127, col: 20, offset: 156674},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5126, col: 34, offset: 156624},
+							pos:  position{line: 5127, col: 34, offset: 156688},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5126, col: 40, offset: 156630},
+							pos:   position{line: 5127, col: 40, offset: 156694},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5126, col: 46, offset: 156636},
+								pos:  position{line: 5127, col: 46, offset: 156700},
 								name: "Boolean",
 							},
 						},
@@ -12898,28 +12899,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5129, col: 1, offset: 156714},
+			pos:  position{line: 5130, col: 1, offset: 156778},
 			expr: &actionExpr{
-				pos: position{line: 5129, col: 17, offset: 156730},
+				pos: position{line: 5130, col: 17, offset: 156794},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5129, col: 17, offset: 156730},
-					exprs: []any{
+					pos: position{line: 5130, col: 17, offset: 156794},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5129, col: 17, offset: 156730},
+							pos:        position{line: 5130, col: 17, offset: 156794},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5129, col: 28, offset: 156741},
+							pos:  position{line: 5130, col: 28, offset: 156805},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5129, col: 34, offset: 156747},
+							pos:   position{line: 5130, col: 34, offset: 156811},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5129, col: 40, offset: 156753},
+								pos:  position{line: 5130, col: 40, offset: 156817},
 								name: "Boolean",
 							},
 						},
@@ -12929,24 +12930,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5133, col: 1, offset: 156829},
+			pos:  position{line: 5134, col: 1, offset: 156893},
 			expr: &actionExpr{
-				pos: position{line: 5133, col: 14, offset: 156842},
+				pos: position{line: 5134, col: 14, offset: 156906},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5133, col: 14, offset: 156842},
+					pos: position{line: 5134, col: 14, offset: 156906},
 					expr: &seqExpr{
-						pos: position{line: 5133, col: 15, offset: 156843},
-						exprs: []any{
+						pos: position{line: 5134, col: 15, offset: 156907},
+						exprs: []interface{}{
 							&notExpr{
-								pos: position{line: 5133, col: 15, offset: 156843},
+								pos: position{line: 5134, col: 15, offset: 156907},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5133, col: 16, offset: 156844},
+									pos:  position{line: 5134, col: 16, offset: 156908},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5133, col: 22, offset: 156850,
+								line: 5134, col: 22, offset: 156914,
 							},
 						},
 					},
@@ -12955,39 +12956,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5138, col: 1, offset: 156923},
+			pos:  position{line: 5139, col: 1, offset: 156987},
 			expr: &actionExpr{
-				pos: position{line: 5138, col: 18, offset: 156940},
+				pos: position{line: 5139, col: 18, offset: 157004},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5138, col: 18, offset: 156940},
-					exprs: []any{
+					pos: position{line: 5139, col: 18, offset: 157004},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 18, offset: 156940},
+							pos:  position{line: 5139, col: 18, offset: 157004},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 23, offset: 156945},
+							pos:  position{line: 5139, col: 23, offset: 157009},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5138, col: 36, offset: 156958},
+							pos:   position{line: 5139, col: 36, offset: 157022},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5138, col: 49, offset: 156971},
+								pos: position{line: 5139, col: 49, offset: 157035},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5138, col: 49, offset: 156971},
+									pos:  position{line: 5139, col: 49, offset: 157035},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5138, col: 70, offset: 156992},
+							pos:   position{line: 5139, col: 70, offset: 157056},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5138, col: 77, offset: 156999},
+								pos: position{line: 5139, col: 77, offset: 157063},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5138, col: 77, offset: 156999},
+									pos:  position{line: 5139, col: 77, offset: 157063},
 									name: "FillNullFieldList",
 								},
 							},
@@ -12998,32 +12999,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5168, col: 1, offset: 157762},
+			pos:  position{line: 5169, col: 1, offset: 157826},
 			expr: &actionExpr{
-				pos: position{line: 5168, col: 24, offset: 157785},
+				pos: position{line: 5169, col: 24, offset: 157849},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5168, col: 24, offset: 157785},
-					exprs: []any{
+					pos: position{line: 5169, col: 24, offset: 157849},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5168, col: 24, offset: 157785},
+							pos:  position{line: 5169, col: 24, offset: 157849},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5168, col: 30, offset: 157791},
+							pos:        position{line: 5169, col: 30, offset: 157855},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5168, col: 38, offset: 157799},
+							pos:  position{line: 5169, col: 38, offset: 157863},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5168, col: 44, offset: 157805},
+							pos:   position{line: 5169, col: 44, offset: 157869},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5168, col: 48, offset: 157809},
+								pos:  position{line: 5169, col: 48, offset: 157873},
 								name: "String",
 							},
 						},
@@ -13033,22 +13034,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5172, col: 1, offset: 157855},
+			pos:  position{line: 5173, col: 1, offset: 157919},
 			expr: &actionExpr{
-				pos: position{line: 5172, col: 22, offset: 157876},
+				pos: position{line: 5173, col: 22, offset: 157940},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5172, col: 22, offset: 157876},
-					exprs: []any{
+					pos: position{line: 5173, col: 22, offset: 157940},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5172, col: 22, offset: 157876},
+							pos:  position{line: 5173, col: 22, offset: 157940},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5172, col: 28, offset: 157882},
+							pos:   position{line: 5173, col: 28, offset: 157946},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5172, col: 38, offset: 157892},
+								pos:  position{line: 5173, col: 38, offset: 157956},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13058,36 +13059,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5176, col: 1, offset: 157951},
+			pos:  position{line: 5177, col: 1, offset: 158015},
 			expr: &actionExpr{
-				pos: position{line: 5176, col: 18, offset: 157968},
+				pos: position{line: 5177, col: 18, offset: 158032},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5176, col: 18, offset: 157968},
-					exprs: []any{
+					pos: position{line: 5177, col: 18, offset: 158032},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5176, col: 18, offset: 157968},
+							pos:  position{line: 5177, col: 18, offset: 158032},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5176, col: 23, offset: 157973},
+							pos:  position{line: 5177, col: 23, offset: 158037},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5176, col: 36, offset: 157986},
+							pos:   position{line: 5177, col: 36, offset: 158050},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5176, col: 42, offset: 157992},
+								pos:  position{line: 5177, col: 42, offset: 158056},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5176, col: 56, offset: 158006},
+							pos:   position{line: 5177, col: 56, offset: 158070},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5176, col: 65, offset: 158015},
+								pos: position{line: 5177, col: 65, offset: 158079},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5176, col: 65, offset: 158015},
+									pos:  position{line: 5177, col: 65, offset: 158079},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13098,22 +13099,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5205, col: 1, offset: 158791},
+			pos:  position{line: 5206, col: 1, offset: 158855},
 			expr: &actionExpr{
-				pos: position{line: 5205, col: 18, offset: 158808},
+				pos: position{line: 5206, col: 18, offset: 158872},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5205, col: 18, offset: 158808},
-					exprs: []any{
+					pos: position{line: 5206, col: 18, offset: 158872},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5205, col: 18, offset: 158808},
+							pos:  position{line: 5206, col: 18, offset: 158872},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5205, col: 24, offset: 158814},
+							pos:   position{line: 5206, col: 24, offset: 158878},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5205, col: 34, offset: 158824},
+								pos:  position{line: 5206, col: 34, offset: 158888},
 								name: "FieldName",
 							},
 						},
@@ -13123,32 +13124,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5209, col: 1, offset: 158865},
+			pos:  position{line: 5210, col: 1, offset: 158929},
 			expr: &actionExpr{
-				pos: position{line: 5209, col: 18, offset: 158882},
+				pos: position{line: 5210, col: 18, offset: 158946},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5209, col: 18, offset: 158882},
-					exprs: []any{
+					pos: position{line: 5210, col: 18, offset: 158946},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5209, col: 18, offset: 158882},
+							pos:  position{line: 5210, col: 18, offset: 158946},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5209, col: 24, offset: 158888},
+							pos:        position{line: 5210, col: 24, offset: 158952},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5209, col: 32, offset: 158896},
+							pos:  position{line: 5210, col: 32, offset: 158960},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5209, col: 38, offset: 158902},
+							pos:   position{line: 5210, col: 38, offset: 158966},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5209, col: 47, offset: 158911},
+								pos:  position{line: 5210, col: 47, offset: 158975},
 								name: "IntegerAsString",
 							},
 						},
@@ -13158,26 +13159,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5213, col: 1, offset: 158957},
+			pos:  position{line: 5214, col: 1, offset: 159021},
 			expr: &actionExpr{
-				pos: position{line: 5213, col: 16, offset: 158972},
+				pos: position{line: 5214, col: 16, offset: 159036},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5213, col: 16, offset: 158972},
-					exprs: []any{
+					pos: position{line: 5214, col: 16, offset: 159036},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5213, col: 16, offset: 158972},
+							pos:  position{line: 5214, col: 16, offset: 159036},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5213, col: 22, offset: 158978},
+							pos:  position{line: 5214, col: 22, offset: 159042},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5213, col: 32, offset: 158988},
+							pos:   position{line: 5214, col: 32, offset: 159052},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5213, col: 42, offset: 158998},
+								pos:  position{line: 5214, col: 42, offset: 159062},
 								name: "BoolExpr",
 							},
 						},
@@ -13187,28 +13188,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5217, col: 1, offset: 159058},
+			pos:  position{line: 5218, col: 1, offset: 159122},
 			expr: &actionExpr{
-				pos: position{line: 5217, col: 28, offset: 159085},
+				pos: position{line: 5218, col: 28, offset: 159149},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5217, col: 28, offset: 159085},
-					exprs: []any{
+					pos: position{line: 5218, col: 28, offset: 159149},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5217, col: 28, offset: 159085},
+							pos:        position{line: 5218, col: 28, offset: 159149},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5217, col: 37, offset: 159094},
+							pos:  position{line: 5218, col: 37, offset: 159158},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5217, col: 43, offset: 159100},
+							pos:   position{line: 5218, col: 43, offset: 159164},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5217, col: 51, offset: 159108},
+								pos:  position{line: 5218, col: 51, offset: 159172},
 								name: "Boolean",
 							},
 						},
@@ -13218,28 +13219,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5226, col: 1, offset: 159292},
+			pos:  position{line: 5227, col: 1, offset: 159356},
 			expr: &actionExpr{
-				pos: position{line: 5226, col: 28, offset: 159319},
+				pos: position{line: 5227, col: 28, offset: 159383},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5226, col: 28, offset: 159319},
-					exprs: []any{
+					pos: position{line: 5227, col: 28, offset: 159383},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5226, col: 28, offset: 159319},
+							pos:        position{line: 5227, col: 28, offset: 159383},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5226, col: 37, offset: 159328},
+							pos:  position{line: 5227, col: 37, offset: 159392},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5226, col: 43, offset: 159334},
+							pos:   position{line: 5227, col: 43, offset: 159398},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5226, col: 51, offset: 159342},
+								pos:  position{line: 5227, col: 51, offset: 159406},
 								name: "Boolean",
 							},
 						},
@@ -13249,28 +13250,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5235, col: 1, offset: 159526},
+			pos:  position{line: 5236, col: 1, offset: 159590},
 			expr: &actionExpr{
-				pos: position{line: 5235, col: 27, offset: 159552},
+				pos: position{line: 5236, col: 27, offset: 159616},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5235, col: 27, offset: 159552},
-					exprs: []any{
+					pos: position{line: 5236, col: 27, offset: 159616},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5235, col: 27, offset: 159552},
+							pos:        position{line: 5236, col: 27, offset: 159616},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5235, col: 35, offset: 159560},
+							pos:  position{line: 5236, col: 35, offset: 159624},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5235, col: 41, offset: 159566},
+							pos:   position{line: 5236, col: 41, offset: 159630},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5235, col: 48, offset: 159573},
+								pos:  position{line: 5236, col: 48, offset: 159637},
 								name: "PositiveInteger",
 							},
 						},
@@ -13280,28 +13281,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5244, col: 1, offset: 159764},
+			pos:  position{line: 5245, col: 1, offset: 159828},
 			expr: &actionExpr{
-				pos: position{line: 5244, col: 25, offset: 159788},
+				pos: position{line: 5245, col: 25, offset: 159852},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5244, col: 25, offset: 159788},
-					exprs: []any{
+					pos: position{line: 5245, col: 25, offset: 159852},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5244, col: 25, offset: 159788},
+							pos:        position{line: 5245, col: 25, offset: 159852},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5244, col: 31, offset: 159794},
+							pos:  position{line: 5245, col: 31, offset: 159858},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5244, col: 37, offset: 159800},
+							pos:   position{line: 5245, col: 37, offset: 159864},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5244, col: 44, offset: 159807},
+								pos:  position{line: 5245, col: 44, offset: 159871},
 								name: "PositiveInteger",
 							},
 						},
@@ -13311,30 +13312,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5253, col: 1, offset: 159994},
+			pos:  position{line: 5254, col: 1, offset: 160058},
 			expr: &actionExpr{
-				pos: position{line: 5253, col: 22, offset: 160015},
+				pos: position{line: 5254, col: 22, offset: 160079},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5253, col: 22, offset: 160015},
+					pos:   position{line: 5254, col: 22, offset: 160079},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5253, col: 41, offset: 160034},
-						alternatives: []any{
+						pos: position{line: 5254, col: 41, offset: 160098},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 5253, col: 41, offset: 160034},
+								pos:  position{line: 5254, col: 41, offset: 160098},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5253, col: 67, offset: 160060},
+								pos:  position{line: 5254, col: 67, offset: 160124},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5253, col: 93, offset: 160086},
+								pos:  position{line: 5254, col: 93, offset: 160150},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5253, col: 118, offset: 160111},
+								pos:  position{line: 5254, col: 118, offset: 160175},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13344,35 +13345,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5257, col: 1, offset: 160172},
+			pos:  position{line: 5258, col: 1, offset: 160236},
 			expr: &actionExpr{
-				pos: position{line: 5257, col: 26, offset: 160197},
+				pos: position{line: 5258, col: 26, offset: 160261},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5257, col: 26, offset: 160197},
-					exprs: []any{
+					pos: position{line: 5258, col: 26, offset: 160261},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 5257, col: 26, offset: 160197},
+							pos:   position{line: 5258, col: 26, offset: 160261},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5257, col: 34, offset: 160205},
+								pos:  position{line: 5258, col: 34, offset: 160269},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5257, col: 53, offset: 160224},
+							pos:   position{line: 5258, col: 53, offset: 160288},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5257, col: 58, offset: 160229},
+								pos: position{line: 5258, col: 58, offset: 160293},
 								expr: &seqExpr{
-									pos: position{line: 5257, col: 59, offset: 160230},
-									exprs: []any{
+									pos: position{line: 5258, col: 59, offset: 160294},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 5257, col: 59, offset: 160230},
+											pos:  position{line: 5258, col: 59, offset: 160294},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5257, col: 65, offset: 160236},
+											pos:  position{line: 5258, col: 65, offset: 160300},
 											name: "InputLookupOption",
 										},
 									},
@@ -13385,35 +13386,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5299, col: 1, offset: 161682},
+			pos:  position{line: 5300, col: 1, offset: 161746},
 			expr: &actionExpr{
-				pos: position{line: 5299, col: 21, offset: 161702},
+				pos: position{line: 5300, col: 21, offset: 161766},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5299, col: 21, offset: 161702},
-					exprs: []any{
+					pos: position{line: 5300, col: 21, offset: 161766},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5299, col: 21, offset: 161702},
+							pos:  position{line: 5300, col: 21, offset: 161766},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5299, col: 26, offset: 161707},
+							pos:  position{line: 5300, col: 26, offset: 161771},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5299, col: 42, offset: 161723},
+							pos:   position{line: 5300, col: 42, offset: 161787},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5299, col: 60, offset: 161741},
+								pos: position{line: 5300, col: 60, offset: 161805},
 								expr: &seqExpr{
-									pos: position{line: 5299, col: 61, offset: 161742},
-									exprs: []any{
+									pos: position{line: 5300, col: 61, offset: 161806},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 5299, col: 61, offset: 161742},
+											pos:  position{line: 5300, col: 61, offset: 161806},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5299, col: 83, offset: 161764},
+											pos:  position{line: 5300, col: 83, offset: 161828},
 											name: "SPACE",
 										},
 									},
@@ -13421,20 +13422,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5299, col: 91, offset: 161772},
+							pos:   position{line: 5300, col: 91, offset: 161836},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5299, col: 101, offset: 161782},
+								pos:  position{line: 5300, col: 101, offset: 161846},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5299, col: 109, offset: 161790},
+							pos:   position{line: 5300, col: 109, offset: 161854},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5299, col: 121, offset: 161802},
+								pos: position{line: 5300, col: 121, offset: 161866},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5299, col: 122, offset: 161803},
+									pos:  position{line: 5300, col: 122, offset: 161867},
 									name: "WhereClause",
 								},
 							},
@@ -13445,15 +13446,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5322, col: 1, offset: 162491},
+			pos:  position{line: 5323, col: 1, offset: 162555},
 			expr: &actionExpr{
-				pos: position{line: 5322, col: 24, offset: 162514},
+				pos: position{line: 5323, col: 24, offset: 162578},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5322, col: 24, offset: 162514},
+					pos:   position{line: 5323, col: 24, offset: 162578},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5322, col: 41, offset: 162531},
+						pos:  position{line: 5323, col: 41, offset: 162595},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13461,26 +13462,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5333, col: 1, offset: 162930},
+			pos:  position{line: 5334, col: 1, offset: 162994},
 			expr: &actionExpr{
-				pos: position{line: 5333, col: 20, offset: 162949},
+				pos: position{line: 5334, col: 20, offset: 163013},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5333, col: 20, offset: 162949},
+					pos:   position{line: 5334, col: 20, offset: 163013},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5333, col: 28, offset: 162957},
-						alternatives: []any{
+						pos: position{line: 5334, col: 28, offset: 163021},
+						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 5333, col: 28, offset: 162957},
+								pos:  position{line: 5334, col: 28, offset: 163021},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5333, col: 52, offset: 162981},
+								pos:  position{line: 5334, col: 52, offset: 163045},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5333, col: 68, offset: 162997},
+								pos:  position{line: 5334, col: 68, offset: 163061},
 								name: "MaxOutOption",
 							},
 						},
@@ -13490,28 +13491,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5338, col: 1, offset: 163095},
+			pos:  position{line: 5339, col: 1, offset: 163159},
 			expr: &actionExpr{
-				pos: position{line: 5338, col: 26, offset: 163120},
+				pos: position{line: 5339, col: 26, offset: 163184},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5338, col: 26, offset: 163120},
-					exprs: []any{
+					pos: position{line: 5339, col: 26, offset: 163184},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5338, col: 26, offset: 163120},
+							pos:        position{line: 5339, col: 26, offset: 163184},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5338, col: 44, offset: 163138},
+							pos:  position{line: 5339, col: 44, offset: 163202},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5338, col: 50, offset: 163144},
+							pos:   position{line: 5339, col: 50, offset: 163208},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5338, col: 58, offset: 163152},
+								pos:  position{line: 5339, col: 58, offset: 163216},
 								name: "Boolean",
 							},
 						},
@@ -13521,28 +13522,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5345, col: 1, offset: 163291},
+			pos:  position{line: 5346, col: 1, offset: 163355},
 			expr: &actionExpr{
-				pos: position{line: 5345, col: 18, offset: 163308},
+				pos: position{line: 5346, col: 18, offset: 163372},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5345, col: 18, offset: 163308},
-					exprs: []any{
+					pos: position{line: 5346, col: 18, offset: 163372},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5345, col: 18, offset: 163308},
+							pos:        position{line: 5346, col: 18, offset: 163372},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5345, col: 28, offset: 163318},
+							pos:  position{line: 5346, col: 28, offset: 163382},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5345, col: 34, offset: 163324},
+							pos:   position{line: 5346, col: 34, offset: 163388},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5345, col: 39, offset: 163329},
+								pos:  position{line: 5346, col: 39, offset: 163393},
 								name: "IntegerAsString",
 							},
 						},
@@ -13552,28 +13553,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5356, col: 1, offset: 163630},
+			pos:  position{line: 5357, col: 1, offset: 163694},
 			expr: &actionExpr{
-				pos: position{line: 5356, col: 17, offset: 163646},
+				pos: position{line: 5357, col: 17, offset: 163710},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5356, col: 17, offset: 163646},
-					exprs: []any{
+					pos: position{line: 5357, col: 17, offset: 163710},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5356, col: 17, offset: 163646},
+							pos:        position{line: 5357, col: 17, offset: 163710},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5356, col: 26, offset: 163655},
+							pos:  position{line: 5357, col: 26, offset: 163719},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5356, col: 32, offset: 163661},
+							pos:   position{line: 5357, col: 32, offset: 163725},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5356, col: 36, offset: 163665},
+								pos:  position{line: 5357, col: 36, offset: 163729},
 								name: "IntegerAsString",
 							},
 						},
@@ -13583,43 +13584,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5368, col: 1, offset: 164020},
+			pos:  position{line: 5369, col: 1, offset: 164084},
 			expr: &actionExpr{
-				pos: position{line: 5368, col: 14, offset: 164033},
+				pos: position{line: 5369, col: 14, offset: 164097},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5368, col: 14, offset: 164033},
-					exprs: []any{
+					pos: position{line: 5369, col: 14, offset: 164097},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5368, col: 14, offset: 164033},
+							pos:        position{line: 5369, col: 14, offset: 164097},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5368, col: 18, offset: 164037},
+							pos: position{line: 5369, col: 18, offset: 164101},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5368, col: 18, offset: 164037},
+								pos:  position{line: 5369, col: 18, offset: 164101},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5368, col: 25, offset: 164044},
+							pos:   position{line: 5369, col: 25, offset: 164108},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5368, col: 32, offset: 164051},
+								pos:  position{line: 5369, col: 32, offset: 164115},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5368, col: 44, offset: 164063},
+							pos: position{line: 5369, col: 44, offset: 164127},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5368, col: 44, offset: 164063},
+								pos:  position{line: 5369, col: 44, offset: 164127},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5368, col: 51, offset: 164070},
+							pos:        position{line: 5369, col: 51, offset: 164134},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13630,35 +13631,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5373, col: 1, offset: 164159},
+			pos:  position{line: 5374, col: 1, offset: 164223},
 			expr: &actionExpr{
-				pos: position{line: 5373, col: 25, offset: 164183},
+				pos: position{line: 5374, col: 25, offset: 164247},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5373, col: 25, offset: 164183},
-					exprs: []any{
+					pos: position{line: 5374, col: 25, offset: 164247},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 5373, col: 25, offset: 164183},
+							pos:   position{line: 5374, col: 25, offset: 164247},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5373, col: 31, offset: 164189},
+								pos:  position{line: 5374, col: 31, offset: 164253},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5373, col: 47, offset: 164205},
+							pos:   position{line: 5374, col: 47, offset: 164269},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5373, col: 52, offset: 164210},
+								pos: position{line: 5374, col: 52, offset: 164274},
 								expr: &seqExpr{
-									pos: position{line: 5373, col: 53, offset: 164211},
-									exprs: []any{
+									pos: position{line: 5374, col: 53, offset: 164275},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 5373, col: 53, offset: 164211},
+											pos:  position{line: 5374, col: 53, offset: 164275},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5373, col: 59, offset: 164217},
+											pos:  position{line: 5374, col: 59, offset: 164281},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13671,37 +13672,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5400, col: 1, offset: 165027},
+			pos:  position{line: 5401, col: 1, offset: 165091},
 			expr: &actionExpr{
-				pos: position{line: 5400, col: 16, offset: 165042},
+				pos: position{line: 5401, col: 16, offset: 165106},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5400, col: 16, offset: 165042},
-					exprs: []any{
+					pos: position{line: 5401, col: 16, offset: 165106},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5400, col: 16, offset: 165042},
+							pos:  position{line: 5401, col: 16, offset: 165106},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5400, col: 21, offset: 165047},
+							pos:  position{line: 5401, col: 21, offset: 165111},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5400, col: 32, offset: 165058},
+							pos:   position{line: 5401, col: 32, offset: 165122},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5400, col: 40, offset: 165066},
+								pos: position{line: 5401, col: 40, offset: 165130},
 								expr: &seqExpr{
-									pos: position{line: 5400, col: 41, offset: 165067},
-									exprs: []any{
+									pos: position{line: 5401, col: 41, offset: 165131},
+									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 5400, col: 41, offset: 165067},
+											pos:  position{line: 5401, col: 41, offset: 165131},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5400, col: 57, offset: 165083},
+											pos: position{line: 5401, col: 57, offset: 165147},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5400, col: 57, offset: 165083},
+												pos:  position{line: 5401, col: 57, offset: 165147},
 												name: "SPACE",
 											},
 										},
@@ -13710,10 +13711,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5400, col: 66, offset: 165092},
+							pos:   position{line: 5401, col: 66, offset: 165156},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5400, col: 76, offset: 165102},
+								pos:  position{line: 5401, col: 76, offset: 165166},
 								name: "Subsearch",
 							},
 						},
@@ -13723,45 +13724,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5442, col: 1, offset: 166639},
+			pos:  position{line: 5443, col: 1, offset: 166703},
 			expr: &actionExpr{
-				pos: position{line: 5442, col: 17, offset: 166655},
+				pos: position{line: 5443, col: 17, offset: 166719},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5442, col: 17, offset: 166655},
-					exprs: []any{
+					pos: position{line: 5443, col: 17, offset: 166719},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5442, col: 17, offset: 166655},
+							pos:  position{line: 5443, col: 17, offset: 166719},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5442, col: 23, offset: 166661},
+							pos:   position{line: 5443, col: 23, offset: 166725},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5442, col: 31, offset: 166669},
-								alternatives: []any{
+								pos: position{line: 5443, col: 31, offset: 166733},
+								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 31, offset: 166669},
+										pos:  position{line: 5443, col: 31, offset: 166733},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 54, offset: 166692},
+										pos:  position{line: 5443, col: 54, offset: 166756},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 74, offset: 166712},
+										pos:  position{line: 5443, col: 74, offset: 166776},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 91, offset: 166729},
+										pos:  position{line: 5443, col: 91, offset: 166793},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 115, offset: 166753},
+										pos:  position{line: 5443, col: 115, offset: 166817},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5442, col: 135, offset: 166773},
+										pos:  position{line: 5443, col: 135, offset: 166837},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -13773,51 +13774,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5446, col: 1, offset: 166828},
+			pos:  position{line: 5447, col: 1, offset: 166892},
 			expr: &actionExpr{
-				pos: position{line: 5446, col: 25, offset: 166852},
+				pos: position{line: 5447, col: 25, offset: 166916},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5446, col: 26, offset: 166853},
-					exprs: []any{
+					pos: position{line: 5447, col: 26, offset: 166917},
+					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 5446, col: 26, offset: 166853},
+							pos:   position{line: 5447, col: 26, offset: 166917},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5446, col: 33, offset: 166860},
-								alternatives: []any{
+								pos: position{line: 5447, col: 33, offset: 166924},
+								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 5446, col: 33, offset: 166860},
+										pos:        position{line: 5447, col: 33, offset: 166924},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5446, col: 42, offset: 166869},
+										pos:        position{line: 5447, col: 42, offset: 166933},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5446, col: 51, offset: 166878},
+										pos:        position{line: 5447, col: 51, offset: 166942},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5446, col: 60, offset: 166887},
+										pos:        position{line: 5447, col: 60, offset: 166951},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5446, col: 68, offset: 166895},
+										pos:        position{line: 5447, col: 68, offset: 166959},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5446, col: 76, offset: 166903},
+										pos:        position{line: 5447, col: 76, offset: 166967},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -13826,19 +13827,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5446, col: 84, offset: 166911},
+							pos:  position{line: 5447, col: 84, offset: 166975},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5446, col: 92, offset: 166919},
+							pos:   position{line: 5447, col: 92, offset: 166983},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5446, col: 105, offset: 166932},
+								pos:  position{line: 5447, col: 105, offset: 166996},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5446, col: 116, offset: 166943},
+							pos:  position{line: 5447, col: 116, offset: 167007},
 							name: "R_PAREN",
 						},
 					},
@@ -13847,15 +13848,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5472, col: 1, offset: 167701},
+			pos:  position{line: 5473, col: 1, offset: 167765},
 			expr: &actionExpr{
-				pos: position{line: 5472, col: 30, offset: 167730},
+				pos: position{line: 5473, col: 30, offset: 167794},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5472, col: 30, offset: 167730},
+					pos:   position{line: 5473, col: 30, offset: 167794},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5472, col: 43, offset: 167743},
+						pos:  position{line: 5473, col: 43, offset: 167807},
 						name: "StringExpr",
 					},
 				},
@@ -13863,61 +13864,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5497, col: 1, offset: 168451},
+			pos:  position{line: 5498, col: 1, offset: 168515},
 			expr: &actionExpr{
-				pos: position{line: 5497, col: 22, offset: 168472},
+				pos: position{line: 5498, col: 22, offset: 168536},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5497, col: 22, offset: 168472},
-					exprs: []any{
+					pos: position{line: 5498, col: 22, offset: 168536},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5497, col: 22, offset: 168472},
+							pos:        position{line: 5498, col: 22, offset: 168536},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5497, col: 37, offset: 168487},
+							pos:  position{line: 5498, col: 37, offset: 168551},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5497, col: 43, offset: 168493},
+							pos:   position{line: 5498, col: 43, offset: 168557},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5497, col: 50, offset: 168500},
-								alternatives: []any{
+								pos: position{line: 5498, col: 50, offset: 168564},
+								alternatives: []interface{}{
 									&litMatcher{
-										pos:        position{line: 5497, col: 50, offset: 168500},
+										pos:        position{line: 5498, col: 50, offset: 168564},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5497, col: 59, offset: 168509},
+										pos:        position{line: 5498, col: 59, offset: 168573},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5497, col: 68, offset: 168518},
+										pos:        position{line: 5498, col: 68, offset: 168582},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5497, col: 77, offset: 168527},
+										pos:        position{line: 5498, col: 77, offset: 168591},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5497, col: 85, offset: 168535},
+										pos:        position{line: 5498, col: 85, offset: 168599},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5497, col: 93, offset: 168543},
+										pos:        position{line: 5498, col: 93, offset: 168607},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -13931,28 +13932,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5510, col: 1, offset: 168872},
+			pos:  position{line: 5511, col: 1, offset: 168936},
 			expr: &actionExpr{
-				pos: position{line: 5510, col: 19, offset: 168890},
+				pos: position{line: 5511, col: 19, offset: 168954},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5510, col: 19, offset: 168890},
-					exprs: []any{
+					pos: position{line: 5511, col: 19, offset: 168954},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5510, col: 19, offset: 168890},
+							pos:        position{line: 5511, col: 19, offset: 168954},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5510, col: 31, offset: 168902},
+							pos:  position{line: 5511, col: 31, offset: 168966},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5510, col: 37, offset: 168908},
+							pos:   position{line: 5511, col: 37, offset: 168972},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5510, col: 45, offset: 168916},
+								pos:  position{line: 5511, col: 45, offset: 168980},
 								name: "Boolean",
 							},
 						},
@@ -13962,28 +13963,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5517, col: 1, offset: 169039},
+			pos:  position{line: 5518, col: 1, offset: 169103},
 			expr: &actionExpr{
-				pos: position{line: 5517, col: 26, offset: 169064},
+				pos: position{line: 5518, col: 26, offset: 169128},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5517, col: 26, offset: 169064},
-					exprs: []any{
+					pos: position{line: 5518, col: 26, offset: 169128},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5517, col: 26, offset: 169064},
+							pos:        position{line: 5518, col: 26, offset: 169128},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5517, col: 45, offset: 169083},
+							pos:  position{line: 5518, col: 45, offset: 169147},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5517, col: 51, offset: 169089},
+							pos:   position{line: 5518, col: 51, offset: 169153},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5517, col: 59, offset: 169097},
+								pos:  position{line: 5518, col: 59, offset: 169161},
 								name: "Boolean",
 							},
 						},
@@ -13993,28 +13994,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5524, col: 1, offset: 169227},
+			pos:  position{line: 5525, col: 1, offset: 169291},
 			expr: &actionExpr{
-				pos: position{line: 5524, col: 22, offset: 169248},
+				pos: position{line: 5525, col: 22, offset: 169312},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5524, col: 22, offset: 169248},
-					exprs: []any{
+					pos: position{line: 5525, col: 22, offset: 169312},
+					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 5524, col: 22, offset: 169248},
+							pos:        position{line: 5525, col: 22, offset: 169312},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5524, col: 37, offset: 169263},
+							pos:  position{line: 5525, col: 37, offset: 169327},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5524, col: 43, offset: 169269},
+							pos:   position{line: 5525, col: 43, offset: 169333},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5524, col: 50, offset: 169276},
+								pos:  position{line: 5525, col: 50, offset: 169340},
 								name: "String",
 							},
 						},
@@ -14024,28 +14025,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5531, col: 1, offset: 169402},
+			pos:  position{line: 5532, col: 1, offset: 169466},
 			expr: &actionExpr{
-				pos: position{line: 5531, col: 16, offset: 169417},
+				pos: position{line: 5532, col: 16, offset: 169481},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5531, col: 16, offset: 169417},
-					exprs: []any{
+					pos: position{line: 5532, col: 16, offset: 169481},
+					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 5531, col: 16, offset: 169417},
+							pos:  position{line: 5532, col: 16, offset: 169481},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5531, col: 21, offset: 169422},
+							pos:  position{line: 5532, col: 21, offset: 169486},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5531, col: 32, offset: 169433},
+							pos:   position{line: 5532, col: 32, offset: 169497},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5531, col: 40, offset: 169441},
+								pos: position{line: 5532, col: 40, offset: 169505},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5531, col: 41, offset: 169442},
+									pos:  position{line: 5532, col: 41, offset: 169506},
 									name: "ToJsonOption",
 								},
 							},
@@ -14056,132 +14057,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5584, col: 1, offset: 171524},
+			pos:  position{line: 5585, col: 1, offset: 171588},
 			expr: &choiceExpr{
-				pos: position{line: 5584, col: 12, offset: 171535},
-				alternatives: []any{
+				pos: position{line: 5585, col: 12, offset: 171599},
+				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 12, offset: 171535},
+						pos:  position{line: 5585, col: 12, offset: 171599},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 24, offset: 171547},
+						pos:  position{line: 5585, col: 24, offset: 171611},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 36, offset: 171559},
+						pos:  position{line: 5585, col: 36, offset: 171623},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 49, offset: 171572},
+						pos:  position{line: 5585, col: 49, offset: 171636},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 61, offset: 171584},
+						pos:  position{line: 5585, col: 61, offset: 171648},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 81, offset: 171604},
+						pos:  position{line: 5585, col: 81, offset: 171668},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 92, offset: 171615},
+						pos:  position{line: 5585, col: 92, offset: 171679},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 112, offset: 171635},
+						pos:  position{line: 5585, col: 112, offset: 171699},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 123, offset: 171646},
+						pos:  position{line: 5585, col: 123, offset: 171710},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 134, offset: 171657},
+						pos:  position{line: 5585, col: 134, offset: 171721},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 144, offset: 171667},
+						pos:  position{line: 5585, col: 144, offset: 171731},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 154, offset: 171677},
+						pos:  position{line: 5585, col: 154, offset: 171741},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 165, offset: 171688},
+						pos:  position{line: 5585, col: 165, offset: 171752},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 178, offset: 171701},
+						pos:  position{line: 5585, col: 178, offset: 171765},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 194, offset: 171717},
+						pos:  position{line: 5585, col: 194, offset: 171781},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 212, offset: 171735},
+						pos:  position{line: 5585, col: 212, offset: 171799},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 224, offset: 171747},
+						pos:  position{line: 5585, col: 224, offset: 171811},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 235, offset: 171758},
+						pos:  position{line: 5585, col: 235, offset: 171822},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 248, offset: 171771},
+						pos:  position{line: 5585, col: 248, offset: 171835},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 260, offset: 171783},
+						pos:  position{line: 5585, col: 260, offset: 171847},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 273, offset: 171796},
+						pos:  position{line: 5585, col: 273, offset: 171860},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 288, offset: 171811},
+						pos:  position{line: 5585, col: 288, offset: 171875},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 301, offset: 171824},
+						pos:  position{line: 5585, col: 301, offset: 171888},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 318, offset: 171841},
+						pos:  position{line: 5585, col: 318, offset: 171905},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 328, offset: 171851},
+						pos:  position{line: 5585, col: 328, offset: 171915},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 346, offset: 171869},
+						pos:  position{line: 5585, col: 346, offset: 171933},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 361, offset: 171884},
+						pos:  position{line: 5585, col: 361, offset: 171948},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 376, offset: 171899},
+						pos:  position{line: 5585, col: 376, offset: 171963},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 391, offset: 171914},
+						pos:  position{line: 5585, col: 391, offset: 171978},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 409, offset: 171932},
+						pos:  position{line: 5585, col: 409, offset: 171996},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5584, col: 422, offset: 171945},
+						pos:  position{line: 5585, col: 422, offset: 172009},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14189,18 +14190,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5585, col: 1, offset: 171957},
+			pos:  position{line: 5586, col: 1, offset: 172021},
 			expr: &seqExpr{
-				pos: position{line: 5585, col: 15, offset: 171971},
-				exprs: []any{
+				pos: position{line: 5586, col: 15, offset: 172035},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5585, col: 15, offset: 171971},
+						pos:        position{line: 5586, col: 15, offset: 172035},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5585, col: 24, offset: 171980},
+						pos:  position{line: 5586, col: 24, offset: 172044},
 						name: "SPACE",
 					},
 				},
@@ -14208,18 +14209,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5586, col: 1, offset: 171986},
+			pos:  position{line: 5587, col: 1, offset: 172050},
 			expr: &seqExpr{
-				pos: position{line: 5586, col: 14, offset: 171999},
-				exprs: []any{
+				pos: position{line: 5587, col: 14, offset: 172063},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5586, col: 14, offset: 171999},
+						pos:        position{line: 5587, col: 14, offset: 172063},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5586, col: 22, offset: 172007},
+						pos:  position{line: 5587, col: 22, offset: 172071},
 						name: "SPACE",
 					},
 				},
@@ -14227,18 +14228,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5587, col: 1, offset: 172013},
+			pos:  position{line: 5588, col: 1, offset: 172077},
 			expr: &seqExpr{
-				pos: position{line: 5587, col: 14, offset: 172026},
-				exprs: []any{
+				pos: position{line: 5588, col: 14, offset: 172090},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5587, col: 14, offset: 172026},
+						pos:        position{line: 5588, col: 14, offset: 172090},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5587, col: 22, offset: 172034},
+						pos:  position{line: 5588, col: 22, offset: 172098},
 						name: "SPACE",
 					},
 				},
@@ -14246,18 +14247,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5588, col: 1, offset: 172040},
+			pos:  position{line: 5589, col: 1, offset: 172104},
 			expr: &seqExpr{
-				pos: position{line: 5588, col: 20, offset: 172059},
-				exprs: []any{
+				pos: position{line: 5589, col: 20, offset: 172123},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5588, col: 20, offset: 172059},
+						pos:        position{line: 5589, col: 20, offset: 172123},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5588, col: 34, offset: 172073},
+						pos:  position{line: 5589, col: 34, offset: 172137},
 						name: "SPACE",
 					},
 				},
@@ -14265,18 +14266,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5589, col: 1, offset: 172079},
+			pos:  position{line: 5590, col: 1, offset: 172143},
 			expr: &seqExpr{
-				pos: position{line: 5589, col: 15, offset: 172093},
-				exprs: []any{
+				pos: position{line: 5590, col: 15, offset: 172157},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5589, col: 15, offset: 172093},
+						pos:        position{line: 5590, col: 15, offset: 172157},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5589, col: 24, offset: 172102},
+						pos:  position{line: 5590, col: 24, offset: 172166},
 						name: "SPACE",
 					},
 				},
@@ -14284,18 +14285,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5590, col: 1, offset: 172108},
+			pos:  position{line: 5591, col: 1, offset: 172172},
 			expr: &seqExpr{
-				pos: position{line: 5590, col: 14, offset: 172121},
-				exprs: []any{
+				pos: position{line: 5591, col: 14, offset: 172185},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5590, col: 14, offset: 172121},
+						pos:        position{line: 5591, col: 14, offset: 172185},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5590, col: 22, offset: 172129},
+						pos:  position{line: 5591, col: 22, offset: 172193},
 						name: "SPACE",
 					},
 				},
@@ -14303,9 +14304,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5591, col: 1, offset: 172135},
+			pos:  position{line: 5592, col: 1, offset: 172199},
 			expr: &litMatcher{
-				pos:        position{line: 5591, col: 22, offset: 172156},
+				pos:        position{line: 5592, col: 22, offset: 172220},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14313,16 +14314,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5592, col: 1, offset: 172163},
+			pos:  position{line: 5593, col: 1, offset: 172227},
 			expr: &seqExpr{
-				pos: position{line: 5592, col: 13, offset: 172175},
-				exprs: []any{
+				pos: position{line: 5593, col: 13, offset: 172239},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5592, col: 13, offset: 172175},
+						pos:  position{line: 5593, col: 13, offset: 172239},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5592, col: 31, offset: 172193},
+						pos:  position{line: 5593, col: 31, offset: 172257},
 						name: "SPACE",
 					},
 				},
@@ -14330,9 +14331,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5593, col: 1, offset: 172199},
+			pos:  position{line: 5594, col: 1, offset: 172263},
 			expr: &litMatcher{
-				pos:        position{line: 5593, col: 22, offset: 172220},
+				pos:        position{line: 5594, col: 22, offset: 172284},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14340,16 +14341,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5594, col: 1, offset: 172227},
+			pos:  position{line: 5595, col: 1, offset: 172291},
 			expr: &seqExpr{
-				pos: position{line: 5594, col: 13, offset: 172239},
-				exprs: []any{
+				pos: position{line: 5595, col: 13, offset: 172303},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5594, col: 13, offset: 172239},
+						pos:  position{line: 5595, col: 13, offset: 172303},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5594, col: 31, offset: 172257},
+						pos:  position{line: 5595, col: 31, offset: 172321},
 						name: "SPACE",
 					},
 				},
@@ -14357,18 +14358,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5595, col: 1, offset: 172263},
+			pos:  position{line: 5596, col: 1, offset: 172327},
 			expr: &seqExpr{
-				pos: position{line: 5595, col: 13, offset: 172275},
-				exprs: []any{
+				pos: position{line: 5596, col: 13, offset: 172339},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5595, col: 13, offset: 172275},
+						pos:        position{line: 5596, col: 13, offset: 172339},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5595, col: 20, offset: 172282},
+						pos:  position{line: 5596, col: 20, offset: 172346},
 						name: "SPACE",
 					},
 				},
@@ -14376,18 +14377,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5596, col: 1, offset: 172288},
+			pos:  position{line: 5597, col: 1, offset: 172352},
 			expr: &seqExpr{
-				pos: position{line: 5596, col: 12, offset: 172299},
-				exprs: []any{
+				pos: position{line: 5597, col: 12, offset: 172363},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5596, col: 12, offset: 172299},
+						pos:        position{line: 5597, col: 12, offset: 172363},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5596, col: 18, offset: 172305},
+						pos:  position{line: 5597, col: 18, offset: 172369},
 						name: "SPACE",
 					},
 				},
@@ -14395,18 +14396,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5597, col: 1, offset: 172311},
+			pos:  position{line: 5598, col: 1, offset: 172375},
 			expr: &seqExpr{
-				pos: position{line: 5597, col: 13, offset: 172323},
-				exprs: []any{
+				pos: position{line: 5598, col: 13, offset: 172387},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5597, col: 13, offset: 172323},
+						pos:        position{line: 5598, col: 13, offset: 172387},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5597, col: 20, offset: 172330},
+						pos:  position{line: 5598, col: 20, offset: 172394},
 						name: "SPACE",
 					},
 				},
@@ -14414,9 +14415,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5598, col: 1, offset: 172336},
+			pos:  position{line: 5599, col: 1, offset: 172400},
 			expr: &litMatcher{
-				pos:        position{line: 5598, col: 12, offset: 172347},
+				pos:        position{line: 5599, col: 12, offset: 172411},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -14424,9 +14425,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5599, col: 1, offset: 172353},
+			pos:  position{line: 5600, col: 1, offset: 172417},
 			expr: &litMatcher{
-				pos:        position{line: 5599, col: 13, offset: 172365},
+				pos:        position{line: 5600, col: 13, offset: 172429},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -14434,18 +14435,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5600, col: 1, offset: 172372},
+			pos:  position{line: 5601, col: 1, offset: 172436},
 			expr: &seqExpr{
-				pos: position{line: 5600, col: 15, offset: 172386},
-				exprs: []any{
+				pos: position{line: 5601, col: 15, offset: 172450},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5600, col: 15, offset: 172386},
+						pos:        position{line: 5601, col: 15, offset: 172450},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5600, col: 24, offset: 172395},
+						pos:  position{line: 5601, col: 24, offset: 172459},
 						name: "SPACE",
 					},
 				},
@@ -14453,18 +14454,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5601, col: 1, offset: 172401},
+			pos:  position{line: 5602, col: 1, offset: 172465},
 			expr: &seqExpr{
-				pos: position{line: 5601, col: 18, offset: 172418},
-				exprs: []any{
+				pos: position{line: 5602, col: 18, offset: 172482},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5601, col: 18, offset: 172418},
+						pos:        position{line: 5602, col: 18, offset: 172482},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5601, col: 30, offset: 172430},
+						pos:  position{line: 5602, col: 30, offset: 172494},
 						name: "SPACE",
 					},
 				},
@@ -14472,18 +14473,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5602, col: 1, offset: 172436},
+			pos:  position{line: 5603, col: 1, offset: 172500},
 			expr: &seqExpr{
-				pos: position{line: 5602, col: 12, offset: 172447},
-				exprs: []any{
+				pos: position{line: 5603, col: 12, offset: 172511},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5602, col: 12, offset: 172447},
+						pos:        position{line: 5603, col: 12, offset: 172511},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5602, col: 18, offset: 172453},
+						pos:  position{line: 5603, col: 18, offset: 172517},
 						name: "SPACE",
 					},
 				},
@@ -14491,9 +14492,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5603, col: 1, offset: 172459},
+			pos:  position{line: 5604, col: 1, offset: 172523},
 			expr: &litMatcher{
-				pos:        position{line: 5603, col: 13, offset: 172471},
+				pos:        position{line: 5604, col: 13, offset: 172535},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -14501,18 +14502,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5604, col: 1, offset: 172478},
+			pos:  position{line: 5605, col: 1, offset: 172542},
 			expr: &seqExpr{
-				pos: position{line: 5604, col: 20, offset: 172497},
-				exprs: []any{
+				pos: position{line: 5605, col: 20, offset: 172561},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5604, col: 20, offset: 172497},
+						pos:        position{line: 5605, col: 20, offset: 172561},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5604, col: 34, offset: 172511},
+						pos:  position{line: 5605, col: 34, offset: 172575},
 						name: "SPACE",
 					},
 				},
@@ -14520,9 +14521,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5605, col: 1, offset: 172517},
+			pos:  position{line: 5606, col: 1, offset: 172581},
 			expr: &litMatcher{
-				pos:        position{line: 5605, col: 14, offset: 172530},
+				pos:        position{line: 5606, col: 14, offset: 172594},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -14530,22 +14531,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5606, col: 1, offset: 172538},
+			pos:  position{line: 5607, col: 1, offset: 172602},
 			expr: &seqExpr{
-				pos: position{line: 5606, col: 21, offset: 172558},
-				exprs: []any{
+				pos: position{line: 5607, col: 21, offset: 172622},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5606, col: 21, offset: 172558},
+						pos:  position{line: 5607, col: 21, offset: 172622},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5606, col: 27, offset: 172564},
+						pos:        position{line: 5607, col: 27, offset: 172628},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5606, col: 36, offset: 172573},
+						pos:  position{line: 5607, col: 36, offset: 172637},
 						name: "SPACE",
 					},
 				},
@@ -14553,9 +14554,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5607, col: 1, offset: 172579},
+			pos:  position{line: 5608, col: 1, offset: 172643},
 			expr: &litMatcher{
-				pos:        position{line: 5607, col: 15, offset: 172593},
+				pos:        position{line: 5608, col: 15, offset: 172657},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14563,9 +14564,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5608, col: 1, offset: 172602},
+			pos:  position{line: 5609, col: 1, offset: 172666},
 			expr: &litMatcher{
-				pos:        position{line: 5608, col: 14, offset: 172615},
+				pos:        position{line: 5609, col: 14, offset: 172679},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14573,9 +14574,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5609, col: 1, offset: 172623},
+			pos:  position{line: 5610, col: 1, offset: 172687},
 			expr: &litMatcher{
-				pos:        position{line: 5609, col: 15, offset: 172637},
+				pos:        position{line: 5610, col: 15, offset: 172701},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14583,9 +14584,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5610, col: 1, offset: 172646},
+			pos:  position{line: 5611, col: 1, offset: 172710},
 			expr: &litMatcher{
-				pos:        position{line: 5610, col: 17, offset: 172662},
+				pos:        position{line: 5611, col: 17, offset: 172726},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14593,9 +14594,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5611, col: 1, offset: 172673},
+			pos:  position{line: 5612, col: 1, offset: 172737},
 			expr: &litMatcher{
-				pos:        position{line: 5611, col: 15, offset: 172687},
+				pos:        position{line: 5612, col: 15, offset: 172751},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14603,9 +14604,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5612, col: 1, offset: 172696},
+			pos:  position{line: 5613, col: 1, offset: 172760},
 			expr: &litMatcher{
-				pos:        position{line: 5612, col: 19, offset: 172714},
+				pos:        position{line: 5613, col: 19, offset: 172778},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14613,9 +14614,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5613, col: 1, offset: 172727},
+			pos:  position{line: 5614, col: 1, offset: 172791},
 			expr: &litMatcher{
-				pos:        position{line: 5613, col: 17, offset: 172743},
+				pos:        position{line: 5614, col: 17, offset: 172807},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14623,9 +14624,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5614, col: 1, offset: 172754},
+			pos:  position{line: 5615, col: 1, offset: 172818},
 			expr: &litMatcher{
-				pos:        position{line: 5614, col: 17, offset: 172770},
+				pos:        position{line: 5615, col: 17, offset: 172834},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14633,18 +14634,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5615, col: 1, offset: 172781},
+			pos:  position{line: 5616, col: 1, offset: 172845},
 			expr: &seqExpr{
-				pos: position{line: 5615, col: 20, offset: 172800},
-				exprs: []any{
+				pos: position{line: 5616, col: 20, offset: 172864},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5615, col: 20, offset: 172800},
+						pos:        position{line: 5616, col: 20, offset: 172864},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5615, col: 34, offset: 172814},
+						pos:  position{line: 5616, col: 34, offset: 172878},
 						name: "SPACE",
 					},
 				},
@@ -14652,28 +14653,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5616, col: 1, offset: 172820},
+			pos:  position{line: 5617, col: 1, offset: 172884},
 			expr: &seqExpr{
-				pos: position{line: 5616, col: 16, offset: 172835},
-				exprs: []any{
+				pos: position{line: 5617, col: 16, offset: 172899},
+				exprs: []interface{}{
 					&zeroOrOneExpr{
-						pos: position{line: 5616, col: 16, offset: 172835},
+						pos: position{line: 5617, col: 16, offset: 172899},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5616, col: 16, offset: 172835},
+							pos:  position{line: 5617, col: 16, offset: 172899},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5616, col: 24, offset: 172843},
-						alternatives: []any{
+						pos: position{line: 5617, col: 24, offset: 172907},
+						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 5616, col: 24, offset: 172843},
+								pos:        position{line: 5617, col: 24, offset: 172907},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5616, col: 30, offset: 172849},
+								pos:        position{line: 5617, col: 30, offset: 172913},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14681,9 +14682,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5616, col: 35, offset: 172854},
+						pos: position{line: 5617, col: 35, offset: 172918},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5616, col: 35, offset: 172854},
+							pos:  position{line: 5617, col: 35, offset: 172918},
 							name: "SPACE",
 						},
 					},
@@ -14692,9 +14693,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5617, col: 1, offset: 172861},
+			pos:  position{line: 5618, col: 1, offset: 172925},
 			expr: &litMatcher{
-				pos:        position{line: 5617, col: 17, offset: 172877},
+				pos:        position{line: 5618, col: 17, offset: 172941},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14702,18 +14703,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5618, col: 1, offset: 172888},
+			pos:  position{line: 5619, col: 1, offset: 172952},
 			expr: &seqExpr{
-				pos: position{line: 5618, col: 15, offset: 172902},
-				exprs: []any{
+				pos: position{line: 5619, col: 15, offset: 172966},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5618, col: 15, offset: 172902},
+						pos:        position{line: 5619, col: 15, offset: 172966},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5618, col: 24, offset: 172911},
+						pos:  position{line: 5619, col: 24, offset: 172975},
 						name: "SPACE",
 					},
 				},
@@ -14721,9 +14722,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5619, col: 1, offset: 172917},
+			pos:  position{line: 5620, col: 1, offset: 172981},
 			expr: &litMatcher{
-				pos:        position{line: 5619, col: 15, offset: 172931},
+				pos:        position{line: 5620, col: 15, offset: 172995},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -14731,115 +14732,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5622, col: 1, offset: 173044},
+			pos:  position{line: 5623, col: 1, offset: 173108},
 			expr: &choiceExpr{
-				pos: position{line: 5622, col: 16, offset: 173059},
-				alternatives: []any{
+				pos: position{line: 5623, col: 16, offset: 173123},
+				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 5622, col: 16, offset: 173059},
+						pos:        position{line: 5623, col: 16, offset: 173123},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5622, col: 47, offset: 173090},
+						pos:        position{line: 5623, col: 47, offset: 173154},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5622, col: 55, offset: 173098},
+						pos:        position{line: 5623, col: 55, offset: 173162},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 16, offset: 173121},
+						pos:        position{line: 5624, col: 16, offset: 173185},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 26, offset: 173131},
+						pos:        position{line: 5624, col: 26, offset: 173195},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 34, offset: 173139},
+						pos:        position{line: 5624, col: 34, offset: 173203},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 42, offset: 173147},
+						pos:        position{line: 5624, col: 42, offset: 173211},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 50, offset: 173155},
+						pos:        position{line: 5624, col: 50, offset: 173219},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 58, offset: 173163},
+						pos:        position{line: 5624, col: 58, offset: 173227},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5623, col: 66, offset: 173171},
+						pos:        position{line: 5624, col: 66, offset: 173235},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 16, offset: 173193},
+						pos:        position{line: 5625, col: 16, offset: 173257},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 26, offset: 173203},
+						pos:        position{line: 5625, col: 26, offset: 173267},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 34, offset: 173211},
+						pos:        position{line: 5625, col: 34, offset: 173275},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 42, offset: 173219},
+						pos:        position{line: 5625, col: 42, offset: 173283},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 50, offset: 173227},
+						pos:        position{line: 5625, col: 50, offset: 173291},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 58, offset: 173235},
+						pos:        position{line: 5625, col: 58, offset: 173299},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 66, offset: 173243},
+						pos:        position{line: 5625, col: 66, offset: 173307},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5624, col: 74, offset: 173251},
+						pos:        position{line: 5625, col: 74, offset: 173315},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -14849,25 +14850,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5625, col: 1, offset: 173257},
+			pos:  position{line: 5626, col: 1, offset: 173321},
 			expr: &choiceExpr{
-				pos: position{line: 5625, col: 16, offset: 173272},
-				alternatives: []any{
+				pos: position{line: 5626, col: 16, offset: 173336},
+				alternatives: []interface{}{
 					&charClassMatcher{
-						pos:        position{line: 5625, col: 16, offset: 173272},
+						pos:        position{line: 5626, col: 16, offset: 173336},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5625, col: 30, offset: 173286},
+						pos:        position{line: 5626, col: 30, offset: 173350},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5625, col: 36, offset: 173292},
+						pos:        position{line: 5626, col: 36, offset: 173356},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -14877,18 +14878,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5629, col: 1, offset: 173448},
+			pos:  position{line: 5630, col: 1, offset: 173512},
 			expr: &seqExpr{
-				pos: position{line: 5629, col: 8, offset: 173455},
-				exprs: []any{
+				pos: position{line: 5630, col: 8, offset: 173519},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5629, col: 8, offset: 173455},
+						pos:        position{line: 5630, col: 8, offset: 173519},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5629, col: 14, offset: 173461},
+						pos:  position{line: 5630, col: 14, offset: 173525},
 						name: "SPACE",
 					},
 				},
@@ -14896,22 +14897,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5630, col: 1, offset: 173467},
+			pos:  position{line: 5631, col: 1, offset: 173531},
 			expr: &seqExpr{
-				pos: position{line: 5630, col: 7, offset: 173473},
-				exprs: []any{
+				pos: position{line: 5631, col: 7, offset: 173537},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5630, col: 7, offset: 173473},
+						pos:  position{line: 5631, col: 7, offset: 173537},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5630, col: 13, offset: 173479},
+						pos:        position{line: 5631, col: 13, offset: 173543},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5630, col: 18, offset: 173484},
+						pos:  position{line: 5631, col: 18, offset: 173548},
 						name: "SPACE",
 					},
 				},
@@ -14919,22 +14920,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5631, col: 1, offset: 173490},
+			pos:  position{line: 5632, col: 1, offset: 173554},
 			expr: &seqExpr{
-				pos: position{line: 5631, col: 8, offset: 173497},
-				exprs: []any{
+				pos: position{line: 5632, col: 8, offset: 173561},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5631, col: 8, offset: 173497},
+						pos:  position{line: 5632, col: 8, offset: 173561},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5631, col: 14, offset: 173503},
+						pos:        position{line: 5632, col: 14, offset: 173567},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5631, col: 20, offset: 173509},
+						pos:  position{line: 5632, col: 20, offset: 173573},
 						name: "SPACE",
 					},
 				},
@@ -14942,22 +14943,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5632, col: 1, offset: 173515},
+			pos:  position{line: 5633, col: 1, offset: 173579},
 			expr: &seqExpr{
-				pos: position{line: 5632, col: 9, offset: 173523},
-				exprs: []any{
+				pos: position{line: 5633, col: 9, offset: 173587},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5632, col: 9, offset: 173523},
+						pos:  position{line: 5633, col: 9, offset: 173587},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5632, col: 24, offset: 173538},
+						pos:        position{line: 5633, col: 24, offset: 173602},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5632, col: 28, offset: 173542},
+						pos:  position{line: 5633, col: 28, offset: 173606},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -14965,22 +14966,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5633, col: 1, offset: 173557},
+			pos:  position{line: 5634, col: 1, offset: 173621},
 			expr: &seqExpr{
-				pos: position{line: 5633, col: 7, offset: 173563},
-				exprs: []any{
+				pos: position{line: 5634, col: 7, offset: 173627},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5633, col: 7, offset: 173563},
+						pos:  position{line: 5634, col: 7, offset: 173627},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5633, col: 13, offset: 173569},
+						pos:        position{line: 5634, col: 13, offset: 173633},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5633, col: 19, offset: 173575},
+						pos:  position{line: 5634, col: 19, offset: 173639},
 						name: "SPACE",
 					},
 				},
@@ -14988,22 +14989,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5634, col: 1, offset: 173601},
+			pos:  position{line: 5635, col: 1, offset: 173665},
 			expr: &seqExpr{
-				pos: position{line: 5634, col: 7, offset: 173607},
-				exprs: []any{
+				pos: position{line: 5635, col: 7, offset: 173671},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5634, col: 7, offset: 173607},
+						pos:  position{line: 5635, col: 7, offset: 173671},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5634, col: 13, offset: 173613},
+						pos:        position{line: 5635, col: 13, offset: 173677},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5634, col: 19, offset: 173619},
+						pos:  position{line: 5635, col: 19, offset: 173683},
 						name: "SPACE",
 					},
 				},
@@ -15011,22 +15012,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5636, col: 1, offset: 173646},
+			pos:  position{line: 5637, col: 1, offset: 173710},
 			expr: &seqExpr{
-				pos: position{line: 5636, col: 10, offset: 173655},
-				exprs: []any{
+				pos: position{line: 5637, col: 10, offset: 173719},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5636, col: 10, offset: 173655},
+						pos:  position{line: 5637, col: 10, offset: 173719},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5636, col: 25, offset: 173670},
+						pos:        position{line: 5637, col: 25, offset: 173734},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5636, col: 29, offset: 173674},
+						pos:  position{line: 5637, col: 29, offset: 173738},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15034,22 +15035,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5637, col: 1, offset: 173689},
+			pos:  position{line: 5638, col: 1, offset: 173753},
 			expr: &seqExpr{
-				pos: position{line: 5637, col: 10, offset: 173698},
-				exprs: []any{
+				pos: position{line: 5638, col: 10, offset: 173762},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5637, col: 10, offset: 173698},
+						pos:  position{line: 5638, col: 10, offset: 173762},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5637, col: 25, offset: 173713},
+						pos:        position{line: 5638, col: 25, offset: 173777},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5637, col: 29, offset: 173717},
+						pos:  position{line: 5638, col: 29, offset: 173781},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15057,9 +15058,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5638, col: 1, offset: 173732},
+			pos:  position{line: 5639, col: 1, offset: 173796},
 			expr: &litMatcher{
-				pos:        position{line: 5638, col: 10, offset: 173741},
+				pos:        position{line: 5639, col: 10, offset: 173805},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15067,18 +15068,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5639, col: 1, offset: 173745},
+			pos:  position{line: 5640, col: 1, offset: 173809},
 			expr: &seqExpr{
-				pos: position{line: 5639, col: 12, offset: 173756},
-				exprs: []any{
+				pos: position{line: 5640, col: 12, offset: 173820},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5639, col: 12, offset: 173756},
+						pos:        position{line: 5640, col: 12, offset: 173820},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5639, col: 16, offset: 173760},
+						pos:  position{line: 5640, col: 16, offset: 173824},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15086,16 +15087,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5640, col: 1, offset: 173775},
+			pos:  position{line: 5641, col: 1, offset: 173839},
 			expr: &seqExpr{
-				pos: position{line: 5640, col: 12, offset: 173786},
-				exprs: []any{
+				pos: position{line: 5641, col: 12, offset: 173850},
+				exprs: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5640, col: 12, offset: 173786},
+						pos:  position{line: 5641, col: 12, offset: 173850},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5640, col: 27, offset: 173801},
+						pos:        position{line: 5641, col: 27, offset: 173865},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15105,40 +15106,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5642, col: 1, offset: 173806},
+			pos:  position{line: 5643, col: 1, offset: 173870},
 			expr: &notExpr{
-				pos: position{line: 5642, col: 8, offset: 173813},
+				pos: position{line: 5643, col: 8, offset: 173877},
 				expr: &anyMatcher{
-					line: 5642, col: 9, offset: 173814,
+					line: 5643, col: 9, offset: 173878,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5643, col: 1, offset: 173816},
+			pos:  position{line: 5644, col: 1, offset: 173880},
 			expr: &choiceExpr{
-				pos: position{line: 5643, col: 15, offset: 173830},
-				alternatives: []any{
+				pos: position{line: 5644, col: 15, offset: 173894},
+				alternatives: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5643, col: 15, offset: 173830},
+						pos:        position{line: 5644, col: 15, offset: 173894},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5643, col: 21, offset: 173836},
+						pos:        position{line: 5644, col: 21, offset: 173900},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5643, col: 28, offset: 173843},
+						pos:        position{line: 5644, col: 28, offset: 173907},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5643, col: 35, offset: 173850},
+						pos:        position{line: 5644, col: 35, offset: 173914},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15148,37 +15149,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5644, col: 1, offset: 173855},
+			pos:  position{line: 5645, col: 1, offset: 173919},
 			expr: &choiceExpr{
-				pos: position{line: 5644, col: 10, offset: 173864},
-				alternatives: []any{
+				pos: position{line: 5645, col: 10, offset: 173928},
+				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 5644, col: 11, offset: 173865},
-						exprs: []any{
+						pos: position{line: 5645, col: 11, offset: 173929},
+						exprs: []interface{}{
 							&zeroOrOneExpr{
-								pos: position{line: 5644, col: 11, offset: 173865},
+								pos: position{line: 5645, col: 11, offset: 173929},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5644, col: 11, offset: 173865},
+									pos:  position{line: 5645, col: 11, offset: 173929},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5644, col: 23, offset: 173877},
+								pos:  position{line: 5645, col: 23, offset: 173941},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5644, col: 31, offset: 173885},
+								pos: position{line: 5645, col: 31, offset: 173949},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5644, col: 31, offset: 173885},
+									pos:  position{line: 5645, col: 31, offset: 173949},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5644, col: 46, offset: 173900},
+						pos: position{line: 5645, col: 46, offset: 173964},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5644, col: 46, offset: 173900},
+							pos:  position{line: 5645, col: 46, offset: 173964},
 							name: "WHITESPACE",
 						},
 					},
@@ -15187,38 +15188,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5645, col: 1, offset: 173912},
+			pos:  position{line: 5646, col: 1, offset: 173976},
 			expr: &seqExpr{
-				pos: position{line: 5645, col: 12, offset: 173923},
-				exprs: []any{
+				pos: position{line: 5646, col: 12, offset: 173987},
+				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 5645, col: 12, offset: 173923},
+						pos:        position{line: 5646, col: 12, offset: 173987},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5645, col: 18, offset: 173929},
+						pos: position{line: 5646, col: 18, offset: 173993},
 						expr: &seqExpr{
-							pos: position{line: 5645, col: 19, offset: 173930},
-							exprs: []any{
+							pos: position{line: 5646, col: 19, offset: 173994},
+							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 5645, col: 19, offset: 173930},
+									pos: position{line: 5646, col: 19, offset: 173994},
 									expr: &litMatcher{
-										pos:        position{line: 5645, col: 21, offset: 173932},
+										pos:        position{line: 5646, col: 21, offset: 173996},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5645, col: 28, offset: 173939,
+									line: 5646, col: 28, offset: 174003,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5645, col: 32, offset: 173943},
+						pos:        position{line: 5646, col: 32, offset: 174007},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15228,16 +15229,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5646, col: 1, offset: 173949},
+			pos:  position{line: 5647, col: 1, offset: 174013},
 			expr: &choiceExpr{
-				pos: position{line: 5646, col: 20, offset: 173968},
-				alternatives: []any{
+				pos: position{line: 5647, col: 20, offset: 174032},
+				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5646, col: 20, offset: 173968},
+						pos:  position{line: 5647, col: 20, offset: 174032},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5646, col: 28, offset: 173976},
+						pos:        position{line: 5647, col: 28, offset: 174040},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15247,16 +15248,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5647, col: 1, offset: 173979},
+			pos:  position{line: 5648, col: 1, offset: 174043},
 			expr: &choiceExpr{
-				pos: position{line: 5647, col: 19, offset: 173997},
-				alternatives: []any{
+				pos: position{line: 5648, col: 19, offset: 174061},
+				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 5647, col: 19, offset: 173997},
+						pos:  position{line: 5648, col: 19, offset: 174061},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5647, col: 27, offset: 174005},
+						pos:  position{line: 5648, col: 27, offset: 174069},
 						name: "SPACE",
 					},
 				},
@@ -15265,7 +15266,7 @@ var g = &grammar{
 	},
 }
 
-func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBlocks any) (any, error) {
+func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBlocks interface{}) (interface{}, error) {
 	var q ast.QueryStruct
 	q.SearchFilter = initialSearch.(*ast.Node)
 
@@ -15332,13 +15333,13 @@ func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBloc
 	return q, nil
 }
 
-func (p *parser) callonStart2() (any, error) {
+func (p *parser) callonStart2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart2(stack["indexBlock"], stack["initialSearch"], stack["filterBlocks"], stack["queryAggBlocks"])
 }
 
-func (c *current) onStart20(genTimesOption, queryAggBlocks any) (any, error) {
+func (c *current) onStart20(genTimesOption, queryAggBlocks interface{}) (interface{}, error) {
 	var q ast.QueryStruct
 	q.PipeCommands = &structs.QueryAggregators{
 		PipeCommandType: structs.GenerateEventType,
@@ -15358,13 +15359,13 @@ func (c *current) onStart20(genTimesOption, queryAggBlocks any) (any, error) {
 	return q, nil
 }
 
-func (p *parser) callonStart20() (any, error) {
+func (p *parser) callonStart20() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart20(stack["genTimesOption"], stack["queryAggBlocks"])
 }
 
-func (c *current) onStart35(inputLookup, queryAggBlocks any) (any, error) {
+func (c *current) onStart35(inputLookup, queryAggBlocks interface{}) (interface{}, error) {
 	var q ast.QueryStruct
 	inpLookup := inputLookup.(*structs.QueryAggregators)
 	inpLookup.GenerateEvent.InputLookup.IsFirstCommand = true
@@ -15380,23 +15381,23 @@ func (c *current) onStart35(inputLookup, queryAggBlocks any) (any, error) {
 	return q, nil
 }
 
-func (p *parser) callonStart35() (any, error) {
+func (p *parser) callonStart35() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart35(stack["inputLookup"], stack["queryAggBlocks"])
 }
 
-func (c *current) onIndexAssign1(index, indexName any) (any, error) {
+func (c *current) onIndexAssign1(index, indexName interface{}) (interface{}, error) {
 	return removeQuotes(indexName), nil
 }
 
-func (p *parser) callonIndexAssign1() (any, error) {
+func (p *parser) callonIndexAssign1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexAssign1(stack["index"], stack["indexName"])
 }
 
-func (c *current) onIndexExpression1(first, rest any) (any, error) {
+func (c *current) onIndexExpression1(first, rest interface{}) (interface{}, error) {
 
 	if rest == nil {
 		if first.(string) == "" {
@@ -15421,36 +15422,36 @@ func (c *current) onIndexExpression1(first, rest any) (any, error) {
 	return finalIndexes, nil
 }
 
-func (p *parser) callonIndexExpression1() (any, error) {
+func (p *parser) callonIndexExpression1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexExpression1(stack["first"], stack["rest"])
 }
 
-func (c *current) onIndexBlock1(indexName any) (any, error) {
+func (c *current) onIndexBlock1(indexName interface{}) (interface{}, error) {
 	return indexName, nil
 }
 
-func (p *parser) callonIndexBlock1() (any, error) {
+func (p *parser) callonIndexBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexBlock1(stack["indexName"])
 }
 
-func (c *current) onPartialTimestamp1() (any, error) {
+func (c *current) onPartialTimestamp1() (interface{}, error) {
 	timestamp := string(c.text)
 	completeTimestamp := fmt.Sprintf("%s:00:00:00", timestamp)
 
 	return completeTimestamp, nil
 }
 
-func (p *parser) callonPartialTimestamp1() (any, error) {
+func (p *parser) callonPartialTimestamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPartialTimestamp1()
 }
 
-func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr any) (any, error) {
+func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr interface{}) (interface{}, error) {
 	timeOffset, err := strconv.ParseInt(intStr.(string), 10, 64)
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the integer: %v", err)
@@ -15468,13 +15469,13 @@ func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr any) (any, error) {
 	return finalTime.UnixMilli(), nil
 }
 
-func (p *parser) callonIntegerAsTimeToUnixEpochMs1() (any, error) {
+func (p *parser) callonIntegerAsTimeToUnixEpochMs1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIntegerAsTimeToUnixEpochMs1(stack["intStr"])
 }
 
-func (c *current) onDateTimeToUnixEpochMs1(timeStamp any) (any, error) {
+func (c *current) onDateTimeToUnixEpochMs1(timeStamp interface{}) (interface{}, error) {
 	unixEpochInMs, err := sutils.ConvertCustomDateTimeFormatToEpochMs(timeStamp.(string))
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the timestamp: %v", err)
@@ -15482,23 +15483,23 @@ func (c *current) onDateTimeToUnixEpochMs1(timeStamp any) (any, error) {
 	return unixEpochInMs, nil
 }
 
-func (p *parser) callonDateTimeToUnixEpochMs1() (any, error) {
+func (p *parser) callonDateTimeToUnixEpochMs1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDateTimeToUnixEpochMs1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimestamp1(epochInMilli any) (any, error) {
+func (c *current) onGenTimestamp1(epochInMilli interface{}) (interface{}, error) {
 	return epochInMilli, nil
 }
 
-func (p *parser) callonGenTimestamp1() (any, error) {
+func (p *parser) callonGenTimestamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimestamp1(stack["epochInMilli"])
 }
 
-func (c *current) onGenTimesOptionEnd1(timeStamp any) (any, error) {
+func (c *current) onGenTimesOptionEnd1(timeStamp interface{}) (interface{}, error) {
 	return &GenTimesOptionArgs{
 		argOption: "end",
 		genTimesOption: &structs.GenTimes{
@@ -15507,13 +15508,13 @@ func (c *current) onGenTimesOptionEnd1(timeStamp any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionEnd1() (any, error) {
+func (p *parser) callonGenTimesOptionEnd1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionEnd1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimesOptionStart1(timeStamp any) (any, error) {
+func (c *current) onGenTimesOptionStart1(timeStamp interface{}) (interface{}, error) {
 	return &GenTimesOptionArgs{
 		argOption: "start",
 		genTimesOption: &structs.GenTimes{
@@ -15522,13 +15523,13 @@ func (c *current) onGenTimesOptionStart1(timeStamp any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionStart1() (any, error) {
+func (p *parser) callonGenTimesOptionStart1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionStart1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimesOptionIncrement1(intStr, unitStr any) (any, error) {
+func (c *current) onGenTimesOptionIncrement1(intStr, unitStr interface{}) (interface{}, error) {
 	spanNum, err := strconv.ParseInt(intStr.(string), 10, 64)
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the integer: %v", err)
@@ -15569,23 +15570,23 @@ func (c *current) onGenTimesOptionIncrement1(intStr, unitStr any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionIncrement1() (any, error) {
+func (p *parser) callonGenTimesOptionIncrement1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionIncrement1(stack["intStr"], stack["unitStr"])
 }
 
-func (c *current) onGenTimesOption1(genTimesOption any) (any, error) {
+func (c *current) onGenTimesOption1(genTimesOption interface{}) (interface{}, error) {
 	return genTimesOption, nil
 }
 
-func (p *parser) callonGenTimesOption1() (any, error) {
+func (p *parser) callonGenTimesOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOption1(stack["genTimesOption"])
 }
 
-func (c *current) onGenTimesOptionList1(first, rest any) (any, error) {
+func (c *current) onGenTimesOptionList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 
@@ -15637,54 +15638,54 @@ func (c *current) onGenTimesOptionList1(first, rest any) (any, error) {
 	return genTimeOption, nil
 }
 
-func (p *parser) callonGenTimesOptionList1() (any, error) {
+func (p *parser) callonGenTimesOptionList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onInitialSearchBlock1(clause any) (any, error) {
+func (c *current) onInitialSearchBlock1(clause interface{}) (interface{}, error) {
 	return clause, nil
 }
 
-func (p *parser) callonInitialSearchBlock1() (any, error) {
+func (p *parser) callonInitialSearchBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInitialSearchBlock1(stack["clause"])
 }
 
-func (c *current) onSearchBlock1(clause any) (any, error) {
+func (c *current) onSearchBlock1(clause interface{}) (interface{}, error) {
 	return clause, nil
 }
 
-func (p *parser) callonSearchBlock1() (any, error) {
+func (p *parser) callonSearchBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSearchBlock1(stack["clause"])
 }
 
-func (c *current) onFilterBlock1(block any) (any, error) {
+func (c *current) onFilterBlock1(block interface{}) (interface{}, error) {
 	return block, nil
 }
 
-func (p *parser) callonFilterBlock1() (any, error) {
+func (p *parser) callonFilterBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFilterBlock1(stack["block"])
 }
 
-func (c *current) onQueryAggergatorBlock1(block any) (any, error) {
+func (c *current) onQueryAggergatorBlock1(block interface{}) (interface{}, error) {
 	queryAgg := block.(*structs.QueryAggregators)
 	return queryAgg, nil
 }
 
-func (p *parser) callonQueryAggergatorBlock1() (any, error) {
+func (p *parser) callonQueryAggergatorBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQueryAggergatorBlock1(stack["block"])
 }
 
-func (c *current) onFieldSelectBlock1(op, fields any) (any, error) {
+func (c *current) onFieldSelectBlock1(op, fields interface{}) (interface{}, error) {
 	columnsRequest := &structs.ColumnsRequest{}
 	if op == nil || string(op.([]byte)) == "+" {
 		columnsRequest.IncludeColumns = fields.([]string)
@@ -15703,13 +15704,13 @@ func (c *current) onFieldSelectBlock1(op, fields any) (any, error) {
 	return queryAggregator, nil
 }
 
-func (p *parser) callonFieldSelectBlock1() (any, error) {
+func (p *parser) callonFieldSelectBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldSelectBlock1(stack["op"], stack["fields"])
 }
 
-func (c *current) onCommonAggregatorBlock1(aggs, byFields any) (any, error) {
+func (c *current) onCommonAggregatorBlock1(aggs, byFields interface{}) (interface{}, error) {
 	aggNode := &structs.QueryAggregators{}
 
 	// Extract the MeasureAggregators and check if any of the aggregation fields
@@ -15772,13 +15773,13 @@ func (c *current) onCommonAggregatorBlock1(aggs, byFields any) (any, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonCommonAggregatorBlock1() (any, error) {
+func (p *parser) callonCommonAggregatorBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonAggregatorBlock1(stack["aggs"], stack["byFields"])
 }
 
-func (c *current) onAggregatorBlock1(aggs, options any) (any, error) {
+func (c *current) onAggregatorBlock1(aggs, options interface{}) (interface{}, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 
 	if options != nil {
@@ -15790,13 +15791,13 @@ func (c *current) onAggregatorBlock1(aggs, options any) (any, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonAggregatorBlock1() (any, error) {
+func (p *parser) callonAggregatorBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregatorBlock1(stack["aggs"], stack["options"])
 }
 
-func (c *current) onStatsOptions1(option any) (any, error) {
+func (c *current) onStatsOptions1(option interface{}) (interface{}, error) {
 	//Default value
 	options := initializeStatsOptions()
 
@@ -15833,24 +15834,24 @@ func (c *current) onStatsOptions1(option any) (any, error) {
 	return options, nil
 }
 
-func (p *parser) callonStatsOptions1() (any, error) {
+func (p *parser) callonStatsOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOptions1(stack["option"])
 }
 
-func (c *current) onStatsOption1(optionCMD, str any) (any, error) {
+func (c *current) onStatsOption1(optionCMD, str interface{}) (interface{}, error) {
 	optionArr := []string{optionCMD.(string), str.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonStatsOption1() (any, error) {
+func (p *parser) callonStatsOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOption1(stack["optionCMD"], stack["str"])
 }
 
-func (c *current) onStatsOptionCMD1(option any) (any, error) {
+func (c *current) onStatsOptionCMD1(option interface{}) (interface{}, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: StatsOptionCMD: %v", err)
@@ -15858,13 +15859,13 @@ func (c *current) onStatsOptionCMD1(option any) (any, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonStatsOptionCMD1() (any, error) {
+func (p *parser) callonStatsOptionCMD1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOptionCMD1(stack["option"])
 }
 
-func (c *current) onGroupbyBlock1(fields any) (any, error) {
+func (c *current) onGroupbyBlock1(fields interface{}) (interface{}, error) {
 	// Wildcard fields are not allowed. See https://docs.splunk.com/Documentation/Splunk/9.1.0/SearchReference/Stats
 	for _, field := range fields.([]string) {
 		if strings.Contains(field, "*") {
@@ -15875,13 +15876,13 @@ func (c *current) onGroupbyBlock1(fields any) (any, error) {
 	return fields, nil
 }
 
-func (p *parser) callonGroupbyBlock1() (any, error) {
+func (p *parser) callonGroupbyBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGroupbyBlock1(stack["fields"])
 }
 
-func (c *current) onStreamStatsOptionResetOnChange1(boolVal any) (any, error) {
+func (c *current) onStreamStatsOptionResetOnChange1(boolVal interface{}) (interface{}, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetOnChange: boolVal.(bool),
 	}
@@ -15893,13 +15894,13 @@ func (c *current) onStreamStatsOptionResetOnChange1(boolVal any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetOnChange1() (any, error) {
+func (p *parser) callonStreamStatsOptionResetOnChange1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetOnChange1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionCurrent1(boolVal any) (any, error) {
+func (c *current) onStreamStatsOptionCurrent1(boolVal interface{}) (interface{}, error) {
 	ssOption := &structs.StreamStatsOptions{
 		Current: boolVal.(bool),
 	}
@@ -15911,13 +15912,13 @@ func (c *current) onStreamStatsOptionCurrent1(boolVal any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionCurrent1() (any, error) {
+func (p *parser) callonStreamStatsOptionCurrent1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionCurrent1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionGlobal1(boolVal any) (any, error) {
+func (c *current) onStreamStatsOptionGlobal1(boolVal interface{}) (interface{}, error) {
 	// TODO: Verify if needed, in splunk it does nothing as of now based on experiments.
 	ssOption := &structs.StreamStatsOptions{
 		Global: boolVal.(bool),
@@ -15930,13 +15931,13 @@ func (c *current) onStreamStatsOptionGlobal1(boolVal any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionGlobal1() (any, error) {
+func (p *parser) callonStreamStatsOptionGlobal1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionGlobal1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionAllNum1(boolVal any) (any, error) {
+func (c *current) onStreamStatsOptionAllNum1(boolVal interface{}) (interface{}, error) {
 	// TODO: Verify if needed, in splunk it does nothing as of now based on experiments.
 	ssOption := &structs.StreamStatsOptions{
 		AllNum: boolVal.(bool),
@@ -15949,13 +15950,13 @@ func (c *current) onStreamStatsOptionAllNum1(boolVal any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionAllNum1() (any, error) {
+func (p *parser) callonStreamStatsOptionAllNum1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionAllNum1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionWindow1(windowSize any) (any, error) {
+func (c *current) onStreamStatsOptionWindow1(windowSize interface{}) (interface{}, error) {
 	window, err := strconv.ParseUint(windowSize.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid window size: %v, must be a positive integer", windowSize.(string))
@@ -15974,13 +15975,13 @@ func (c *current) onStreamStatsOptionWindow1(windowSize any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionWindow1() (any, error) {
+func (p *parser) callonStreamStatsOptionWindow1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionWindow1(stack["windowSize"])
 }
 
-func (c *current) onStreamStatsOptionResetBefore1(boolExpr any) (any, error) {
+func (c *current) onStreamStatsOptionResetBefore1(boolExpr interface{}) (interface{}, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetBefore: boolExpr.(*structs.BoolExpr),
 	}
@@ -15992,13 +15993,13 @@ func (c *current) onStreamStatsOptionResetBefore1(boolExpr any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetBefore1() (any, error) {
+func (p *parser) callonStreamStatsOptionResetBefore1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetBefore1(stack["boolExpr"])
 }
 
-func (c *current) onStreamStatsOptionResetAfter1(boolExpr any) (any, error) {
+func (c *current) onStreamStatsOptionResetAfter1(boolExpr interface{}) (interface{}, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetAfter: boolExpr.(*structs.BoolExpr),
 	}
@@ -16010,13 +16011,13 @@ func (c *current) onStreamStatsOptionResetAfter1(boolExpr any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetAfter1() (any, error) {
+func (p *parser) callonStreamStatsOptionResetAfter1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetAfter1(stack["boolExpr"])
 }
 
-func (c *current) onStreamStatsOptionTimeWindow1(spanLength any) (any, error) {
+func (c *current) onStreamStatsOptionTimeWindow1(spanLength interface{}) (interface{}, error) {
 	spanLen := spanLength.(*structs.BinSpanLength)
 	if spanLen.TimeScale == sutils.TMInvalid {
 		return nil, fmt.Errorf("Invalid Syntax, time_window option cannot be used without time scale")
@@ -16032,23 +16033,23 @@ func (c *current) onStreamStatsOptionTimeWindow1(spanLength any) (any, error) {
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionTimeWindow1() (any, error) {
+func (p *parser) callonStreamStatsOptionTimeWindow1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionTimeWindow1(stack["spanLength"])
 }
 
-func (c *current) onStreamStatsOption1(ssOption any) (any, error) {
+func (c *current) onStreamStatsOption1(ssOption interface{}) (interface{}, error) {
 	return ssOption, nil
 }
 
-func (p *parser) callonStreamStatsOption1() (any, error) {
+func (p *parser) callonStreamStatsOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOption1(stack["ssOption"])
 }
 
-func (c *current) onStreamStatsOptionList1(first, rest any) (any, error) {
+func (c *current) onStreamStatsOptionList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]bool)
 
@@ -16107,13 +16108,13 @@ func (c *current) onStreamStatsOptionList1(first, rest any) (any, error) {
 	return ssOption, nil
 }
 
-func (p *parser) callonStreamStatsOptionList1() (any, error) {
+func (p *parser) callonStreamStatsOptionList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onStreamStatsBlock2(ssOptionList, aggs any) (any, error) {
+func (c *current) onStreamStatsBlock2(ssOptionList, aggs interface{}) (interface{}, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 	ssOptions := ssOptionList.(*structs.StreamStatsOptions)
 
@@ -16125,13 +16126,13 @@ func (c *current) onStreamStatsBlock2(ssOptionList, aggs any) (any, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonStreamStatsBlock2() (any, error) {
+func (p *parser) callonStreamStatsBlock2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsBlock2(stack["ssOptionList"], stack["aggs"])
 }
 
-func (c *current) onStreamStatsBlock11(aggs any) (any, error) {
+func (c *current) onStreamStatsBlock11(aggs interface{}) (interface{}, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 	ssOptions := initializeStreamStatsOptions()
 
@@ -16143,13 +16144,13 @@ func (c *current) onStreamStatsBlock11(aggs any) (any, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonStreamStatsBlock11() (any, error) {
+func (p *parser) callonStreamStatsBlock11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsBlock11(stack["aggs"])
 }
 
-func (c *current) onRegexBlock1(keyAndOp, str any) (any, error) {
+func (c *current) onRegexBlock1(keyAndOp, str interface{}) (interface{}, error) {
 	var key, op string
 	if keyAndOp == nil {
 		key = "*"
@@ -16177,13 +16178,13 @@ func (c *current) onRegexBlock1(keyAndOp, str any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonRegexBlock1() (any, error) {
+func (p *parser) callonRegexBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexBlock1(stack["keyAndOp"], stack["str"])
 }
 
-func (c *current) onRegexAggBlock1(node any) (any, error) {
+func (c *current) onRegexAggBlock1(node interface{}) (interface{}, error) {
 
 	astNode, ok := node.(*ast.Node)
 	if !ok {
@@ -16211,13 +16212,13 @@ func (c *current) onRegexAggBlock1(node any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonRegexAggBlock1() (any, error) {
+func (p *parser) callonRegexAggBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexAggBlock1(stack["node"])
 }
 
-func (c *current) onClauseLevel41(first, rest any) (any, error) {
+func (c *current) onClauseLevel41(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -16235,13 +16236,13 @@ func (c *current) onClauseLevel41(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonClauseLevel41() (any, error) {
+func (p *parser) callonClauseLevel41() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel41(stack["first"], stack["rest"])
 }
 
-func (c *current) onClauseLevel31(first, rest any) (any, error) {
+func (c *current) onClauseLevel31(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -16259,13 +16260,13 @@ func (c *current) onClauseLevel31(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonClauseLevel31() (any, error) {
+func (p *parser) callonClauseLevel31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onClauseLevel22(notList, first any) (any, error) {
+func (c *current) onClauseLevel22(notList, first interface{}) (interface{}, error) {
 	// There's an issue with how queries with AST Not nodes are run, so use
 	// De Morgan's law to manipulate the expression.
 	node := first.(*ast.Node)
@@ -16278,53 +16279,53 @@ func (c *current) onClauseLevel22(notList, first any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonClauseLevel22() (any, error) {
+func (p *parser) callonClauseLevel22() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel22(stack["notList"], stack["first"])
 }
 
-func (c *current) onClauseLevel29(clause any) (any, error) {
+func (c *current) onClauseLevel29(clause interface{}) (interface{}, error) {
 	return clause, nil
 }
 
-func (p *parser) callonClauseLevel29() (any, error) {
+func (p *parser) callonClauseLevel29() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel29(stack["clause"])
 }
 
-func (c *current) onClauseLevel12(clause any) (any, error) {
+func (c *current) onClauseLevel12(clause interface{}) (interface{}, error) {
 	return clause, nil
 }
 
-func (p *parser) callonClauseLevel12() (any, error) {
+func (p *parser) callonClauseLevel12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel12(stack["clause"])
 }
 
-func (c *current) onClauseLevel18(term any) (any, error) {
+func (c *current) onClauseLevel18(term interface{}) (interface{}, error) {
 	return term, nil
 }
 
-func (p *parser) callonClauseLevel18() (any, error) {
+func (p *parser) callonClauseLevel18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel18(stack["term"])
 }
 
-func (c *current) onSearchTerm1(term any) (any, error) {
+func (c *current) onSearchTerm1(term interface{}) (interface{}, error) {
 	return term, nil
 }
 
-func (p *parser) callonSearchTerm1() (any, error) {
+func (p *parser) callonSearchTerm1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSearchTerm1(stack["term"])
 }
 
-func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
+func (c *current) onTimechartBlock1(tcArgs, limitExpr interface{}) (interface{}, error) {
 	aggNode := &structs.QueryAggregators{}
 
 	columnsRequest := &structs.ColumnsRequest{}
@@ -16413,13 +16414,13 @@ func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonTimechartBlock1() (any, error) {
+func (p *parser) callonTimechartBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartBlock1(stack["tcArgs"], stack["limitExpr"])
 }
 
-func (c *current) onTimechartArgumentsList1(first, rest any) (any, error) {
+func (c *current) onTimechartArgumentsList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	timechartArgs := &TimechartArgs{}
 
@@ -16448,23 +16449,23 @@ func (c *current) onTimechartArgumentsList1(first, rest any) (any, error) {
 	return timechartArgs, nil
 }
 
-func (p *parser) callonTimechartArgumentsList1() (any, error) {
+func (p *parser) callonTimechartArgumentsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onTimechartArgument1(tcArg any) (any, error) {
+func (c *current) onTimechartArgument1(tcArg interface{}) (interface{}, error) {
 	return tcArg, nil
 }
 
-func (p *parser) callonTimechartArgument1() (any, error) {
+func (p *parser) callonTimechartArgument1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartArgument1(stack["tcArg"])
 }
 
-func (c *current) onSingleAggExpr1(aggs, splitByClause any) (any, error) {
+func (c *current) onSingleAggExpr1(aggs, splitByClause interface{}) (interface{}, error) {
 	singleAggExpr := &singleAggTemp{
 		aggregators: aggs.([]*aggregator),
 	}
@@ -16476,13 +16477,13 @@ func (c *current) onSingleAggExpr1(aggs, splitByClause any) (any, error) {
 	return singleAggExpr, nil
 }
 
-func (p *parser) callonSingleAggExpr1() (any, error) {
+func (p *parser) callonSingleAggExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleAggExpr1(stack["aggs"], stack["splitByClause"])
 }
 
-func (c *current) onSplitByClause1(field any) (any, error) {
+func (c *current) onSplitByClause1(field interface{}) (interface{}, error) {
 	splitByClause := &structs.SplitByClause{
 		Field: field.(string),
 	}
@@ -16490,13 +16491,13 @@ func (c *current) onSplitByClause1(field any) (any, error) {
 	return splitByClause, nil
 }
 
-func (p *parser) callonSplitByClause1() (any, error) {
+func (p *parser) callonSplitByClause1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSplitByClause1(stack["field"])
 }
 
-func (c *current) onTcOptions1(option any) (any, error) {
+func (c *current) onTcOptions1(option interface{}) (interface{}, error) {
 	//Default value
 	tcOptions := &structs.TcOptions{
 		UseNull:  true,
@@ -16538,24 +16539,24 @@ func (c *current) onTcOptions1(option any) (any, error) {
 	return tcOptions, nil
 }
 
-func (p *parser) callonTcOptions1() (any, error) {
+func (p *parser) callonTcOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOptions1(stack["option"])
 }
 
-func (c *current) onTcOption1(tcOptionCMD, val any) (any, error) {
+func (c *current) onTcOption1(tcOptionCMD, val interface{}) (interface{}, error) {
 	tcOptionArr := []string{tcOptionCMD.(string), val.(string)}
 	return tcOptionArr, nil
 }
 
-func (p *parser) callonTcOption1() (any, error) {
+func (p *parser) callonTcOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOption1(stack["tcOptionCMD"], stack["val"])
 }
 
-func (c *current) onTcOptionCMD1(option any) (any, error) {
+func (c *current) onTcOptionCMD1(option interface{}) (interface{}, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Timechart: TcOptionCMD: %v", err)
@@ -16563,23 +16564,23 @@ func (c *current) onTcOptionCMD1(option any) (any, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonTcOptionCMD1() (any, error) {
+func (p *parser) callonTcOptionCMD1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOptionCMD1(stack["option"])
 }
 
-func (c *current) onAllTimeScale1(timeUnit any) (any, error) {
+func (c *current) onAllTimeScale1(timeUnit interface{}) (interface{}, error) {
 	return timeUnit, nil
 }
 
-func (p *parser) callonAllTimeScale1() (any, error) {
+func (p *parser) callonAllTimeScale1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAllTimeScale1(stack["timeUnit"])
 }
 
-func (c *current) onBinSpanLenOption1(number, timeScale any) (any, error) {
+func (c *current) onBinSpanLenOption1(number, timeScale interface{}) (interface{}, error) {
 	if timeScale != nil {
 		num, err := strconv.ParseInt(number.(string), 10, 64)
 		if err != nil {
@@ -16638,13 +16639,13 @@ func (c *current) onBinSpanLenOption1(number, timeScale any) (any, error) {
 	return spanLength, nil
 }
 
-func (p *parser) callonBinSpanLenOption1() (any, error) {
+func (p *parser) callonBinSpanLenOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinSpanLenOption1(stack["number"], stack["timeScale"])
 }
 
-func (c *current) onBinOptionMinSpan1(spanLength any) (any, error) {
+func (c *current) onBinOptionMinSpan1(spanLength interface{}) (interface{}, error) {
 
 	binOptionArgs := &BinOptionArgs{
 		argOption: "minspan",
@@ -16655,13 +16656,13 @@ func (c *current) onBinOptionMinSpan1(spanLength any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionMinSpan1() (any, error) {
+func (p *parser) callonBinOptionMinSpan1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionMinSpan1(stack["spanLength"])
 }
 
-func (c *current) onBinOptionMaxBins1(intAsStr any) (any, error) {
+func (c *current) onBinOptionMaxBins1(intAsStr interface{}) (interface{}, error) {
 	numBins, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -16678,13 +16679,13 @@ func (c *current) onBinOptionMaxBins1(intAsStr any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionMaxBins1() (any, error) {
+func (p *parser) callonBinOptionMaxBins1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionMaxBins1(stack["intAsStr"])
 }
 
-func (c *current) onBinOptionAlignTime2(utcEpoch any) (any, error) {
+func (c *current) onBinOptionAlignTime2(utcEpoch interface{}) (interface{}, error) {
 	epoch, err := strconv.ParseUint(utcEpoch.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid utc epoch value: %v for align time", utcEpoch.(string))
@@ -16699,13 +16700,13 @@ func (c *current) onBinOptionAlignTime2(utcEpoch any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionAlignTime2() (any, error) {
+func (p *parser) callonBinOptionAlignTime2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionAlignTime2(stack["utcEpoch"])
 }
 
-func (c *current) onBinOptionAlignTime8(timestamp any) (any, error) {
+func (c *current) onBinOptionAlignTime8(timestamp interface{}) (interface{}, error) {
 	var epoch uint64 = 0
 	var err error
 	relTimeModifier := timestamp.(ast.TimeModifier)
@@ -16725,13 +16726,13 @@ func (c *current) onBinOptionAlignTime8(timestamp any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionAlignTime8() (any, error) {
+func (p *parser) callonBinOptionAlignTime8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionAlignTime8(stack["timestamp"])
 }
 
-func (c *current) onBinOptionStart1(number any) (any, error) {
+func (c *current) onBinOptionStart1(number interface{}) (interface{}, error) {
 	start, err := strconv.ParseFloat(number.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Cannot convert %v to float", number.(string))
@@ -16746,13 +16747,13 @@ func (c *current) onBinOptionStart1(number any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionStart1() (any, error) {
+func (p *parser) callonBinOptionStart1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionStart1(stack["number"])
 }
 
-func (c *current) onBinOptionEnd1(number any) (any, error) {
+func (c *current) onBinOptionEnd1(number interface{}) (interface{}, error) {
 	end, err := strconv.ParseFloat(number.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Cannot convert %v to float", number.(string))
@@ -16767,13 +16768,13 @@ func (c *current) onBinOptionEnd1(number any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionEnd1() (any, error) {
+func (p *parser) callonBinOptionEnd1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionEnd1(stack["number"])
 }
 
-func (c *current) onBinOptionSpan2(num1, num2 any) (any, error) {
+func (c *current) onBinOptionSpan2(num1, num2 interface{}) (interface{}, error) {
 	var coeff float64 = 1.0
 	var base float64 = 10.0
 	var err error
@@ -16817,13 +16818,13 @@ func (c *current) onBinOptionSpan2(num1, num2 any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionSpan2() (any, error) {
+func (p *parser) callonBinOptionSpan2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionSpan2(stack["num1"], stack["num2"])
 }
 
-func (c *current) onBinOptionSpan17(spanLen any) (any, error) {
+func (c *current) onBinOptionSpan17(spanLen interface{}) (interface{}, error) {
 
 	spanOptions := &structs.BinSpanOptions{
 		BinSpanLength: spanLen.(*structs.BinSpanLength),
@@ -16838,23 +16839,23 @@ func (c *current) onBinOptionSpan17(spanLen any) (any, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionSpan17() (any, error) {
+func (p *parser) callonBinOptionSpan17() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionSpan17(stack["spanLen"])
 }
 
-func (c *current) onBinCmdOption1(option any) (any, error) {
+func (c *current) onBinCmdOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonBinCmdOption1() (any, error) {
+func (p *parser) callonBinCmdOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinCmdOption1(stack["option"])
 }
 
-func (c *current) onBinCmdOptionsList1(first, rest any) (any, error) {
+func (c *current) onBinCmdOptionsList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]bool)
 
@@ -16899,13 +16900,13 @@ func (c *current) onBinCmdOptionsList1(first, rest any) (any, error) {
 	return binCmdOption, nil
 }
 
-func (p *parser) callonBinCmdOptionsList1() (any, error) {
+func (p *parser) callonBinCmdOptionsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinCmdOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onBinBlock2(binCmdOption, field, newFieldName any) (any, error) {
+func (c *current) onBinBlock2(binCmdOption, field, newFieldName interface{}) (interface{}, error) {
 	letColReq := &structs.LetColumnsRequest{
 		NewColName: field.(string),
 	}
@@ -16933,13 +16934,13 @@ func (c *current) onBinBlock2(binCmdOption, field, newFieldName any) (any, error
 	return queryAgg, nil
 }
 
-func (p *parser) callonBinBlock2() (any, error) {
+func (p *parser) callonBinBlock2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinBlock2(stack["binCmdOption"], stack["field"], stack["newFieldName"])
 }
 
-func (c *current) onBinBlock14(field, newFieldName any) (any, error) {
+func (c *current) onBinBlock14(field, newFieldName interface{}) (interface{}, error) {
 	letColReq := &structs.LetColumnsRequest{
 		NewColName: field.(string),
 	}
@@ -16968,39 +16969,39 @@ func (c *current) onBinBlock14(field, newFieldName any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonBinBlock14() (any, error) {
+func (p *parser) callonBinBlock14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinBlock14(stack["field"], stack["newFieldName"])
 }
 
-func (c *current) onBinOptions1(spanOptions any) (any, error) {
+func (c *current) onBinOptions1(spanOptions interface{}) (interface{}, error) {
 	binOptions := &structs.BinOptions{
 		SpanOptions: spanOptions.(*structs.SpanOptions),
 	}
 	return binOptions, nil
 }
 
-func (p *parser) callonBinOptions1() (any, error) {
+func (p *parser) callonBinOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptions1(stack["spanOptions"])
 }
 
-func (c *current) onSpanOptions1(spanLength any) (any, error) {
+func (c *current) onSpanOptions1(spanLength interface{}) (interface{}, error) {
 	spanOptions := &structs.SpanOptions{
 		SpanLength: spanLength.(*structs.SpanLength),
 	}
 	return spanOptions, nil
 }
 
-func (p *parser) callonSpanOptions1() (any, error) {
+func (p *parser) callonSpanOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpanOptions1(stack["spanLength"])
 }
 
-func (c *current) onSpanLength1(intAsStr, timeScale any) (any, error) {
+func (c *current) onSpanLength1(intAsStr, timeScale interface{}) (interface{}, error) {
 	if timeScale.(sutils.TimeUnit) == sutils.TMYear {
 		return nil, fmt.Errorf("SpanLength: Invalid time unit, year is not supported")
 	}
@@ -17016,13 +17017,13 @@ func (c *current) onSpanLength1(intAsStr, timeScale any) (any, error) {
 	return spanLength, nil
 }
 
-func (p *parser) callonSpanLength1() (any, error) {
+func (p *parser) callonSpanLength1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpanLength1(stack["intAsStr"], stack["timeScale"])
 }
 
-func (c *current) onLimitExpr1(sortBy, intAsStr any) (any, error) {
+func (c *current) onLimitExpr1(sortBy, intAsStr interface{}) (interface{}, error) {
 	num, err := strconv.Atoi(intAsStr.(string))
 	if err != nil {
 		return nil, fmt.Errorf("SpanLength: Invalid num (%v): %v", intAsStr.(string), err)
@@ -17046,13 +17047,13 @@ func (c *current) onLimitExpr1(sortBy, intAsStr any) (any, error) {
 	return limitExpr, nil
 }
 
-func (p *parser) callonLimitExpr1() (any, error) {
+func (p *parser) callonLimitExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLimitExpr1(stack["sortBy"], stack["intAsStr"])
 }
 
-func (c *current) onStatisticBlock1(statisticExpr any) (any, error) {
+func (c *current) onStatisticBlock1(statisticExpr interface{}) (interface{}, error) {
 	letColReq := &structs.LetColumnsRequest{
 		StatisticColRequest: statisticExpr.(*structs.StatisticExpr),
 	}
@@ -17089,13 +17090,13 @@ func (c *current) onStatisticBlock1(statisticExpr any) (any, error) {
 
 }
 
-func (p *parser) callonStatisticBlock1() (any, error) {
+func (p *parser) callonStatisticBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticBlock1(stack["statisticExpr"])
 }
 
-func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options any) (any, error) {
+func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options interface{}) (interface{}, error) {
 
 	statisticExpr := &structs.StatisticExpr{
 		FieldList: fieldList.([]interface{})[1].([]string),
@@ -17136,33 +17137,33 @@ func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options any)
 	return statisticExpr, nil
 }
 
-func (p *parser) callonStatisticExpr1() (any, error) {
+func (p *parser) callonStatisticExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticExpr1(stack["cmd"], stack["limit"], stack["fieldList"], stack["byClause"], stack["options"])
 }
 
-func (c *current) onStatisticLimit2(number any) (any, error) {
+func (c *current) onStatisticLimit2(number interface{}) (interface{}, error) {
 	return number.(string), nil
 }
 
-func (p *parser) callonStatisticLimit2() (any, error) {
+func (p *parser) callonStatisticLimit2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticLimit2(stack["number"])
 }
 
-func (c *current) onStatisticLimit7(limit any) (any, error) {
+func (c *current) onStatisticLimit7(limit interface{}) (interface{}, error) {
 	return limit.(string), nil
 }
 
-func (p *parser) callonStatisticLimit7() (any, error) {
+func (p *parser) callonStatisticLimit7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticLimit7(stack["limit"])
 }
 
-func (c *current) onStatisticOptions1(option any) (any, error) {
+func (c *current) onStatisticOptions1(option interface{}) (interface{}, error) {
 	//Default value
 	options := &structs.StatisticOptions{
 		ShowCount:    true,
@@ -17210,24 +17211,24 @@ func (c *current) onStatisticOptions1(option any) (any, error) {
 	return options, nil
 }
 
-func (p *parser) callonStatisticOptions1() (any, error) {
+func (p *parser) callonStatisticOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOptions1(stack["option"])
 }
 
-func (c *current) onStatisticOption1(optionCMD, field any) (any, error) {
+func (c *current) onStatisticOption1(optionCMD, field interface{}) (interface{}, error) {
 	optionArr := []string{optionCMD.(string), field.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonStatisticOption1() (any, error) {
+func (p *parser) callonStatisticOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOption1(stack["optionCMD"], stack["field"])
 }
 
-func (c *current) onStatisticOptionCMD1(option any) (any, error) {
+func (c *current) onStatisticOptionCMD1(option interface{}) (interface{}, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: StatisticExpr: %v", err)
@@ -17235,33 +17236,33 @@ func (c *current) onStatisticOptionCMD1(option any) (any, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonStatisticOptionCMD1() (any, error) {
+func (p *parser) callonStatisticOptionCMD1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOptionCMD1(stack["option"])
 }
 
-func (c *current) onByClause2(fieldList any) (any, error) {
+func (c *current) onByClause2(fieldList interface{}) (interface{}, error) {
 	return fieldList.([]string), nil
 }
 
-func (p *parser) callonByClause2() (any, error) {
+func (p *parser) callonByClause2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onByClause2(stack["fieldList"])
 }
 
-func (c *current) onByClause7(groupByBlock any) (any, error) {
+func (c *current) onByClause7(groupByBlock interface{}) (interface{}, error) {
 	return groupByBlock.([]string), nil
 }
 
-func (p *parser) callonByClause7() (any, error) {
+func (p *parser) callonByClause7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onByClause7(stack["groupByBlock"])
 }
 
-func (c *current) onDedupBlock1(dedupExpr any) (any, error) {
+func (c *current) onDedupBlock1(dedupExpr interface{}) (interface{}, error) {
 
 	dedupExp := dedupExpr.(*structs.DedupExpr)
 
@@ -17303,13 +17304,13 @@ func (c *current) onDedupBlock1(dedupExpr any) (any, error) {
 	return root, nil
 }
 
-func (p *parser) callonDedupBlock1() (any, error) {
+func (p *parser) callonDedupBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupBlock1(stack["dedupExpr"])
 }
 
-func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByClause any) (any, error) {
+func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByClause interface{}) (interface{}, error) {
 	dedupExpr := &structs.DedupExpr{
 		FieldList:         fieldList.([]string),
 		Limit:             1,
@@ -17366,23 +17367,23 @@ func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByCl
 	return dedupExpr, nil
 }
 
-func (p *parser) callonDedupExpr1() (any, error) {
+func (p *parser) callonDedupExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupExpr1(stack["limitArr"], stack["options1"], stack["fieldList"], stack["options2"], stack["sortByClause"])
 }
 
-func (c *current) onDedupFieldName1(field any) (any, error) {
+func (c *current) onDedupFieldName1(field interface{}) (interface{}, error) {
 	return field, nil
 }
 
-func (p *parser) callonDedupFieldName1() (any, error) {
+func (p *parser) callonDedupFieldName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupFieldName1(stack["field"])
 }
 
-func (c *current) onSpaceSeparatedFieldNameList1(first, rest any) (any, error) {
+func (c *current) onSpaceSeparatedFieldNameList1(first, rest interface{}) (interface{}, error) {
 	var fields []string
 	fields = append(fields, first.(string))
 	for _, r := range rest.([]any) {
@@ -17393,13 +17394,13 @@ func (c *current) onSpaceSeparatedFieldNameList1(first, rest any) (any, error) {
 	return fields, nil
 }
 
-func (p *parser) callonSpaceSeparatedFieldNameList1() (any, error) {
+func (p *parser) callonSpaceSeparatedFieldNameList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpaceSeparatedFieldNameList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onDedupFieldList1(first, rest any) (any, error) {
+func (c *current) onDedupFieldList1(first, rest interface{}) (interface{}, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is " " and the second is a FieldName.
 	restSlice := rest.([]any)
@@ -17416,13 +17417,13 @@ func (c *current) onDedupFieldList1(first, rest any) (any, error) {
 	return fields, nil
 }
 
-func (p *parser) callonDedupFieldList1() (any, error) {
+func (p *parser) callonDedupFieldList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupFieldList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onDedupOptions1(option any) (any, error) {
+func (c *current) onDedupOptions1(option interface{}) (interface{}, error) {
 	//Default value
 	options := &structs.DedupOptions{
 		Consecutive: false,
@@ -17461,24 +17462,24 @@ func (c *current) onDedupOptions1(option any) (any, error) {
 	return options, nil
 }
 
-func (p *parser) callonDedupOptions1() (any, error) {
+func (p *parser) callonDedupOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOptions1(stack["option"])
 }
 
-func (c *current) onDedupOption1(optionCMD, field any) (any, error) {
+func (c *current) onDedupOption1(optionCMD, field interface{}) (interface{}, error) {
 	optionArr := []string{optionCMD.(string), field.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonDedupOption1() (any, error) {
+func (p *parser) callonDedupOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOption1(stack["optionCMD"], stack["field"])
 }
 
-func (c *current) onDedupOptionCMD1(option any) (any, error) {
+func (c *current) onDedupOptionCMD1(option interface{}) (interface{}, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: DedupExpr: %v", err)
@@ -17486,23 +17487,23 @@ func (c *current) onDedupOptionCMD1(option any) (any, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonDedupOptionCMD1() (any, error) {
+func (p *parser) callonDedupOptionCMD1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOptionCMD1(stack["option"])
 }
 
-func (c *current) onDedupSortByClause1(dedupSortEles any) (any, error) {
+func (c *current) onDedupSortByClause1(dedupSortEles interface{}) (interface{}, error) {
 	return dedupSortEles, nil
 }
 
-func (p *parser) callonDedupSortByClause1() (any, error) {
+func (p *parser) callonDedupSortByClause1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupSortByClause1(stack["dedupSortEles"])
 }
 
-func (c *current) onSortElements1(first, rest any) (any, error) {
+func (c *current) onSortElements1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 
 	length := 1 + len(restSlice)
@@ -17517,23 +17518,23 @@ func (c *current) onSortElements1(first, rest any) (any, error) {
 	return sortEles, nil
 }
 
-func (p *parser) callonSortElements1() (any, error) {
+func (p *parser) callonSortElements1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortElements1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSingleSortElement1(element any) (any, error) {
+func (c *current) onSingleSortElement1(element interface{}) (interface{}, error) {
 	return element, nil
 }
 
-func (p *parser) callonSingleSortElement1() (any, error) {
+func (p *parser) callonSingleSortElement1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElement1(stack["element"])
 }
 
-func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field any) (any, error) {
+func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field interface{}) (interface{}, error) {
 	sortByAsc := true
 
 	symbol := sortBySymbol.([]byte)
@@ -17548,13 +17549,13 @@ func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field any) (any,
 	}, nil
 }
 
-func (p *parser) callonSingleSortElementWithoutCast1() (any, error) {
+func (p *parser) callonSingleSortElementWithoutCast1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElementWithoutCast1(stack["sortBySymbol"], stack["field"])
 }
 
-func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field any) (any, error) {
+func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field interface{}) (interface{}, error) {
 	sortByAsc := true
 
 	symbol := sortBySymbol.([]byte)
@@ -17574,13 +17575,13 @@ func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field any) (any
 	}, nil
 }
 
-func (p *parser) callonSingleSortElementWithCast1() (any, error) {
+func (p *parser) callonSingleSortElementWithCast1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElementWithCast1(stack["sortBySymbol"], stack["op"], stack["field"])
 }
 
-func (c *current) onRenameBlock1(renameExpr any) (any, error) {
+func (c *current) onRenameBlock1(renameExpr interface{}) (interface{}, error) {
 	letColReq := &structs.LetColumnsRequest{
 		RenameColRequest: renameExpr.(*structs.RenameExpr),
 	}
@@ -17602,13 +17603,13 @@ func (c *current) onRenameBlock1(renameExpr any) (any, error) {
 	return root, nil
 }
 
-func (p *parser) callonRenameBlock1() (any, error) {
+func (p *parser) callonRenameBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameBlock1(stack["renameExpr"])
 }
 
-func (c *current) onRenameExpr2(originalPattern, newPattern any) (any, error) {
+func (c *current) onRenameExpr2(originalPattern, newPattern interface{}) (interface{}, error) {
 	renameExpr := &structs.RenameExpr{
 		RenameExprMode:  structs.REMPhrase,
 		OriginalPattern: originalPattern.(string),
@@ -17618,13 +17619,13 @@ func (c *current) onRenameExpr2(originalPattern, newPattern any) (any, error) {
 	return renameExpr, nil
 }
 
-func (p *parser) callonRenameExpr2() (any, error) {
+func (p *parser) callonRenameExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameExpr2(stack["originalPattern"], stack["newPattern"])
 }
 
-func (c *current) onRenameExpr9(originalPattern, newPattern any) (any, error) {
+func (c *current) onRenameExpr9(originalPattern, newPattern interface{}) (interface{}, error) {
 	isRegex, err := isRegexRename(originalPattern.(string), newPattern.(string))
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: RenameExpr: %v", err)
@@ -17646,13 +17647,13 @@ func (c *current) onRenameExpr9(originalPattern, newPattern any) (any, error) {
 	return renameExpr, nil
 }
 
-func (p *parser) callonRenameExpr9() (any, error) {
+func (p *parser) callonRenameExpr9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameExpr9(stack["originalPattern"], stack["newPattern"])
 }
 
-func (c *current) onRexBlock1(field, str any) (any, error) {
+func (c *current) onRexBlock1(field, str interface{}) (interface{}, error) {
 	pattern := removeQuotes(str)
 	rexColNames, err := getRexColNames(pattern)
 	if err != nil {
@@ -17679,13 +17680,13 @@ func (c *current) onRexBlock1(field, str any) (any, error) {
 	return root, nil
 }
 
-func (p *parser) callonRexBlock1() (any, error) {
+func (p *parser) callonRexBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRexBlock1(stack["field"], stack["str"])
 }
 
-func (c *current) onSortBlock1(limit, sortByEles any) (any, error) {
+func (c *current) onSortBlock1(limit, sortByEles interface{}) (interface{}, error) {
 
 	sortExpr := &structs.SortExpr{
 		SortEles:    sortByEles.([]*structs.SortElement),
@@ -17723,13 +17724,13 @@ func (c *current) onSortBlock1(limit, sortByEles any) (any, error) {
 	return root, nil
 }
 
-func (p *parser) callonSortBlock1() (any, error) {
+func (p *parser) callonSortBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortBlock1(stack["limit"], stack["sortByEles"])
 }
 
-func (c *current) onSortLimit1(intAsStr any) (any, error) {
+func (c *current) onSortLimit1(intAsStr interface{}) (interface{}, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -17742,13 +17743,13 @@ func (c *current) onSortLimit1(intAsStr any) (any, error) {
 	return limit, nil
 }
 
-func (p *parser) callonSortLimit1() (any, error) {
+func (p *parser) callonSortLimit1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortLimit1(stack["intAsStr"])
 }
 
-func (c *current) onEvalBlock1(first, rest any) (any, error) {
+func (c *current) onEvalBlock1(first, rest interface{}) (interface{}, error) {
 	root := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -17782,13 +17783,13 @@ func (c *current) onEvalBlock1(first, rest any) (any, error) {
 	return root, nil
 }
 
-func (p *parser) callonEvalBlock1() (any, error) {
+func (p *parser) callonEvalBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalBlock1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSingleEval1(field, expr any) (any, error) {
+func (c *current) onSingleEval1(field, expr interface{}) (interface{}, error) {
 	fieldStr := field.(string)
 	if strings.Contains(fieldStr, "*") {
 		return nil, fmt.Errorf("New fields must not contain wildcards; invalid field: %v", field)
@@ -17800,13 +17801,13 @@ func (c *current) onSingleEval1(field, expr any) (any, error) {
 	return letColumnsRequest, nil
 }
 
-func (p *parser) callonSingleEval1() (any, error) {
+func (p *parser) callonSingleEval1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleEval1(stack["field"], stack["expr"])
 }
 
-func (c *current) onEvalExpression1(value any) (any, error) {
+func (c *current) onEvalExpression1(value interface{}) (interface{}, error) {
 	if value.(*structs.ValueExpr).ValueExprMode == structs.VEMBooleanExpr {
 		return nil, fmt.Errorf("Eval fields cannot be assigned a boolean result")
 	}
@@ -17817,13 +17818,13 @@ func (c *current) onEvalExpression1(value any) (any, error) {
 	return letColReq, nil
 }
 
-func (p *parser) callonEvalExpression1() (any, error) {
+func (p *parser) callonEvalExpression1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalExpression1(stack["value"])
 }
 
-func (c *current) onConditionExpr2(condition, trueValue, falseValue any) (any, error) {
+func (c *current) onConditionExpr2(condition, trueValue, falseValue interface{}) (interface{}, error) {
 
 	node := &structs.ConditionExpr{
 		Op:         "if",
@@ -17835,13 +17836,13 @@ func (c *current) onConditionExpr2(condition, trueValue, falseValue any) (any, e
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr2() (any, error) {
+func (p *parser) callonConditionExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr2(stack["condition"], stack["trueValue"], stack["falseValue"])
 }
 
-func (c *current) onConditionExpr15(opName, pair, rest any) (any, error) {
+func (c *current) onConditionExpr15(opName, pair, rest interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: ConditionExpr: %v", err)
@@ -17865,13 +17866,13 @@ func (c *current) onConditionExpr15(opName, pair, rest any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr15() (any, error) {
+func (p *parser) callonConditionExpr15() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr15(stack["opName"], stack["pair"], stack["rest"])
 }
 
-func (c *current) onConditionExpr30(valueExpr, rest any) (any, error) {
+func (c *current) onConditionExpr30(valueExpr, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	valueList := make([]*structs.ValueExpr, 1+len(restSlice))
 	valueList[0] = valueExpr.(*structs.ValueExpr)
@@ -17889,13 +17890,13 @@ func (c *current) onConditionExpr30(valueExpr, rest any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr30() (any, error) {
+func (p *parser) callonConditionExpr30() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr30(stack["valueExpr"], stack["rest"])
 }
 
-func (c *current) onConditionExpr42(leftValue, rightValue any) (any, error) {
+func (c *current) onConditionExpr42(leftValue, rightValue interface{}) (interface{}, error) {
 	valueList := make([]*structs.ValueExpr, 2)
 	valueList[0] = leftValue.(*structs.ValueExpr)
 	valueList[1] = rightValue.(*structs.ValueExpr)
@@ -17908,26 +17909,26 @@ func (c *current) onConditionExpr42(leftValue, rightValue any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr42() (any, error) {
+func (p *parser) callonConditionExpr42() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr42(stack["leftValue"], stack["rightValue"])
 }
 
-func (c *current) onConditionExpr52() (any, error) {
+func (c *current) onConditionExpr52() (interface{}, error) {
 	node := &structs.ConditionExpr{
 		Op: "null",
 	}
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr52() (any, error) {
+func (p *parser) callonConditionExpr52() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr52()
 }
 
-func (c *current) onConditionValuePair1(condition, value any) (any, error) {
+func (c *current) onConditionValuePair1(condition, value interface{}) (interface{}, error) {
 	conditionValuePair := &structs.ConditionValuePair{
 		Condition: condition.(*structs.BoolExpr),
 		Value:     value.(*structs.ValueExpr),
@@ -17935,13 +17936,13 @@ func (c *current) onConditionValuePair1(condition, value any) (any, error) {
 	return conditionValuePair, nil
 }
 
-func (p *parser) callonConditionValuePair1() (any, error) {
+func (p *parser) callonConditionValuePair1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionValuePair1(stack["condition"], stack["value"])
 }
 
-func (c *current) onStringExprAsValueExpr1(stringExpr any) (any, error) {
+func (c *current) onStringExprAsValueExpr1(stringExpr interface{}) (interface{}, error) {
 	strExpr := stringExpr.(*structs.StringExpr)
 	valueExpr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -17951,13 +17952,13 @@ func (c *current) onStringExprAsValueExpr1(stringExpr any) (any, error) {
 	return valueExpr, nil
 }
 
-func (p *parser) callonStringExprAsValueExpr1() (any, error) {
+func (p *parser) callonStringExprAsValueExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExprAsValueExpr1(stack["stringExpr"])
 }
 
-func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr any) (any, error) {
+func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr interface{}) (interface{}, error) {
 	valueExpr := &structs.ValueExpr{
 		ValueExprMode:  structs.VEMMultiValueExpr,
 		MultiValueExpr: multiValueExpr.(*structs.MultiValueExpr),
@@ -17966,23 +17967,23 @@ func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr any) (any, error) 
 	return valueExpr, nil
 }
 
-func (p *parser) callonMultiValueExprAsValueExpr1() (any, error) {
+func (p *parser) callonMultiValueExprAsValueExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExprAsValueExpr1(stack["multiValueExpr"])
 }
 
-func (c *current) onStringOrMultiValueExpr1(strOrMVExpr any) (any, error) {
+func (c *current) onStringOrMultiValueExpr1(strOrMVExpr interface{}) (interface{}, error) {
 	return strOrMVExpr.(*structs.ValueExpr), nil
 }
 
-func (p *parser) callonStringOrMultiValueExpr1() (any, error) {
+func (p *parser) callonStringOrMultiValueExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringOrMultiValueExpr1(stack["strOrMVExpr"])
 }
 
-func (c *current) onMultiValueExpr2(opName, stringExpr, delim any) (any, error) {
+func (c *current) onMultiValueExpr2(opName, stringExpr, delim interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -17995,13 +17996,13 @@ func (c *current) onMultiValueExpr2(opName, stringExpr, delim any) (any, error) 
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr2() (any, error) {
+func (p *parser) callonMultiValueExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr2(stack["opName"], stack["stringExpr"], stack["delim"])
 }
 
-func (c *current) onMultiValueExpr13(opName, value, path any) (any, error) {
+func (c *current) onMultiValueExpr13(opName, value, path interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18014,13 +18015,13 @@ func (c *current) onMultiValueExpr13(opName, value, path any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr13() (any, error) {
+func (p *parser) callonMultiValueExpr13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr13(stack["opName"], stack["value"], stack["path"])
 }
 
-func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endIndex any) (any, error) {
+func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endIndex interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18037,13 +18038,13 @@ func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endInde
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr24() (any, error) {
+func (p *parser) callonMultiValueExpr24() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr24(stack["opName"], stack["multiValueExpr"], stack["startIndex"], stack["endIndex"])
 }
 
-func (c *current) onMultiValueExpr38(opName, multiValueExpr any) (any, error) {
+func (c *current) onMultiValueExpr38(opName, multiValueExpr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18056,13 +18057,13 @@ func (c *current) onMultiValueExpr38(opName, multiValueExpr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr38() (any, error) {
+func (p *parser) callonMultiValueExpr38() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr38(stack["opName"], stack["multiValueExpr"])
 }
 
-func (c *current) onMultiValueExpr48(opName, condition any) (any, error) {
+func (c *current) onMultiValueExpr48(opName, condition interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: Failed to recognize operator: %v, err= %v", opName, err)
@@ -18076,13 +18077,13 @@ func (c *current) onMultiValueExpr48(opName, condition any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr48() (any, error) {
+func (p *parser) callonMultiValueExpr48() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr48(stack["opName"], stack["condition"])
 }
 
-func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr any) (any, error) {
+func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18096,13 +18097,13 @@ func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr any) (any, err
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr56() (any, error) {
+func (p *parser) callonMultiValueExpr56() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr56(stack["opName"], stack["multiValueExpr"], stack["expr"])
 }
 
-func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr any) (any, error) {
+func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18116,13 +18117,13 @@ func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr an
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr67() (any, error) {
+func (p *parser) callonMultiValueExpr67() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr67(stack["opName"], stack["startIndex"], stack["endIndex"], stack["stringExpr"])
 }
 
-func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest any) (any, error) {
+func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18140,13 +18141,13 @@ func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest any) (any, er
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr82() (any, error) {
+func (p *parser) callonMultiValueExpr82() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr82(stack["opName"], stack["mvLeft"], stack["mvRight"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest any) (any, error) {
+func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18172,13 +18173,13 @@ func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest any) (any, err
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr98() (any, error) {
+func (p *parser) callonMultiValueExpr98() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr98(stack["opName"], stack["multiValueExpr"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr114(opName, firstVal, rest any) (any, error) {
+func (c *current) onMultiValueExpr114(opName, firstVal, rest interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18199,13 +18200,13 @@ func (c *current) onMultiValueExpr114(opName, firstVal, rest any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr114() (any, error) {
+func (p *parser) callonMultiValueExpr114() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr114(stack["opName"], stack["firstVal"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr127(field any) (any, error) {
+func (c *current) onMultiValueExpr127(field interface{}) (interface{}, error) {
 	expr := &structs.MultiValueExpr{
 		MultiValueExprMode: structs.MVEMField,
 		FieldName:          field.(string),
@@ -18214,13 +18215,13 @@ func (c *current) onMultiValueExpr127(field any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonMultiValueExpr127() (any, error) {
+func (p *parser) callonMultiValueExpr127() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr127(stack["field"])
 }
 
-func (c *current) onTextExpr2(opName, stringExpr any) (any, error) {
+func (c *current) onTextExpr2(opName, stringExpr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18233,13 +18234,13 @@ func (c *current) onTextExpr2(opName, stringExpr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonTextExpr2() (any, error) {
+func (p *parser) callonTextExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr2(stack["opName"], stack["stringExpr"])
 }
 
-func (c *current) onTextExpr13(opName, firstVal, rest any) (any, error) {
+func (c *current) onTextExpr13(opName, firstVal, rest interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18262,13 +18263,13 @@ func (c *current) onTextExpr13(opName, firstVal, rest any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonTextExpr13() (any, error) {
+func (p *parser) callonTextExpr13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr13(stack["opName"], stack["firstVal"], stack["rest"])
 }
 
-func (c *current) onTextExpr28(opName, multiValueExpr any) (any, error) {
+func (c *current) onTextExpr28(opName, multiValueExpr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18280,13 +18281,13 @@ func (c *current) onTextExpr28(opName, multiValueExpr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonTextExpr28() (any, error) {
+func (p *parser) callonTextExpr28() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr28(stack["opName"], stack["multiValueExpr"])
 }
 
-func (c *current) onTextExpr36(opName, multiValueExpr, delim any) (any, error) {
+func (c *current) onTextExpr36(opName, multiValueExpr, delim interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18299,13 +18300,13 @@ func (c *current) onTextExpr36(opName, multiValueExpr, delim any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonTextExpr36() (any, error) {
+func (p *parser) callonTextExpr36() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr36(stack["opName"], stack["multiValueExpr"], stack["delim"])
 }
 
-func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern any) (any, error) {
+func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("spl peg: TextExpr: %v", err)
@@ -18329,13 +18330,13 @@ func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern any) (any, e
 	return node, nil
 }
 
-func (p *parser) callonTextExpr47() (any, error) {
+func (p *parser) callonTextExpr47() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr47(stack["opName"], stack["multiValueExpr"], stack["regexPattern"])
 }
 
-func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam any) (any, error) {
+func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18361,13 +18362,13 @@ func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam any) 
 	return node, nil
 }
 
-func (p *parser) callonTextExpr58() (any, error) {
+func (p *parser) callonTextExpr58() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr58(stack["opName"], stack["stringExpr"], stack["startIndex"], stack["lengthParam"])
 }
 
-func (c *current) onTextExpr74(value, format any) (any, error) {
+func (c *current) onTextExpr74(value, format interface{}) (interface{}, error) {
 	var formatExpr *structs.StringExpr
 	if format != nil {
 		formatSlice := format.([]interface{})
@@ -18381,13 +18382,13 @@ func (c *current) onTextExpr74(value, format any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr74() (any, error) {
+func (p *parser) callonTextExpr74() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr74(stack["value"], stack["format"])
 }
 
-func (c *current) onTextExpr86(opName, expr, strToRemoveExpr any) (any, error) {
+func (c *current) onTextExpr86(opName, expr, strToRemoveExpr interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18407,13 +18408,13 @@ func (c *current) onTextExpr86(opName, expr, strToRemoveExpr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonTextExpr86() (any, error) {
+func (p *parser) callonTextExpr86() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr86(stack["opName"], stack["expr"], stack["strToRemoveExpr"])
 }
 
-func (c *current) onTextExpr100(mask, ip any) (any, error) {
+func (c *current) onTextExpr100(mask, ip interface{}) (interface{}, error) {
 	return &structs.TextExpr{
 		Op:    "ipmask",
 		Val:   ip.(*structs.ValueExpr),
@@ -18421,13 +18422,13 @@ func (c *current) onTextExpr100(mask, ip any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr100() (any, error) {
+func (p *parser) callonTextExpr100() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr100(stack["mask"], stack["ip"])
 }
 
-func (c *current) onTextExpr110(obj, key, value any) (any, error) {
+func (c *current) onTextExpr110(obj, key, value interface{}) (interface{}, error) {
 	stringExpr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawStringList,
 		StringList:     []string{key.(string), value.(string)},
@@ -18439,13 +18440,13 @@ func (c *current) onTextExpr110(obj, key, value any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr110() (any, error) {
+func (p *parser) callonTextExpr110() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr110(stack["obj"], stack["key"], stack["value"])
 }
 
-func (c *current) onTextExpr123(format, rest any) (any, error) {
+func (c *current) onTextExpr123(format, rest interface{}) (interface{}, error) {
 	textExpr := &structs.TextExpr{
 		Op:    "printf",
 		Param: format.(*structs.StringExpr),
@@ -18464,13 +18465,13 @@ func (c *current) onTextExpr123(format, rest any) (any, error) {
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr123() (any, error) {
+func (p *parser) callonTextExpr123() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr123(stack["format"], stack["rest"])
 }
 
-func (c *current) onTextExpr135(containInternalFields any) (any, error) {
+func (c *current) onTextExpr135(containInternalFields interface{}) (interface{}, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawString,
 		RawString:      "true", // default value
@@ -18493,13 +18494,13 @@ func (c *current) onTextExpr135(containInternalFields any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr135() (any, error) {
+func (p *parser) callonTextExpr135() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr135(stack["containInternalFields"])
 }
 
-func (c *current) onTextExpr147(field, threshold, match, delims any) (any, error) {
+func (c *current) onTextExpr147(field, threshold, match, delims interface{}) (interface{}, error) {
 	textExpr := &structs.TextExpr{
 		Op: "cluster",
 	}
@@ -18540,13 +18541,13 @@ func (c *current) onTextExpr147(field, threshold, match, delims any) (any, error
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr147() (any, error) {
+func (p *parser) callonTextExpr147() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr147(stack["field"], stack["threshold"], stack["match"], stack["delims"])
 }
 
-func (c *current) onTextExpr175(filter any) (any, error) {
+func (c *current) onTextExpr175(filter interface{}) (interface{}, error) {
 	textExpr := &structs.TextExpr{
 		Op: "getfields",
 	}
@@ -18558,26 +18559,26 @@ func (c *current) onTextExpr175(filter any) (any, error) {
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr175() (any, error) {
+func (p *parser) callonTextExpr175() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr175(stack["filter"])
 }
 
-func (c *current) onTextExpr183(valueExpr any) (any, error) {
+func (c *current) onTextExpr183(valueExpr interface{}) (interface{}, error) {
 	return &structs.TextExpr{
 		Op:  "typeof",
 		Val: valueExpr.(*structs.ValueExpr),
 	}, nil
 }
 
-func (p *parser) callonTextExpr183() (any, error) {
+func (p *parser) callonTextExpr183() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr183(stack["valueExpr"])
 }
 
-func (c *current) onTextExpr190(val, regex, replacement any) (any, error) {
+func (c *current) onTextExpr190(val, regex, replacement interface{}) (interface{}, error) {
 	return &structs.TextExpr{
 		Op:        "replace",
 		Val:       val.(*structs.ValueExpr),
@@ -18585,13 +18586,13 @@ func (c *current) onTextExpr190(val, regex, replacement any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr190() (any, error) {
+func (p *parser) callonTextExpr190() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr190(stack["val"], stack["regex"], stack["replacement"])
 }
 
-func (c *current) onTextExpr203(val, format any) (any, error) {
+func (c *current) onTextExpr203(val, format interface{}) (interface{}, error) {
 	return &structs.TextExpr{
 		Op:    "strftime",
 		Val:   val.(*structs.ValueExpr),
@@ -18599,13 +18600,13 @@ func (c *current) onTextExpr203(val, format any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr203() (any, error) {
+func (p *parser) callonTextExpr203() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr203(stack["val"], stack["format"])
 }
 
-func (c *current) onTextExpr213(val, format any) (any, error) {
+func (c *current) onTextExpr213(val, format interface{}) (interface{}, error) {
 	return &structs.TextExpr{
 		Op:    "strptime",
 		Val:   val.(*structs.ValueExpr),
@@ -18613,69 +18614,69 @@ func (c *current) onTextExpr213(val, format any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr213() (any, error) {
+func (p *parser) callonTextExpr213() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr213(stack["val"], stack["format"])
 }
 
-func (c *current) onQuotedPathString1(str any) (any, error) {
+func (c *current) onQuotedPathString1(str interface{}) (interface{}, error) {
 	return &SPathFieldExpr{
 		PathValue:       removeQuotes(str),
 		IsPathFieldName: false,
 	}, nil
 }
 
-func (p *parser) callonQuotedPathString1() (any, error) {
+func (p *parser) callonQuotedPathString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedPathString1(stack["str"])
 }
 
-func (c *current) onUnquotedPathValue1(str any) (any, error) {
+func (c *current) onUnquotedPathValue1(str interface{}) (interface{}, error) {
 	return &SPathFieldExpr{
 		PathValue:       removeQuotes(str),
 		IsPathFieldName: true,
 	}, nil
 }
 
-func (p *parser) callonUnquotedPathValue1() (any, error) {
+func (p *parser) callonUnquotedPathValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedPathValue1(stack["str"])
 }
 
-func (c *current) onStrToRemoveExpr1(strToRemove any) (any, error) {
+func (c *current) onStrToRemoveExpr1(strToRemove interface{}) (interface{}, error) {
 	return strToRemove, nil
 }
 
-func (p *parser) callonStrToRemoveExpr1() (any, error) {
+func (p *parser) callonStrToRemoveExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStrToRemoveExpr1(stack["strToRemove"])
 }
 
-func (c *current) onEvalFieldToRead2() (any, error) {
+func (c *current) onEvalFieldToRead2() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonEvalFieldToRead2() (any, error) {
+func (p *parser) callonEvalFieldToRead2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalFieldToRead2()
 }
 
-func (c *current) onEvalFieldToRead9(field any) (any, error) {
+func (c *current) onEvalFieldToRead9(field interface{}) (interface{}, error) {
 	return field, nil
 }
 
-func (p *parser) callonEvalFieldToRead9() (any, error) {
+func (p *parser) callonEvalFieldToRead9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalFieldToRead9(stack["field"])
 }
 
-func (c *current) onWhereBlock1(condition any) (any, error) {
+func (c *current) onWhereBlock1(condition interface{}) (interface{}, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -18687,23 +18688,23 @@ func (c *current) onWhereBlock1(condition any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonWhereBlock1() (any, error) {
+func (p *parser) callonWhereBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWhereBlock1(stack["condition"])
 }
 
-func (c *current) onBoolExpr1(expr any) (any, error) {
+func (c *current) onBoolExpr1(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonBoolExpr1() (any, error) {
+func (p *parser) callonBoolExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExpr1(stack["expr"])
 }
 
-func (c *current) onBoolExprLevel41(first, rest any) (any, error) {
+func (c *current) onBoolExprLevel41(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -18722,13 +18723,13 @@ func (c *current) onBoolExprLevel41(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel41() (any, error) {
+func (p *parser) callonBoolExprLevel41() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel41(stack["first"], stack["rest"])
 }
 
-func (c *current) onBoolExprLevel31(first, rest any) (any, error) {
+func (c *current) onBoolExprLevel31(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -18747,13 +18748,13 @@ func (c *current) onBoolExprLevel31(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel31() (any, error) {
+func (p *parser) callonBoolExprLevel31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onBoolExprLevel22(first any) (any, error) {
+func (c *current) onBoolExprLevel22(first interface{}) (interface{}, error) {
 	cur := &structs.BoolExpr{
 		IsTerminal: false,
 		BoolOp:     structs.BoolOpNot,
@@ -18764,43 +18765,43 @@ func (c *current) onBoolExprLevel22(first any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel22() (any, error) {
+func (p *parser) callonBoolExprLevel22() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel22(stack["first"])
 }
 
-func (c *current) onBoolExprLevel29(first any) (any, error) {
+func (c *current) onBoolExprLevel29(first interface{}) (interface{}, error) {
 	return first, nil
 }
 
-func (p *parser) callonBoolExprLevel29() (any, error) {
+func (p *parser) callonBoolExprLevel29() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel29(stack["first"])
 }
 
-func (c *current) onBoolExprLevel12(first any) (any, error) {
+func (c *current) onBoolExprLevel12(first interface{}) (interface{}, error) {
 	return first, nil
 }
 
-func (p *parser) callonBoolExprLevel12() (any, error) {
+func (p *parser) callonBoolExprLevel12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel12(stack["first"])
 }
 
-func (c *current) onBoolExprLevel18(expr any) (any, error) {
+func (c *current) onBoolExprLevel18(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonBoolExprLevel18() (any, error) {
+func (p *parser) callonBoolExprLevel18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel18(stack["expr"])
 }
 
-func (c *current) onEvalComparisonExpr2(op, value any) (any, error) {
+func (c *current) onEvalComparisonExpr2(op, value interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: BoolExpr: %v", err)
@@ -18831,13 +18832,13 @@ func (c *current) onEvalComparisonExpr2(op, value any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr2() (any, error) {
+func (p *parser) callonEvalComparisonExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr2(stack["op"], stack["value"])
 }
 
-func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue any) (any, error) {
+func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: BoolExpr: %v", err)
@@ -18851,13 +18852,13 @@ func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue any) (any
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr19() (any, error) {
+func (p *parser) callonEvalComparisonExpr19() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr19(stack["opName"], stack["leftValue"], stack["rightValue"])
 }
 
-func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest any) (any, error) {
+func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ValueExpr, 1+len(restSlice))
 	slice[0] = valueToJudge.(*structs.ValueExpr)
@@ -18876,13 +18877,13 @@ func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest any) (any, err
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr34() (any, error) {
+func (p *parser) callonEvalComparisonExpr34() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr34(stack["left"], stack["valueToJudge"], stack["rest"])
 }
 
-func (c *current) onEvalComparisonExpr49(valueToJudge, rest any) (any, error) {
+func (c *current) onEvalComparisonExpr49(valueToJudge, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ValueExpr, len(restSlice))
 
@@ -18900,13 +18901,13 @@ func (c *current) onEvalComparisonExpr49(valueToJudge, rest any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr49() (any, error) {
+func (p *parser) callonEvalComparisonExpr49() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr49(stack["valueToJudge"], stack["rest"])
 }
 
-func (c *current) onBoolComparisonExpr1(left, op, right any) (any, error) {
+func (c *current) onBoolComparisonExpr1(left, op, right interface{}) (interface{}, error) {
 	expr := &structs.BoolExpr{
 		IsTerminal: true,
 		LeftValue:  left.(*structs.ValueExpr),
@@ -18917,13 +18918,13 @@ func (c *current) onBoolComparisonExpr1(left, op, right any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonBoolComparisonExpr1() (any, error) {
+func (p *parser) callonBoolComparisonExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolComparisonExpr1(stack["left"], stack["op"], stack["right"])
 }
 
-func (c *current) onValueExpr2(condition any) (any, error) {
+func (c *current) onValueExpr2(condition interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMConditionExpr,
@@ -18933,13 +18934,13 @@ func (c *current) onValueExpr2(condition any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr2() (any, error) {
+func (p *parser) callonValueExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr2(stack["condition"])
 }
 
-func (c *current) onValueExpr5(condition any) (any, error) {
+func (c *current) onValueExpr5(condition interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMConditionExpr,
@@ -18949,13 +18950,13 @@ func (c *current) onValueExpr5(condition any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr5() (any, error) {
+func (p *parser) callonValueExpr5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr5(stack["condition"])
 }
 
-func (c *current) onValueExpr11(numeric any) (any, error) {
+func (c *current) onValueExpr11(numeric interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMNumericExpr,
@@ -18965,13 +18966,13 @@ func (c *current) onValueExpr11(numeric any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr11() (any, error) {
+func (p *parser) callonValueExpr11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr11(stack["numeric"])
 }
 
-func (c *current) onValueExpr14(str any) (any, error) {
+func (c *current) onValueExpr14(str interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -18981,13 +18982,13 @@ func (c *current) onValueExpr14(str any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr14() (any, error) {
+func (p *parser) callonValueExpr14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr14(stack["str"])
 }
 
-func (c *current) onValueExpr17(str any) (any, error) {
+func (c *current) onValueExpr17(str interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -18997,13 +18998,13 @@ func (c *current) onValueExpr17(str any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr17() (any, error) {
+func (p *parser) callonValueExpr17() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr17(stack["str"])
 }
 
-func (c *current) onValueExpr23(boolean any) (any, error) {
+func (c *current) onValueExpr23(boolean interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMBooleanExpr,
@@ -19013,13 +19014,13 @@ func (c *current) onValueExpr23(boolean any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr23() (any, error) {
+func (p *parser) callonValueExpr23() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr23(stack["boolean"])
 }
 
-func (c *current) onValueExpr29(multiValueExpr any) (any, error) {
+func (c *current) onValueExpr29(multiValueExpr interface{}) (interface{}, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode:  structs.VEMMultiValueExpr,
@@ -19029,13 +19030,13 @@ func (c *current) onValueExpr29(multiValueExpr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr29() (any, error) {
+func (p *parser) callonValueExpr29() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr29(stack["multiValueExpr"])
 }
 
-func (c *current) onStringExpr2(text any) (any, error) {
+func (c *current) onStringExpr2(text interface{}) (interface{}, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMTextExpr,
 		TextExpr:       text.(*structs.TextExpr),
@@ -19044,13 +19045,13 @@ func (c *current) onStringExpr2(text any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr2() (any, error) {
+func (p *parser) callonStringExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr2(stack["text"])
 }
 
-func (c *current) onStringExpr8(str any) (any, error) {
+func (c *current) onStringExpr8(str interface{}) (interface{}, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawString,
 		RawString:      removeQuotes(str),
@@ -19059,13 +19060,13 @@ func (c *current) onStringExpr8(str any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr8() (any, error) {
+func (p *parser) callonStringExpr8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr8(stack["str"])
 }
 
-func (c *current) onStringExpr14(field any) (any, error) {
+func (c *current) onStringExpr14(field interface{}) (interface{}, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMField,
 		FieldName:      field.(string),
@@ -19074,13 +19075,13 @@ func (c *current) onStringExpr14(field any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr14() (any, error) {
+func (p *parser) callonStringExpr14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr14(stack["field"])
 }
 
-func (c *current) onStringExpr27(concat any) (any, error) {
+func (c *current) onStringExpr27(concat interface{}) (interface{}, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMConcatExpr,
 		ConcatExpr:     concat.(*structs.ConcatExpr),
@@ -19089,13 +19090,13 @@ func (c *current) onStringExpr27(concat any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr27() (any, error) {
+func (p *parser) callonStringExpr27() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr27(stack["concat"])
 }
 
-func (c *current) onConcatExpr1(first, rest any) (any, error) {
+func (c *current) onConcatExpr1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ConcatAtom, 1+len(restSlice))
 	slice[0] = first.(*structs.ConcatAtom)
@@ -19112,13 +19113,13 @@ func (c *current) onConcatExpr1(first, rest any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonConcatExpr1() (any, error) {
+func (p *parser) callonConcatExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onConcatAtom2(text any) (any, error) {
+func (c *current) onConcatAtom2(text interface{}) (interface{}, error) {
 	atom := &structs.ConcatAtom{
 		IsField:  false,
 		Value:    "",
@@ -19128,13 +19129,13 @@ func (c *current) onConcatAtom2(text any) (any, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom2() (any, error) {
+func (p *parser) callonConcatAtom2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom2(stack["text"])
 }
 
-func (c *current) onConcatAtom5(str any) (any, error) {
+func (c *current) onConcatAtom5(str interface{}) (interface{}, error) {
 	atom := &structs.ConcatAtom{
 		IsField: false,
 		Value:   removeQuotes(str),
@@ -19143,13 +19144,13 @@ func (c *current) onConcatAtom5(str any) (any, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom5() (any, error) {
+func (p *parser) callonConcatAtom5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom5(stack["str"])
 }
 
-func (c *current) onConcatAtom8(number any) (any, error) {
+func (c *current) onConcatAtom8(number interface{}) (interface{}, error) {
 	atom := &structs.ConcatAtom{
 		IsField: false,
 		Value:   number.(string),
@@ -19158,13 +19159,13 @@ func (c *current) onConcatAtom8(number any) (any, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom8() (any, error) {
+func (p *parser) callonConcatAtom8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom8(stack["number"])
 }
 
-func (c *current) onConcatAtom11(field any) (any, error) {
+func (c *current) onConcatAtom11(field interface{}) (interface{}, error) {
 	atom := &structs.ConcatAtom{
 		IsField: true,
 		Value:   field.(string),
@@ -19173,23 +19174,23 @@ func (c *current) onConcatAtom11(field any) (any, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom11() (any, error) {
+func (p *parser) callonConcatAtom11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom11(stack["field"])
 }
 
-func (c *current) onNumericExpr1(expr any) (any, error) {
+func (c *current) onNumericExpr1(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExpr1() (any, error) {
+func (p *parser) callonNumericExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExpr1(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel31(first, rest any) (any, error) {
+func (c *current) onNumericExprLevel31(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -19209,13 +19210,13 @@ func (c *current) onNumericExprLevel31(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonNumericExprLevel31() (any, error) {
+func (p *parser) callonNumericExprLevel31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onNumericExprLevel21(first, rest any) (any, error) {
+func (c *current) onNumericExprLevel21(first, rest interface{}) (interface{}, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -19235,13 +19236,13 @@ func (c *current) onNumericExprLevel21(first, rest any) (any, error) {
 	return cur, nil
 }
 
-func (p *parser) callonNumericExprLevel21() (any, error) {
+func (p *parser) callonNumericExprLevel21() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel21(stack["first"], stack["rest"])
 }
 
-func (c *current) onNumericParamExpr1(expr any) (any, error) {
+func (c *current) onNumericParamExpr1(expr interface{}) (interface{}, error) {
 	rightNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19250,33 +19251,33 @@ func (c *current) onNumericParamExpr1(expr any) (any, error) {
 	return rightNumericExpr, nil
 }
 
-func (p *parser) callonNumericParamExpr1() (any, error) {
+func (p *parser) callonNumericParamExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericParamExpr1(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel12(expr any) (any, error) {
+func (c *current) onNumericExprLevel12(expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel12() (any, error) {
+func (p *parser) callonNumericExprLevel12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel12(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel18(numericEvalExpr any) (any, error) {
+func (c *current) onNumericExprLevel18(numericEvalExpr interface{}) (interface{}, error) {
 	return numericEvalExpr, nil
 }
 
-func (p *parser) callonNumericExprLevel18() (any, error) {
+func (p *parser) callonNumericExprLevel18() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel18(stack["numericEvalExpr"])
 }
 
-func (c *current) onNumericExprLevel111(field any) (any, error) {
+func (c *current) onNumericExprLevel111(field interface{}) (interface{}, error) {
 	expr := &structs.NumericExpr{
 		IsTerminal:      true,
 		ValueIsField:    true,
@@ -19287,13 +19288,13 @@ func (c *current) onNumericExprLevel111(field any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel111() (any, error) {
+func (p *parser) callonNumericExprLevel111() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel111(stack["field"])
 }
 
-func (c *current) onNumericExprLevel114(number any) (any, error) {
+func (c *current) onNumericExprLevel114(number interface{}) (interface{}, error) {
 	expr := &structs.NumericExpr{
 		IsTerminal:      true,
 		ValueIsField:    false,
@@ -19304,13 +19305,13 @@ func (c *current) onNumericExprLevel114(number any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel114() (any, error) {
+func (p *parser) callonNumericExprLevel114() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel114(stack["number"])
 }
 
-func (c *current) onNumericEvalExpr2(opName, expr any) (any, error) {
+func (c *current) onNumericEvalExpr2(opName, expr interface{}) (interface{}, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19331,13 +19332,13 @@ func (c *current) onNumericEvalExpr2(opName, expr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr2() (any, error) {
+func (p *parser) callonNumericEvalExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr2(stack["opName"], stack["expr"])
 }
 
-func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision any) (any, error) {
+func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision interface{}) (interface{}, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19359,13 +19360,13 @@ func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision any) (any,
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr31() (any, error) {
+func (p *parser) callonNumericEvalExpr31() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr31(stack["roundExpr"], stack["expr"], stack["roundPrecision"])
 }
 
-func (c *current) onNumericEvalExpr42(opName any) (any, error) {
+func (c *current) onNumericEvalExpr42(opName interface{}) (interface{}, error) {
 	//transfer []uint8 to string
 	strData, ok := opName.([]byte)
 	if !ok {
@@ -19379,13 +19380,13 @@ func (c *current) onNumericEvalExpr42(opName any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonNumericEvalExpr42() (any, error) {
+func (p *parser) callonNumericEvalExpr42() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr42(stack["opName"])
 }
 
-func (c *current) onNumericEvalExpr52(stringExpr, baseExpr any) (any, error) {
+func (c *current) onNumericEvalExpr52(stringExpr, baseExpr interface{}) (interface{}, error) {
 	stringExprConverted, ok := stringExpr.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert stringExpr as *structs.StringExpr")
@@ -19414,23 +19415,23 @@ func (c *current) onNumericEvalExpr52(stringExpr, baseExpr any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr52() (any, error) {
+func (p *parser) callonNumericEvalExpr52() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr52(stack["stringExpr"], stack["baseExpr"])
 }
 
-func (c *current) onNumericEvalExpr64(lenExpr, expr any) (any, error) {
+func (c *current) onNumericEvalExpr64(lenExpr, expr interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericEvalExpr64() (any, error) {
+func (p *parser) callonNumericEvalExpr64() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr64(stack["lenExpr"], stack["expr"])
 }
 
-func (c *current) onNumericEvalExpr72(opName, expr, param any) (any, error) {
+func (c *current) onNumericEvalExpr72(opName, expr, param interface{}) (interface{}, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19461,13 +19462,13 @@ func (c *current) onNumericEvalExpr72(opName, expr, param any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr72() (any, error) {
+func (p *parser) callonNumericEvalExpr72() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr72(stack["opName"], stack["expr"], stack["param"])
 }
 
-func (c *current) onNumericEvalExpr85(opName, expr, param any) (any, error) {
+func (c *current) onNumericEvalExpr85(opName, expr, param interface{}) (interface{}, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19497,13 +19498,13 @@ func (c *current) onNumericEvalExpr85(opName, expr, param any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr85() (any, error) {
+func (p *parser) callonNumericEvalExpr85() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr85(stack["opName"], stack["expr"], stack["param"])
 }
 
-func (c *current) onNumericEvalExpr96(opName, expr, specifier any) (any, error) {
+func (c *current) onNumericEvalExpr96(opName, expr, specifier interface{}) (interface{}, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: NumericExpr: %v", err)
@@ -19520,13 +19521,13 @@ func (c *current) onNumericEvalExpr96(opName, expr, specifier any) (any, error) 
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr96() (any, error) {
+func (p *parser) callonNumericEvalExpr96() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr96(stack["opName"], stack["expr"], stack["specifier"])
 }
 
-func (c *current) onLenExpr2(str any) (any, error) {
+func (c *current) onLenExpr2(str interface{}) (interface{}, error) {
 
 	leftNumericExpr := &structs.NumericExpr{
 		IsTerminal:      true,
@@ -19543,13 +19544,13 @@ func (c *current) onLenExpr2(str any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonLenExpr2() (any, error) {
+func (p *parser) callonLenExpr2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLenExpr2(stack["str"])
 }
 
-func (c *current) onLenExpr8(field any) (any, error) {
+func (c *current) onLenExpr8(field interface{}) (interface{}, error) {
 
 	leftNumericExpr := &structs.NumericExpr{
 		IsTerminal:      true,
@@ -19566,13 +19567,13 @@ func (c *current) onLenExpr8(field any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonLenExpr8() (any, error) {
+func (p *parser) callonLenExpr8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLenExpr8(stack["field"])
 }
 
-func (c *current) onHeadOptionNull1(boolVal any) (any, error) {
+func (c *current) onHeadOptionNull1(boolVal interface{}) (interface{}, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "null",
 		headExpr: &structs.HeadExpr{
@@ -19583,13 +19584,13 @@ func (c *current) onHeadOptionNull1(boolVal any) (any, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionNull1() (any, error) {
+func (p *parser) callonHeadOptionNull1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionNull1(stack["boolVal"])
 }
 
-func (c *current) onHeadOptionKeeplast1(boolVal any) (any, error) {
+func (c *current) onHeadOptionKeeplast1(boolVal interface{}) (interface{}, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "keeplast",
 		headExpr: &structs.HeadExpr{
@@ -19600,13 +19601,13 @@ func (c *current) onHeadOptionKeeplast1(boolVal any) (any, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionKeeplast1() (any, error) {
+func (p *parser) callonHeadOptionKeeplast1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionKeeplast1(stack["boolVal"])
 }
 
-func (c *current) onHeadOptionLimit1(intAsStr any) (any, error) {
+func (c *current) onHeadOptionLimit1(intAsStr interface{}) (interface{}, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -19621,13 +19622,13 @@ func (c *current) onHeadOptionLimit1(intAsStr any) (any, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionLimit1() (any, error) {
+func (p *parser) callonHeadOptionLimit1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionLimit1(stack["intAsStr"])
 }
 
-func (c *current) onHeadOptionExpr1(boolExpr any) (any, error) {
+func (c *current) onHeadOptionExpr1(boolExpr interface{}) (interface{}, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "boolexpr",
 		headExpr: &structs.HeadExpr{
@@ -19638,23 +19639,23 @@ func (c *current) onHeadOptionExpr1(boolExpr any) (any, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionExpr1() (any, error) {
+func (p *parser) callonHeadOptionExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionExpr1(stack["boolExpr"])
 }
 
-func (c *current) onHeadOption1(option any) (any, error) {
+func (c *current) onHeadOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonHeadOption1() (any, error) {
+func (p *parser) callonHeadOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOption1(stack["option"])
 }
 
-func (c *current) onHeadOptionList1(first, rest any) (any, error) {
+func (c *current) onHeadOptionList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 
@@ -19709,13 +19710,13 @@ func (c *current) onHeadOptionList1(first, rest any) (any, error) {
 	return headExpr, nil
 }
 
-func (p *parser) callonHeadOptionList1() (any, error) {
+func (p *parser) callonHeadOptionList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onHeadBlock2(headExpr any) (any, error) {
+func (c *current) onHeadBlock2(headExpr interface{}) (interface{}, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -19727,13 +19728,13 @@ func (c *current) onHeadBlock2(headExpr any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock2() (any, error) {
+func (p *parser) callonHeadBlock2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock2(stack["headExpr"])
 }
 
-func (c *current) onHeadBlock8(intAsStr any) (any, error) {
+func (c *current) onHeadBlock8(intAsStr interface{}) (interface{}, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -19754,13 +19755,13 @@ func (c *current) onHeadBlock8(intAsStr any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock8() (any, error) {
+func (p *parser) callonHeadBlock8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock8(stack["intAsStr"])
 }
 
-func (c *current) onHeadBlock14() (any, error) {
+func (c *current) onHeadBlock14() (interface{}, error) {
 
 	headExpr := &structs.HeadExpr{
 		MaxRows: uint64(10), // From https://docs.splunk.com/Documentation/Splunk/9.1.0/SearchReference/Head
@@ -19777,13 +19778,13 @@ func (c *current) onHeadBlock14() (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock14() (any, error) {
+func (p *parser) callonHeadBlock14() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock14()
 }
 
-func (c *current) onTailBlock2(intAsStr any) (any, error) {
+func (c *current) onTailBlock2(intAsStr interface{}) (interface{}, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -19805,13 +19806,13 @@ func (c *current) onTailBlock2(intAsStr any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonTailBlock2() (any, error) {
+func (p *parser) callonTailBlock2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTailBlock2(stack["intAsStr"])
 }
 
-func (c *current) onTailBlock8() (any, error) {
+func (c *current) onTailBlock8() (interface{}, error) {
 
 	tExpr := &structs.TailExpr{
 		TailRecords: make(map[string]map[string]interface{}, 0),
@@ -19829,13 +19830,13 @@ func (c *current) onTailBlock8() (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonTailBlock8() (any, error) {
+func (p *parser) callonTailBlock8() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTailBlock8()
 }
 
-func (c *current) onAggregationList1(first, rest any) (any, error) {
+func (c *current) onAggregationList1(first, rest interface{}) (interface{}, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is ", " and the second is an Aggregator.
 	restSlice := rest.([]any)
@@ -19852,13 +19853,13 @@ func (c *current) onAggregationList1(first, rest any) (any, error) {
 	return aggsSlice, nil
 }
 
-func (p *parser) callonAggregationList1() (any, error) {
+func (p *parser) callonAggregationList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregationList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onAggregator1(aggFunc, asField any) (any, error) {
+func (c *current) onAggregator1(aggFunc, asField interface{}) (interface{}, error) {
 	agg := &aggregator{}
 	agg.measureAgg = aggFunc.(*structs.MeasureAggregator)
 
@@ -19870,43 +19871,43 @@ func (c *current) onAggregator1(aggFunc, asField any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggregator1() (any, error) {
+func (p *parser) callonAggregator1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregator1(stack["aggFunc"], stack["asField"])
 }
 
-func (c *current) onAggFunction1(agg any) (any, error) {
+func (c *current) onAggFunction1(agg interface{}) (interface{}, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggFunction1() (any, error) {
+func (p *parser) callonAggFunction1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggFunction1(stack["agg"])
 }
 
-func (c *current) onCommonAggName1() (any, error) {
+func (c *current) onCommonAggName1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonCommonAggName1() (any, error) {
+func (p *parser) callonCommonAggName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonAggName1()
 }
 
-func (c *current) onCommonPercAggName1() (any, error) {
+func (c *current) onCommonPercAggName1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonCommonPercAggName1() (any, error) {
+func (p *parser) callonCommonPercAggName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonPercAggName1()
 }
 
-func (c *current) onAsField1(field any) (any, error) {
+func (c *current) onAsField1(field interface{}) (interface{}, error) {
 	fieldStr := field.(string)
 
 	if strings.Contains(fieldStr, "*") {
@@ -19920,13 +19921,13 @@ func (c *current) onAsField1(field any) (any, error) {
 	return fieldStr, nil
 }
 
-func (p *parser) callonAsField1() (any, error) {
+func (p *parser) callonAsField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAsField1(stack["field"])
 }
 
-func (c *current) onAggCount2(valueExpr any) (any, error) {
+func (c *current) onAggCount2(valueExpr interface{}) (interface{}, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:      "",
 		MeasureFunc:     sutils.Count,
@@ -19937,13 +19938,13 @@ func (c *current) onAggCount2(valueExpr any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount2() (any, error) {
+func (p *parser) callonAggCount2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount2(stack["valueExpr"])
 }
 
-func (c *current) onAggCount12(field any) (any, error) {
+func (c *current) onAggCount12(field interface{}) (interface{}, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:  field.(string),
 		MeasureFunc: sutils.Count,
@@ -19952,13 +19953,13 @@ func (c *current) onAggCount12(field any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount12() (any, error) {
+func (p *parser) callonAggCount12() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount12(stack["field"])
 }
 
-func (c *current) onAggCount21() (any, error) {
+func (c *current) onAggCount21() (interface{}, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:  "*",
 		MeasureFunc: sutils.Count,
@@ -19967,13 +19968,13 @@ func (c *current) onAggCount21() (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount21() (any, error) {
+func (p *parser) callonAggCount21() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount21()
 }
 
-func (c *current) onAggCommon2(aggName, valueExpr any) (any, error) {
+func (c *current) onAggCommon2(aggName, valueExpr interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -19989,13 +19990,13 @@ func (c *current) onAggCommon2(aggName, valueExpr any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCommon2() (any, error) {
+func (p *parser) callonAggCommon2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCommon2(stack["aggName"], stack["valueExpr"])
 }
 
-func (c *current) onAggCommon11(aggName, field any) (any, error) {
+func (c *current) onAggCommon11(aggName, field interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20025,14 +20026,15 @@ func (c *current) onAggCommon11(aggName, field any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCommon11() (any, error) {
+func (p *parser) callonAggCommon11() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCommon11(stack["aggName"], stack["field"])
 }
 
-func (c *current) onPercentileVal1(numStr any) (any, error) {
-	floatVal, err := utils.FastParseFloat([]byte(numStr.(string)))
+func (c *current) onPercentileVal1(numStr interface{}) (interface{}, error) {
+	// floatVal, err := utils.FastParseFloat([]byte(numStr.(string)))
+	floatVal, err := strconv.ParseFloat(numStr.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid percentage value: %v", numStr.(string))
 	}
@@ -20043,13 +20045,13 @@ func (c *current) onPercentileVal1(numStr any) (any, error) {
 	return floatVal, nil
 }
 
-func (p *parser) callonPercentileVal1() (any, error) {
+func (p *parser) callonPercentileVal1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPercentileVal1(stack["numStr"])
 }
 
-func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr any) (any, error) {
+func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20066,13 +20068,13 @@ func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr any) (any, 
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon2() (any, error) {
+func (p *parser) callonAggPercCommon2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon2(stack["aggName"], stack["percentileVal"], stack["valueExpr"])
 }
 
-func (c *current) onAggPercCommon13(aggName, percentileVal, field any) (any, error) {
+func (c *current) onAggPercCommon13(aggName, percentileVal, field interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20088,13 +20090,13 @@ func (c *current) onAggPercCommon13(aggName, percentileVal, field any) (any, err
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon13() (any, error) {
+func (p *parser) callonAggPercCommon13() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon13(stack["aggName"], stack["percentileVal"], stack["field"])
 }
 
-func (c *current) onAggPercCommon23(field any) (any, error) {
+func (c *current) onAggPercCommon23(field interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction("median")
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20110,13 +20112,13 @@ func (c *current) onAggPercCommon23(field any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon23() (any, error) {
+func (p *parser) callonAggPercCommon23() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon23(stack["field"])
 }
 
-func (c *current) onAggPercCommon30(valueExpr any) (any, error) {
+func (c *current) onAggPercCommon30(valueExpr interface{}) (interface{}, error) {
 	measureFunc := GetAggregateFunction("median")
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20133,23 +20135,23 @@ func (c *current) onAggPercCommon30(valueExpr any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon30() (any, error) {
+func (p *parser) callonAggPercCommon30() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon30(stack["valueExpr"])
 }
 
-func (c *current) onFieldWithNumberValue1(keyValuePair any) (any, error) {
+func (c *current) onFieldWithNumberValue1(keyValuePair interface{}) (interface{}, error) {
 	return keyValuePair, nil
 }
 
-func (p *parser) callonFieldWithNumberValue1() (any, error) {
+func (p *parser) callonFieldWithNumberValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithNumberValue1(stack["keyValuePair"])
 }
 
-func (c *current) onNamedFieldWithNumberValue1(key, op, value any) (any, error) {
+func (c *current) onNamedFieldWithNumberValue1(key, op, value interface{}) (interface{}, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20162,13 +20164,13 @@ func (c *current) onNamedFieldWithNumberValue1(key, op, value any) (any, error) 
 	return node, nil
 }
 
-func (p *parser) callonNamedFieldWithNumberValue1() (any, error) {
+func (p *parser) callonNamedFieldWithNumberValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNamedFieldWithNumberValue1(stack["key"], stack["op"], stack["value"])
 }
 
-func (c *current) onUnnamedFieldWithNumberValue1(value any) (any, error) {
+func (c *current) onUnnamedFieldWithNumberValue1(value interface{}) (interface{}, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20181,13 +20183,13 @@ func (c *current) onUnnamedFieldWithNumberValue1(value any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonUnnamedFieldWithNumberValue1() (any, error) {
+func (p *parser) callonUnnamedFieldWithNumberValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnnamedFieldWithNumberValue1(stack["value"])
 }
 
-func (c *current) onFieldWithBooleanValue1(key, op, value any) (any, error) {
+func (c *current) onFieldWithBooleanValue1(key, op, value interface{}) (interface{}, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20200,23 +20202,23 @@ func (c *current) onFieldWithBooleanValue1(key, op, value any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonFieldWithBooleanValue1() (any, error) {
+func (p *parser) callonFieldWithBooleanValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithBooleanValue1(stack["key"], stack["op"], stack["value"])
 }
 
-func (c *current) onFieldWithStringValue1(keyValuePair any) (any, error) {
+func (c *current) onFieldWithStringValue1(keyValuePair interface{}) (interface{}, error) {
 	return keyValuePair, nil
 }
 
-func (p *parser) callonFieldWithStringValue1() (any, error) {
+func (p *parser) callonFieldWithStringValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithStringValue1(stack["keyValuePair"])
 }
 
-func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (any, error) {
+func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq interface{}) (interface{}, error) {
 	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
@@ -20232,13 +20234,13 @@ func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (an
 	return node, nil
 }
 
-func (p *parser) callonNamedFieldWithStringValue1() (any, error) {
+func (p *parser) callonNamedFieldWithStringValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNamedFieldWithStringValue1(stack["key"], stack["op"], stack["stringSearchReq"])
 }
 
-func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, error) {
+func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq interface{}) (interface{}, error) {
 	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
@@ -20254,13 +20256,13 @@ func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, erro
 	return node, nil
 }
 
-func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
+func (p *parser) callonUnnamedFieldWithStringValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnnamedFieldWithStringValue1(stack["stringSearchReq"])
 }
 
-func (c *current) onCaseSensitiveString1(value any) (any, error) {
+func (c *current) onCaseSensitiveString1(value interface{}) (interface{}, error) {
 	return &StringSearchRequest{
 		value:           value,
 		originalValue:   value,
@@ -20268,13 +20270,13 @@ func (c *current) onCaseSensitiveString1(value any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonCaseSensitiveString1() (any, error) {
+func (p *parser) callonCaseSensitiveString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseSensitiveString1(stack["value"])
 }
 
-func (c *current) onCaseInsensitiveString2(value any) (any, error) {
+func (c *current) onCaseInsensitiveString2(value interface{}) (interface{}, error) {
 	return &StringSearchRequest{
 		value:           strings.ToLower(value.(string)),
 		originalValue:   value,
@@ -20283,13 +20285,13 @@ func (c *current) onCaseInsensitiveString2(value any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonCaseInsensitiveString2() (any, error) {
+func (p *parser) callonCaseInsensitiveString2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseInsensitiveString2(stack["value"])
 }
 
-func (c *current) onCaseInsensitiveString9(value any) (any, error) {
+func (c *current) onCaseInsensitiveString9(value interface{}) (interface{}, error) {
 	return &StringSearchRequest{
 		value:           strings.ToLower(value.(string)),
 		originalValue:   value,
@@ -20297,13 +20299,13 @@ func (c *current) onCaseInsensitiveString9(value any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonCaseInsensitiveString9() (any, error) {
+func (p *parser) callonCaseInsensitiveString9() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseInsensitiveString9(stack["value"])
 }
 
-func (c *current) onFieldNameList1(first, rest any) (any, error) {
+func (c *current) onFieldNameList1(first, rest interface{}) (interface{}, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is ", " and the second is a FieldName.
 	restSlice := rest.([]any)
@@ -20320,13 +20322,13 @@ func (c *current) onFieldNameList1(first, rest any) (any, error) {
 	return fields, nil
 }
 
-func (p *parser) callonFieldNameList1() (any, error) {
+func (p *parser) callonFieldNameList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldNameList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onEarliestAndLatest1(earliestTime, latestTime any) (any, error) {
+func (c *current) onEarliestAndLatest1(earliestTime, latestTime interface{}) (interface{}, error) {
 	var startEpoch int64 = 0
 	var endEpoch int64 = 0
 	var err error
@@ -20367,13 +20369,13 @@ func (c *current) onEarliestAndLatest1(earliestTime, latestTime any) (any, error
 	return node, nil
 }
 
-func (p *parser) callonEarliestAndLatest1() (any, error) {
+func (p *parser) callonEarliestAndLatest1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEarliestAndLatest1(stack["earliestTime"], stack["latestTime"])
 }
 
-func (c *current) onEarliestOnly1(earliestTime any) (any, error) {
+func (c *current) onEarliestOnly1(earliestTime interface{}) (interface{}, error) {
 	var startEpoch int64 = 0
 	var err error
 
@@ -20401,56 +20403,56 @@ func (c *current) onEarliestOnly1(earliestTime any) (any, error) {
 	return node, nil
 }
 
-func (p *parser) callonEarliestOnly1() (any, error) {
+func (p *parser) callonEarliestOnly1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEarliestOnly1(stack["earliestTime"])
 }
 
-func (c *current) onRelIntegerAsString1() (any, error) {
+func (c *current) onRelIntegerAsString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonRelIntegerAsString1() (any, error) {
+func (p *parser) callonRelIntegerAsString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelIntegerAsString1()
 }
 
-func (c *current) onWeekSnap1() (any, error) {
+func (c *current) onWeekSnap1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonWeekSnap1() (any, error) {
+func (p *parser) callonWeekSnap1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWeekSnap1()
 }
 
-func (c *current) onRelTimeUnit1(timeUnit any) (any, error) {
+func (c *current) onRelTimeUnit1(timeUnit interface{}) (interface{}, error) {
 	if sutils.IsSubseconds(timeUnit.(sutils.TimeUnit)) {
 		return nil, fmt.Errorf("Relative Time Format does not support subseconds")
 	}
 	return strconv.Itoa(int(timeUnit.(sutils.TimeUnit))), nil
 }
 
-func (p *parser) callonRelTimeUnit1() (any, error) {
+func (p *parser) callonRelTimeUnit1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelTimeUnit1(stack["timeUnit"])
 }
 
-func (c *current) onSnap1(snap any) (any, error) {
+func (c *current) onSnap1(snap interface{}) (interface{}, error) {
 	return snap.(string), nil
 }
 
-func (p *parser) callonSnap1() (any, error) {
+func (p *parser) callonSnap1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSnap1(stack["snap"])
 }
 
-func (c *current) onOffset1(off, tuOff any) (any, error) {
+func (c *current) onOffset1(off, tuOff interface{}) (interface{}, error) {
 	var offsetNum int64 = 0
 	var err error
 	offStr := off.(string)
@@ -20478,13 +20480,13 @@ func (c *current) onOffset1(off, tuOff any) (any, error) {
 	return relTimeOffset, nil
 }
 
-func (p *parser) callonOffset1() (any, error) {
+func (p *parser) callonOffset1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOffset1(stack["off"], stack["tuOff"])
 }
 
-func (c *current) onChainedRelativeTimestamp1(first, rest any) (any, error) {
+func (c *current) onChainedRelativeTimestamp1(first, rest interface{}) (interface{}, error) {
 	var offsets []ast.RelativeTimeOffset
 	var snaps []string
 
@@ -20531,13 +20533,13 @@ func (c *current) onChainedRelativeTimestamp1(first, rest any) (any, error) {
 	return timeModifier, nil
 }
 
-func (p *parser) callonChainedRelativeTimestamp1() (any, error) {
+func (p *parser) callonChainedRelativeTimestamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onChainedRelativeTimestamp1(stack["first"], stack["rest"])
 }
 
-func (c *current) onRelativeTimestamp1(defaultTime, chained any) (any, error) {
+func (c *current) onRelativeTimestamp1(defaultTime, chained interface{}) (interface{}, error) {
 
 	if defaultTime != nil {
 		if chained != nil {
@@ -20562,13 +20564,13 @@ func (c *current) onRelativeTimestamp1(defaultTime, chained any) (any, error) {
 	return chained, nil
 }
 
-func (p *parser) callonRelativeTimestamp1() (any, error) {
+func (p *parser) callonRelativeTimestamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelativeTimestamp1(stack["defaultTime"], stack["chained"])
 }
 
-func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam any) (any, error) {
+func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam interface{}) (interface{}, error) {
 
 	if offset == nil && snapParam == nil {
 		return nil, fmt.Errorf("Invalid Relative Time Format: Need either offset or snap param")
@@ -20594,180 +20596,180 @@ func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam any) (
 	return timeModifier, nil
 }
 
-func (p *parser) callonRelativeTimeCommandTimestampFormat1() (any, error) {
+func (p *parser) callonRelativeTimeCommandTimestampFormat1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelativeTimeCommandTimestampFormat1(stack["offset"], stack["snapParam"])
 }
 
-func (c *current) onFullTimeStamp1() (any, error) {
+func (c *current) onFullTimeStamp1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFullTimeStamp1() (any, error) {
+func (p *parser) callonFullTimeStamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFullTimeStamp1()
 }
 
-func (c *current) onAbsoluteTimestamp1(timestamp any) (any, error) {
+func (c *current) onAbsoluteTimestamp1(timestamp interface{}) (interface{}, error) {
 	relTimeModifier := ast.TimeModifier{
 		AbsoluteTime: timestamp.(string),
 	}
 	return relTimeModifier, nil
 }
 
-func (p *parser) callonAbsoluteTimestamp1() (any, error) {
+func (p *parser) callonAbsoluteTimestamp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAbsoluteTimestamp1(stack["timestamp"])
 }
 
-func (c *current) onFieldName2() (any, error) {
+func (c *current) onFieldName2() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFieldName2() (any, error) {
+func (p *parser) callonFieldName2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldName2()
 }
 
-func (c *current) onFieldName7() (any, error) {
+func (c *current) onFieldName7() (interface{}, error) {
 	return removeQuotes(string(c.text)), nil
 }
 
-func (p *parser) callonFieldName7() (any, error) {
+func (p *parser) callonFieldName7() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldName7()
 }
 
-func (c *current) onFieldNameStartWith_1() (any, error) {
+func (c *current) onFieldNameStartWith_1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFieldNameStartWith_1() (any, error) {
+func (p *parser) callonFieldNameStartWith_1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldNameStartWith_1()
 }
 
-func (c *current) onString1(str any) (any, error) {
+func (c *current) onString1(str interface{}) (interface{}, error) {
 	return str, nil
 }
 
-func (p *parser) callonString1() (any, error) {
+func (p *parser) callonString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onString1(stack["str"])
 }
 
-func (c *current) onQuotedString1() (any, error) {
+func (c *current) onQuotedString1() (interface{}, error) {
 	// The returned string has quotes as the first and last character.
 	return string(c.text), nil
 }
 
-func (p *parser) callonQuotedString1() (any, error) {
+func (p *parser) callonQuotedString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedString1()
 }
 
-func (c *current) onUnquotedString1() (any, error) {
+func (c *current) onUnquotedString1() (interface{}, error) {
 	// Return the string wrapped in quotes.
 	str := "\"" + string(c.text) + "\""
 	return str, nil
 }
 
-func (p *parser) callonUnquotedString1() (any, error) {
+func (p *parser) callonUnquotedString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedString1()
 }
 
-func (c *current) onUnquotedStringWithTemplateWildCard1() (any, error) {
+func (c *current) onUnquotedStringWithTemplateWildCard1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonUnquotedStringWithTemplateWildCard1() (any, error) {
+func (p *parser) callonUnquotedStringWithTemplateWildCard1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedStringWithTemplateWildCard1()
 }
 
-func (c *current) onBoolean1() (any, error) {
+func (c *current) onBoolean1() (interface{}, error) {
 	boolValue, _ := strconv.ParseBool(string(c.text))
 	return boolValue, nil
 }
 
-func (p *parser) callonBoolean1() (any, error) {
+func (p *parser) callonBoolean1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolean1()
 }
 
-func (c *current) onRenamePattern1() (any, error) {
+func (c *current) onRenamePattern1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonRenamePattern1() (any, error) {
+func (p *parser) callonRenamePattern1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenamePattern1()
 }
 
-func (c *current) onNumber1(number any) (any, error) {
+func (c *current) onNumber1(number interface{}) (interface{}, error) {
 	return json.Number(number.(string)), nil
 }
 
-func (p *parser) callonNumber1() (any, error) {
+func (p *parser) callonNumber1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumber1(stack["number"])
 }
 
-func (c *current) onNumberAsString1(number any) (any, error) {
+func (c *current) onNumberAsString1(number interface{}) (interface{}, error) {
 	return number, nil
 }
 
-func (p *parser) callonNumberAsString1() (any, error) {
+func (p *parser) callonNumberAsString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumberAsString1(stack["number"])
 }
 
-func (c *current) onFloatAsString1() (any, error) {
+func (c *current) onFloatAsString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFloatAsString1() (any, error) {
+func (p *parser) callonFloatAsString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFloatAsString1()
 }
 
-func (c *current) onIntegerAsString1() (any, error) {
+func (c *current) onIntegerAsString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonIntegerAsString1() (any, error) {
+func (p *parser) callonIntegerAsString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIntegerAsString1()
 }
 
-func (c *current) onPositiveIntegerAsString1() (any, error) {
+func (c *current) onPositiveIntegerAsString1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonPositiveIntegerAsString1() (any, error) {
+func (p *parser) callonPositiveIntegerAsString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPositiveIntegerAsString1()
 }
 
-func (c *current) onPositiveInteger1(intStr any) (any, error) {
+func (c *current) onPositiveInteger1(intStr interface{}) (interface{}, error) {
 	num, err := strconv.ParseUint(intStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid Positive Integer value: (%v): , err: %v", intStr.(string), err)
@@ -20775,13 +20777,13 @@ func (c *current) onPositiveInteger1(intStr any) (any, error) {
 	return num, nil
 }
 
-func (p *parser) callonPositiveInteger1() (any, error) {
+func (p *parser) callonPositiveInteger1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPositiveInteger1(stack["intStr"])
 }
 
-func (c *current) onEqualityOperator1(op any) (any, error) {
+func (c *current) onEqualityOperator1(op interface{}) (interface{}, error) {
 	opStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: EqualityOperator: %v", err)
@@ -20792,13 +20794,13 @@ func (c *current) onEqualityOperator1(op any) (any, error) {
 	return opStr, nil
 }
 
-func (p *parser) callonEqualityOperator1() (any, error) {
+func (p *parser) callonEqualityOperator1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOperator1(stack["op"])
 }
 
-func (c *current) onInequalityOperator1(op any) (any, error) {
+func (c *current) onInequalityOperator1(op interface{}) (interface{}, error) {
 	opStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: InequalityOperator: %v", err)
@@ -20806,163 +20808,163 @@ func (c *current) onInequalityOperator1(op any) (any, error) {
 	return opStr, nil
 }
 
-func (p *parser) callonInequalityOperator1() (any, error) {
+func (p *parser) callonInequalityOperator1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInequalityOperator1(stack["op"])
 }
 
-func (c *current) onEqualityOrInequality2(op any) (any, error) {
+func (c *current) onEqualityOrInequality2(op interface{}) (interface{}, error) {
 	return op, nil
 }
 
-func (p *parser) callonEqualityOrInequality2() (any, error) {
+func (p *parser) callonEqualityOrInequality2() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOrInequality2(stack["op"])
 }
 
-func (c *current) onEqualityOrInequality5(op any) (any, error) {
+func (c *current) onEqualityOrInequality5(op interface{}) (interface{}, error) {
 	return op, nil
 }
 
-func (p *parser) callonEqualityOrInequality5() (any, error) {
+func (p *parser) callonEqualityOrInequality5() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOrInequality5(stack["op"])
 }
 
-func (c *current) onOpPlus1() (any, error) {
+func (c *current) onOpPlus1() (interface{}, error) {
 	return "+", nil
 }
 
-func (p *parser) callonOpPlus1() (any, error) {
+func (p *parser) callonOpPlus1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpPlus1()
 }
 
-func (c *current) onOpMinus1() (any, error) {
+func (c *current) onOpMinus1() (interface{}, error) {
 	return "-", nil
 }
 
-func (p *parser) callonOpMinus1() (any, error) {
+func (p *parser) callonOpMinus1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMinus1()
 }
 
-func (c *current) onOpMul1() (any, error) {
+func (c *current) onOpMul1() (interface{}, error) {
 	return "*", nil
 }
 
-func (p *parser) callonOpMul1() (any, error) {
+func (p *parser) callonOpMul1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMul1()
 }
 
-func (c *current) onOpDiv1() (any, error) {
+func (c *current) onOpDiv1() (interface{}, error) {
 	return "/", nil
 }
 
-func (p *parser) callonOpDiv1() (any, error) {
+func (p *parser) callonOpDiv1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpDiv1()
 }
 
-func (c *current) onOpMod1() (any, error) {
+func (c *current) onOpMod1() (interface{}, error) {
 	return "%", nil
 }
 
-func (p *parser) callonOpMod1() (any, error) {
+func (p *parser) callonOpMod1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMod1()
 }
 
-func (c *current) onSecond1() (any, error) {
+func (c *current) onSecond1() (interface{}, error) {
 	return sutils.TMSecond, nil
 }
 
-func (p *parser) callonSecond1() (any, error) {
+func (p *parser) callonSecond1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSecond1()
 }
 
-func (c *current) onMinute1() (any, error) {
+func (c *current) onMinute1() (interface{}, error) {
 	return sutils.TMMinute, nil
 }
 
-func (p *parser) callonMinute1() (any, error) {
+func (p *parser) callonMinute1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMinute1()
 }
 
-func (c *current) onHour1() (any, error) {
+func (c *current) onHour1() (interface{}, error) {
 	return sutils.TMHour, nil
 }
 
-func (p *parser) callonHour1() (any, error) {
+func (p *parser) callonHour1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHour1()
 }
 
-func (c *current) onDay1() (any, error) {
+func (c *current) onDay1() (interface{}, error) {
 	return sutils.TMDay, nil
 }
 
-func (p *parser) callonDay1() (any, error) {
+func (p *parser) callonDay1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDay1()
 }
 
-func (c *current) onWeek1() (any, error) {
+func (c *current) onWeek1() (interface{}, error) {
 	return sutils.TMWeek, nil
 }
 
-func (p *parser) callonWeek1() (any, error) {
+func (p *parser) callonWeek1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWeek1()
 }
 
-func (c *current) onMonth1() (any, error) {
+func (c *current) onMonth1() (interface{}, error) {
 	return sutils.TMMonth, nil
 }
 
-func (p *parser) callonMonth1() (any, error) {
+func (p *parser) callonMonth1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMonth1()
 }
 
-func (c *current) onQuarter1() (any, error) {
+func (c *current) onQuarter1() (interface{}, error) {
 	return sutils.TMQuarter, nil
 }
 
-func (p *parser) callonQuarter1() (any, error) {
+func (p *parser) callonQuarter1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuarter1()
 }
 
-func (c *current) onYear1() (any, error) {
+func (c *current) onYear1() (interface{}, error) {
 	return sutils.TMYear, nil
 }
 
-func (p *parser) callonYear1() (any, error) {
+func (p *parser) callonYear1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onYear1()
 }
 
-func (c *current) onSubseconds1() (any, error) {
+func (c *current) onSubseconds1() (interface{}, error) {
 	timeUnit, err := sutils.ConvertSubseconds(string(c.text))
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Subseconds: %v", err)
@@ -20970,13 +20972,13 @@ func (c *current) onSubseconds1() (any, error) {
 	return timeUnit, nil
 }
 
-func (p *parser) callonSubseconds1() (any, error) {
+func (p *parser) callonSubseconds1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSubseconds1()
 }
 
-func (c *current) onTransactionBlock1(txnOptions any) (any, error) {
+func (c *current) onTransactionBlock1(txnOptions interface{}) (interface{}, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType:      structs.TransactionType,
 		TransactionArguments: txnOptions.(*structs.TransactionArguments),
@@ -20985,13 +20987,13 @@ func (c *current) onTransactionBlock1(txnOptions any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonTransactionBlock1() (any, error) {
+func (p *parser) callonTransactionBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionBlock1(stack["txnOptions"])
 }
 
-func (c *current) onTransactionOptions1(txnOptions any) (any, error) {
+func (c *current) onTransactionOptions1(txnOptions interface{}) (interface{}, error) {
 
 	transactionRequest := &structs.TransactionArguments{}
 
@@ -21005,13 +21007,13 @@ func (c *current) onTransactionOptions1(txnOptions any) (any, error) {
 	return transactionRequest, nil
 }
 
-func (p *parser) callonTransactionOptions1() (any, error) {
+func (p *parser) callonTransactionOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionOptions1(stack["txnOptions"])
 }
 
-func (c *current) onTransactionDefinitionOptionsList1(first, rest any) (any, error) {
+func (c *current) onTransactionDefinitionOptionsList1(first, rest interface{}) (interface{}, error) {
 
 	restSlice := rest.([]any)
 	txnArgs := &TxnArgs{
@@ -21046,23 +21048,23 @@ func (c *current) onTransactionDefinitionOptionsList1(first, rest any) (any, err
 	return txnArgs, nil
 }
 
-func (p *parser) callonTransactionDefinitionOptionsList1() (any, error) {
+func (p *parser) callonTransactionDefinitionOptionsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionDefinitionOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onTransactionDefinitionOption1(option any) (any, error) {
+func (c *current) onTransactionDefinitionOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonTransactionDefinitionOption1() (any, error) {
+func (p *parser) callonTransactionDefinitionOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionDefinitionOption1(stack["option"])
 }
 
-func (c *current) onTransactionSpaceSeparatedFieldList1(fields any) (any, error) {
+func (c *current) onTransactionSpaceSeparatedFieldList1(fields interface{}) (interface{}, error) {
 	txnArg := &TxnArgs{
 		argOption: "fields",
 		arguments: &structs.TransactionArguments{
@@ -21073,13 +21075,13 @@ func (c *current) onTransactionSpaceSeparatedFieldList1(fields any) (any, error)
 	return txnArg, nil
 }
 
-func (p *parser) callonTransactionSpaceSeparatedFieldList1() (any, error) {
+func (p *parser) callonTransactionSpaceSeparatedFieldList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionSpaceSeparatedFieldList1(stack["fields"])
 }
 
-func (c *current) onStartsWithOption1(strExpr any) (any, error) {
+func (c *current) onStartsWithOption1(strExpr interface{}) (interface{}, error) {
 	txnArg := &TxnArgs{
 		argOption: "startswith",
 		arguments: &structs.TransactionArguments{
@@ -21089,13 +21091,13 @@ func (c *current) onStartsWithOption1(strExpr any) (any, error) {
 	return txnArg, nil
 }
 
-func (p *parser) callonStartsWithOption1() (any, error) {
+func (p *parser) callonStartsWithOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStartsWithOption1(stack["strExpr"])
 }
 
-func (c *current) onEndsWithOption1(strExpr any) (any, error) {
+func (c *current) onEndsWithOption1(strExpr interface{}) (interface{}, error) {
 	txnArg := &TxnArgs{
 		argOption: "endswith",
 		arguments: &structs.TransactionArguments{
@@ -21105,33 +21107,33 @@ func (c *current) onEndsWithOption1(strExpr any) (any, error) {
 	return txnArg, nil
 }
 
-func (p *parser) callonEndsWithOption1() (any, error) {
+func (p *parser) callonEndsWithOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEndsWithOption1(stack["strExpr"])
 }
 
-func (c *current) onTransactionFilterString1(strExpr any) (any, error) {
+func (c *current) onTransactionFilterString1(strExpr interface{}) (interface{}, error) {
 	return strExpr, nil
 }
 
-func (p *parser) callonTransactionFilterString1() (any, error) {
+func (p *parser) callonTransactionFilterString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionFilterString1(stack["strExpr"])
 }
 
-func (c *current) onTransactionQuotedString1(str any) (any, error) {
+func (c *current) onTransactionQuotedString1(str interface{}) (interface{}, error) {
 	return str, nil
 }
 
-func (p *parser) callonTransactionQuotedString1() (any, error) {
+func (p *parser) callonTransactionQuotedString1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedString1(stack["str"])
 }
 
-func (c *current) onTransactionQuotedStringSearchExpr1(searchClause any) (any, error) {
+func (c *current) onTransactionQuotedStringSearchExpr1(searchClause interface{}) (interface{}, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		SearchNode: searchClause.(*ast.Node),
 	}
@@ -21139,24 +21141,24 @@ func (c *current) onTransactionQuotedStringSearchExpr1(searchClause any) (any, e
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionQuotedStringSearchExpr1() (any, error) {
+func (p *parser) callonTransactionQuotedStringSearchExpr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedStringSearchExpr1(stack["searchClause"])
 }
 
-func (c *current) onQuotedStringNoOp1() (any, error) {
+func (c *current) onQuotedStringNoOp1() (interface{}, error) {
 	// The returned string has quotes as the first and last character.
 	return string(c.text), nil
 }
 
-func (p *parser) callonQuotedStringNoOp1() (any, error) {
+func (p *parser) callonQuotedStringNoOp1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedStringNoOp1()
 }
 
-func (c *current) onTransactionQuotedStringValue1(str any) (any, error) {
+func (c *current) onTransactionQuotedStringValue1(str interface{}) (interface{}, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		StringValue: removeQuotes(str.(string)),
 	}
@@ -21164,13 +21166,13 @@ func (c *current) onTransactionQuotedStringValue1(str any) (any, error) {
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionQuotedStringValue1() (any, error) {
+func (p *parser) callonTransactionQuotedStringValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedStringValue1(stack["str"])
 }
 
-func (c *current) onTransactionSearch1(expr any) (any, error) {
+func (c *current) onTransactionSearch1(expr interface{}) (interface{}, error) {
 
 	filterStrExpr := &structs.FilterStringExpr{
 		SearchNode: expr.(*ast.Node),
@@ -21179,13 +21181,13 @@ func (c *current) onTransactionSearch1(expr any) (any, error) {
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionSearch1() (any, error) {
+func (p *parser) callonTransactionSearch1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionSearch1(stack["expr"])
 }
 
-func (c *current) onTransactionEval1(condition any) (any, error) {
+func (c *current) onTransactionEval1(condition interface{}) (interface{}, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		EvalBoolExpr: condition.(*structs.BoolExpr),
 	}
@@ -21193,23 +21195,23 @@ func (c *current) onTransactionEval1(condition any) (any, error) {
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionEval1() (any, error) {
+func (p *parser) callonTransactionEval1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionEval1(stack["condition"])
 }
 
-func (c *current) onMultiValueBlock1(mvQueryAggNode any) (any, error) {
+func (c *current) onMultiValueBlock1(mvQueryAggNode interface{}) (interface{}, error) {
 	return mvQueryAggNode, nil
 }
 
-func (p *parser) callonMultiValueBlock1() (any, error) {
+func (p *parser) callonMultiValueBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueBlock1(stack["mvQueryAggNode"])
 }
 
-func (c *current) onMakeMVBlock1(mvColOptionExpr, field any) (any, error) {
+func (c *current) onMakeMVBlock1(mvColOptionExpr, field interface{}) (interface{}, error) {
 	var mvColExpr *structs.MultiValueColLetRequest
 
 	if mvColOptionExpr != nil {
@@ -21238,13 +21240,13 @@ func (c *current) onMakeMVBlock1(mvColOptionExpr, field any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonMakeMVBlock1() (any, error) {
+func (p *parser) callonMakeMVBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMakeMVBlock1(stack["mvColOptionExpr"], stack["field"])
 }
 
-func (c *current) onMVBlockOptionsList1(first, rest any) (any, error) {
+func (c *current) onMVBlockOptionsList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 
 	numOptions := 1 + len(restSlice)
@@ -21278,33 +21280,33 @@ func (c *current) onMVBlockOptionsList1(first, rest any) (any, error) {
 	return mvColExpr, nil
 }
 
-func (p *parser) callonMVBlockOptionsList1() (any, error) {
+func (p *parser) callonMVBlockOptionsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMVBlockOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onMVBlockOption1(option any) (any, error) {
+func (c *current) onMVBlockOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonMVBlockOption1() (any, error) {
+func (p *parser) callonMVBlockOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMVBlockOption1(stack["option"])
 }
 
-func (c *current) onDelimOption1(delimExpr any) (any, error) {
+func (c *current) onDelimOption1(delimExpr interface{}) (interface{}, error) {
 	return delimExpr, nil
 }
 
-func (p *parser) callonDelimOption1() (any, error) {
+func (p *parser) callonDelimOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDelimOption1(stack["delimExpr"])
 }
 
-func (c *current) onStringDelimiter1(str any) (any, error) {
+func (c *current) onStringDelimiter1(str interface{}) (interface{}, error) {
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "delimiter",
 		mvColExpr: &structs.MultiValueColLetRequest{
@@ -21315,13 +21317,13 @@ func (c *current) onStringDelimiter1(str any) (any, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonStringDelimiter1() (any, error) {
+func (p *parser) callonStringDelimiter1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringDelimiter1(stack["str"])
 }
 
-func (c *current) onRegexDelimiter1(str any) (any, error) {
+func (c *current) onRegexDelimiter1(str interface{}) (interface{}, error) {
 	pattern := removeQuotes(str)
 	_, err := regexp.Compile(pattern)
 	if err != nil {
@@ -21339,13 +21341,13 @@ func (c *current) onRegexDelimiter1(str any) (any, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonRegexDelimiter1() (any, error) {
+func (p *parser) callonRegexDelimiter1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexDelimiter1(stack["str"])
 }
 
-func (c *current) onAllowEmptyOption1(boolVal any) (any, error) {
+func (c *current) onAllowEmptyOption1(boolVal interface{}) (interface{}, error) {
 
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "allowempty",
@@ -21357,13 +21359,13 @@ func (c *current) onAllowEmptyOption1(boolVal any) (any, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonAllowEmptyOption1() (any, error) {
+func (p *parser) callonAllowEmptyOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAllowEmptyOption1(stack["boolVal"])
 }
 
-func (c *current) onSetSvOption1(boolVal any) (any, error) {
+func (c *current) onSetSvOption1(boolVal interface{}) (interface{}, error) {
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "setsv",
 		mvColExpr: &structs.MultiValueColLetRequest{
@@ -21374,26 +21376,26 @@ func (c *current) onSetSvOption1(boolVal any) (any, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonSetSvOption1() (any, error) {
+func (p *parser) callonSetSvOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSetSvOption1(stack["boolVal"])
 }
 
-func (c *current) onSPathBlock1(spathExpr any) (any, error) {
+func (c *current) onSPathBlock1(spathExpr interface{}) (interface{}, error) {
 	if spathExpr == nil {
 		return createSPathExpr("", "", "")
 	}
 	return spathExpr, nil
 }
 
-func (p *parser) callonSPathBlock1() (any, error) {
+func (p *parser) callonSPathBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathBlock1(stack["spathExpr"])
 }
 
-func (c *current) onSPathArgumentsList1(first, rest any) (any, error) {
+func (c *current) onSPathArgumentsList1(first, rest interface{}) (interface{}, error) {
 
 	restSlice := rest.([]any)
 
@@ -21425,43 +21427,43 @@ func (c *current) onSPathArgumentsList1(first, rest any) (any, error) {
 	return createSPathExpr(inputField, pathField, outputField)
 }
 
-func (p *parser) callonSPathArgumentsList1() (any, error) {
+func (p *parser) callonSPathArgumentsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSPathArgument1(arg any) (any, error) {
+func (c *current) onSPathArgument1(arg interface{}) (interface{}, error) {
 	return arg, nil
 }
 
-func (p *parser) callonSPathArgument1() (any, error) {
+func (p *parser) callonSPathArgument1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathArgument1(stack["arg"])
 }
 
-func (c *current) onInputField1(field any) (any, error) {
+func (c *current) onInputField1(field interface{}) (interface{}, error) {
 	return "input=" + field.(string), nil
 }
 
-func (p *parser) callonInputField1() (any, error) {
+func (p *parser) callonInputField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputField1(stack["field"])
 }
 
-func (c *current) onOutputField1(field any) (any, error) {
+func (c *current) onOutputField1(field interface{}) (interface{}, error) {
 	return "output=" + field.(string), nil
 }
 
-func (p *parser) callonOutputField1() (any, error) {
+func (p *parser) callonOutputField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOutputField1(stack["field"])
 }
 
-func (c *current) onPathField1() (any, error) {
+func (c *current) onPathField1() (interface{}, error) {
 	pathField := string(c.text)
 	if strings.HasPrefix(pathField, "path") {
 		pathField = strings.TrimSpace(strings.TrimPrefix(pathField, "path="))
@@ -21473,13 +21475,13 @@ func (c *current) onPathField1() (any, error) {
 	return "path=" + pathField, nil
 }
 
-func (p *parser) callonPathField1() (any, error) {
+func (p *parser) callonPathField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPathField1()
 }
 
-func (c *current) onFormatBlock1(formatArgExpr any) (any, error) {
+func (c *current) onFormatBlock1(formatArgExpr interface{}) (interface{}, error) {
 	var formatResultExpr *structs.FormatResultsRequest
 
 	if formatArgExpr != nil {
@@ -21501,13 +21503,13 @@ func (c *current) onFormatBlock1(formatArgExpr any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonFormatBlock1() (any, error) {
+func (p *parser) callonFormatBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatBlock1(stack["formatArgExpr"])
 }
 
-func (c *current) onFormatArgumentsList1(first, rest any) (any, error) {
+func (c *current) onFormatArgumentsList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 
 	numOptions := 1 + len(restSlice)
@@ -21541,23 +21543,23 @@ func (c *current) onFormatArgumentsList1(first, rest any) (any, error) {
 	return formatResultExpr, nil
 }
 
-func (p *parser) callonFormatArgumentsList1() (any, error) {
+func (p *parser) callonFormatArgumentsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onFormatArgument1(argExpr any) (any, error) {
+func (c *current) onFormatArgument1(argExpr interface{}) (interface{}, error) {
 	return argExpr, nil
 }
 
-func (p *parser) callonFormatArgument1() (any, error) {
+func (p *parser) callonFormatArgument1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatArgument1(stack["argExpr"])
 }
 
-func (c *current) onFormatSeparator1(str any) (any, error) {
+func (c *current) onFormatSeparator1(str interface{}) (interface{}, error) {
 	return &FormatResultsRequestArguments{
 		argOption: "mvsep",
 		formatResultExpr: &structs.FormatResultsRequest{
@@ -21566,13 +21568,13 @@ func (c *current) onFormatSeparator1(str any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatSeparator1() (any, error) {
+func (p *parser) callonFormatSeparator1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatSeparator1(stack["str"])
 }
 
-func (c *current) onFormatMaxResults1(numStr any) (any, error) {
+func (c *current) onFormatMaxResults1(numStr interface{}) (interface{}, error) {
 	num, err := strconv.ParseUint(numStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid Max results value is set for format: (%v): Error=%v", numStr.(string), err)
@@ -21585,13 +21587,13 @@ func (c *current) onFormatMaxResults1(numStr any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatMaxResults1() (any, error) {
+func (p *parser) callonFormatMaxResults1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatMaxResults1(stack["numStr"])
 }
 
-func (c *current) onFormatEmptyStr1(str any) (any, error) {
+func (c *current) onFormatEmptyStr1(str interface{}) (interface{}, error) {
 	return &FormatResultsRequestArguments{
 		argOption: "emptystr",
 		formatResultExpr: &structs.FormatResultsRequest{
@@ -21600,13 +21602,13 @@ func (c *current) onFormatEmptyStr1(str any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatEmptyStr1() (any, error) {
+func (p *parser) callonFormatEmptyStr1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatEmptyStr1(stack["str"])
 }
 
-func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, colEnd, rowSeparator, rowEnd any) (any, error) {
+func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, colEnd, rowSeparator, rowEnd interface{}) (interface{}, error) {
 	rowColOptions := &structs.RowColOptions{
 		RowPrefix:       removeQuotes(rowPrefix),
 		ColumnPrefix:    removeQuotes(colPrefix),
@@ -21624,26 +21626,26 @@ func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, col
 	}, nil
 }
 
-func (p *parser) callonFormatRowColOptions1() (any, error) {
+func (p *parser) callonFormatRowColOptions1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatRowColOptions1(stack["rowPrefix"], stack["colPrefix"], stack["colSeparator"], stack["colEnd"], stack["rowSeparator"], stack["rowEnd"])
 }
 
-func (c *current) onEventCountBlock1(eventCountExpr any) (any, error) {
+func (c *current) onEventCountBlock1(eventCountExpr interface{}) (interface{}, error) {
 	if eventCountExpr == nil {
 		return createEventCountExpr([]string{"*"}, true, false, true)
 	}
 	return eventCountExpr, nil
 }
 
-func (p *parser) callonEventCountBlock1() (any, error) {
+func (p *parser) callonEventCountBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountBlock1(stack["eventCountExpr"])
 }
 
-func (c *current) onEventCountArgumentsList1(first, rest any) (any, error) {
+func (c *current) onEventCountArgumentsList1(first, rest interface{}) (interface{}, error) {
 
 	restSlice := rest.([]any)
 
@@ -21699,73 +21701,73 @@ func (c *current) onEventCountArgumentsList1(first, rest any) (any, error) {
 	return createEventCountExpr(indices, list_vix, report_size, summarize)
 }
 
-func (p *parser) callonEventCountArgumentsList1() (any, error) {
+func (p *parser) callonEventCountArgumentsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onEventCountArgument1(arg any) (any, error) {
+func (c *current) onEventCountArgument1(arg interface{}) (interface{}, error) {
 	return arg, nil
 }
 
-func (p *parser) callonEventCountArgument1() (any, error) {
+func (p *parser) callonEventCountArgument1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountArgument1(stack["arg"])
 }
 
-func (c *current) onIndexField1(index any) (any, error) {
+func (c *current) onIndexField1(index interface{}) (interface{}, error) {
 	return "index=" + index.(string), nil
 }
 
-func (p *parser) callonIndexField1() (any, error) {
+func (p *parser) callonIndexField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexField1(stack["index"])
 }
 
-func (c *current) onSummarizeField1(field any) (any, error) {
+func (c *current) onSummarizeField1(field interface{}) (interface{}, error) {
 	return "summarize=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonSummarizeField1() (any, error) {
+func (p *parser) callonSummarizeField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSummarizeField1(stack["field"])
 }
 
-func (c *current) onReportSizeField1(field any) (any, error) {
+func (c *current) onReportSizeField1(field interface{}) (interface{}, error) {
 	return "report_size=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonReportSizeField1() (any, error) {
+func (p *parser) callonReportSizeField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onReportSizeField1(stack["field"])
 }
 
-func (c *current) onListVixField1(field any) (any, error) {
+func (c *current) onListVixField1(field interface{}) (interface{}, error) {
 	return "list_vix=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonListVixField1() (any, error) {
+func (p *parser) callonListVixField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onListVixField1(stack["field"])
 }
 
-func (c *current) onIndexName1() (any, error) {
+func (c *current) onIndexName1() (interface{}, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonIndexName1() (any, error) {
+func (p *parser) callonIndexName1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexName1()
 }
 
-func (c *current) onFillNullBlock1(valueOption, fields any) (any, error) {
+func (c *current) onFillNullBlock1(valueOption, fields interface{}) (interface{}, error) {
 	valueStr := "0"
 	fieldList := make([]string, 0)
 
@@ -21795,33 +21797,33 @@ func (c *current) onFillNullBlock1(valueOption, fields any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonFillNullBlock1() (any, error) {
+func (p *parser) callonFillNullBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullBlock1(stack["valueOption"], stack["fields"])
 }
 
-func (c *current) onFillNullValueOption1(str any) (any, error) {
+func (c *current) onFillNullValueOption1(str interface{}) (interface{}, error) {
 	return removeQuotes(str), nil
 }
 
-func (p *parser) callonFillNullValueOption1() (any, error) {
+func (p *parser) callonFillNullValueOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullValueOption1(stack["str"])
 }
 
-func (c *current) onFillNullFieldList1(fieldList any) (any, error) {
+func (c *current) onFillNullFieldList1(fieldList interface{}) (interface{}, error) {
 	return fieldList, nil
 }
 
-func (p *parser) callonFillNullFieldList1() (any, error) {
+func (p *parser) callonFillNullFieldList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullFieldList1(stack["fieldList"])
 }
 
-func (c *current) onMvexpandBlock1(field, limitStr any) (any, error) {
+func (c *current) onMvexpandBlock1(field, limitStr interface{}) (interface{}, error) {
 	limit := utils.None[int64]()
 	if limitStr != nil {
 		value, err := strconv.ParseInt(limitStr.(string), 10, 64)
@@ -21850,43 +21852,43 @@ func (c *current) onMvexpandBlock1(field, limitStr any) (any, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonMvexpandBlock1() (any, error) {
+func (p *parser) callonMvexpandBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandBlock1(stack["field"], stack["limitStr"])
 }
 
-func (c *current) onMvexpandField1(fieldName any) (any, error) {
+func (c *current) onMvexpandField1(fieldName interface{}) (interface{}, error) {
 	return fieldName, nil
 }
 
-func (p *parser) callonMvexpandField1() (any, error) {
+func (p *parser) callonMvexpandField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandField1(stack["fieldName"])
 }
 
-func (c *current) onMvexpandLimit1(intValue any) (any, error) {
+func (c *current) onMvexpandLimit1(intValue interface{}) (interface{}, error) {
 	return intValue, nil
 }
 
-func (p *parser) callonMvexpandLimit1() (any, error) {
+func (p *parser) callonMvexpandLimit1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandLimit1(stack["intValue"])
 }
 
-func (c *current) onWhereClause1(condition any) (any, error) {
+func (c *current) onWhereClause1(condition interface{}) (interface{}, error) {
 	return condition.(*structs.BoolExpr), nil
 }
 
-func (p *parser) callonWhereClause1() (any, error) {
+func (p *parser) callonWhereClause1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWhereClause1(stack["condition"])
 }
 
-func (c *current) onInputLookupOptionAppend1(boolVal any) (any, error) {
+func (c *current) onInputLookupOptionAppend1(boolVal interface{}) (interface{}, error) {
 	return &InputLookupOptionArgs{
 		argOption: "append",
 		inputLookupOption: &structs.InputLookup{
@@ -21895,13 +21897,13 @@ func (c *current) onInputLookupOptionAppend1(boolVal any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionAppend1() (any, error) {
+func (p *parser) callonInputLookupOptionAppend1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionAppend1(stack["boolVal"])
 }
 
-func (c *current) onInputLookupOptionStrict1(boolVal any) (any, error) {
+func (c *current) onInputLookupOptionStrict1(boolVal interface{}) (interface{}, error) {
 	return &InputLookupOptionArgs{
 		argOption: "strict",
 		inputLookupOption: &structs.InputLookup{
@@ -21910,13 +21912,13 @@ func (c *current) onInputLookupOptionStrict1(boolVal any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionStrict1() (any, error) {
+func (p *parser) callonInputLookupOptionStrict1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionStrict1(stack["boolVal"])
 }
 
-func (c *current) onInputLookupOptionStart1(posInt any) (any, error) {
+func (c *current) onInputLookupOptionStart1(posInt interface{}) (interface{}, error) {
 	return &InputLookupOptionArgs{
 		argOption: "start",
 		inputLookupOption: &structs.InputLookup{
@@ -21925,13 +21927,13 @@ func (c *current) onInputLookupOptionStart1(posInt any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionStart1() (any, error) {
+func (p *parser) callonInputLookupOptionStart1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionStart1(stack["posInt"])
 }
 
-func (c *current) onInputLookupOptionMax1(posInt any) (any, error) {
+func (c *current) onInputLookupOptionMax1(posInt interface{}) (interface{}, error) {
 	return &InputLookupOptionArgs{
 		argOption: "max",
 		inputLookupOption: &structs.InputLookup{
@@ -21940,23 +21942,23 @@ func (c *current) onInputLookupOptionMax1(posInt any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionMax1() (any, error) {
+func (p *parser) callonInputLookupOptionMax1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionMax1(stack["posInt"])
 }
 
-func (c *current) onInputLookupOption1(inputLookupOption any) (any, error) {
+func (c *current) onInputLookupOption1(inputLookupOption interface{}) (interface{}, error) {
 	return inputLookupOption, nil
 }
 
-func (p *parser) callonInputLookupOption1() (any, error) {
+func (p *parser) callonInputLookupOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOption1(stack["inputLookupOption"])
 }
 
-func (c *current) onInputLookupOptionList1(first, rest any) (any, error) {
+func (c *current) onInputLookupOptionList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 	numOptions := 1 + len(restSlice)
@@ -21996,13 +21998,13 @@ func (c *current) onInputLookupOptionList1(first, rest any) (any, error) {
 	return inputLookupOption, nil
 }
 
-func (p *parser) callonInputLookupOptionList1() (any, error) {
+func (p *parser) callonInputLookupOptionList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause any) (any, error) {
+func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause interface{}) (interface{}, error) {
 	inputLookup := &structs.InputLookup{}
 	if inputLookupOption != nil {
 		inputLookupOption := inputLookupOption.([]any)
@@ -22025,13 +22027,13 @@ func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause a
 	}, nil
 }
 
-func (p *parser) callonInputLookupBlock1() (any, error) {
+func (p *parser) callonInputLookupBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupBlock1(stack["inputLookupOption"], stack["filename"], stack["whereClause"])
 }
 
-func (c *current) onInputLookupAggBlock1(inputLookupBlock any) (any, error) {
+func (c *current) onInputLookupAggBlock1(inputLookupBlock interface{}) (interface{}, error) {
 	inputLookup := inputLookupBlock.(*structs.QueryAggregators)
 	if !inputLookup.GenerateEvent.InputLookup.Append {
 		return nil, fmt.Errorf("An Inputlookup command which is not the first command must have append as true")
@@ -22041,36 +22043,36 @@ func (c *current) onInputLookupAggBlock1(inputLookupBlock any) (any, error) {
 	return inputLookup, nil
 }
 
-func (p *parser) callonInputLookupAggBlock1() (any, error) {
+func (p *parser) callonInputLookupAggBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupAggBlock1(stack["inputLookupBlock"])
 }
 
-func (c *current) onAppendCmdOption1(option any) (any, error) {
+func (c *current) onAppendCmdOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonAppendCmdOption1() (any, error) {
+func (p *parser) callonAppendCmdOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendCmdOption1(stack["option"])
 }
 
-func (c *current) onExtendTimeRangeOption1(boolean any) (any, error) {
+func (c *current) onExtendTimeRangeOption1(boolean interface{}) (interface{}, error) {
 	return &structs.AppendCmdOption{
 		OptionType: "extendtimerange",
 		Value:      boolean == "true",
 	}, nil
 }
 
-func (p *parser) callonExtendTimeRangeOption1() (any, error) {
+func (p *parser) callonExtendTimeRangeOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onExtendTimeRangeOption1(stack["boolean"])
 }
 
-func (c *current) onMaxTimeOption1(time any) (any, error) {
+func (c *current) onMaxTimeOption1(time interface{}) (interface{}, error) {
 	maxTimeInt, err := strconv.ParseUint(time.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid maxtime (%v): %v", time.(string), err)
@@ -22081,13 +22083,13 @@ func (c *current) onMaxTimeOption1(time any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonMaxTimeOption1() (any, error) {
+func (p *parser) callonMaxTimeOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMaxTimeOption1(stack["time"])
 }
 
-func (c *current) onMaxOutOption1(max any) (any, error) {
+func (c *current) onMaxOutOption1(max interface{}) (interface{}, error) {
 	maxOutInt, err := strconv.ParseUint(max.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid maxout (%v): %v", max.(string), err)
@@ -22098,23 +22100,23 @@ func (c *current) onMaxOutOption1(max any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonMaxOutOption1() (any, error) {
+func (p *parser) callonMaxOutOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMaxOutOption1(stack["max"])
 }
 
-func (c *current) onSubsearch1(search any) (any, error) {
+func (c *current) onSubsearch1(search interface{}) (interface{}, error) {
 	return search, nil
 }
 
-func (p *parser) callonSubsearch1() (any, error) {
+func (p *parser) callonSubsearch1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSubsearch1(stack["search"])
 }
 
-func (c *current) onAppendCmdOptionsList1(first, rest any) (any, error) {
+func (c *current) onAppendCmdOptionsList1(first, rest interface{}) (interface{}, error) {
 	restSlice := rest.([]any)
 	numOptions := 1 + len(restSlice)
 	appendCmdOptions := &structs.AppendCmdOptions{}
@@ -22140,13 +22142,13 @@ func (c *current) onAppendCmdOptionsList1(first, rest any) (any, error) {
 	return appendCmdOptions, nil
 }
 
-func (p *parser) callonAppendCmdOptionsList1() (any, error) {
+func (p *parser) callonAppendCmdOptionsList1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendCmdOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onAppendBlock1(options, subsearch any) (any, error) {
+func (c *current) onAppendBlock1(options, subsearch interface{}) (interface{}, error) {
 	appendOptions := &structs.AppendCmdOptions{
 		ExtendTimeRange: false,
 		MaxTime:         60,
@@ -22188,23 +22190,23 @@ func (c *current) onAppendBlock1(options, subsearch any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonAppendBlock1() (any, error) {
+func (p *parser) callonAppendBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendBlock1(stack["options"], stack["subsearch"])
 }
 
-func (c *current) onToJsonOption1(option any) (any, error) {
+func (c *current) onToJsonOption1(option interface{}) (interface{}, error) {
 	return option, nil
 }
 
-func (p *parser) callonToJsonOption1() (any, error) {
+func (p *parser) callonToJsonOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonOption1(stack["option"])
 }
 
-func (c *current) onToJsonFunctionOption1(dtype, regexPattern any) (any, error) {
+func (c *current) onToJsonFunctionOption1(dtype, regexPattern interface{}) (interface{}, error) {
 	regex, ok := regexPattern.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: regexPattern type assertion to StringExpr failed")
@@ -22230,13 +22232,13 @@ func (c *current) onToJsonFunctionOption1(dtype, regexPattern any) (any, error) 
 	}, nil
 }
 
-func (p *parser) callonToJsonFunctionOption1() (any, error) {
+func (p *parser) callonToJsonFunctionOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonFunctionOption1(stack["dtype"], stack["regexPattern"])
 }
 
-func (c *current) onToJsonFunctionPostProcess1(regexPattern any) (any, error) {
+func (c *current) onToJsonFunctionPostProcess1(regexPattern interface{}) (interface{}, error) {
 	regex, ok := regexPattern.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: regexPattern type assertion to StringExpr failed")
@@ -22261,13 +22263,13 @@ func (c *current) onToJsonFunctionPostProcess1(regexPattern any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonToJsonFunctionPostProcess1() (any, error) {
+func (p *parser) callonToJsonFunctionPostProcess1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonFunctionPostProcess1(stack["regexPattern"])
 }
 
-func (c *current) onDefaultTypeOption1(dtype any) (any, error) {
+func (c *current) onDefaultTypeOption1(dtype interface{}) (interface{}, error) {
 	optionDtype := stringToToJsonDtype(string(dtype.([]byte)))
 	gobRegex := utils.GobbableRegex{}
 	option := &structs.ToJsonFieldsDtypeOptions{
@@ -22280,52 +22282,52 @@ func (c *current) onDefaultTypeOption1(dtype any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonDefaultTypeOption1() (any, error) {
+func (p *parser) callonDefaultTypeOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDefaultTypeOption1(stack["dtype"])
 }
 
-func (c *current) onFillNullOption1(boolVal any) (any, error) {
+func (c *current) onFillNullOption1(boolVal interface{}) (interface{}, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_FILL_NULL,
 		Value:      boolVal.(bool),
 	}, nil
 }
 
-func (p *parser) callonFillNullOption1() (any, error) {
+func (p *parser) callonFillNullOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullOption1(stack["boolVal"])
 }
 
-func (c *current) onIncludeInternalOption1(boolVal any) (any, error) {
+func (c *current) onIncludeInternalOption1(boolVal interface{}) (interface{}, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_INCLUDE_INTERNAL,
 		Value:      boolVal.(bool),
 	}, nil
 }
 
-func (p *parser) callonIncludeInternalOption1() (any, error) {
+func (p *parser) callonIncludeInternalOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIncludeInternalOption1(stack["boolVal"])
 }
 
-func (c *current) onOutputFieldOption1(strVal any) (any, error) {
+func (c *current) onOutputFieldOption1(strVal interface{}) (interface{}, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_OUTPUT_FIELD,
 		Value:      strVal.(string),
 	}, nil
 }
 
-func (p *parser) callonOutputFieldOption1() (any, error) {
+func (p *parser) callonOutputFieldOption1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOutputFieldOption1(stack["strVal"])
 }
 
-func (c *current) onToJsonBlock1(options any) (any, error) {
+func (c *current) onToJsonBlock1(options interface{}) (interface{}, error) {
 	defaultDtypeRegex := utils.GobbableRegex{}
 	err := defaultDtypeRegex.SetRegex(`.*`)
 	if err != nil {
@@ -22376,7 +22378,7 @@ func (c *current) onToJsonBlock1(options any) (any, error) {
 	}, nil
 }
 
-func (p *parser) callonToJsonBlock1() (any, error) {
+func (p *parser) callonToJsonBlock1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonBlock1(stack["options"])
@@ -22396,7 +22398,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expressions parsed")
+	errMaxExprCnt = errors.New("max number of expresssions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -22520,7 +22522,7 @@ func Recover(b bool) Option {
 
 // GlobalStore creates an Option to set a key to a certain value in
 // the globalStore.
-func GlobalStore(key string, value any) Option {
+func GlobalStore(key string, value interface{}) Option {
 	return func(p *parser) Option {
 		old := p.cur.globalStore[key]
 		p.cur.globalStore[key] = value
@@ -22530,7 +22532,7 @@ func GlobalStore(key string, value any) Option {
 
 // InitState creates an Option to set a key to a certain value in
 // the global "state" store.
-func InitState(key string, value any) Option {
+func InitState(key string, value interface{}) Option {
 	return func(p *parser) Option {
 		old := p.cur.state[key]
 		p.cur.state[key] = value
@@ -22539,7 +22541,7 @@ func InitState(key string, value any) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i any, err error) {
+func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -22554,8 +22556,8 @@ func ParseFile(filename string, opts ...Option) (i any, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (any, error) {
-	b, err := io.ReadAll(r)
+func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
+	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -22565,7 +22567,7 @@ func ParseReader(filename string, r io.Reader, opts ...Option) (any, error) {
 
 // Parse parses the data from b using filename as information in the
 // error messages.
-func Parse(filename string, b []byte, opts ...Option) (any, error) {
+func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
 	return newParser(filename, b, opts...).parse(g)
 }
 
@@ -22603,7 +22605,7 @@ type current struct {
 	globalStore storeDict
 }
 
-type storeDict map[string]any
+type storeDict map[string]interface{}
 
 // the AST types...
 
@@ -22616,30 +22618,30 @@ type rule struct {
 	pos         position
 	name        string
 	displayName string
-	expr        any
+	expr        interface{}
 }
 
 type choiceExpr struct {
 	pos          position
-	alternatives []any
+	alternatives []interface{}
 }
 
 type actionExpr struct {
 	pos  position
-	expr any
-	run  func(*parser) (any, error)
+	expr interface{}
+	run  func(*parser) (interface{}, error)
 }
 
 type recoveryExpr struct {
 	pos          position
-	expr         any
-	recoverExpr  any
+	expr         interface{}
+	recoverExpr  interface{}
 	failureLabel []string
 }
 
 type seqExpr struct {
 	pos   position
-	exprs []any
+	exprs []interface{}
 }
 
 type throwExpr struct {
@@ -22650,21 +22652,19 @@ type throwExpr struct {
 type labeledExpr struct {
 	pos   position
 	label string
-	expr  any
+	expr  interface{}
 }
 
 type expr struct {
 	pos  position
-	expr any
+	expr interface{}
 }
 
-type (
-	andExpr        expr
-	notExpr        expr
-	zeroOrOneExpr  expr
-	zeroOrMoreExpr expr
-	oneOrMoreExpr  expr
-)
+type andExpr expr
+type notExpr expr
+type zeroOrOneExpr expr
+type zeroOrMoreExpr expr
+type oneOrMoreExpr expr
 
 type ruleRefExpr struct {
 	pos  position
@@ -22805,7 +22805,7 @@ func (p *parser) setOptions(opts []Option) {
 }
 
 type resultTuple struct {
-	v   any
+	v   interface{}
 	b   bool
 	end savepoint
 }
@@ -22849,12 +22849,12 @@ type parser struct {
 	memoize bool
 	// memoization table for the packrat algorithm:
 	// map[offset in source] map[expression or rule] {value, match}
-	memo map[int]map[any]resultTuple
+	memo map[int]map[interface{}]resultTuple
 
 	// rules table, maps the rule identifier to the rule node
 	rules map[string]*rule
 	// variables stack, map of label to value
-	vstack []map[string]any
+	vstack []map[string]interface{}
 	// rule stack, allows identification of the current rule in errors
 	rstack []*rule
 
@@ -22874,7 +22874,7 @@ type parser struct {
 
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
-	recoveryStack []map[string]any
+	recoveryStack []map[string]interface{}
 }
 
 // push a variable set on the vstack.
@@ -22894,7 +22894,7 @@ func (p *parser) pushV() {
 		return
 	}
 
-	m = make(map[string]any)
+	m = make(map[string]interface{})
 	p.vstack[len(p.vstack)-1] = m
 }
 
@@ -22910,7 +22910,7 @@ func (p *parser) popV() {
 }
 
 // push a recovery expression with its labels to the recoveryStack
-func (p *parser) pushRecovery(labels []string, expr any) {
+func (p *parser) pushRecovery(labels []string, expr interface{}) {
 	if cap(p.recoveryStack) == len(p.recoveryStack) {
 		// create new empty slot in the stack
 		p.recoveryStack = append(p.recoveryStack, nil)
@@ -22919,7 +22919,7 @@ func (p *parser) pushRecovery(labels []string, expr any) {
 		p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)+1]
 	}
 
-	m := make(map[string]any, len(labels))
+	m := make(map[string]interface{}, len(labels))
 	for _, fl := range labels {
 		m[fl] = expr
 	}
@@ -22944,19 +22944,14 @@ func (p *parser) print(prefix, s string) string {
 	return s
 }
 
-func (p *parser) printIndent(mark string, s string) string {
-	return p.print(strings.Repeat(" ", p.depth)+mark, s)
-}
-
 func (p *parser) in(s string) string {
-	res := p.printIndent(">", s)
 	p.depth++
-	return res
+	return p.print(strings.Repeat(" ", p.depth)+">", s)
 }
 
 func (p *parser) out(s string) string {
 	p.depth--
-	return p.printIndent("<", s)
+	return p.print(strings.Repeat(" ", p.depth)+"<", s)
 }
 
 func (p *parser) addErr(err error) {
@@ -23044,11 +23039,11 @@ func (p *parser) restore(pt savepoint) {
 // copies of the state to allow the parser to properly restore the state in
 // the case of backtracking.
 type Cloner interface {
-	Clone() any
+	Clone() interface{}
 }
 
 var statePool = &sync.Pool{
-	New: func() any { return make(storeDict) },
+	New: func() interface{} { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {
@@ -23090,7 +23085,7 @@ func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
 }
 
-func (p *parser) getMemoized(node any) (resultTuple, bool) {
+func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
 	if len(p.memo) == 0 {
 		return resultTuple{}, false
 	}
@@ -23102,13 +23097,13 @@ func (p *parser) getMemoized(node any) (resultTuple, bool) {
 	return res, ok
 }
 
-func (p *parser) setMemoized(pt savepoint, node any, tuple resultTuple) {
+func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
 	if p.memo == nil {
-		p.memo = make(map[int]map[any]resultTuple)
+		p.memo = make(map[int]map[interface{}]resultTuple)
 	}
 	m := p.memo[pt.offset]
 	if m == nil {
-		m = make(map[any]resultTuple)
+		m = make(map[interface{}]resultTuple)
 		p.memo[pt.offset] = m
 	}
 	m[node] = tuple
@@ -23121,7 +23116,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
-func (p *parser) parse(g *grammar) (val any, err error) {
+func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
 		return nil, p.errs.err()
@@ -23157,7 +23152,7 @@ func (p *parser) parse(g *grammar) (val any, err error) {
 	}
 
 	p.read() // advance to first rune
-	val, ok = p.parseRuleWrap(startRule)
+	val, ok = p.parseRule(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values
@@ -23198,52 +23193,36 @@ func listJoin(list []string, sep string, lastSep string) string {
 	}
 }
 
-func (p *parser) parseRuleMemoize(rule *rule) (any, bool) {
-	res, ok := p.getMemoized(rule)
-	if ok {
-		p.restore(res.end)
-		return res.v, res.b
-	}
-
-	startMark := p.pt
-	val, ok := p.parseRule(rule)
-	p.setMemoized(startMark, rule, resultTuple{val, ok, p.pt})
-
-	return val, ok
-}
-
-func (p *parser) parseRuleWrap(rule *rule) (any, bool) {
+func (p *parser) parseRule(rule *rule) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRule " + rule.name))
 	}
-	var (
-		val       any
-		ok        bool
-		startMark = p.pt
-	)
 
 	if p.memoize {
-		val, ok = p.parseRuleMemoize(rule)
-	} else {
-		val, ok = p.parseRule(rule)
+		res, ok := p.getMemoized(rule)
+		if ok {
+			p.restore(res.end)
+			return res.v, res.b
+		}
 	}
 
-	if ok && p.debug {
-		p.printIndent("MATCH", string(p.sliceFrom(startMark)))
-	}
-	return val, ok
-}
-
-func (p *parser) parseRule(rule *rule) (any, bool) {
+	start := p.pt
 	p.rstack = append(p.rstack, rule)
 	p.pushV()
-	val, ok := p.parseExprWrap(rule.expr)
+	val, ok := p.parseExpr(rule.expr)
 	p.popV()
 	p.rstack = p.rstack[:len(p.rstack)-1]
+	if ok && p.debug {
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+	}
+
+	if p.memoize {
+		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+	}
 	return val, ok
 }
 
-func (p *parser) parseExprWrap(expr any) (any, bool) {
+func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	var pt savepoint
 
 	if p.memoize {
@@ -23255,21 +23234,12 @@ func (p *parser) parseExprWrap(expr any) (any, bool) {
 		pt = p.pt
 	}
 
-	val, ok := p.parseExpr(expr)
-
-	if p.memoize {
-		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
-	}
-	return val, ok
-}
-
-func (p *parser) parseExpr(expr any) (any, bool) {
 	p.ExprCnt++
 	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
-	var val any
+	var val interface{}
 	var ok bool
 	switch expr := expr.(type) {
 	case *actionExpr:
@@ -23311,16 +23281,19 @@ func (p *parser) parseExpr(expr any) (any, bool) {
 	default:
 		panic(fmt.Sprintf("unknown expression type %T", expr))
 	}
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
 	return val, ok
 }
 
-func (p *parser) parseActionExpr(act *actionExpr) (any, bool) {
+func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseActionExpr"))
 	}
 
 	start := p.pt
-	val, ok := p.parseExprWrap(act.expr)
+	val, ok := p.parseExpr(act.expr)
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
@@ -23334,12 +23307,12 @@ func (p *parser) parseActionExpr(act *actionExpr) (any, bool) {
 		val = actVal
 	}
 	if ok && p.debug {
-		p.printIndent("MATCH", string(p.sliceFrom(start)))
+		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
 	}
 	return val, ok
 }
 
-func (p *parser) parseAndCodeExpr(and *andCodeExpr) (any, bool) {
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAndCodeExpr"))
 	}
@@ -23355,7 +23328,7 @@ func (p *parser) parseAndCodeExpr(and *andCodeExpr) (any, bool) {
 	return nil, ok
 }
 
-func (p *parser) parseAndExpr(and *andExpr) (any, bool) {
+func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAndExpr"))
 	}
@@ -23363,7 +23336,7 @@ func (p *parser) parseAndExpr(and *andExpr) (any, bool) {
 	pt := p.pt
 	state := p.cloneState()
 	p.pushV()
-	_, ok := p.parseExprWrap(and.expr)
+	_, ok := p.parseExpr(and.expr)
 	p.popV()
 	p.restoreState(state)
 	p.restore(pt)
@@ -23371,7 +23344,7 @@ func (p *parser) parseAndExpr(and *andExpr) (any, bool) {
 	return nil, ok
 }
 
-func (p *parser) parseAnyMatcher(any *anyMatcher) (any, bool) {
+func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
@@ -23387,7 +23360,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (any, bool) {
 	return p.sliceFrom(start), true
 }
 
-func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (any, bool) {
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))
 	}
@@ -23468,7 +23441,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	m[alt]++
 }
 
-func (p *parser) parseChoiceExpr(ch *choiceExpr) (any, bool) {
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
@@ -23480,7 +23453,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (any, bool) {
 		state := p.cloneState()
 
 		p.pushV()
-		val, ok := p.parseExprWrap(alt)
+		val, ok := p.parseExpr(alt)
 		p.popV()
 		if ok {
 			p.incChoiceAltCnt(ch, altI)
@@ -23492,13 +23465,13 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (any, bool) {
 	return nil, false
 }
 
-func (p *parser) parseLabeledExpr(lab *labeledExpr) (any, bool) {
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseLabeledExpr"))
 	}
 
 	p.pushV()
-	val, ok := p.parseExprWrap(lab.expr)
+	val, ok := p.parseExpr(lab.expr)
 	p.popV()
 	if ok && lab.label != "" {
 		m := p.vstack[len(p.vstack)-1]
@@ -23507,7 +23480,7 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (any, bool) {
 	return val, ok
 }
 
-func (p *parser) parseLitMatcher(lit *litMatcher) (any, bool) {
+func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseLitMatcher"))
 	}
@@ -23529,7 +23502,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (any, bool) {
 	return p.sliceFrom(start), true
 }
 
-func (p *parser) parseNotCodeExpr(not *notCodeExpr) (any, bool) {
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseNotCodeExpr"))
 	}
@@ -23545,7 +23518,7 @@ func (p *parser) parseNotCodeExpr(not *notCodeExpr) (any, bool) {
 	return nil, !ok
 }
 
-func (p *parser) parseNotExpr(not *notExpr) (any, bool) {
+func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseNotExpr"))
 	}
@@ -23554,7 +23527,7 @@ func (p *parser) parseNotExpr(not *notExpr) (any, bool) {
 	state := p.cloneState()
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
-	_, ok := p.parseExprWrap(not.expr)
+	_, ok := p.parseExpr(not.expr)
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restoreState(state)
@@ -23563,16 +23536,16 @@ func (p *parser) parseNotExpr(not *notExpr) (any, bool) {
 	return nil, !ok
 }
 
-func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (any, bool) {
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseOneOrMoreExpr"))
 	}
 
-	var vals []any
+	var vals []interface{}
 
 	for {
 		p.pushV()
-		val, ok := p.parseExprWrap(expr.expr)
+		val, ok := p.parseExpr(expr.expr)
 		p.popV()
 		if !ok {
 			if len(vals) == 0 {
@@ -23585,19 +23558,19 @@ func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (any, bool) {
 	}
 }
 
-func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (any, bool) {
+func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
 	}
 
 	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
-	val, ok := p.parseExprWrap(recover.expr)
+	val, ok := p.parseExpr(recover.expr)
 	p.popRecovery()
 
 	return val, ok
 }
 
-func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (any, bool) {
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRuleRefExpr " + ref.name))
 	}
@@ -23611,20 +23584,20 @@ func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (any, bool) {
 		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
 		return nil, false
 	}
-	return p.parseRuleWrap(rule)
+	return p.parseRule(rule)
 }
 
-func (p *parser) parseSeqExpr(seq *seqExpr) (any, bool) {
+func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseSeqExpr"))
 	}
 
-	vals := make([]any, 0, len(seq.exprs))
+	vals := make([]interface{}, 0, len(seq.exprs))
 
 	pt := p.pt
 	state := p.cloneState()
 	for _, expr := range seq.exprs {
-		val, ok := p.parseExprWrap(expr)
+		val, ok := p.parseExpr(expr)
 		if !ok {
 			p.restoreState(state)
 			p.restore(pt)
@@ -23635,7 +23608,7 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (any, bool) {
 	return vals, true
 }
 
-func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (any, bool) {
+func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseStateCodeExpr"))
 	}
@@ -23647,14 +23620,14 @@ func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (any, bool) {
 	return nil, true
 }
 
-func (p *parser) parseThrowExpr(expr *throwExpr) (any, bool) {
+func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseThrowExpr"))
 	}
 
 	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
 		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
-			if val, ok := p.parseExprWrap(recoverExpr); ok {
+			if val, ok := p.parseExpr(recoverExpr); ok {
 				return val, ok
 			}
 		}
@@ -23663,16 +23636,16 @@ func (p *parser) parseThrowExpr(expr *throwExpr) (any, bool) {
 	return nil, false
 }
 
-func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (any, bool) {
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseZeroOrMoreExpr"))
 	}
 
-	var vals []any
+	var vals []interface{}
 
 	for {
 		p.pushV()
-		val, ok := p.parseExprWrap(expr.expr)
+		val, ok := p.parseExpr(expr.expr)
 		p.popV()
 		if !ok {
 			return vals, true
@@ -23681,13 +23654,13 @@ func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (any, bool) {
 	}
 }
 
-func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (any, bool) {
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
 	if p.debug {
 		defer p.out(p.in("parseZeroOrOneExpr"))
 	}
 
 	p.pushV()
-	val, _ := p.parseExprWrap(expr.expr)
+	val, _ := p.parseExpr(expr.expr)
 	p.popV()
 	// whether it matched or not, consider it a match
 	return val, true

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -4007,7 +4007,7 @@ AggCommon <- aggName:CommonAggName L_PAREN "eval" valueExpr:ValueExpr R_PAREN {
 }
 
 PercentileVal <- numStr:(FloatAsString / IntegerAsString) {
-    floatVal, err := utils.FastParseFloat([]byte(numStr.(string)))
+    floatVal, err := strconv.ParseFloat(numStr.(string), 64)
     if err != nil {
         return nil, fmt.Errorf("Invalid percentage value: %v", numStr.(string))
     }

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -10286,7 +10286,7 @@ func performCommon_aggEval_Constant_Field(t *testing.T, measureFunc sutils.Aggre
 	if isField {
 		randomStr = utils.GetRandomString(10, utils.Alpha)
 	} else {
-		randomStr = fmt.Sprintf("%v", rand.Float64())
+		randomStr = strconv.FormatFloat(rand.Float64(), 'f', -1, 64)
 	}
 	measureFuncStr, param := getMeasureFuncStr(measureFunc)
 	measureWithEvalStr := measureFuncStr + `(eval(` + randomStr + `))`
@@ -10331,7 +10331,7 @@ func performCommon_aggEval_ConditionalExpr(t *testing.T, measureFunc sutils.Aggr
 	// Query Form: app_name=bracecould | stats sum(http_status), measureFunc(eval(if(http_status=500, trueValueField, falseValueConstant)))
 	measureFuncStr, param := getMeasureFuncStr(measureFunc)
 	trueValueField := utils.GetRandomString(10, utils.Alpha)
-	falseValueConstant := fmt.Sprintf("%v", rand.Float64())
+	falseValueConstant := strconv.FormatFloat(rand.Float64(), 'f', -1, 64)
 	measureWithEvalStr := measureFuncStr + `(eval(if(http_status=500, ` + trueValueField + `, ` + falseValueConstant + `)))`
 
 	query := []byte(`app_name=bracecould | stats sum(http_status), ` + measureWithEvalStr)


### PR DESCRIPTION
# Description
This fixes two issue with floating point numbers in the parser tests:
1. A number (e.g. `0.0005`) may be formatted using scientific notation (`5e-4`) when it is converted to string using `fmt.Sprintf()`. This results in expressions such as `eval(5e-4)`. SigLens does not currently support the use of `e` in floats.
2. [While generating the tests](https://github.com/t-sunk/siglens/blob/9384a28b1c9870e2239df69b61df8f3d2906fa96/pkg/ast/spl/tests/splParser_test.go#L10176), we use [`strconv.FormatFloat()`](https://pkg.go.dev/strconv#FormatFloat), which is meant for use with [`strconv.ParseFloat()`](https://pkg.go.dev/strconv#ParseFloat). However we were using [a different function](https://github.com/siglens/siglens/blob/9ccb4c73a2a383cacf1a49819d59d31817b6c1ff/pkg/ast/spl/spl.peg#L4010) to parse this string to a float within the grammar, which gave inconsistent results.

# Testing
Running the test `Test_Aggs` 100 times, it passes:
```
cd ~/siglens/pkg/ast/spl/tests/
go test -v -run '^Test_Aggs$' -count=100
```