### PR TITLE
Fix pagination issue for stats queries

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -722,8 +722,6 @@ function processLiveTailQueryUpdate(res, eventType, totalEventsSearched, timeToF
 }
 
 function processQueryUpdate(res, eventType, totalEventsSearched, timeToFirstByte, totalHits) {
-    lastQType = res.qtype;
-
     if (res.hits && res.hits.records !== null && res.hits.records.length >= 1 && res.qtype === 'logs-query') {
         if (res.columnsOrder != undefined && res.columnsOrder.length > 0) {
             lastColumnsOrder = _.uniq(['timestamp', 'logs', ...res.columnsOrder]);
@@ -798,6 +796,8 @@ function processLiveTailCompleteUpdate(res, eventType, totalEventsSearched, time
 }
 
 function processCompleteUpdate(res, eventType, totalEventsSearched, timeToFirstByte, eqRel) {
+    lastQType = res.qtype;
+
     let totalHits = res.totalMatched ? res.totalMatched.value : 0;
 
     if (res.qtype === 'logs-query' && res.hits && res.hits.records) {


### PR DESCRIPTION
# Description
Fix a bug where pagination did not work correctly for certain stats queries (e.g., `* | dedup consecutive=true city | stats count by ssn`). Although worked for stats queries like `* | stats count by ssn`.

**Root Cause:**
The frontend determines pagination logic based on the query type (logs or aggs/seg-stats). Previously, this check was done at the QUERY_UPDATE phase. However, for some stats queries, the query type was still `logs` at this point, which caused incorrect pagination handling.

**Fix:**
The query type check has been moved to the COMPLETE state where the correct query type is available. This ensures pagination behaves correctly for all stats queries
