### PR TITLE
Convert null CValueEnclosure to empty string

### DIFF
--- a/pkg/segment/utils/segconsts.go
+++ b/pkg/segment/utils/segconsts.go
@@ -1060,7 +1060,7 @@ func (e *CValueEnclosure) GetValueAsString() (string, error) {
 		return strconv.FormatInt(e.CVal.(int64), 10), nil
 	case SS_DT_FLOAT:
 		return fmt.Sprintf("%f", e.CVal.(float64)), nil
-	case SS_DT_BACKFILL:
+	case SS_DT_BACKFILL, SS_INVALID:
 		return "", nil
 	default:
 		return "", fmt.Errorf("CValueEnclosure.GetValueAsString: unsupported Dtype: %v", e.Dtype)


### PR DESCRIPTION
# Description
Previously for this query
```
Referer != "" | rex field=Referer "^https?://(?:www\.)?(?<k>[^/]+)" | stats avg(eval(len(Referer))) as l, count as c, min(eval(Referer)) by k | where c > 100000 | sort 25 -l
```
when some segments had the `Referer` field used by `rex` but other segments didn't have that field, we'd get this error
<img width="611" height="554" alt="image" src="https://github.com/user-attachments/assets/419a63bc-87ca-4a27-802e-56310f2250bf" />

Now we extract an empty string as the value instead of erroring.

# Testing
Describe how you tested this code. How can the reviewers reproduce your tests?
