### PR TITLE
Grammar Implementation for all eval json functions

### DIFF
--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -8920,33 +8920,84 @@ var g = &grammar{
 							},
 						},
 					},
+					&actionExpr{
+						pos: position{line: 4000, col: 3, offset: 123477},
+						run: (*parser).callonJsonExpr48,
+						expr: &seqExpr{
+							pos: position{line: 4000, col: 3, offset: 123477},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 4000, col: 3, offset: 123477},
+									val:        "json_array",
+									ignoreCase: false,
+									want:       "\"json_array\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4000, col: 16, offset: 123490},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 4000, col: 24, offset: 123498},
+									label: "value",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4000, col: 30, offset: 123504},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 4000, col: 45, offset: 123519},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 4000, col: 50, offset: 123524},
+										expr: &seqExpr{
+											pos: position{line: 4000, col: 51, offset: 123525},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 4000, col: 51, offset: 123525},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 4000, col: 57, offset: 123531},
+													name: "JsonExprLevel1",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4000, col: 74, offset: 123548},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 4001, col: 1, offset: 123476},
+			pos:  position{line: 4040, col: 1, offset: 124706},
 			expr: &choiceExpr{
-				pos: position{line: 4001, col: 12, offset: 123487},
+				pos: position{line: 4040, col: 12, offset: 124717},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4001, col: 12, offset: 123487},
+						pos: position{line: 4040, col: 12, offset: 124717},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 4001, col: 12, offset: 123487},
+							pos: position{line: 4040, col: 12, offset: 124717},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4001, col: 12, offset: 123487},
+									pos:   position{line: 4040, col: 12, offset: 124717},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4001, col: 16, offset: 123491},
+										pos:  position{line: 4040, col: 16, offset: 124721},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4001, col: 29, offset: 123504},
+									pos: position{line: 4040, col: 29, offset: 124734},
 									expr: &ruleRefExpr{
-										pos:  position{line: 4001, col: 31, offset: 123506},
+										pos:  position{line: 4040, col: 31, offset: 124736},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8954,50 +9005,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4017, col: 3, offset: 123881},
+						pos: position{line: 4056, col: 3, offset: 125111},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 4017, col: 3, offset: 123881},
+							pos: position{line: 4056, col: 3, offset: 125111},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4017, col: 3, offset: 123881},
+									pos:   position{line: 4056, col: 3, offset: 125111},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4017, col: 9, offset: 123887},
+										pos:  position{line: 4056, col: 9, offset: 125117},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4017, col: 25, offset: 123903},
+									pos: position{line: 4056, col: 25, offset: 125133},
 									expr: &choiceExpr{
-										pos: position{line: 4017, col: 27, offset: 123905},
+										pos: position{line: 4056, col: 27, offset: 125135},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 27, offset: 123905},
+												pos:  position{line: 4056, col: 27, offset: 125135},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 36, offset: 123914},
+												pos:  position{line: 4056, col: 36, offset: 125144},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 46, offset: 123924},
+												pos:  position{line: 4056, col: 46, offset: 125154},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 54, offset: 123932},
+												pos:  position{line: 4056, col: 54, offset: 125162},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 62, offset: 123940},
+												pos:  position{line: 4056, col: 62, offset: 125170},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4017, col: 70, offset: 123948},
+												pos:  position{line: 4056, col: 70, offset: 125178},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 4017, col: 84, offset: 123962},
+												pos:        position{line: 4056, col: 84, offset: 125192},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -9013,28 +9064,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 4034, col: 1, offset: 124313},
+			pos:  position{line: 4073, col: 1, offset: 125543},
 			expr: &actionExpr{
-				pos: position{line: 4034, col: 19, offset: 124331},
+				pos: position{line: 4073, col: 19, offset: 125561},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 4034, col: 19, offset: 124331},
+					pos: position{line: 4073, col: 19, offset: 125561},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4034, col: 19, offset: 124331},
+							pos:        position{line: 4073, col: 19, offset: 125561},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4034, col: 26, offset: 124338},
+							pos:  position{line: 4073, col: 26, offset: 125568},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4034, col: 32, offset: 124344},
+							pos:   position{line: 4073, col: 32, offset: 125574},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4034, col: 40, offset: 124352},
+								pos:  position{line: 4073, col: 40, offset: 125582},
 								name: "Boolean",
 							},
 						},
@@ -9044,28 +9095,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 4045, col: 1, offset: 124541},
+			pos:  position{line: 4084, col: 1, offset: 125771},
 			expr: &actionExpr{
-				pos: position{line: 4045, col: 23, offset: 124563},
+				pos: position{line: 4084, col: 23, offset: 125793},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 4045, col: 23, offset: 124563},
+					pos: position{line: 4084, col: 23, offset: 125793},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4045, col: 23, offset: 124563},
+							pos:        position{line: 4084, col: 23, offset: 125793},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4045, col: 34, offset: 124574},
+							pos:  position{line: 4084, col: 34, offset: 125804},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4045, col: 40, offset: 124580},
+							pos:   position{line: 4084, col: 40, offset: 125810},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4045, col: 48, offset: 124588},
+								pos:  position{line: 4084, col: 48, offset: 125818},
 								name: "Boolean",
 							},
 						},
@@ -9075,28 +9126,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 4056, col: 1, offset: 124785},
+			pos:  position{line: 4095, col: 1, offset: 126015},
 			expr: &actionExpr{
-				pos: position{line: 4056, col: 20, offset: 124804},
+				pos: position{line: 4095, col: 20, offset: 126034},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4056, col: 20, offset: 124804},
+					pos: position{line: 4095, col: 20, offset: 126034},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4056, col: 20, offset: 124804},
+							pos:        position{line: 4095, col: 20, offset: 126034},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4056, col: 28, offset: 124812},
+							pos:  position{line: 4095, col: 28, offset: 126042},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4056, col: 34, offset: 124818},
+							pos:   position{line: 4095, col: 34, offset: 126048},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4056, col: 43, offset: 124827},
+								pos:  position{line: 4095, col: 43, offset: 126057},
 								name: "IntegerAsString",
 							},
 						},
@@ -9106,15 +9157,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 4071, col: 1, offset: 125189},
+			pos:  position{line: 4110, col: 1, offset: 126419},
 			expr: &actionExpr{
-				pos: position{line: 4071, col: 19, offset: 125207},
+				pos: position{line: 4110, col: 19, offset: 126437},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 4071, col: 19, offset: 125207},
+					pos:   position{line: 4110, col: 19, offset: 126437},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4071, col: 28, offset: 125216},
+						pos:  position{line: 4110, col: 28, offset: 126446},
 						name: "BoolExpr",
 					},
 				},
@@ -9122,30 +9173,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 4082, col: 1, offset: 125428},
+			pos:  position{line: 4121, col: 1, offset: 126658},
 			expr: &actionExpr{
-				pos: position{line: 4082, col: 15, offset: 125442},
+				pos: position{line: 4121, col: 15, offset: 126672},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4082, col: 15, offset: 125442},
+					pos:   position{line: 4121, col: 15, offset: 126672},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4082, col: 23, offset: 125450},
+						pos: position{line: 4121, col: 23, offset: 126680},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4082, col: 23, offset: 125450},
+								pos:  position{line: 4121, col: 23, offset: 126680},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4082, col: 44, offset: 125471},
+								pos:  position{line: 4121, col: 44, offset: 126701},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4082, col: 61, offset: 125488},
+								pos:  position{line: 4121, col: 61, offset: 126718},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4082, col: 79, offset: 125506},
+								pos:  position{line: 4121, col: 79, offset: 126736},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -9155,35 +9206,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 4086, col: 1, offset: 125550},
+			pos:  position{line: 4125, col: 1, offset: 126780},
 			expr: &actionExpr{
-				pos: position{line: 4086, col: 19, offset: 125568},
+				pos: position{line: 4125, col: 19, offset: 126798},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4086, col: 19, offset: 125568},
+					pos: position{line: 4125, col: 19, offset: 126798},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4086, col: 19, offset: 125568},
+							pos:   position{line: 4125, col: 19, offset: 126798},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4086, col: 26, offset: 125575},
+								pos:  position{line: 4125, col: 26, offset: 126805},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4086, col: 37, offset: 125586},
+							pos:   position{line: 4125, col: 37, offset: 126816},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4086, col: 43, offset: 125592},
+								pos: position{line: 4125, col: 43, offset: 126822},
 								expr: &seqExpr{
-									pos: position{line: 4086, col: 44, offset: 125593},
+									pos: position{line: 4125, col: 44, offset: 126823},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4086, col: 44, offset: 125593},
+											pos:  position{line: 4125, col: 44, offset: 126823},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4086, col: 50, offset: 125599},
+											pos:  position{line: 4125, col: 50, offset: 126829},
 											name: "HeadOption",
 										},
 									},
@@ -9196,29 +9247,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4143, col: 1, offset: 127399},
+			pos:  position{line: 4182, col: 1, offset: 128629},
 			expr: &choiceExpr{
-				pos: position{line: 4143, col: 14, offset: 127412},
+				pos: position{line: 4182, col: 14, offset: 128642},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4143, col: 14, offset: 127412},
+						pos: position{line: 4182, col: 14, offset: 128642},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4143, col: 14, offset: 127412},
+							pos: position{line: 4182, col: 14, offset: 128642},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4143, col: 14, offset: 127412},
+									pos:  position{line: 4182, col: 14, offset: 128642},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4143, col: 19, offset: 127417},
+									pos:  position{line: 4182, col: 19, offset: 128647},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4143, col: 28, offset: 127426},
+									pos:   position{line: 4182, col: 28, offset: 128656},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4143, col: 37, offset: 127435},
+										pos:  position{line: 4182, col: 37, offset: 128665},
 										name: "HeadOptionList",
 									},
 								},
@@ -9226,24 +9277,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4154, col: 3, offset: 127754},
+						pos: position{line: 4193, col: 3, offset: 128984},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4154, col: 3, offset: 127754},
+							pos: position{line: 4193, col: 3, offset: 128984},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4154, col: 3, offset: 127754},
+									pos:  position{line: 4193, col: 3, offset: 128984},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4154, col: 8, offset: 127759},
+									pos:  position{line: 4193, col: 8, offset: 128989},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4154, col: 17, offset: 127768},
+									pos:   position{line: 4193, col: 17, offset: 128998},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4154, col: 26, offset: 127777},
+										pos:  position{line: 4193, col: 26, offset: 129007},
 										name: "IntegerAsString",
 									},
 								},
@@ -9251,17 +9302,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4174, col: 3, offset: 128294},
+						pos: position{line: 4213, col: 3, offset: 129524},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4174, col: 3, offset: 128294},
+							pos: position{line: 4213, col: 3, offset: 129524},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4174, col: 3, offset: 128294},
+									pos:  position{line: 4213, col: 3, offset: 129524},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4174, col: 8, offset: 128299},
+									pos:  position{line: 4213, col: 8, offset: 129529},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9272,29 +9323,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4192, col: 1, offset: 128769},
+			pos:  position{line: 4231, col: 1, offset: 129999},
 			expr: &choiceExpr{
-				pos: position{line: 4192, col: 14, offset: 128782},
+				pos: position{line: 4231, col: 14, offset: 130012},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4192, col: 14, offset: 128782},
+						pos: position{line: 4231, col: 14, offset: 130012},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4192, col: 14, offset: 128782},
+							pos: position{line: 4231, col: 14, offset: 130012},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4192, col: 14, offset: 128782},
+									pos:  position{line: 4231, col: 14, offset: 130012},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4192, col: 19, offset: 128787},
+									pos:  position{line: 4231, col: 19, offset: 130017},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4192, col: 28, offset: 128796},
+									pos:   position{line: 4231, col: 28, offset: 130026},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4192, col: 37, offset: 128805},
+										pos:  position{line: 4231, col: 37, offset: 130035},
 										name: "IntegerAsString",
 									},
 								},
@@ -9302,17 +9353,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4213, col: 3, offset: 129379},
+						pos: position{line: 4252, col: 3, offset: 130609},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4213, col: 3, offset: 129379},
+							pos: position{line: 4252, col: 3, offset: 130609},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4213, col: 3, offset: 129379},
+									pos:  position{line: 4252, col: 3, offset: 130609},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4213, col: 8, offset: 129384},
+									pos:  position{line: 4252, col: 8, offset: 130614},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9323,44 +9374,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4234, col: 1, offset: 130002},
+			pos:  position{line: 4273, col: 1, offset: 131232},
 			expr: &actionExpr{
-				pos: position{line: 4234, col: 20, offset: 130021},
+				pos: position{line: 4273, col: 20, offset: 131251},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4234, col: 20, offset: 130021},
+					pos: position{line: 4273, col: 20, offset: 131251},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4234, col: 20, offset: 130021},
+							pos:   position{line: 4273, col: 20, offset: 131251},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4234, col: 26, offset: 130027},
+								pos:  position{line: 4273, col: 26, offset: 131257},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4234, col: 37, offset: 130038},
+							pos:   position{line: 4273, col: 37, offset: 131268},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4234, col: 42, offset: 130043},
+								pos: position{line: 4273, col: 42, offset: 131273},
 								expr: &seqExpr{
-									pos: position{line: 4234, col: 43, offset: 130044},
+									pos: position{line: 4273, col: 43, offset: 131274},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4234, col: 44, offset: 130045},
+											pos: position{line: 4273, col: 44, offset: 131275},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4234, col: 44, offset: 130045},
+													pos:  position{line: 4273, col: 44, offset: 131275},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4234, col: 52, offset: 130053},
+													pos:  position{line: 4273, col: 52, offset: 131283},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4234, col: 59, offset: 130060},
+											pos:  position{line: 4273, col: 59, offset: 131290},
 											name: "Aggregator",
 										},
 									},
@@ -9373,28 +9424,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4251, col: 1, offset: 130563},
+			pos:  position{line: 4290, col: 1, offset: 131793},
 			expr: &actionExpr{
-				pos: position{line: 4251, col: 15, offset: 130577},
+				pos: position{line: 4290, col: 15, offset: 131807},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4251, col: 15, offset: 130577},
+					pos: position{line: 4290, col: 15, offset: 131807},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4251, col: 15, offset: 130577},
+							pos:   position{line: 4290, col: 15, offset: 131807},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4251, col: 23, offset: 130585},
+								pos:  position{line: 4290, col: 23, offset: 131815},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4251, col: 35, offset: 130597},
+							pos:   position{line: 4290, col: 35, offset: 131827},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4251, col: 43, offset: 130605},
+								pos: position{line: 4290, col: 43, offset: 131835},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4251, col: 43, offset: 130605},
+									pos:  position{line: 4290, col: 43, offset: 131835},
 									name: "AsField",
 								},
 							},
@@ -9405,26 +9456,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4267, col: 1, offset: 131446},
+			pos:  position{line: 4306, col: 1, offset: 132676},
 			expr: &actionExpr{
-				pos: position{line: 4267, col: 16, offset: 131461},
+				pos: position{line: 4306, col: 16, offset: 132691},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4267, col: 16, offset: 131461},
+					pos:   position{line: 4306, col: 16, offset: 132691},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4267, col: 21, offset: 131466},
+						pos: position{line: 4306, col: 21, offset: 132696},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4267, col: 21, offset: 131466},
+								pos:  position{line: 4306, col: 21, offset: 132696},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4267, col: 32, offset: 131477},
+								pos:  position{line: 4306, col: 32, offset: 132707},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4267, col: 48, offset: 131493},
+								pos:  position{line: 4306, col: 48, offset: 132723},
 								name: "AggCommon",
 							},
 						},
@@ -9434,165 +9485,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4272, col: 1, offset: 131661},
+			pos:  position{line: 4311, col: 1, offset: 132891},
 			expr: &actionExpr{
-				pos: position{line: 4272, col: 18, offset: 131678},
+				pos: position{line: 4311, col: 18, offset: 132908},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4272, col: 19, offset: 131679},
+					pos: position{line: 4311, col: 19, offset: 132909},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4272, col: 19, offset: 131679},
+							pos:        position{line: 4311, col: 19, offset: 132909},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 30, offset: 131690},
+							pos:        position{line: 4311, col: 30, offset: 132920},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 39, offset: 131699},
+							pos:        position{line: 4311, col: 39, offset: 132929},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 47, offset: 131707},
+							pos:        position{line: 4311, col: 47, offset: 132937},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 57, offset: 131717},
+							pos:        position{line: 4311, col: 57, offset: 132947},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 65, offset: 131725},
+							pos:        position{line: 4311, col: 65, offset: 132955},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 76, offset: 131736},
+							pos:        position{line: 4311, col: 76, offset: 132966},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 86, offset: 131746},
+							pos:        position{line: 4311, col: 86, offset: 132976},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 95, offset: 131755},
+							pos:        position{line: 4311, col: 95, offset: 132985},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 105, offset: 131765},
+							pos:        position{line: 4311, col: 105, offset: 132995},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 114, offset: 131774},
+							pos:        position{line: 4311, col: 114, offset: 133004},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 122, offset: 131782},
+							pos:        position{line: 4311, col: 122, offset: 133012},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 133, offset: 131793},
+							pos:        position{line: 4311, col: 133, offset: 133023},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4272, col: 142, offset: 131802},
+							pos:        position{line: 4311, col: 142, offset: 133032},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 1, offset: 131811},
+							pos:        position{line: 4312, col: 1, offset: 133041},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 10, offset: 131820},
+							pos:        position{line: 4312, col: 10, offset: 133050},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 26, offset: 131836},
+							pos:        position{line: 4312, col: 26, offset: 133066},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 37, offset: 131847},
+							pos:        position{line: 4312, col: 37, offset: 133077},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 46, offset: 131856},
+							pos:        position{line: 4312, col: 46, offset: 133086},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 56, offset: 131866},
+							pos:        position{line: 4312, col: 56, offset: 133096},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 72, offset: 131882},
+							pos:        position{line: 4312, col: 72, offset: 133112},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 82, offset: 131892},
+							pos:        position{line: 4312, col: 82, offset: 133122},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 100, offset: 131910},
+							pos:        position{line: 4312, col: 100, offset: 133140},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 113, offset: 131923},
+							pos:        position{line: 4312, col: 113, offset: 133153},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 132, offset: 131942},
+							pos:        position{line: 4312, col: 132, offset: 133172},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4273, col: 139, offset: 131949},
+							pos:        position{line: 4312, col: 139, offset: 133179},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9603,33 +9654,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4277, col: 1, offset: 131992},
+			pos:  position{line: 4316, col: 1, offset: 133222},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 22, offset: 132013},
+				pos: position{line: 4316, col: 22, offset: 133243},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4277, col: 23, offset: 132014},
+					pos: position{line: 4316, col: 23, offset: 133244},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4277, col: 23, offset: 132014},
+							pos:        position{line: 4316, col: 23, offset: 133244},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 37, offset: 132028},
+							pos:        position{line: 4316, col: 37, offset: 133258},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 51, offset: 132042},
+							pos:        position{line: 4316, col: 51, offset: 133272},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4277, col: 60, offset: 132051},
+							pos:        position{line: 4316, col: 60, offset: 133281},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9640,29 +9691,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4281, col: 1, offset: 132092},
+			pos:  position{line: 4320, col: 1, offset: 133322},
 			expr: &actionExpr{
-				pos: position{line: 4281, col: 12, offset: 132103},
+				pos: position{line: 4320, col: 12, offset: 133333},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4281, col: 12, offset: 132103},
+					pos: position{line: 4320, col: 12, offset: 133333},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4281, col: 12, offset: 132103},
+							pos:  position{line: 4320, col: 12, offset: 133333},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4281, col: 15, offset: 132106},
+							pos:   position{line: 4320, col: 15, offset: 133336},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4281, col: 23, offset: 132114},
+								pos: position{line: 4320, col: 23, offset: 133344},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4281, col: 23, offset: 132114},
+										pos:  position{line: 4320, col: 23, offset: 133344},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4281, col: 35, offset: 132126},
+										pos:  position{line: 4320, col: 35, offset: 133356},
 										name: "String",
 									},
 								},
@@ -9674,27 +9725,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4295, col: 1, offset: 132455},
+			pos:  position{line: 4334, col: 1, offset: 133685},
 			expr: &choiceExpr{
-				pos: position{line: 4295, col: 13, offset: 132467},
+				pos: position{line: 4334, col: 13, offset: 133697},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4295, col: 13, offset: 132467},
+						pos: position{line: 4334, col: 13, offset: 133697},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4295, col: 13, offset: 132467},
+							pos: position{line: 4334, col: 13, offset: 133697},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4295, col: 14, offset: 132468},
+									pos: position{line: 4334, col: 14, offset: 133698},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4295, col: 14, offset: 132468},
+											pos:        position{line: 4334, col: 14, offset: 133698},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4295, col: 24, offset: 132478},
+											pos:        position{line: 4334, col: 24, offset: 133708},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9702,47 +9753,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4295, col: 29, offset: 132483},
+									pos:  position{line: 4334, col: 29, offset: 133713},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4295, col: 37, offset: 132491},
+									pos:        position{line: 4334, col: 37, offset: 133721},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4295, col: 44, offset: 132498},
+									pos:   position{line: 4334, col: 44, offset: 133728},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4295, col: 54, offset: 132508},
+										pos:  position{line: 4334, col: 54, offset: 133738},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4295, col: 64, offset: 132518},
+									pos:  position{line: 4334, col: 64, offset: 133748},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4305, col: 3, offset: 132747},
+						pos: position{line: 4344, col: 3, offset: 133977},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4305, col: 3, offset: 132747},
+							pos: position{line: 4344, col: 3, offset: 133977},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4305, col: 4, offset: 132748},
+									pos: position{line: 4344, col: 4, offset: 133978},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4305, col: 4, offset: 132748},
+											pos:        position{line: 4344, col: 4, offset: 133978},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4305, col: 14, offset: 132758},
+											pos:        position{line: 4344, col: 14, offset: 133988},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9750,38 +9801,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4305, col: 19, offset: 132763},
+									pos:  position{line: 4344, col: 19, offset: 133993},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4305, col: 27, offset: 132771},
+									pos:   position{line: 4344, col: 27, offset: 134001},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4305, col: 33, offset: 132777},
+										pos:  position{line: 4344, col: 33, offset: 134007},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4305, col: 43, offset: 132787},
+									pos:  position{line: 4344, col: 43, offset: 134017},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4312, col: 5, offset: 132939},
+						pos: position{line: 4351, col: 5, offset: 134169},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4312, col: 6, offset: 132940},
+							pos: position{line: 4351, col: 6, offset: 134170},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4312, col: 6, offset: 132940},
+									pos:        position{line: 4351, col: 6, offset: 134170},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4312, col: 16, offset: 132950},
+									pos:        position{line: 4351, col: 16, offset: 134180},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9794,77 +9845,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4321, col: 1, offset: 133087},
+			pos:  position{line: 4360, col: 1, offset: 134317},
 			expr: &choiceExpr{
-				pos: position{line: 4321, col: 14, offset: 133100},
+				pos: position{line: 4360, col: 14, offset: 134330},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4321, col: 14, offset: 133100},
+						pos: position{line: 4360, col: 14, offset: 134330},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4321, col: 14, offset: 133100},
+							pos: position{line: 4360, col: 14, offset: 134330},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4321, col: 14, offset: 133100},
+									pos:   position{line: 4360, col: 14, offset: 134330},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4321, col: 22, offset: 133108},
+										pos:  position{line: 4360, col: 22, offset: 134338},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4321, col: 36, offset: 133122},
+									pos:  position{line: 4360, col: 36, offset: 134352},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4321, col: 44, offset: 133130},
+									pos:        position{line: 4360, col: 44, offset: 134360},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4321, col: 51, offset: 133137},
+									pos:   position{line: 4360, col: 51, offset: 134367},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4321, col: 61, offset: 133147},
+										pos:  position{line: 4360, col: 61, offset: 134377},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4321, col: 71, offset: 133157},
+									pos:  position{line: 4360, col: 71, offset: 134387},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4336, col: 3, offset: 133568},
+						pos: position{line: 4375, col: 3, offset: 134798},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4336, col: 3, offset: 133568},
+							pos: position{line: 4375, col: 3, offset: 134798},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4336, col: 3, offset: 133568},
+									pos:   position{line: 4375, col: 3, offset: 134798},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4336, col: 11, offset: 133576},
+										pos:  position{line: 4375, col: 11, offset: 134806},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4336, col: 25, offset: 133590},
+									pos:  position{line: 4375, col: 25, offset: 134820},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4336, col: 33, offset: 133598},
+									pos:   position{line: 4375, col: 33, offset: 134828},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4336, col: 39, offset: 133604},
+										pos:  position{line: 4375, col: 39, offset: 134834},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4336, col: 49, offset: 133614},
+									pos:  position{line: 4375, col: 49, offset: 134844},
 									name: "R_PAREN",
 								},
 							},
@@ -9875,22 +9926,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4366, col: 1, offset: 134595},
+			pos:  position{line: 4405, col: 1, offset: 135825},
 			expr: &actionExpr{
-				pos: position{line: 4366, col: 18, offset: 134612},
+				pos: position{line: 4405, col: 18, offset: 135842},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4366, col: 18, offset: 134612},
+					pos:   position{line: 4405, col: 18, offset: 135842},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4366, col: 26, offset: 134620},
+						pos: position{line: 4405, col: 26, offset: 135850},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4366, col: 26, offset: 134620},
+								pos:  position{line: 4405, col: 26, offset: 135850},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4366, col: 42, offset: 134636},
+								pos:  position{line: 4405, col: 42, offset: 135866},
 								name: "IntegerAsString",
 							},
 						},
@@ -9900,161 +9951,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4378, col: 1, offset: 135003},
+			pos:  position{line: 4417, col: 1, offset: 136233},
 			expr: &choiceExpr{
-				pos: position{line: 4378, col: 18, offset: 135020},
+				pos: position{line: 4417, col: 18, offset: 136250},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4378, col: 18, offset: 135020},
+						pos: position{line: 4417, col: 18, offset: 136250},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4378, col: 18, offset: 135020},
+							pos: position{line: 4417, col: 18, offset: 136250},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4378, col: 18, offset: 135020},
+									pos:   position{line: 4417, col: 18, offset: 136250},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4378, col: 26, offset: 135028},
+										pos:  position{line: 4417, col: 26, offset: 136258},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4378, col: 44, offset: 135046},
+									pos:   position{line: 4417, col: 44, offset: 136276},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4378, col: 58, offset: 135060},
+										pos:  position{line: 4417, col: 58, offset: 136290},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4378, col: 72, offset: 135074},
+									pos:  position{line: 4417, col: 72, offset: 136304},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4378, col: 80, offset: 135082},
+									pos:        position{line: 4417, col: 80, offset: 136312},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4378, col: 87, offset: 135089},
+									pos:   position{line: 4417, col: 87, offset: 136319},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4378, col: 97, offset: 135099},
+										pos:  position{line: 4417, col: 97, offset: 136329},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4378, col: 107, offset: 135109},
+									pos:  position{line: 4417, col: 107, offset: 136339},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4394, col: 3, offset: 135633},
+						pos: position{line: 4433, col: 3, offset: 136863},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4394, col: 3, offset: 135633},
+							pos: position{line: 4433, col: 3, offset: 136863},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4394, col: 3, offset: 135633},
+									pos:   position{line: 4433, col: 3, offset: 136863},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4394, col: 11, offset: 135641},
+										pos:  position{line: 4433, col: 11, offset: 136871},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4394, col: 29, offset: 135659},
+									pos:   position{line: 4433, col: 29, offset: 136889},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4394, col: 43, offset: 135673},
+										pos:  position{line: 4433, col: 43, offset: 136903},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4394, col: 57, offset: 135687},
+									pos:  position{line: 4433, col: 57, offset: 136917},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4394, col: 65, offset: 135695},
+									pos:   position{line: 4433, col: 65, offset: 136925},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4394, col: 71, offset: 135701},
+										pos:  position{line: 4433, col: 71, offset: 136931},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4394, col: 81, offset: 135711},
+									pos:  position{line: 4433, col: 81, offset: 136941},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4409, col: 3, offset: 136191},
+						pos: position{line: 4448, col: 3, offset: 137421},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4409, col: 3, offset: 136191},
+							pos: position{line: 4448, col: 3, offset: 137421},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4409, col: 4, offset: 136192},
+									pos:        position{line: 4448, col: 4, offset: 137422},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4409, col: 14, offset: 136202},
+									pos:  position{line: 4448, col: 14, offset: 137432},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4409, col: 22, offset: 136210},
+									pos:   position{line: 4448, col: 22, offset: 137440},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4409, col: 28, offset: 136216},
+										pos:  position{line: 4448, col: 28, offset: 137446},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4409, col: 38, offset: 136226},
+									pos:  position{line: 4448, col: 38, offset: 137456},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4424, col: 3, offset: 136613},
+						pos: position{line: 4463, col: 3, offset: 137843},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4424, col: 3, offset: 136613},
+							pos: position{line: 4463, col: 3, offset: 137843},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4424, col: 4, offset: 136614},
+									pos:        position{line: 4463, col: 4, offset: 137844},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4424, col: 14, offset: 136624},
+									pos:  position{line: 4463, col: 14, offset: 137854},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4424, col: 22, offset: 136632},
+									pos:        position{line: 4463, col: 22, offset: 137862},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4424, col: 29, offset: 136639},
+									pos:   position{line: 4463, col: 29, offset: 137869},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4424, col: 39, offset: 136649},
+										pos:  position{line: 4463, col: 39, offset: 137879},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4424, col: 49, offset: 136659},
+									pos:  position{line: 4463, col: 49, offset: 137889},
 									name: "R_PAREN",
 								},
 							},
@@ -10065,22 +10116,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4442, col: 1, offset: 137090},
+			pos:  position{line: 4481, col: 1, offset: 138320},
 			expr: &actionExpr{
-				pos: position{line: 4442, col: 25, offset: 137114},
+				pos: position{line: 4481, col: 25, offset: 138344},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4442, col: 25, offset: 137114},
+					pos:   position{line: 4481, col: 25, offset: 138344},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4442, col: 39, offset: 137128},
+						pos: position{line: 4481, col: 39, offset: 138358},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4442, col: 39, offset: 137128},
+								pos:  position{line: 4481, col: 39, offset: 138358},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4442, col: 67, offset: 137156},
+								pos:  position{line: 4481, col: 67, offset: 138386},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -10090,43 +10141,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4446, col: 1, offset: 137219},
+			pos:  position{line: 4485, col: 1, offset: 138449},
 			expr: &actionExpr{
-				pos: position{line: 4446, col: 30, offset: 137248},
+				pos: position{line: 4485, col: 30, offset: 138478},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4446, col: 30, offset: 137248},
+					pos: position{line: 4485, col: 30, offset: 138478},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4446, col: 30, offset: 137248},
+							pos:   position{line: 4485, col: 30, offset: 138478},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4446, col: 34, offset: 137252},
+								pos:  position{line: 4485, col: 34, offset: 138482},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4446, col: 44, offset: 137262},
+							pos:   position{line: 4485, col: 44, offset: 138492},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4446, col: 48, offset: 137266},
+								pos: position{line: 4485, col: 48, offset: 138496},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4446, col: 48, offset: 137266},
+										pos:  position{line: 4485, col: 48, offset: 138496},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4446, col: 67, offset: 137285},
+										pos:  position{line: 4485, col: 67, offset: 138515},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4446, col: 87, offset: 137305},
+							pos:   position{line: 4485, col: 87, offset: 138535},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4446, col: 93, offset: 137311},
+								pos:  position{line: 4485, col: 93, offset: 138541},
 								name: "Number",
 							},
 						},
@@ -10136,15 +10187,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4459, col: 1, offset: 137545},
+			pos:  position{line: 4498, col: 1, offset: 138775},
 			expr: &actionExpr{
-				pos: position{line: 4459, col: 32, offset: 137576},
+				pos: position{line: 4498, col: 32, offset: 138806},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4459, col: 32, offset: 137576},
+					pos:   position{line: 4498, col: 32, offset: 138806},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4459, col: 38, offset: 137582},
+						pos:  position{line: 4498, col: 38, offset: 138812},
 						name: "Number",
 					},
 				},
@@ -10152,34 +10203,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4472, col: 1, offset: 137799},
+			pos:  position{line: 4511, col: 1, offset: 139029},
 			expr: &actionExpr{
-				pos: position{line: 4472, col: 26, offset: 137824},
+				pos: position{line: 4511, col: 26, offset: 139054},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4472, col: 26, offset: 137824},
+					pos: position{line: 4511, col: 26, offset: 139054},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4472, col: 26, offset: 137824},
+							pos:   position{line: 4511, col: 26, offset: 139054},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4472, col: 30, offset: 137828},
+								pos:  position{line: 4511, col: 30, offset: 139058},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4472, col: 40, offset: 137838},
+							pos:   position{line: 4511, col: 40, offset: 139068},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4472, col: 43, offset: 137841},
+								pos:  position{line: 4511, col: 43, offset: 139071},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4472, col: 60, offset: 137858},
+							pos:   position{line: 4511, col: 60, offset: 139088},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4472, col: 66, offset: 137864},
+								pos:  position{line: 4511, col: 66, offset: 139094},
 								name: "Boolean",
 							},
 						},
@@ -10189,22 +10240,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4485, col: 1, offset: 138099},
+			pos:  position{line: 4524, col: 1, offset: 139329},
 			expr: &actionExpr{
-				pos: position{line: 4485, col: 25, offset: 138123},
+				pos: position{line: 4524, col: 25, offset: 139353},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4485, col: 25, offset: 138123},
+					pos:   position{line: 4524, col: 25, offset: 139353},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4485, col: 39, offset: 138137},
+						pos: position{line: 4524, col: 39, offset: 139367},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4485, col: 39, offset: 138137},
+								pos:  position{line: 4524, col: 39, offset: 139367},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4485, col: 67, offset: 138165},
+								pos:  position{line: 4524, col: 67, offset: 139395},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -10214,41 +10265,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4489, col: 1, offset: 138228},
+			pos:  position{line: 4528, col: 1, offset: 139458},
 			expr: &actionExpr{
-				pos: position{line: 4489, col: 30, offset: 138257},
+				pos: position{line: 4528, col: 30, offset: 139487},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4489, col: 30, offset: 138257},
+					pos: position{line: 4528, col: 30, offset: 139487},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4489, col: 30, offset: 138257},
+							pos:   position{line: 4528, col: 30, offset: 139487},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4489, col: 34, offset: 138261},
+								pos:  position{line: 4528, col: 34, offset: 139491},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4489, col: 44, offset: 138271},
+							pos:   position{line: 4528, col: 44, offset: 139501},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4489, col: 47, offset: 138274},
+								pos:  position{line: 4528, col: 47, offset: 139504},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4489, col: 64, offset: 138291},
+							pos:   position{line: 4528, col: 64, offset: 139521},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4489, col: 81, offset: 138308},
+								pos: position{line: 4528, col: 81, offset: 139538},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4489, col: 81, offset: 138308},
+										pos:  position{line: 4528, col: 81, offset: 139538},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4489, col: 103, offset: 138330},
+										pos:  position{line: 4528, col: 103, offset: 139560},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10260,22 +10311,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4505, col: 1, offset: 138762},
+			pos:  position{line: 4544, col: 1, offset: 139992},
 			expr: &actionExpr{
-				pos: position{line: 4505, col: 32, offset: 138793},
+				pos: position{line: 4544, col: 32, offset: 140023},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4505, col: 32, offset: 138793},
+					pos:   position{line: 4544, col: 32, offset: 140023},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4505, col: 49, offset: 138810},
+						pos: position{line: 4544, col: 49, offset: 140040},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4505, col: 49, offset: 138810},
+								pos:  position{line: 4544, col: 49, offset: 140040},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4505, col: 71, offset: 138832},
+								pos:  position{line: 4544, col: 71, offset: 140062},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10285,33 +10336,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4522, col: 1, offset: 139343},
+			pos:  position{line: 4561, col: 1, offset: 140573},
 			expr: &actionExpr{
-				pos: position{line: 4522, col: 24, offset: 139366},
+				pos: position{line: 4561, col: 24, offset: 140596},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4522, col: 24, offset: 139366},
+					pos: position{line: 4561, col: 24, offset: 140596},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4522, col: 24, offset: 139366},
+							pos:        position{line: 4561, col: 24, offset: 140596},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4522, col: 31, offset: 139373},
+							pos:  position{line: 4561, col: 31, offset: 140603},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4522, col: 39, offset: 139381},
+							pos:   position{line: 4561, col: 39, offset: 140611},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4522, col: 45, offset: 139387},
+								pos:  position{line: 4561, col: 45, offset: 140617},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4522, col: 52, offset: 139394},
+							pos:  position{line: 4561, col: 52, offset: 140624},
 							name: "R_PAREN",
 						},
 					},
@@ -10320,49 +10371,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4531, col: 1, offset: 139631},
+			pos:  position{line: 4570, col: 1, offset: 140861},
 			expr: &choiceExpr{
-				pos: position{line: 4531, col: 26, offset: 139656},
+				pos: position{line: 4570, col: 26, offset: 140886},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4531, col: 26, offset: 139656},
+						pos: position{line: 4570, col: 26, offset: 140886},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4531, col: 26, offset: 139656},
+							pos: position{line: 4570, col: 26, offset: 140886},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4531, col: 26, offset: 139656},
+									pos:        position{line: 4570, col: 26, offset: 140886},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4531, col: 33, offset: 139663},
+									pos:  position{line: 4570, col: 33, offset: 140893},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4531, col: 41, offset: 139671},
+									pos:   position{line: 4570, col: 41, offset: 140901},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4531, col: 47, offset: 139677},
+										pos:  position{line: 4570, col: 47, offset: 140907},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4531, col: 54, offset: 139684},
+									pos:  position{line: 4570, col: 54, offset: 140914},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4540, col: 3, offset: 139874},
+						pos: position{line: 4579, col: 3, offset: 141104},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4540, col: 3, offset: 139874},
+							pos:   position{line: 4579, col: 3, offset: 141104},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4540, col: 9, offset: 139880},
+								pos:  position{line: 4579, col: 9, offset: 141110},
 								name: "String",
 							},
 						},
@@ -10372,35 +10423,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4550, col: 1, offset: 140160},
+			pos:  position{line: 4589, col: 1, offset: 141390},
 			expr: &actionExpr{
-				pos: position{line: 4550, col: 18, offset: 140177},
+				pos: position{line: 4589, col: 18, offset: 141407},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4550, col: 18, offset: 140177},
+					pos: position{line: 4589, col: 18, offset: 141407},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4550, col: 18, offset: 140177},
+							pos:   position{line: 4589, col: 18, offset: 141407},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4550, col: 24, offset: 140183},
+								pos:  position{line: 4589, col: 24, offset: 141413},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4550, col: 34, offset: 140193},
+							pos:   position{line: 4589, col: 34, offset: 141423},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4550, col: 39, offset: 140198},
+								pos: position{line: 4589, col: 39, offset: 141428},
 								expr: &seqExpr{
-									pos: position{line: 4550, col: 40, offset: 140199},
+									pos: position{line: 4589, col: 40, offset: 141429},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4550, col: 40, offset: 140199},
+											pos:  position{line: 4589, col: 40, offset: 141429},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4550, col: 46, offset: 140205},
+											pos:  position{line: 4589, col: 46, offset: 141435},
 											name: "FieldName",
 										},
 									},
@@ -10413,16 +10464,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4567, col: 1, offset: 140700},
+			pos:  position{line: 4606, col: 1, offset: 141930},
 			expr: &choiceExpr{
-				pos: position{line: 4567, col: 18, offset: 140717},
+				pos: position{line: 4606, col: 18, offset: 141947},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4567, col: 18, offset: 140717},
+						pos:  position{line: 4606, col: 18, offset: 141947},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4567, col: 38, offset: 140737},
+						pos:  position{line: 4606, col: 38, offset: 141967},
 						name: "EarliestOnly",
 					},
 				},
@@ -10430,62 +10481,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4569, col: 1, offset: 140751},
+			pos:  position{line: 4608, col: 1, offset: 141981},
 			expr: &actionExpr{
-				pos: position{line: 4569, col: 22, offset: 140772},
+				pos: position{line: 4608, col: 22, offset: 142002},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4569, col: 22, offset: 140772},
+					pos: position{line: 4608, col: 22, offset: 142002},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4569, col: 22, offset: 140772},
+							pos:  position{line: 4608, col: 22, offset: 142002},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4569, col: 35, offset: 140785},
+							pos:  position{line: 4608, col: 35, offset: 142015},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4569, col: 41, offset: 140791},
+							pos:   position{line: 4608, col: 41, offset: 142021},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4569, col: 55, offset: 140805},
+								pos: position{line: 4608, col: 55, offset: 142035},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4569, col: 55, offset: 140805},
+										pos:  position{line: 4608, col: 55, offset: 142035},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4569, col: 75, offset: 140825},
+										pos:  position{line: 4608, col: 75, offset: 142055},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4569, col: 94, offset: 140844},
+							pos:  position{line: 4608, col: 94, offset: 142074},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4569, col: 100, offset: 140850},
+							pos:  position{line: 4608, col: 100, offset: 142080},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4569, col: 111, offset: 140861},
+							pos:  position{line: 4608, col: 111, offset: 142091},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4569, col: 117, offset: 140867},
+							pos:   position{line: 4608, col: 117, offset: 142097},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4569, col: 129, offset: 140879},
+								pos: position{line: 4608, col: 129, offset: 142109},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4569, col: 129, offset: 140879},
+										pos:  position{line: 4608, col: 129, offset: 142109},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4569, col: 149, offset: 140899},
+										pos:  position{line: 4608, col: 149, offset: 142129},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10497,33 +10548,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4610, col: 1, offset: 142038},
+			pos:  position{line: 4649, col: 1, offset: 143268},
 			expr: &actionExpr{
-				pos: position{line: 4610, col: 17, offset: 142054},
+				pos: position{line: 4649, col: 17, offset: 143284},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4610, col: 17, offset: 142054},
+					pos: position{line: 4649, col: 17, offset: 143284},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4610, col: 17, offset: 142054},
+							pos:  position{line: 4649, col: 17, offset: 143284},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4610, col: 30, offset: 142067},
+							pos:  position{line: 4649, col: 30, offset: 143297},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4610, col: 36, offset: 142073},
+							pos:   position{line: 4649, col: 36, offset: 143303},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4610, col: 50, offset: 142087},
+								pos: position{line: 4649, col: 50, offset: 143317},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4610, col: 50, offset: 142087},
+										pos:  position{line: 4649, col: 50, offset: 143317},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4610, col: 70, offset: 142107},
+										pos:  position{line: 4649, col: 70, offset: 143337},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10535,24 +10586,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4638, col: 1, offset: 142815},
+			pos:  position{line: 4677, col: 1, offset: 144045},
 			expr: &actionExpr{
-				pos: position{line: 4638, col: 23, offset: 142837},
+				pos: position{line: 4677, col: 23, offset: 144067},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4638, col: 23, offset: 142837},
+					pos: position{line: 4677, col: 23, offset: 144067},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4638, col: 23, offset: 142837},
+							pos:        position{line: 4677, col: 23, offset: 144067},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4638, col: 27, offset: 142841},
+							pos: position{line: 4677, col: 27, offset: 144071},
 							expr: &charClassMatcher{
-								pos:        position{line: 4638, col: 27, offset: 142841},
+								pos:        position{line: 4677, col: 27, offset: 144071},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10565,21 +10616,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4642, col: 1, offset: 142884},
+			pos:  position{line: 4681, col: 1, offset: 144114},
 			expr: &actionExpr{
-				pos: position{line: 4642, col: 13, offset: 142896},
+				pos: position{line: 4681, col: 13, offset: 144126},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4642, col: 14, offset: 142897},
+					pos: position{line: 4681, col: 14, offset: 144127},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4642, col: 14, offset: 142897},
+							pos:        position{line: 4681, col: 14, offset: 144127},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4642, col: 17, offset: 142900},
+							pos:        position{line: 4681, col: 17, offset: 144130},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10591,15 +10642,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4646, col: 1, offset: 142943},
+			pos:  position{line: 4685, col: 1, offset: 144173},
 			expr: &actionExpr{
-				pos: position{line: 4646, col: 16, offset: 142958},
+				pos: position{line: 4685, col: 16, offset: 144188},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4646, col: 16, offset: 142958},
+					pos:   position{line: 4685, col: 16, offset: 144188},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4646, col: 26, offset: 142968},
+						pos:  position{line: 4685, col: 26, offset: 144198},
 						name: "AllTimeScale",
 					},
 				},
@@ -10607,31 +10658,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4653, col: 1, offset: 143195},
+			pos:  position{line: 4692, col: 1, offset: 144425},
 			expr: &actionExpr{
-				pos: position{line: 4653, col: 9, offset: 143203},
+				pos: position{line: 4692, col: 9, offset: 144433},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4653, col: 9, offset: 143203},
+					pos: position{line: 4692, col: 9, offset: 144433},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4653, col: 9, offset: 143203},
+							pos:        position{line: 4692, col: 9, offset: 144433},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4653, col: 13, offset: 143207},
+							pos:   position{line: 4692, col: 13, offset: 144437},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4653, col: 19, offset: 143213},
+								pos: position{line: 4692, col: 19, offset: 144443},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4653, col: 19, offset: 143213},
+										pos:  position{line: 4692, col: 19, offset: 144443},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4653, col: 30, offset: 143224},
+										pos:  position{line: 4692, col: 30, offset: 144454},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10643,26 +10694,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4657, col: 1, offset: 143272},
+			pos:  position{line: 4696, col: 1, offset: 144502},
 			expr: &actionExpr{
-				pos: position{line: 4657, col: 11, offset: 143282},
+				pos: position{line: 4696, col: 11, offset: 144512},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4657, col: 11, offset: 143282},
+					pos: position{line: 4696, col: 11, offset: 144512},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4657, col: 11, offset: 143282},
+							pos:   position{line: 4696, col: 11, offset: 144512},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4657, col: 16, offset: 143287},
+								pos:  position{line: 4696, col: 16, offset: 144517},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4657, col: 36, offset: 143307},
+							pos:   position{line: 4696, col: 36, offset: 144537},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4657, col: 43, offset: 143314},
+								pos:  position{line: 4696, col: 43, offset: 144544},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10672,44 +10723,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4685, col: 1, offset: 144053},
+			pos:  position{line: 4724, col: 1, offset: 145283},
 			expr: &actionExpr{
-				pos: position{line: 4685, col: 29, offset: 144081},
+				pos: position{line: 4724, col: 29, offset: 145311},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4685, col: 29, offset: 144081},
+					pos: position{line: 4724, col: 29, offset: 145311},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4685, col: 29, offset: 144081},
+							pos:   position{line: 4724, col: 29, offset: 145311},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4685, col: 36, offset: 144088},
+								pos: position{line: 4724, col: 36, offset: 145318},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4685, col: 36, offset: 144088},
+										pos:  position{line: 4724, col: 36, offset: 145318},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4685, col: 45, offset: 144097},
+										pos:  position{line: 4724, col: 45, offset: 145327},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4685, col: 51, offset: 144103},
+							pos:   position{line: 4724, col: 51, offset: 145333},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4685, col: 57, offset: 144109},
+								pos: position{line: 4724, col: 57, offset: 145339},
 								expr: &choiceExpr{
-									pos: position{line: 4685, col: 58, offset: 144110},
+									pos: position{line: 4724, col: 58, offset: 145340},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4685, col: 58, offset: 144110},
+											pos:  position{line: 4724, col: 58, offset: 145340},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4685, col: 67, offset: 144119},
+											pos:  position{line: 4724, col: 67, offset: 145349},
 											name: "Snap",
 										},
 									},
@@ -10722,29 +10773,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4732, col: 1, offset: 145551},
+			pos:  position{line: 4771, col: 1, offset: 146781},
 			expr: &actionExpr{
-				pos: position{line: 4732, col: 22, offset: 145572},
+				pos: position{line: 4771, col: 22, offset: 146802},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4732, col: 22, offset: 145572},
+					pos: position{line: 4771, col: 22, offset: 146802},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4732, col: 22, offset: 145572},
+							pos:   position{line: 4771, col: 22, offset: 146802},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4732, col: 34, offset: 145584},
+								pos: position{line: 4771, col: 34, offset: 146814},
 								expr: &choiceExpr{
-									pos: position{line: 4732, col: 35, offset: 145585},
+									pos: position{line: 4771, col: 35, offset: 146815},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4732, col: 35, offset: 145585},
+											pos:        position{line: 4771, col: 35, offset: 146815},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4732, col: 43, offset: 145593},
+											pos:        position{line: 4771, col: 43, offset: 146823},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10754,12 +10805,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4732, col: 49, offset: 145599},
+							pos:   position{line: 4771, col: 49, offset: 146829},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4732, col: 57, offset: 145607},
+								pos: position{line: 4771, col: 57, offset: 146837},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4732, col: 58, offset: 145608},
+									pos:  position{line: 4771, col: 58, offset: 146838},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10770,31 +10821,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4757, col: 1, offset: 146291},
+			pos:  position{line: 4796, col: 1, offset: 147521},
 			expr: &actionExpr{
-				pos: position{line: 4757, col: 39, offset: 146329},
+				pos: position{line: 4796, col: 39, offset: 147559},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4757, col: 39, offset: 146329},
+					pos: position{line: 4796, col: 39, offset: 147559},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4757, col: 39, offset: 146329},
+							pos:   position{line: 4796, col: 39, offset: 147559},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4757, col: 46, offset: 146336},
+								pos: position{line: 4796, col: 46, offset: 147566},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4757, col: 47, offset: 146337},
+									pos:  position{line: 4796, col: 47, offset: 147567},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4757, col: 56, offset: 146346},
+							pos:   position{line: 4796, col: 56, offset: 147576},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4757, col: 66, offset: 146356},
+								pos: position{line: 4796, col: 66, offset: 147586},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4757, col: 67, offset: 146357},
+									pos:  position{line: 4796, col: 67, offset: 147587},
 									name: "Snap",
 								},
 							},
@@ -10805,136 +10856,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4784, col: 1, offset: 146987},
+			pos:  position{line: 4823, col: 1, offset: 148217},
 			expr: &actionExpr{
-				pos: position{line: 4784, col: 18, offset: 147004},
+				pos: position{line: 4823, col: 18, offset: 148234},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4784, col: 18, offset: 147004},
+					pos: position{line: 4823, col: 18, offset: 148234},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 18, offset: 147004},
+							pos:        position{line: 4823, col: 18, offset: 148234},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 23, offset: 147009},
+							pos:        position{line: 4823, col: 23, offset: 148239},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4784, col: 29, offset: 147015},
+							pos:        position{line: 4823, col: 29, offset: 148245},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 33, offset: 147019},
+							pos:        position{line: 4823, col: 33, offset: 148249},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 38, offset: 147024},
+							pos:        position{line: 4823, col: 38, offset: 148254},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4784, col: 44, offset: 147030},
+							pos:        position{line: 4823, col: 44, offset: 148260},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 48, offset: 147034},
+							pos:        position{line: 4823, col: 48, offset: 148264},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 53, offset: 147039},
+							pos:        position{line: 4823, col: 53, offset: 148269},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 58, offset: 147044},
+							pos:        position{line: 4823, col: 58, offset: 148274},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 63, offset: 147049},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4784, col: 69, offset: 147055},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4784, col: 73, offset: 147059},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4784, col: 78, offset: 147064},
+							pos:        position{line: 4823, col: 63, offset: 148279},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4784, col: 84, offset: 147070},
+							pos:        position{line: 4823, col: 69, offset: 148285},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 88, offset: 147074},
+							pos:        position{line: 4823, col: 73, offset: 148289},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 93, offset: 147079},
+							pos:        position{line: 4823, col: 78, offset: 148294},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4784, col: 99, offset: 147085},
+							pos:        position{line: 4823, col: 84, offset: 148300},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 103, offset: 147089},
+							pos:        position{line: 4823, col: 88, offset: 148304},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4784, col: 108, offset: 147094},
+							pos:        position{line: 4823, col: 93, offset: 148309},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4823, col: 99, offset: 148315},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4823, col: 103, offset: 148319},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4823, col: 108, offset: 148324},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10946,15 +10997,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4788, col: 1, offset: 147136},
+			pos:  position{line: 4827, col: 1, offset: 148366},
 			expr: &actionExpr{
-				pos: position{line: 4788, col: 22, offset: 147157},
+				pos: position{line: 4827, col: 22, offset: 148387},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4788, col: 22, offset: 147157},
+					pos:   position{line: 4827, col: 22, offset: 148387},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4788, col: 32, offset: 147167},
+						pos:  position{line: 4827, col: 32, offset: 148397},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10962,18 +11013,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4799, col: 1, offset: 147610},
+			pos:  position{line: 4838, col: 1, offset: 148840},
 			expr: &choiceExpr{
-				pos: position{line: 4799, col: 14, offset: 147623},
+				pos: position{line: 4838, col: 14, offset: 148853},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4799, col: 14, offset: 147623},
+						pos: position{line: 4838, col: 14, offset: 148853},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4799, col: 14, offset: 147623},
+							pos: position{line: 4838, col: 14, offset: 148853},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4799, col: 14, offset: 147623},
+									pos:        position{line: 4838, col: 14, offset: 148853},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10981,9 +11032,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4799, col: 29, offset: 147638},
+									pos: position{line: 4838, col: 29, offset: 148868},
 									expr: &charClassMatcher{
-										pos:        position{line: 4799, col: 29, offset: 147638},
+										pos:        position{line: 4838, col: 29, offset: 148868},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10995,10 +11046,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4802, col: 3, offset: 147694},
+						pos: position{line: 4841, col: 3, offset: 148924},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4802, col: 3, offset: 147694},
+							pos:  position{line: 4841, col: 3, offset: 148924},
 							name: "QuotedString",
 						},
 					},
@@ -11007,15 +11058,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4806, col: 1, offset: 147757},
+			pos:  position{line: 4845, col: 1, offset: 148987},
 			expr: &actionExpr{
-				pos: position{line: 4806, col: 24, offset: 147780},
+				pos: position{line: 4845, col: 24, offset: 149010},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4806, col: 24, offset: 147780},
+					pos: position{line: 4845, col: 24, offset: 149010},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4806, col: 24, offset: 147780},
+							pos:        position{line: 4845, col: 24, offset: 149010},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11023,9 +11074,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4806, col: 39, offset: 147795},
+							pos: position{line: 4845, col: 39, offset: 149025},
 							expr: &charClassMatcher{
-								pos:        position{line: 4806, col: 39, offset: 147795},
+								pos:        position{line: 4845, col: 39, offset: 149025},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11039,22 +11090,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4810, col: 1, offset: 147848},
+			pos:  position{line: 4849, col: 1, offset: 149078},
 			expr: &actionExpr{
-				pos: position{line: 4810, col: 11, offset: 147858},
+				pos: position{line: 4849, col: 11, offset: 149088},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4810, col: 11, offset: 147858},
+					pos:   position{line: 4849, col: 11, offset: 149088},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4810, col: 16, offset: 147863},
+						pos: position{line: 4849, col: 16, offset: 149093},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4810, col: 16, offset: 147863},
+								pos:  position{line: 4849, col: 16, offset: 149093},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4810, col: 31, offset: 147878},
+								pos:  position{line: 4849, col: 31, offset: 149108},
 								name: "UnquotedString",
 							},
 						},
@@ -11064,38 +11115,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4814, col: 1, offset: 147919},
+			pos:  position{line: 4853, col: 1, offset: 149149},
 			expr: &actionExpr{
-				pos: position{line: 4814, col: 17, offset: 147935},
+				pos: position{line: 4853, col: 17, offset: 149165},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4814, col: 17, offset: 147935},
+					pos: position{line: 4853, col: 17, offset: 149165},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4814, col: 17, offset: 147935},
+							pos:        position{line: 4853, col: 17, offset: 149165},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4814, col: 21, offset: 147939},
+							pos: position{line: 4853, col: 21, offset: 149169},
 							expr: &choiceExpr{
-								pos: position{line: 4814, col: 22, offset: 147940},
+								pos: position{line: 4853, col: 22, offset: 149170},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4814, col: 22, offset: 147940},
+										pos: position{line: 4853, col: 22, offset: 149170},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4814, col: 22, offset: 147940},
+												pos: position{line: 4853, col: 22, offset: 149170},
 												expr: &litMatcher{
-													pos:        position{line: 4814, col: 23, offset: 147941},
+													pos:        position{line: 4853, col: 23, offset: 149171},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4814, col: 28, offset: 147946},
+												pos:        position{line: 4853, col: 28, offset: 149176},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -11104,16 +11155,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4814, col: 35, offset: 147953},
+										pos: position{line: 4853, col: 35, offset: 149183},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4814, col: 35, offset: 147953},
+												pos:        position{line: 4853, col: 35, offset: 149183},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4814, col: 40, offset: 147958,
+												line: 4853, col: 40, offset: 149188,
 											},
 										},
 									},
@@ -11121,7 +11172,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4814, col: 44, offset: 147962},
+							pos:        position{line: 4853, col: 44, offset: 149192},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11132,48 +11183,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4819, col: 1, offset: 148073},
+			pos:  position{line: 4858, col: 1, offset: 149303},
 			expr: &actionExpr{
-				pos: position{line: 4819, col: 19, offset: 148091},
+				pos: position{line: 4858, col: 19, offset: 149321},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4819, col: 19, offset: 148091},
+					pos: position{line: 4858, col: 19, offset: 149321},
 					expr: &choiceExpr{
-						pos: position{line: 4819, col: 20, offset: 148092},
+						pos: position{line: 4858, col: 20, offset: 149322},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4819, col: 20, offset: 148092},
+								pos:        position{line: 4858, col: 20, offset: 149322},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4819, col: 27, offset: 148099},
+								pos: position{line: 4858, col: 27, offset: 149329},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4819, col: 27, offset: 148099},
+										pos: position{line: 4858, col: 27, offset: 149329},
 										expr: &choiceExpr{
-											pos: position{line: 4819, col: 29, offset: 148101},
+											pos: position{line: 4858, col: 29, offset: 149331},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4819, col: 29, offset: 148101},
+													pos:  position{line: 4858, col: 29, offset: 149331},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4819, col: 43, offset: 148115},
+													pos:        position{line: 4858, col: 43, offset: 149345},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4819, col: 49, offset: 148121},
+													pos:  position{line: 4858, col: 49, offset: 149351},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4819, col: 54, offset: 148126,
+										line: 4858, col: 54, offset: 149356,
 									},
 								},
 							},
@@ -11184,12 +11235,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4826, col: 1, offset: 148241},
+			pos:  position{line: 4865, col: 1, offset: 149471},
 			expr: &choiceExpr{
-				pos: position{line: 4826, col: 16, offset: 148256},
+				pos: position{line: 4865, col: 16, offset: 149486},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4826, col: 16, offset: 148256},
+						pos:        position{line: 4865, col: 16, offset: 149486},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11197,18 +11248,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4826, col: 37, offset: 148277},
+						pos: position{line: 4865, col: 37, offset: 149507},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4826, col: 37, offset: 148277},
+								pos:        position{line: 4865, col: 37, offset: 149507},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4826, col: 41, offset: 148281},
+								pos: position{line: 4865, col: 41, offset: 149511},
 								expr: &charClassMatcher{
-									pos:        position{line: 4826, col: 41, offset: 148281},
+									pos:        position{line: 4865, col: 41, offset: 149511},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -11216,7 +11267,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4826, col: 48, offset: 148288},
+								pos:        position{line: 4865, col: 48, offset: 149518},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -11228,46 +11279,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4828, col: 1, offset: 148294},
+			pos:  position{line: 4867, col: 1, offset: 149524},
 			expr: &actionExpr{
-				pos: position{line: 4828, col: 39, offset: 148332},
+				pos: position{line: 4867, col: 39, offset: 149562},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4828, col: 39, offset: 148332},
+					pos: position{line: 4867, col: 39, offset: 149562},
 					expr: &choiceExpr{
-						pos: position{line: 4828, col: 40, offset: 148333},
+						pos: position{line: 4867, col: 40, offset: 149563},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4828, col: 40, offset: 148333},
+								pos:  position{line: 4867, col: 40, offset: 149563},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4828, col: 54, offset: 148347},
+								pos: position{line: 4867, col: 54, offset: 149577},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4828, col: 54, offset: 148347},
+										pos: position{line: 4867, col: 54, offset: 149577},
 										expr: &choiceExpr{
-											pos: position{line: 4828, col: 56, offset: 148349},
+											pos: position{line: 4867, col: 56, offset: 149579},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4828, col: 56, offset: 148349},
+													pos:  position{line: 4867, col: 56, offset: 149579},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4828, col: 70, offset: 148363},
+													pos:        position{line: 4867, col: 70, offset: 149593},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4828, col: 76, offset: 148369},
+													pos:  position{line: 4867, col: 76, offset: 149599},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4828, col: 81, offset: 148374,
+										line: 4867, col: 81, offset: 149604,
 									},
 								},
 							},
@@ -11278,21 +11329,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4832, col: 1, offset: 148414},
+			pos:  position{line: 4871, col: 1, offset: 149644},
 			expr: &actionExpr{
-				pos: position{line: 4832, col: 12, offset: 148425},
+				pos: position{line: 4871, col: 12, offset: 149655},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4832, col: 13, offset: 148426},
+					pos: position{line: 4871, col: 13, offset: 149656},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4832, col: 13, offset: 148426},
+							pos:        position{line: 4871, col: 13, offset: 149656},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4832, col: 22, offset: 148435},
+							pos:        position{line: 4871, col: 22, offset: 149665},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11303,14 +11354,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4838, col: 1, offset: 148589},
+			pos:  position{line: 4877, col: 1, offset: 149819},
 			expr: &actionExpr{
-				pos: position{line: 4838, col: 18, offset: 148606},
+				pos: position{line: 4877, col: 18, offset: 149836},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4838, col: 18, offset: 148606},
+					pos: position{line: 4877, col: 18, offset: 149836},
 					expr: &charClassMatcher{
-						pos:        position{line: 4838, col: 18, offset: 148606},
+						pos:        position{line: 4877, col: 18, offset: 149836},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11322,15 +11373,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4842, col: 1, offset: 148657},
+			pos:  position{line: 4881, col: 1, offset: 149887},
 			expr: &actionExpr{
-				pos: position{line: 4842, col: 11, offset: 148667},
+				pos: position{line: 4881, col: 11, offset: 149897},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4842, col: 11, offset: 148667},
+					pos:   position{line: 4881, col: 11, offset: 149897},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4842, col: 18, offset: 148674},
+						pos:  position{line: 4881, col: 18, offset: 149904},
 						name: "NumberAsString",
 					},
 				},
@@ -11338,59 +11389,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4848, col: 1, offset: 148863},
+			pos:  position{line: 4887, col: 1, offset: 150093},
 			expr: &actionExpr{
-				pos: position{line: 4848, col: 19, offset: 148881},
+				pos: position{line: 4887, col: 19, offset: 150111},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4848, col: 19, offset: 148881},
+					pos: position{line: 4887, col: 19, offset: 150111},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4848, col: 19, offset: 148881},
+							pos:   position{line: 4887, col: 19, offset: 150111},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4848, col: 27, offset: 148889},
+								pos: position{line: 4887, col: 27, offset: 150119},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4848, col: 27, offset: 148889},
+										pos:  position{line: 4887, col: 27, offset: 150119},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4848, col: 43, offset: 148905},
+										pos:  position{line: 4887, col: 43, offset: 150135},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4848, col: 60, offset: 148922},
+							pos: position{line: 4887, col: 60, offset: 150152},
 							expr: &choiceExpr{
-								pos: position{line: 4848, col: 62, offset: 148924},
+								pos: position{line: 4887, col: 62, offset: 150154},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4848, col: 62, offset: 148924},
+										pos:  position{line: 4887, col: 62, offset: 150154},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4848, col: 70, offset: 148932},
+										pos:        position{line: 4887, col: 70, offset: 150162},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4848, col: 76, offset: 148938},
+										pos:        position{line: 4887, col: 76, offset: 150168},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4848, col: 82, offset: 148944},
+										pos:        position{line: 4887, col: 82, offset: 150174},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4848, col: 88, offset: 148950},
+										pos:  position{line: 4887, col: 88, offset: 150180},
 										name: "EOF",
 									},
 								},
@@ -11402,17 +11453,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4854, col: 1, offset: 149079},
+			pos:  position{line: 4893, col: 1, offset: 150309},
 			expr: &actionExpr{
-				pos: position{line: 4854, col: 18, offset: 149096},
+				pos: position{line: 4893, col: 18, offset: 150326},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4854, col: 18, offset: 149096},
+					pos: position{line: 4893, col: 18, offset: 150326},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4854, col: 18, offset: 149096},
+							pos: position{line: 4893, col: 18, offset: 150326},
 							expr: &charClassMatcher{
-								pos:        position{line: 4854, col: 18, offset: 149096},
+								pos:        position{line: 4893, col: 18, offset: 150326},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11420,9 +11471,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4854, col: 24, offset: 149102},
+							pos: position{line: 4893, col: 24, offset: 150332},
 							expr: &charClassMatcher{
-								pos:        position{line: 4854, col: 24, offset: 149102},
+								pos:        position{line: 4893, col: 24, offset: 150332},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11430,15 +11481,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4854, col: 31, offset: 149109},
+							pos:        position{line: 4893, col: 31, offset: 150339},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4854, col: 35, offset: 149113},
+							pos: position{line: 4893, col: 35, offset: 150343},
 							expr: &charClassMatcher{
-								pos:        position{line: 4854, col: 35, offset: 149113},
+								pos:        position{line: 4893, col: 35, offset: 150343},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11451,17 +11502,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4859, col: 1, offset: 149208},
+			pos:  position{line: 4898, col: 1, offset: 150438},
 			expr: &actionExpr{
-				pos: position{line: 4859, col: 20, offset: 149227},
+				pos: position{line: 4898, col: 20, offset: 150457},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4859, col: 20, offset: 149227},
+					pos: position{line: 4898, col: 20, offset: 150457},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4859, col: 20, offset: 149227},
+							pos: position{line: 4898, col: 20, offset: 150457},
 							expr: &charClassMatcher{
-								pos:        position{line: 4859, col: 20, offset: 149227},
+								pos:        position{line: 4898, col: 20, offset: 150457},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11469,9 +11520,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4859, col: 26, offset: 149233},
+							pos: position{line: 4898, col: 26, offset: 150463},
 							expr: &charClassMatcher{
-								pos:        position{line: 4859, col: 26, offset: 149233},
+								pos:        position{line: 4898, col: 26, offset: 150463},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11484,14 +11535,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4863, col: 1, offset: 149276},
+			pos:  position{line: 4902, col: 1, offset: 150506},
 			expr: &actionExpr{
-				pos: position{line: 4863, col: 28, offset: 149303},
+				pos: position{line: 4902, col: 28, offset: 150533},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4863, col: 28, offset: 149303},
+					pos: position{line: 4902, col: 28, offset: 150533},
 					expr: &charClassMatcher{
-						pos:        position{line: 4863, col: 28, offset: 149303},
+						pos:        position{line: 4902, col: 28, offset: 150533},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11502,15 +11553,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4867, col: 1, offset: 149346},
+			pos:  position{line: 4906, col: 1, offset: 150576},
 			expr: &actionExpr{
-				pos: position{line: 4867, col: 20, offset: 149365},
+				pos: position{line: 4906, col: 20, offset: 150595},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4867, col: 20, offset: 149365},
+					pos:   position{line: 4906, col: 20, offset: 150595},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4867, col: 27, offset: 149372},
+						pos:  position{line: 4906, col: 27, offset: 150602},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11518,37 +11569,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4875, col: 1, offset: 149619},
+			pos:  position{line: 4914, col: 1, offset: 150849},
 			expr: &actionExpr{
-				pos: position{line: 4875, col: 21, offset: 149639},
+				pos: position{line: 4914, col: 21, offset: 150869},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4875, col: 21, offset: 149639},
+					pos: position{line: 4914, col: 21, offset: 150869},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4875, col: 21, offset: 149639},
+							pos:  position{line: 4914, col: 21, offset: 150869},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4875, col: 36, offset: 149654},
+							pos:   position{line: 4914, col: 36, offset: 150884},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4875, col: 40, offset: 149658},
+								pos: position{line: 4914, col: 40, offset: 150888},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4875, col: 40, offset: 149658},
+										pos:        position{line: 4914, col: 40, offset: 150888},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4875, col: 47, offset: 149665},
+										pos:        position{line: 4914, col: 47, offset: 150895},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4875, col: 53, offset: 149671},
+										pos:        position{line: 4914, col: 53, offset: 150901},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11557,7 +11608,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4875, col: 59, offset: 149677},
+							pos:  position{line: 4914, col: 59, offset: 150907},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11566,43 +11617,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4886, col: 1, offset: 149907},
+			pos:  position{line: 4925, col: 1, offset: 151137},
 			expr: &actionExpr{
-				pos: position{line: 4886, col: 23, offset: 149929},
+				pos: position{line: 4925, col: 23, offset: 151159},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4886, col: 23, offset: 149929},
+					pos: position{line: 4925, col: 23, offset: 151159},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4886, col: 23, offset: 149929},
+							pos:  position{line: 4925, col: 23, offset: 151159},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4886, col: 38, offset: 149944},
+							pos:   position{line: 4925, col: 38, offset: 151174},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4886, col: 42, offset: 149948},
+								pos: position{line: 4925, col: 42, offset: 151178},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4886, col: 42, offset: 149948},
+										pos:        position{line: 4925, col: 42, offset: 151178},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4886, col: 49, offset: 149955},
+										pos:        position{line: 4925, col: 49, offset: 151185},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4886, col: 55, offset: 149961},
+										pos:        position{line: 4925, col: 55, offset: 151191},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4886, col: 62, offset: 149968},
+										pos:        position{line: 4925, col: 62, offset: 151198},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11611,7 +11662,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4886, col: 67, offset: 149973},
+							pos:  position{line: 4925, col: 67, offset: 151203},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11620,30 +11671,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4894, col: 1, offset: 150156},
+			pos:  position{line: 4933, col: 1, offset: 151386},
 			expr: &choiceExpr{
-				pos: position{line: 4894, col: 25, offset: 150180},
+				pos: position{line: 4933, col: 25, offset: 151410},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4894, col: 25, offset: 150180},
+						pos: position{line: 4933, col: 25, offset: 151410},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4894, col: 25, offset: 150180},
+							pos:   position{line: 4933, col: 25, offset: 151410},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4894, col: 28, offset: 150183},
+								pos:  position{line: 4933, col: 28, offset: 151413},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4897, col: 3, offset: 150225},
+						pos: position{line: 4936, col: 3, offset: 151455},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4897, col: 3, offset: 150225},
+							pos:   position{line: 4936, col: 3, offset: 151455},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4897, col: 6, offset: 150228},
+								pos:  position{line: 4936, col: 6, offset: 151458},
 								name: "InequalityOperator",
 							},
 						},
@@ -11653,25 +11704,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4901, col: 1, offset: 150271},
+			pos:  position{line: 4940, col: 1, offset: 151501},
 			expr: &actionExpr{
-				pos: position{line: 4901, col: 11, offset: 150281},
+				pos: position{line: 4940, col: 11, offset: 151511},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4901, col: 11, offset: 150281},
+					pos: position{line: 4940, col: 11, offset: 151511},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4901, col: 11, offset: 150281},
+							pos:  position{line: 4940, col: 11, offset: 151511},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4901, col: 26, offset: 150296},
+							pos:        position{line: 4940, col: 26, offset: 151526},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4901, col: 30, offset: 150300},
+							pos:  position{line: 4940, col: 30, offset: 151530},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11680,25 +11731,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4905, col: 1, offset: 150340},
+			pos:  position{line: 4944, col: 1, offset: 151570},
 			expr: &actionExpr{
-				pos: position{line: 4905, col: 12, offset: 150351},
+				pos: position{line: 4944, col: 12, offset: 151581},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4905, col: 12, offset: 150351},
+					pos: position{line: 4944, col: 12, offset: 151581},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4905, col: 12, offset: 150351},
+							pos:  position{line: 4944, col: 12, offset: 151581},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4905, col: 27, offset: 150366},
+							pos:        position{line: 4944, col: 27, offset: 151596},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4905, col: 31, offset: 150370},
+							pos:  position{line: 4944, col: 31, offset: 151600},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11707,25 +11758,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4909, col: 1, offset: 150410},
+			pos:  position{line: 4948, col: 1, offset: 151640},
 			expr: &actionExpr{
-				pos: position{line: 4909, col: 10, offset: 150419},
+				pos: position{line: 4948, col: 10, offset: 151649},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4909, col: 10, offset: 150419},
+					pos: position{line: 4948, col: 10, offset: 151649},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4909, col: 10, offset: 150419},
+							pos:  position{line: 4948, col: 10, offset: 151649},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4909, col: 25, offset: 150434},
+							pos:        position{line: 4948, col: 25, offset: 151664},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4909, col: 29, offset: 150438},
+							pos:  position{line: 4948, col: 29, offset: 151668},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11734,25 +11785,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4913, col: 1, offset: 150478},
+			pos:  position{line: 4952, col: 1, offset: 151708},
 			expr: &actionExpr{
-				pos: position{line: 4913, col: 10, offset: 150487},
+				pos: position{line: 4952, col: 10, offset: 151717},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4913, col: 10, offset: 150487},
+					pos: position{line: 4952, col: 10, offset: 151717},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4913, col: 10, offset: 150487},
+							pos:  position{line: 4952, col: 10, offset: 151717},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4913, col: 25, offset: 150502},
+							pos:        position{line: 4952, col: 25, offset: 151732},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4913, col: 29, offset: 150506},
+							pos:  position{line: 4952, col: 29, offset: 151736},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11761,25 +11812,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4917, col: 1, offset: 150546},
+			pos:  position{line: 4956, col: 1, offset: 151776},
 			expr: &actionExpr{
-				pos: position{line: 4917, col: 10, offset: 150555},
+				pos: position{line: 4956, col: 10, offset: 151785},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4917, col: 10, offset: 150555},
+					pos: position{line: 4956, col: 10, offset: 151785},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4917, col: 10, offset: 150555},
+							pos:  position{line: 4956, col: 10, offset: 151785},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4917, col: 25, offset: 150570},
+							pos:        position{line: 4956, col: 25, offset: 151800},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4917, col: 29, offset: 150574},
+							pos:  position{line: 4956, col: 29, offset: 151804},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11788,39 +11839,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4922, col: 1, offset: 150638},
+			pos:  position{line: 4961, col: 1, offset: 151868},
 			expr: &actionExpr{
-				pos: position{line: 4922, col: 11, offset: 150648},
+				pos: position{line: 4961, col: 11, offset: 151878},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4922, col: 12, offset: 150649},
+					pos: position{line: 4961, col: 12, offset: 151879},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4922, col: 12, offset: 150649},
+							pos:        position{line: 4961, col: 12, offset: 151879},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4922, col: 24, offset: 150661},
+							pos:        position{line: 4961, col: 24, offset: 151891},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4922, col: 35, offset: 150672},
+							pos:        position{line: 4961, col: 35, offset: 151902},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4922, col: 44, offset: 150681},
+							pos:        position{line: 4961, col: 44, offset: 151911},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4922, col: 52, offset: 150689},
+							pos:        position{line: 4961, col: 52, offset: 151919},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11831,39 +11882,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4926, col: 1, offset: 150731},
+			pos:  position{line: 4965, col: 1, offset: 151961},
 			expr: &actionExpr{
-				pos: position{line: 4926, col: 11, offset: 150741},
+				pos: position{line: 4965, col: 11, offset: 151971},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4926, col: 12, offset: 150742},
+					pos: position{line: 4965, col: 12, offset: 151972},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4926, col: 12, offset: 150742},
+							pos:        position{line: 4965, col: 12, offset: 151972},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4926, col: 24, offset: 150754},
+							pos:        position{line: 4965, col: 24, offset: 151984},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4926, col: 35, offset: 150765},
+							pos:        position{line: 4965, col: 35, offset: 151995},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4926, col: 44, offset: 150774},
+							pos:        position{line: 4965, col: 44, offset: 152004},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4926, col: 52, offset: 150782},
+							pos:        position{line: 4965, col: 52, offset: 152012},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11874,39 +11925,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4930, col: 1, offset: 150824},
+			pos:  position{line: 4969, col: 1, offset: 152054},
 			expr: &actionExpr{
-				pos: position{line: 4930, col: 9, offset: 150832},
+				pos: position{line: 4969, col: 9, offset: 152062},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4930, col: 10, offset: 150833},
+					pos: position{line: 4969, col: 10, offset: 152063},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4930, col: 10, offset: 150833},
+							pos:        position{line: 4969, col: 10, offset: 152063},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4930, col: 20, offset: 150843},
+							pos:        position{line: 4969, col: 20, offset: 152073},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4930, col: 29, offset: 150852},
+							pos:        position{line: 4969, col: 29, offset: 152082},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4930, col: 37, offset: 150860},
+							pos:        position{line: 4969, col: 37, offset: 152090},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4930, col: 44, offset: 150867},
+							pos:        position{line: 4969, col: 44, offset: 152097},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11917,27 +11968,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4934, col: 1, offset: 150907},
+			pos:  position{line: 4973, col: 1, offset: 152137},
 			expr: &actionExpr{
-				pos: position{line: 4934, col: 8, offset: 150914},
+				pos: position{line: 4973, col: 8, offset: 152144},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4934, col: 9, offset: 150915},
+					pos: position{line: 4973, col: 9, offset: 152145},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4934, col: 9, offset: 150915},
+							pos:        position{line: 4973, col: 9, offset: 152145},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4934, col: 18, offset: 150924},
+							pos:        position{line: 4973, col: 18, offset: 152154},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4934, col: 26, offset: 150932},
+							pos:        position{line: 4973, col: 26, offset: 152162},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11948,27 +11999,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4938, col: 1, offset: 150971},
+			pos:  position{line: 4977, col: 1, offset: 152201},
 			expr: &actionExpr{
-				pos: position{line: 4938, col: 9, offset: 150979},
+				pos: position{line: 4977, col: 9, offset: 152209},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4938, col: 10, offset: 150980},
+					pos: position{line: 4977, col: 10, offset: 152210},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4938, col: 10, offset: 150980},
+							pos:        position{line: 4977, col: 10, offset: 152210},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4938, col: 20, offset: 150990},
+							pos:        position{line: 4977, col: 20, offset: 152220},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4938, col: 29, offset: 150999},
+							pos:        position{line: 4977, col: 29, offset: 152229},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11979,27 +12030,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4942, col: 1, offset: 151039},
+			pos:  position{line: 4981, col: 1, offset: 152269},
 			expr: &actionExpr{
-				pos: position{line: 4942, col: 10, offset: 151048},
+				pos: position{line: 4981, col: 10, offset: 152278},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4942, col: 11, offset: 151049},
+					pos: position{line: 4981, col: 11, offset: 152279},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4942, col: 11, offset: 151049},
+							pos:        position{line: 4981, col: 11, offset: 152279},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4942, col: 22, offset: 151060},
+							pos:        position{line: 4981, col: 22, offset: 152290},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4942, col: 32, offset: 151070},
+							pos:        position{line: 4981, col: 32, offset: 152300},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -12010,39 +12061,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4946, col: 1, offset: 151113},
+			pos:  position{line: 4985, col: 1, offset: 152343},
 			expr: &actionExpr{
-				pos: position{line: 4946, col: 12, offset: 151124},
+				pos: position{line: 4985, col: 12, offset: 152354},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4946, col: 13, offset: 151125},
+					pos: position{line: 4985, col: 13, offset: 152355},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4946, col: 13, offset: 151125},
+							pos:        position{line: 4985, col: 13, offset: 152355},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 26, offset: 151138},
+							pos:        position{line: 4985, col: 26, offset: 152368},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 38, offset: 151150},
+							pos:        position{line: 4985, col: 38, offset: 152380},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 47, offset: 151159},
+							pos:        position{line: 4985, col: 47, offset: 152389},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 55, offset: 151167},
+							pos:        position{line: 4985, col: 55, offset: 152397},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -12053,39 +12104,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4950, col: 1, offset: 151210},
+			pos:  position{line: 4989, col: 1, offset: 152440},
 			expr: &actionExpr{
-				pos: position{line: 4950, col: 9, offset: 151218},
+				pos: position{line: 4989, col: 9, offset: 152448},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4950, col: 10, offset: 151219},
+					pos: position{line: 4989, col: 10, offset: 152449},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4950, col: 10, offset: 151219},
+							pos:        position{line: 4989, col: 10, offset: 152449},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4950, col: 20, offset: 151229},
+							pos:        position{line: 4989, col: 20, offset: 152459},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4950, col: 29, offset: 151238},
+							pos:        position{line: 4989, col: 29, offset: 152468},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4950, col: 37, offset: 151246},
+							pos:        position{line: 4989, col: 37, offset: 152476},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4950, col: 44, offset: 151253},
+							pos:        position{line: 4989, col: 44, offset: 152483},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -12096,33 +12147,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4955, col: 1, offset: 151385},
+			pos:  position{line: 4994, col: 1, offset: 152615},
 			expr: &actionExpr{
-				pos: position{line: 4955, col: 15, offset: 151399},
+				pos: position{line: 4994, col: 15, offset: 152629},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4955, col: 16, offset: 151400},
+					pos: position{line: 4994, col: 16, offset: 152630},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4955, col: 16, offset: 151400},
+							pos:        position{line: 4994, col: 16, offset: 152630},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4955, col: 23, offset: 151407},
+							pos:        position{line: 4994, col: 23, offset: 152637},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4955, col: 30, offset: 151414},
+							pos:        position{line: 4994, col: 30, offset: 152644},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4955, col: 37, offset: 151421},
+							pos:        position{line: 4994, col: 37, offset: 152651},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -12133,26 +12184,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4964, col: 1, offset: 151645},
+			pos:  position{line: 5003, col: 1, offset: 152875},
 			expr: &actionExpr{
-				pos: position{line: 4964, col: 21, offset: 151665},
+				pos: position{line: 5003, col: 21, offset: 152895},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4964, col: 21, offset: 151665},
+					pos: position{line: 5003, col: 21, offset: 152895},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4964, col: 21, offset: 151665},
+							pos:  position{line: 5003, col: 21, offset: 152895},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4964, col: 26, offset: 151670},
+							pos:  position{line: 5003, col: 26, offset: 152900},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4964, col: 42, offset: 151686},
+							pos:   position{line: 5003, col: 42, offset: 152916},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4964, col: 53, offset: 151697},
+								pos:  position{line: 5003, col: 53, offset: 152927},
 								name: "TransactionOptions",
 							},
 						},
@@ -12162,17 +12213,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4974, col: 1, offset: 152072},
+			pos:  position{line: 5013, col: 1, offset: 153302},
 			expr: &actionExpr{
-				pos: position{line: 4974, col: 23, offset: 152094},
+				pos: position{line: 5013, col: 23, offset: 153324},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4974, col: 23, offset: 152094},
+					pos:   position{line: 5013, col: 23, offset: 153324},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4974, col: 34, offset: 152105},
+						pos: position{line: 5013, col: 34, offset: 153335},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4974, col: 34, offset: 152105},
+							pos:  position{line: 5013, col: 34, offset: 153335},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -12181,35 +12232,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4989, col: 1, offset: 152496},
+			pos:  position{line: 5028, col: 1, offset: 153726},
 			expr: &actionExpr{
-				pos: position{line: 4989, col: 37, offset: 152532},
+				pos: position{line: 5028, col: 37, offset: 153762},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4989, col: 37, offset: 152532},
+					pos: position{line: 5028, col: 37, offset: 153762},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4989, col: 37, offset: 152532},
+							pos:   position{line: 5028, col: 37, offset: 153762},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4989, col: 43, offset: 152538},
+								pos:  position{line: 5028, col: 43, offset: 153768},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4989, col: 71, offset: 152566},
+							pos:   position{line: 5028, col: 71, offset: 153796},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4989, col: 76, offset: 152571},
+								pos: position{line: 5028, col: 76, offset: 153801},
 								expr: &seqExpr{
-									pos: position{line: 4989, col: 77, offset: 152572},
+									pos: position{line: 5028, col: 77, offset: 153802},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4989, col: 77, offset: 152572},
+											pos:  position{line: 5028, col: 77, offset: 153802},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4989, col: 83, offset: 152578},
+											pos:  position{line: 5028, col: 83, offset: 153808},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -12222,26 +12273,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 5024, col: 1, offset: 153567},
+			pos:  position{line: 5063, col: 1, offset: 154797},
 			expr: &actionExpr{
-				pos: position{line: 5024, col: 32, offset: 153598},
+				pos: position{line: 5063, col: 32, offset: 154828},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5024, col: 32, offset: 153598},
+					pos:   position{line: 5063, col: 32, offset: 154828},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5024, col: 40, offset: 153606},
+						pos: position{line: 5063, col: 40, offset: 154836},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5024, col: 40, offset: 153606},
+								pos:  position{line: 5063, col: 40, offset: 154836},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5024, col: 77, offset: 153643},
+								pos:  position{line: 5063, col: 77, offset: 154873},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5024, col: 96, offset: 153662},
+								pos:  position{line: 5063, col: 96, offset: 154892},
 								name: "EndsWithOption",
 							},
 						},
@@ -12251,15 +12302,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 5028, col: 1, offset: 153706},
+			pos:  position{line: 5067, col: 1, offset: 154936},
 			expr: &actionExpr{
-				pos: position{line: 5028, col: 39, offset: 153744},
+				pos: position{line: 5067, col: 39, offset: 154974},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 5028, col: 39, offset: 153744},
+					pos:   position{line: 5067, col: 39, offset: 154974},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5028, col: 46, offset: 153751},
+						pos:  position{line: 5067, col: 46, offset: 154981},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12267,28 +12318,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 5039, col: 1, offset: 153967},
+			pos:  position{line: 5078, col: 1, offset: 155197},
 			expr: &actionExpr{
-				pos: position{line: 5039, col: 21, offset: 153987},
+				pos: position{line: 5078, col: 21, offset: 155217},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5039, col: 21, offset: 153987},
+					pos: position{line: 5078, col: 21, offset: 155217},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5039, col: 21, offset: 153987},
+							pos:        position{line: 5078, col: 21, offset: 155217},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 34, offset: 154000},
+							pos:  position{line: 5078, col: 34, offset: 155230},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5039, col: 40, offset: 154006},
+							pos:   position{line: 5078, col: 40, offset: 155236},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5039, col: 48, offset: 154014},
+								pos:  position{line: 5078, col: 48, offset: 155244},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12298,28 +12349,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 5049, col: 1, offset: 154252},
+			pos:  position{line: 5088, col: 1, offset: 155482},
 			expr: &actionExpr{
-				pos: position{line: 5049, col: 19, offset: 154270},
+				pos: position{line: 5088, col: 19, offset: 155500},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5049, col: 19, offset: 154270},
+					pos: position{line: 5088, col: 19, offset: 155500},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5049, col: 19, offset: 154270},
+							pos:        position{line: 5088, col: 19, offset: 155500},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5049, col: 30, offset: 154281},
+							pos:  position{line: 5088, col: 30, offset: 155511},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5049, col: 36, offset: 154287},
+							pos:   position{line: 5088, col: 36, offset: 155517},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5049, col: 44, offset: 154295},
+								pos:  position{line: 5088, col: 44, offset: 155525},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12329,26 +12380,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 5060, col: 1, offset: 154564},
+			pos:  position{line: 5099, col: 1, offset: 155794},
 			expr: &actionExpr{
-				pos: position{line: 5060, col: 28, offset: 154591},
+				pos: position{line: 5099, col: 28, offset: 155821},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5060, col: 28, offset: 154591},
+					pos:   position{line: 5099, col: 28, offset: 155821},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5060, col: 37, offset: 154600},
+						pos: position{line: 5099, col: 37, offset: 155830},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5060, col: 37, offset: 154600},
+								pos:  position{line: 5099, col: 37, offset: 155830},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5060, col: 63, offset: 154626},
+								pos:  position{line: 5099, col: 63, offset: 155856},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5060, col: 81, offset: 154644},
+								pos:  position{line: 5099, col: 81, offset: 155874},
 								name: "TransactionSearch",
 							},
 						},
@@ -12358,22 +12409,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 5064, col: 1, offset: 154692},
+			pos:  position{line: 5103, col: 1, offset: 155922},
 			expr: &actionExpr{
-				pos: position{line: 5064, col: 28, offset: 154719},
+				pos: position{line: 5103, col: 28, offset: 155949},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5064, col: 28, offset: 154719},
+					pos:   position{line: 5103, col: 28, offset: 155949},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 5064, col: 33, offset: 154724},
+						pos: position{line: 5103, col: 33, offset: 155954},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5064, col: 33, offset: 154724},
+								pos:  position{line: 5103, col: 33, offset: 155954},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5064, col: 64, offset: 154755},
+								pos:  position{line: 5103, col: 64, offset: 155985},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12383,29 +12434,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 5068, col: 1, offset: 154815},
+			pos:  position{line: 5107, col: 1, offset: 156045},
 			expr: &actionExpr{
-				pos: position{line: 5068, col: 38, offset: 154852},
+				pos: position{line: 5107, col: 38, offset: 156082},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 5068, col: 38, offset: 154852},
+					pos: position{line: 5107, col: 38, offset: 156082},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5068, col: 38, offset: 154852},
+							pos:        position{line: 5107, col: 38, offset: 156082},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 5068, col: 42, offset: 154856},
+							pos:   position{line: 5107, col: 42, offset: 156086},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5068, col: 55, offset: 154869},
+								pos:  position{line: 5107, col: 55, offset: 156099},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5068, col: 68, offset: 154882},
+							pos:        position{line: 5107, col: 68, offset: 156112},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12416,23 +12467,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 5076, col: 1, offset: 155021},
+			pos:  position{line: 5115, col: 1, offset: 156251},
 			expr: &actionExpr{
-				pos: position{line: 5076, col: 21, offset: 155041},
+				pos: position{line: 5115, col: 21, offset: 156271},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 5076, col: 21, offset: 155041},
+					pos: position{line: 5115, col: 21, offset: 156271},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5076, col: 21, offset: 155041},
+							pos:        position{line: 5115, col: 21, offset: 156271},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 5076, col: 25, offset: 155045},
+							pos: position{line: 5115, col: 25, offset: 156275},
 							expr: &charClassMatcher{
-								pos:        position{line: 5076, col: 25, offset: 155045},
+								pos:        position{line: 5115, col: 25, offset: 156275},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12440,7 +12491,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5076, col: 44, offset: 155064},
+							pos:        position{line: 5115, col: 44, offset: 156294},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12451,15 +12502,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 5081, col: 1, offset: 155175},
+			pos:  position{line: 5120, col: 1, offset: 156405},
 			expr: &actionExpr{
-				pos: position{line: 5081, col: 33, offset: 155207},
+				pos: position{line: 5120, col: 33, offset: 156437},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 5081, col: 33, offset: 155207},
+					pos:   position{line: 5120, col: 33, offset: 156437},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5081, col: 37, offset: 155211},
+						pos:  position{line: 5120, col: 37, offset: 156441},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12467,15 +12518,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 5089, col: 1, offset: 155366},
+			pos:  position{line: 5128, col: 1, offset: 156596},
 			expr: &actionExpr{
-				pos: position{line: 5089, col: 22, offset: 155387},
+				pos: position{line: 5128, col: 22, offset: 156617},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 5089, col: 22, offset: 155387},
+					pos:   position{line: 5128, col: 22, offset: 156617},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5089, col: 27, offset: 155392},
+						pos:  position{line: 5128, col: 27, offset: 156622},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12483,37 +12534,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 5099, col: 1, offset: 155564},
+			pos:  position{line: 5138, col: 1, offset: 156794},
 			expr: &actionExpr{
-				pos: position{line: 5099, col: 20, offset: 155583},
+				pos: position{line: 5138, col: 20, offset: 156813},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 5099, col: 20, offset: 155583},
+					pos: position{line: 5138, col: 20, offset: 156813},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5099, col: 20, offset: 155583},
+							pos:        position{line: 5138, col: 20, offset: 156813},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5099, col: 27, offset: 155590},
+							pos:  position{line: 5138, col: 27, offset: 156820},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5099, col: 42, offset: 155605},
+							pos:  position{line: 5138, col: 42, offset: 156835},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5099, col: 50, offset: 155613},
+							pos:   position{line: 5138, col: 50, offset: 156843},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5099, col: 60, offset: 155623},
+								pos:  position{line: 5138, col: 60, offset: 156853},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5099, col: 69, offset: 155632},
+							pos:  position{line: 5138, col: 69, offset: 156862},
 							name: "R_PAREN",
 						},
 					},
@@ -12522,22 +12573,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5109, col: 1, offset: 155935},
+			pos:  position{line: 5148, col: 1, offset: 157165},
 			expr: &actionExpr{
-				pos: position{line: 5109, col: 20, offset: 155954},
+				pos: position{line: 5148, col: 20, offset: 157184},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5109, col: 20, offset: 155954},
+					pos: position{line: 5148, col: 20, offset: 157184},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5109, col: 20, offset: 155954},
+							pos:  position{line: 5148, col: 20, offset: 157184},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5109, col: 25, offset: 155959},
+							pos:   position{line: 5148, col: 25, offset: 157189},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5109, col: 42, offset: 155976},
+								pos:  position{line: 5148, col: 42, offset: 157206},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12547,41 +12598,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5113, col: 1, offset: 156025},
+			pos:  position{line: 5152, col: 1, offset: 157255},
 			expr: &actionExpr{
-				pos: position{line: 5113, col: 16, offset: 156040},
+				pos: position{line: 5152, col: 16, offset: 157270},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5113, col: 16, offset: 156040},
+					pos: position{line: 5152, col: 16, offset: 157270},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5113, col: 16, offset: 156040},
+							pos:  position{line: 5152, col: 16, offset: 157270},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5113, col: 27, offset: 156051},
+							pos:  position{line: 5152, col: 27, offset: 157281},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5113, col: 33, offset: 156057},
+							pos:   position{line: 5152, col: 33, offset: 157287},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5113, col: 50, offset: 156074},
+								pos: position{line: 5152, col: 50, offset: 157304},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5113, col: 50, offset: 156074},
+									pos:  position{line: 5152, col: 50, offset: 157304},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5113, col: 70, offset: 156094},
+							pos:  position{line: 5152, col: 70, offset: 157324},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5113, col: 85, offset: 156109},
+							pos:   position{line: 5152, col: 85, offset: 157339},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5113, col: 91, offset: 156115},
+								pos:  position{line: 5152, col: 91, offset: 157345},
 								name: "FieldName",
 							},
 						},
@@ -12591,35 +12642,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5142, col: 1, offset: 156886},
+			pos:  position{line: 5181, col: 1, offset: 158116},
 			expr: &actionExpr{
-				pos: position{line: 5142, col: 23, offset: 156908},
+				pos: position{line: 5181, col: 23, offset: 158138},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5142, col: 23, offset: 156908},
+					pos: position{line: 5181, col: 23, offset: 158138},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5142, col: 23, offset: 156908},
+							pos:   position{line: 5181, col: 23, offset: 158138},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5142, col: 31, offset: 156916},
+								pos:  position{line: 5181, col: 31, offset: 158146},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5142, col: 46, offset: 156931},
+							pos:   position{line: 5181, col: 46, offset: 158161},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5142, col: 52, offset: 156937},
+								pos: position{line: 5181, col: 52, offset: 158167},
 								expr: &seqExpr{
-									pos: position{line: 5142, col: 53, offset: 156938},
+									pos: position{line: 5181, col: 53, offset: 158168},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5142, col: 53, offset: 156938},
+											pos:  position{line: 5181, col: 53, offset: 158168},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5142, col: 59, offset: 156944},
+											pos:  position{line: 5181, col: 59, offset: 158174},
 											name: "MVBlockOption",
 										},
 									},
@@ -12632,26 +12683,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5176, col: 1, offset: 158000},
+			pos:  position{line: 5215, col: 1, offset: 159230},
 			expr: &actionExpr{
-				pos: position{line: 5176, col: 18, offset: 158017},
+				pos: position{line: 5215, col: 18, offset: 159247},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5176, col: 18, offset: 158017},
+					pos:   position{line: 5215, col: 18, offset: 159247},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5176, col: 27, offset: 158026},
+						pos: position{line: 5215, col: 27, offset: 159256},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5176, col: 27, offset: 158026},
+								pos:  position{line: 5215, col: 27, offset: 159256},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5176, col: 41, offset: 158040},
+								pos:  position{line: 5215, col: 41, offset: 159270},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5176, col: 60, offset: 158059},
+								pos:  position{line: 5215, col: 60, offset: 159289},
 								name: "SetSvOption",
 							},
 						},
@@ -12661,22 +12712,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5180, col: 1, offset: 158100},
+			pos:  position{line: 5219, col: 1, offset: 159330},
 			expr: &actionExpr{
-				pos: position{line: 5180, col: 16, offset: 158115},
+				pos: position{line: 5219, col: 16, offset: 159345},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5180, col: 16, offset: 158115},
+					pos:   position{line: 5219, col: 16, offset: 159345},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5180, col: 28, offset: 158127},
+						pos: position{line: 5219, col: 28, offset: 159357},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5180, col: 28, offset: 158127},
+								pos:  position{line: 5219, col: 28, offset: 159357},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5180, col: 46, offset: 158145},
+								pos:  position{line: 5219, col: 46, offset: 159375},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12686,28 +12737,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5184, col: 1, offset: 158192},
+			pos:  position{line: 5223, col: 1, offset: 159422},
 			expr: &actionExpr{
-				pos: position{line: 5184, col: 20, offset: 158211},
+				pos: position{line: 5223, col: 20, offset: 159441},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5184, col: 20, offset: 158211},
+					pos: position{line: 5223, col: 20, offset: 159441},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5184, col: 20, offset: 158211},
+							pos:        position{line: 5223, col: 20, offset: 159441},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5184, col: 28, offset: 158219},
+							pos:  position{line: 5223, col: 28, offset: 159449},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5184, col: 34, offset: 158225},
+							pos:   position{line: 5223, col: 34, offset: 159455},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5184, col: 38, offset: 158229},
+								pos:  position{line: 5223, col: 38, offset: 159459},
 								name: "QuotedString",
 							},
 						},
@@ -12717,28 +12768,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5195, col: 1, offset: 158480},
+			pos:  position{line: 5234, col: 1, offset: 159710},
 			expr: &actionExpr{
-				pos: position{line: 5195, col: 19, offset: 158498},
+				pos: position{line: 5234, col: 19, offset: 159728},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5195, col: 19, offset: 158498},
+					pos: position{line: 5234, col: 19, offset: 159728},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5195, col: 19, offset: 158498},
+							pos:        position{line: 5234, col: 19, offset: 159728},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5195, col: 31, offset: 158510},
+							pos:  position{line: 5234, col: 31, offset: 159740},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5195, col: 37, offset: 158516},
+							pos:   position{line: 5234, col: 37, offset: 159746},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5195, col: 41, offset: 158520},
+								pos:  position{line: 5234, col: 41, offset: 159750},
 								name: "QuotedString",
 							},
 						},
@@ -12748,28 +12799,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5213, col: 1, offset: 158991},
+			pos:  position{line: 5252, col: 1, offset: 160221},
 			expr: &actionExpr{
-				pos: position{line: 5213, col: 21, offset: 159011},
+				pos: position{line: 5252, col: 21, offset: 160241},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5213, col: 21, offset: 159011},
+					pos: position{line: 5252, col: 21, offset: 160241},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5213, col: 21, offset: 159011},
+							pos:        position{line: 5252, col: 21, offset: 160241},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5213, col: 34, offset: 159024},
+							pos:  position{line: 5252, col: 34, offset: 160254},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5213, col: 40, offset: 159030},
+							pos:   position{line: 5252, col: 40, offset: 160260},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5213, col: 48, offset: 159038},
+								pos:  position{line: 5252, col: 48, offset: 160268},
 								name: "Boolean",
 							},
 						},
@@ -12779,28 +12830,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5225, col: 1, offset: 159278},
+			pos:  position{line: 5264, col: 1, offset: 160508},
 			expr: &actionExpr{
-				pos: position{line: 5225, col: 16, offset: 159293},
+				pos: position{line: 5264, col: 16, offset: 160523},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5225, col: 16, offset: 159293},
+					pos: position{line: 5264, col: 16, offset: 160523},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5225, col: 16, offset: 159293},
+							pos:        position{line: 5264, col: 16, offset: 160523},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5225, col: 24, offset: 159301},
+							pos:  position{line: 5264, col: 24, offset: 160531},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5225, col: 30, offset: 159307},
+							pos:   position{line: 5264, col: 30, offset: 160537},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5225, col: 38, offset: 159315},
+								pos:  position{line: 5264, col: 38, offset: 160545},
 								name: "Boolean",
 							},
 						},
@@ -12810,28 +12861,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5237, col: 1, offset: 159580},
+			pos:  position{line: 5276, col: 1, offset: 160810},
 			expr: &actionExpr{
-				pos: position{line: 5237, col: 15, offset: 159594},
+				pos: position{line: 5276, col: 15, offset: 160824},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5237, col: 15, offset: 159594},
+					pos: position{line: 5276, col: 15, offset: 160824},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5237, col: 15, offset: 159594},
+							pos:  position{line: 5276, col: 15, offset: 160824},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5237, col: 20, offset: 159599},
+							pos:  position{line: 5276, col: 20, offset: 160829},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5237, col: 30, offset: 159609},
+							pos:   position{line: 5276, col: 30, offset: 160839},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5237, col: 40, offset: 159619},
+								pos: position{line: 5276, col: 40, offset: 160849},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5237, col: 40, offset: 159619},
+									pos:  position{line: 5276, col: 40, offset: 160849},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12842,39 +12893,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5244, col: 1, offset: 159745},
+			pos:  position{line: 5283, col: 1, offset: 160975},
 			expr: &actionExpr{
-				pos: position{line: 5244, col: 23, offset: 159767},
+				pos: position{line: 5283, col: 23, offset: 160997},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5244, col: 23, offset: 159767},
+					pos: position{line: 5283, col: 23, offset: 160997},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5244, col: 23, offset: 159767},
+							pos:  position{line: 5283, col: 23, offset: 160997},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5244, col: 29, offset: 159773},
+							pos:   position{line: 5283, col: 29, offset: 161003},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5244, col: 35, offset: 159779},
+								pos:  position{line: 5283, col: 35, offset: 161009},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5244, col: 49, offset: 159793},
+							pos:   position{line: 5283, col: 49, offset: 161023},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5244, col: 54, offset: 159798},
+								pos: position{line: 5283, col: 54, offset: 161028},
 								expr: &seqExpr{
-									pos: position{line: 5244, col: 55, offset: 159799},
+									pos: position{line: 5283, col: 55, offset: 161029},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5244, col: 55, offset: 159799},
+											pos:  position{line: 5283, col: 55, offset: 161029},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5244, col: 61, offset: 159805},
+											pos:  position{line: 5283, col: 61, offset: 161035},
 											name: "SPathArgument",
 										},
 									},
@@ -12887,26 +12938,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5276, col: 1, offset: 160698},
+			pos:  position{line: 5315, col: 1, offset: 161928},
 			expr: &actionExpr{
-				pos: position{line: 5276, col: 18, offset: 160715},
+				pos: position{line: 5315, col: 18, offset: 161945},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5276, col: 18, offset: 160715},
+					pos:   position{line: 5315, col: 18, offset: 161945},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5276, col: 23, offset: 160720},
+						pos: position{line: 5315, col: 23, offset: 161950},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5276, col: 23, offset: 160720},
+								pos:  position{line: 5315, col: 23, offset: 161950},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5276, col: 36, offset: 160733},
+								pos:  position{line: 5315, col: 36, offset: 161963},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5276, col: 50, offset: 160747},
+								pos:  position{line: 5315, col: 50, offset: 161977},
 								name: "PathField",
 							},
 						},
@@ -12916,28 +12967,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5280, col: 1, offset: 160783},
+			pos:  position{line: 5319, col: 1, offset: 162013},
 			expr: &actionExpr{
-				pos: position{line: 5280, col: 15, offset: 160797},
+				pos: position{line: 5319, col: 15, offset: 162027},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5280, col: 15, offset: 160797},
+					pos: position{line: 5319, col: 15, offset: 162027},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5280, col: 15, offset: 160797},
+							pos:        position{line: 5319, col: 15, offset: 162027},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5280, col: 23, offset: 160805},
+							pos:  position{line: 5319, col: 23, offset: 162035},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5280, col: 29, offset: 160811},
+							pos:   position{line: 5319, col: 29, offset: 162041},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5280, col: 35, offset: 160817},
+								pos:  position{line: 5319, col: 35, offset: 162047},
 								name: "FieldName",
 							},
 						},
@@ -12947,28 +12998,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5283, col: 1, offset: 160873},
+			pos:  position{line: 5322, col: 1, offset: 162103},
 			expr: &actionExpr{
-				pos: position{line: 5283, col: 16, offset: 160888},
+				pos: position{line: 5322, col: 16, offset: 162118},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5283, col: 16, offset: 160888},
+					pos: position{line: 5322, col: 16, offset: 162118},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5283, col: 16, offset: 160888},
+							pos:        position{line: 5322, col: 16, offset: 162118},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5283, col: 25, offset: 160897},
+							pos:  position{line: 5322, col: 25, offset: 162127},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5283, col: 31, offset: 160903},
+							pos:   position{line: 5322, col: 31, offset: 162133},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5283, col: 37, offset: 160909},
+								pos:  position{line: 5322, col: 37, offset: 162139},
 								name: "FieldName",
 							},
 						},
@@ -12978,34 +13029,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5286, col: 1, offset: 160966},
+			pos:  position{line: 5325, col: 1, offset: 162196},
 			expr: &actionExpr{
-				pos: position{line: 5286, col: 14, offset: 160979},
+				pos: position{line: 5325, col: 14, offset: 162209},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5286, col: 15, offset: 160980},
+					pos: position{line: 5325, col: 15, offset: 162210},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5286, col: 15, offset: 160980},
+							pos: position{line: 5325, col: 15, offset: 162210},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5286, col: 15, offset: 160980},
+									pos:        position{line: 5325, col: 15, offset: 162210},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5286, col: 22, offset: 160987},
+									pos:  position{line: 5325, col: 22, offset: 162217},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5286, col: 28, offset: 160993},
+									pos:  position{line: 5325, col: 28, offset: 162223},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5286, col: 47, offset: 161012},
+							pos:  position{line: 5325, col: 47, offset: 162242},
 							name: "SPathFieldString",
 						},
 					},
@@ -13014,16 +13065,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5298, col: 1, offset: 161424},
+			pos:  position{line: 5337, col: 1, offset: 162654},
 			expr: &choiceExpr{
-				pos: position{line: 5298, col: 21, offset: 161444},
+				pos: position{line: 5337, col: 21, offset: 162674},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5298, col: 21, offset: 161444},
+						pos:  position{line: 5337, col: 21, offset: 162674},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5298, col: 36, offset: 161459},
+						pos:  position{line: 5337, col: 36, offset: 162689},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -13031,28 +13082,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5301, col: 1, offset: 161532},
+			pos:  position{line: 5340, col: 1, offset: 162762},
 			expr: &actionExpr{
-				pos: position{line: 5301, col: 16, offset: 161547},
+				pos: position{line: 5340, col: 16, offset: 162777},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5301, col: 16, offset: 161547},
+					pos: position{line: 5340, col: 16, offset: 162777},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5301, col: 16, offset: 161547},
+							pos:  position{line: 5340, col: 16, offset: 162777},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5301, col: 21, offset: 161552},
+							pos:  position{line: 5340, col: 21, offset: 162782},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5301, col: 32, offset: 161563},
+							pos:   position{line: 5340, col: 32, offset: 162793},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5301, col: 46, offset: 161577},
+								pos: position{line: 5340, col: 46, offset: 162807},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5301, col: 46, offset: 161577},
+									pos:  position{line: 5340, col: 46, offset: 162807},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -13063,39 +13114,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5323, col: 1, offset: 162186},
+			pos:  position{line: 5362, col: 1, offset: 163416},
 			expr: &actionExpr{
-				pos: position{line: 5323, col: 24, offset: 162209},
+				pos: position{line: 5362, col: 24, offset: 163439},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5323, col: 24, offset: 162209},
+					pos: position{line: 5362, col: 24, offset: 163439},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5323, col: 24, offset: 162209},
+							pos:  position{line: 5362, col: 24, offset: 163439},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5323, col: 30, offset: 162215},
+							pos:   position{line: 5362, col: 30, offset: 163445},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5323, col: 37, offset: 162222},
+								pos:  position{line: 5362, col: 37, offset: 163452},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5323, col: 52, offset: 162237},
+							pos:   position{line: 5362, col: 52, offset: 163467},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5323, col: 57, offset: 162242},
+								pos: position{line: 5362, col: 57, offset: 163472},
 								expr: &seqExpr{
-									pos: position{line: 5323, col: 58, offset: 162243},
+									pos: position{line: 5362, col: 58, offset: 163473},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5323, col: 58, offset: 162243},
+											pos:  position{line: 5362, col: 58, offset: 163473},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5323, col: 64, offset: 162249},
+											pos:  position{line: 5362, col: 64, offset: 163479},
 											name: "FormatArgument",
 										},
 									},
@@ -13108,30 +13159,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5357, col: 1, offset: 163438},
+			pos:  position{line: 5396, col: 1, offset: 164668},
 			expr: &actionExpr{
-				pos: position{line: 5357, col: 19, offset: 163456},
+				pos: position{line: 5396, col: 19, offset: 164686},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5357, col: 19, offset: 163456},
+					pos:   position{line: 5396, col: 19, offset: 164686},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5357, col: 28, offset: 163465},
+						pos: position{line: 5396, col: 28, offset: 164695},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5357, col: 28, offset: 163465},
+								pos:  position{line: 5396, col: 28, offset: 164695},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5357, col: 46, offset: 163483},
+								pos:  position{line: 5396, col: 46, offset: 164713},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5357, col: 65, offset: 163502},
+								pos:  position{line: 5396, col: 65, offset: 164732},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5357, col: 82, offset: 163519},
+								pos:  position{line: 5396, col: 82, offset: 164749},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -13141,28 +13192,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5361, col: 1, offset: 163569},
+			pos:  position{line: 5400, col: 1, offset: 164799},
 			expr: &actionExpr{
-				pos: position{line: 5361, col: 20, offset: 163588},
+				pos: position{line: 5400, col: 20, offset: 164818},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5361, col: 20, offset: 163588},
+					pos: position{line: 5400, col: 20, offset: 164818},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5361, col: 20, offset: 163588},
+							pos:        position{line: 5400, col: 20, offset: 164818},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5361, col: 28, offset: 163596},
+							pos:  position{line: 5400, col: 28, offset: 164826},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5361, col: 34, offset: 163602},
+							pos:   position{line: 5400, col: 34, offset: 164832},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5361, col: 38, offset: 163606},
+								pos:  position{line: 5400, col: 38, offset: 164836},
 								name: "QuotedString",
 							},
 						},
@@ -13172,28 +13223,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5370, col: 1, offset: 163818},
+			pos:  position{line: 5409, col: 1, offset: 165048},
 			expr: &actionExpr{
-				pos: position{line: 5370, col: 21, offset: 163838},
+				pos: position{line: 5409, col: 21, offset: 165068},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5370, col: 21, offset: 163838},
+					pos: position{line: 5409, col: 21, offset: 165068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5370, col: 21, offset: 163838},
+							pos:        position{line: 5409, col: 21, offset: 165068},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5370, col: 34, offset: 163851},
+							pos:  position{line: 5409, col: 34, offset: 165081},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5370, col: 40, offset: 163857},
+							pos:   position{line: 5409, col: 40, offset: 165087},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5370, col: 47, offset: 163864},
+								pos:  position{line: 5409, col: 47, offset: 165094},
 								name: "IntegerAsString",
 							},
 						},
@@ -13203,28 +13254,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5383, col: 1, offset: 164270},
+			pos:  position{line: 5422, col: 1, offset: 165500},
 			expr: &actionExpr{
-				pos: position{line: 5383, col: 19, offset: 164288},
+				pos: position{line: 5422, col: 19, offset: 165518},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5383, col: 19, offset: 164288},
+					pos: position{line: 5422, col: 19, offset: 165518},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5383, col: 19, offset: 164288},
+							pos:        position{line: 5422, col: 19, offset: 165518},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5383, col: 30, offset: 164299},
+							pos:  position{line: 5422, col: 30, offset: 165529},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5383, col: 36, offset: 164305},
+							pos:   position{line: 5422, col: 36, offset: 165535},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5383, col: 40, offset: 164309},
+								pos:  position{line: 5422, col: 40, offset: 165539},
 								name: "QuotedString",
 							},
 						},
@@ -13234,78 +13285,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5392, col: 1, offset: 164524},
+			pos:  position{line: 5431, col: 1, offset: 165754},
 			expr: &actionExpr{
-				pos: position{line: 5392, col: 24, offset: 164547},
+				pos: position{line: 5431, col: 24, offset: 165777},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5392, col: 24, offset: 164547},
+					pos: position{line: 5431, col: 24, offset: 165777},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5392, col: 24, offset: 164547},
+							pos:   position{line: 5431, col: 24, offset: 165777},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 34, offset: 164557},
+								pos:  position{line: 5431, col: 34, offset: 165787},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5392, col: 47, offset: 164570},
+							pos:  position{line: 5431, col: 47, offset: 165800},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5392, col: 53, offset: 164576},
+							pos:   position{line: 5431, col: 53, offset: 165806},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 63, offset: 164586},
+								pos:  position{line: 5431, col: 63, offset: 165816},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5392, col: 76, offset: 164599},
+							pos:  position{line: 5431, col: 76, offset: 165829},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5392, col: 82, offset: 164605},
+							pos:   position{line: 5431, col: 82, offset: 165835},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 95, offset: 164618},
+								pos:  position{line: 5431, col: 95, offset: 165848},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5392, col: 108, offset: 164631},
+							pos:  position{line: 5431, col: 108, offset: 165861},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5392, col: 114, offset: 164637},
+							pos:   position{line: 5431, col: 114, offset: 165867},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 121, offset: 164644},
+								pos:  position{line: 5431, col: 121, offset: 165874},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5392, col: 134, offset: 164657},
+							pos:  position{line: 5431, col: 134, offset: 165887},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5392, col: 140, offset: 164663},
+							pos:   position{line: 5431, col: 140, offset: 165893},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 153, offset: 164676},
+								pos:  position{line: 5431, col: 153, offset: 165906},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5392, col: 166, offset: 164689},
+							pos:  position{line: 5431, col: 166, offset: 165919},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5392, col: 172, offset: 164695},
+							pos:   position{line: 5431, col: 172, offset: 165925},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5392, col: 179, offset: 164702},
+								pos:  position{line: 5431, col: 179, offset: 165932},
 								name: "QuotedString",
 							},
 						},
@@ -13315,28 +13366,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5410, col: 1, offset: 165278},
+			pos:  position{line: 5449, col: 1, offset: 166508},
 			expr: &actionExpr{
-				pos: position{line: 5410, col: 20, offset: 165297},
+				pos: position{line: 5449, col: 20, offset: 166527},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5410, col: 20, offset: 165297},
+					pos: position{line: 5449, col: 20, offset: 166527},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5410, col: 20, offset: 165297},
+							pos:  position{line: 5449, col: 20, offset: 166527},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5410, col: 25, offset: 165302},
+							pos:  position{line: 5449, col: 25, offset: 166532},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5410, col: 40, offset: 165317},
+							pos:   position{line: 5449, col: 40, offset: 166547},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5410, col: 55, offset: 165332},
+								pos: position{line: 5449, col: 55, offset: 166562},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5410, col: 55, offset: 165332},
+									pos:  position{line: 5449, col: 55, offset: 166562},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13347,42 +13398,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5417, col: 1, offset: 165485},
+			pos:  position{line: 5456, col: 1, offset: 166715},
 			expr: &actionExpr{
-				pos: position{line: 5417, col: 28, offset: 165512},
+				pos: position{line: 5456, col: 28, offset: 166742},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5417, col: 28, offset: 165512},
+					pos: position{line: 5456, col: 28, offset: 166742},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5417, col: 28, offset: 165512},
+							pos:  position{line: 5456, col: 28, offset: 166742},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5417, col: 34, offset: 165518},
+							pos:   position{line: 5456, col: 34, offset: 166748},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5417, col: 40, offset: 165524},
+								pos: position{line: 5456, col: 40, offset: 166754},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5417, col: 40, offset: 165524},
+									pos:  position{line: 5456, col: 40, offset: 166754},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5417, col: 60, offset: 165544},
+							pos:   position{line: 5456, col: 60, offset: 166774},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5417, col: 65, offset: 165549},
+								pos: position{line: 5456, col: 65, offset: 166779},
 								expr: &seqExpr{
-									pos: position{line: 5417, col: 66, offset: 165550},
+									pos: position{line: 5456, col: 66, offset: 166780},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5417, col: 66, offset: 165550},
+											pos:  position{line: 5456, col: 66, offset: 166780},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5417, col: 72, offset: 165556},
+											pos:  position{line: 5456, col: 72, offset: 166786},
 											name: "EventCountArgument",
 										},
 									},
@@ -13395,30 +13446,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5473, col: 1, offset: 167433},
+			pos:  position{line: 5512, col: 1, offset: 168663},
 			expr: &actionExpr{
-				pos: position{line: 5473, col: 23, offset: 167455},
+				pos: position{line: 5512, col: 23, offset: 168685},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5473, col: 23, offset: 167455},
+					pos:   position{line: 5512, col: 23, offset: 168685},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5473, col: 28, offset: 167460},
+						pos: position{line: 5512, col: 28, offset: 168690},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5473, col: 28, offset: 167460},
+								pos:  position{line: 5512, col: 28, offset: 168690},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5473, col: 41, offset: 167473},
+								pos:  position{line: 5512, col: 41, offset: 168703},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5473, col: 58, offset: 167490},
+								pos:  position{line: 5512, col: 58, offset: 168720},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5473, col: 76, offset: 167508},
+								pos:  position{line: 5512, col: 76, offset: 168738},
 								name: "ListVixField",
 							},
 						},
@@ -13428,28 +13479,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5477, col: 1, offset: 167547},
+			pos:  position{line: 5516, col: 1, offset: 168777},
 			expr: &actionExpr{
-				pos: position{line: 5477, col: 15, offset: 167561},
+				pos: position{line: 5516, col: 15, offset: 168791},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5477, col: 15, offset: 167561},
+					pos: position{line: 5516, col: 15, offset: 168791},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5477, col: 15, offset: 167561},
+							pos:        position{line: 5516, col: 15, offset: 168791},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5477, col: 23, offset: 167569},
+							pos:  position{line: 5516, col: 23, offset: 168799},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5477, col: 29, offset: 167575},
+							pos:   position{line: 5516, col: 29, offset: 168805},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5477, col: 35, offset: 167581},
+								pos:  position{line: 5516, col: 35, offset: 168811},
 								name: "IndexName",
 							},
 						},
@@ -13459,28 +13510,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5480, col: 1, offset: 167637},
+			pos:  position{line: 5519, col: 1, offset: 168867},
 			expr: &actionExpr{
-				pos: position{line: 5480, col: 19, offset: 167655},
+				pos: position{line: 5519, col: 19, offset: 168885},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5480, col: 19, offset: 167655},
+					pos: position{line: 5519, col: 19, offset: 168885},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5480, col: 19, offset: 167655},
+							pos:        position{line: 5519, col: 19, offset: 168885},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5480, col: 31, offset: 167667},
+							pos:  position{line: 5519, col: 31, offset: 168897},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5480, col: 37, offset: 167673},
+							pos:   position{line: 5519, col: 37, offset: 168903},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5480, col: 43, offset: 167679},
+								pos:  position{line: 5519, col: 43, offset: 168909},
 								name: "Boolean",
 							},
 						},
@@ -13490,28 +13541,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5483, col: 1, offset: 167755},
+			pos:  position{line: 5522, col: 1, offset: 168985},
 			expr: &actionExpr{
-				pos: position{line: 5483, col: 20, offset: 167774},
+				pos: position{line: 5522, col: 20, offset: 169004},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5483, col: 20, offset: 167774},
+					pos: position{line: 5522, col: 20, offset: 169004},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5483, col: 20, offset: 167774},
+							pos:        position{line: 5522, col: 20, offset: 169004},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5483, col: 34, offset: 167788},
+							pos:  position{line: 5522, col: 34, offset: 169018},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5483, col: 40, offset: 167794},
+							pos:   position{line: 5522, col: 40, offset: 169024},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5483, col: 46, offset: 167800},
+								pos:  position{line: 5522, col: 46, offset: 169030},
 								name: "Boolean",
 							},
 						},
@@ -13521,28 +13572,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5486, col: 1, offset: 167878},
+			pos:  position{line: 5525, col: 1, offset: 169108},
 			expr: &actionExpr{
-				pos: position{line: 5486, col: 17, offset: 167894},
+				pos: position{line: 5525, col: 17, offset: 169124},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5486, col: 17, offset: 167894},
+					pos: position{line: 5525, col: 17, offset: 169124},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5486, col: 17, offset: 167894},
+							pos:        position{line: 5525, col: 17, offset: 169124},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5486, col: 28, offset: 167905},
+							pos:  position{line: 5525, col: 28, offset: 169135},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5486, col: 34, offset: 167911},
+							pos:   position{line: 5525, col: 34, offset: 169141},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5486, col: 40, offset: 167917},
+								pos:  position{line: 5525, col: 40, offset: 169147},
 								name: "Boolean",
 							},
 						},
@@ -13552,24 +13603,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5490, col: 1, offset: 167993},
+			pos:  position{line: 5529, col: 1, offset: 169223},
 			expr: &actionExpr{
-				pos: position{line: 5490, col: 14, offset: 168006},
+				pos: position{line: 5529, col: 14, offset: 169236},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5490, col: 14, offset: 168006},
+					pos: position{line: 5529, col: 14, offset: 169236},
 					expr: &seqExpr{
-						pos: position{line: 5490, col: 15, offset: 168007},
+						pos: position{line: 5529, col: 15, offset: 169237},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5490, col: 15, offset: 168007},
+								pos: position{line: 5529, col: 15, offset: 169237},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5490, col: 16, offset: 168008},
+									pos:  position{line: 5529, col: 16, offset: 169238},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5490, col: 22, offset: 168014,
+								line: 5529, col: 22, offset: 169244,
 							},
 						},
 					},
@@ -13578,39 +13629,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5495, col: 1, offset: 168087},
+			pos:  position{line: 5534, col: 1, offset: 169317},
 			expr: &actionExpr{
-				pos: position{line: 5495, col: 18, offset: 168104},
+				pos: position{line: 5534, col: 18, offset: 169334},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5495, col: 18, offset: 168104},
+					pos: position{line: 5534, col: 18, offset: 169334},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5495, col: 18, offset: 168104},
+							pos:  position{line: 5534, col: 18, offset: 169334},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5495, col: 23, offset: 168109},
+							pos:  position{line: 5534, col: 23, offset: 169339},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5495, col: 36, offset: 168122},
+							pos:   position{line: 5534, col: 36, offset: 169352},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5495, col: 49, offset: 168135},
+								pos: position{line: 5534, col: 49, offset: 169365},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5495, col: 49, offset: 168135},
+									pos:  position{line: 5534, col: 49, offset: 169365},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5495, col: 70, offset: 168156},
+							pos:   position{line: 5534, col: 70, offset: 169386},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5495, col: 77, offset: 168163},
+								pos: position{line: 5534, col: 77, offset: 169393},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5495, col: 77, offset: 168163},
+									pos:  position{line: 5534, col: 77, offset: 169393},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13621,32 +13672,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5525, col: 1, offset: 168926},
+			pos:  position{line: 5564, col: 1, offset: 170156},
 			expr: &actionExpr{
-				pos: position{line: 5525, col: 24, offset: 168949},
+				pos: position{line: 5564, col: 24, offset: 170179},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5525, col: 24, offset: 168949},
+					pos: position{line: 5564, col: 24, offset: 170179},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5525, col: 24, offset: 168949},
+							pos:  position{line: 5564, col: 24, offset: 170179},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5525, col: 30, offset: 168955},
+							pos:        position{line: 5564, col: 30, offset: 170185},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5525, col: 38, offset: 168963},
+							pos:  position{line: 5564, col: 38, offset: 170193},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5525, col: 44, offset: 168969},
+							pos:   position{line: 5564, col: 44, offset: 170199},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5525, col: 48, offset: 168973},
+								pos:  position{line: 5564, col: 48, offset: 170203},
 								name: "String",
 							},
 						},
@@ -13656,22 +13707,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5529, col: 1, offset: 169019},
+			pos:  position{line: 5568, col: 1, offset: 170249},
 			expr: &actionExpr{
-				pos: position{line: 5529, col: 22, offset: 169040},
+				pos: position{line: 5568, col: 22, offset: 170270},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5529, col: 22, offset: 169040},
+					pos: position{line: 5568, col: 22, offset: 170270},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5529, col: 22, offset: 169040},
+							pos:  position{line: 5568, col: 22, offset: 170270},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5529, col: 28, offset: 169046},
+							pos:   position{line: 5568, col: 28, offset: 170276},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5529, col: 38, offset: 169056},
+								pos:  position{line: 5568, col: 38, offset: 170286},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13681,36 +13732,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5533, col: 1, offset: 169115},
+			pos:  position{line: 5572, col: 1, offset: 170345},
 			expr: &actionExpr{
-				pos: position{line: 5533, col: 18, offset: 169132},
+				pos: position{line: 5572, col: 18, offset: 170362},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5533, col: 18, offset: 169132},
+					pos: position{line: 5572, col: 18, offset: 170362},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5533, col: 18, offset: 169132},
+							pos:  position{line: 5572, col: 18, offset: 170362},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5533, col: 23, offset: 169137},
+							pos:  position{line: 5572, col: 23, offset: 170367},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5533, col: 36, offset: 169150},
+							pos:   position{line: 5572, col: 36, offset: 170380},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5533, col: 42, offset: 169156},
+								pos:  position{line: 5572, col: 42, offset: 170386},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5533, col: 56, offset: 169170},
+							pos:   position{line: 5572, col: 56, offset: 170400},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5533, col: 65, offset: 169179},
+								pos: position{line: 5572, col: 65, offset: 170409},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5533, col: 65, offset: 169179},
+									pos:  position{line: 5572, col: 65, offset: 170409},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13721,22 +13772,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5562, col: 1, offset: 169955},
+			pos:  position{line: 5601, col: 1, offset: 171185},
 			expr: &actionExpr{
-				pos: position{line: 5562, col: 18, offset: 169972},
+				pos: position{line: 5601, col: 18, offset: 171202},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5562, col: 18, offset: 169972},
+					pos: position{line: 5601, col: 18, offset: 171202},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5562, col: 18, offset: 169972},
+							pos:  position{line: 5601, col: 18, offset: 171202},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5562, col: 24, offset: 169978},
+							pos:   position{line: 5601, col: 24, offset: 171208},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5562, col: 34, offset: 169988},
+								pos:  position{line: 5601, col: 34, offset: 171218},
 								name: "FieldName",
 							},
 						},
@@ -13746,32 +13797,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5566, col: 1, offset: 170029},
+			pos:  position{line: 5605, col: 1, offset: 171259},
 			expr: &actionExpr{
-				pos: position{line: 5566, col: 18, offset: 170046},
+				pos: position{line: 5605, col: 18, offset: 171276},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5566, col: 18, offset: 170046},
+					pos: position{line: 5605, col: 18, offset: 171276},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5566, col: 18, offset: 170046},
+							pos:  position{line: 5605, col: 18, offset: 171276},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5566, col: 24, offset: 170052},
+							pos:        position{line: 5605, col: 24, offset: 171282},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5566, col: 32, offset: 170060},
+							pos:  position{line: 5605, col: 32, offset: 171290},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5566, col: 38, offset: 170066},
+							pos:   position{line: 5605, col: 38, offset: 171296},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5566, col: 47, offset: 170075},
+								pos:  position{line: 5605, col: 47, offset: 171305},
 								name: "IntegerAsString",
 							},
 						},
@@ -13781,26 +13832,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5570, col: 1, offset: 170121},
+			pos:  position{line: 5609, col: 1, offset: 171351},
 			expr: &actionExpr{
-				pos: position{line: 5570, col: 16, offset: 170136},
+				pos: position{line: 5609, col: 16, offset: 171366},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5570, col: 16, offset: 170136},
+					pos: position{line: 5609, col: 16, offset: 171366},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5570, col: 16, offset: 170136},
+							pos:  position{line: 5609, col: 16, offset: 171366},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5570, col: 22, offset: 170142},
+							pos:  position{line: 5609, col: 22, offset: 171372},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5570, col: 32, offset: 170152},
+							pos:   position{line: 5609, col: 32, offset: 171382},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5570, col: 42, offset: 170162},
+								pos:  position{line: 5609, col: 42, offset: 171392},
 								name: "BoolExpr",
 							},
 						},
@@ -13810,28 +13861,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5574, col: 1, offset: 170222},
+			pos:  position{line: 5613, col: 1, offset: 171452},
 			expr: &actionExpr{
-				pos: position{line: 5574, col: 28, offset: 170249},
+				pos: position{line: 5613, col: 28, offset: 171479},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5574, col: 28, offset: 170249},
+					pos: position{line: 5613, col: 28, offset: 171479},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5574, col: 28, offset: 170249},
+							pos:        position{line: 5613, col: 28, offset: 171479},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5574, col: 37, offset: 170258},
+							pos:  position{line: 5613, col: 37, offset: 171488},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5574, col: 43, offset: 170264},
+							pos:   position{line: 5613, col: 43, offset: 171494},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5574, col: 51, offset: 170272},
+								pos:  position{line: 5613, col: 51, offset: 171502},
 								name: "Boolean",
 							},
 						},
@@ -13841,28 +13892,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5583, col: 1, offset: 170456},
+			pos:  position{line: 5622, col: 1, offset: 171686},
 			expr: &actionExpr{
-				pos: position{line: 5583, col: 28, offset: 170483},
+				pos: position{line: 5622, col: 28, offset: 171713},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5583, col: 28, offset: 170483},
+					pos: position{line: 5622, col: 28, offset: 171713},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5583, col: 28, offset: 170483},
+							pos:        position{line: 5622, col: 28, offset: 171713},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5583, col: 37, offset: 170492},
+							pos:  position{line: 5622, col: 37, offset: 171722},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5583, col: 43, offset: 170498},
+							pos:   position{line: 5622, col: 43, offset: 171728},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5583, col: 51, offset: 170506},
+								pos:  position{line: 5622, col: 51, offset: 171736},
 								name: "Boolean",
 							},
 						},
@@ -13872,28 +13923,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5592, col: 1, offset: 170690},
+			pos:  position{line: 5631, col: 1, offset: 171920},
 			expr: &actionExpr{
-				pos: position{line: 5592, col: 27, offset: 170716},
+				pos: position{line: 5631, col: 27, offset: 171946},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5592, col: 27, offset: 170716},
+					pos: position{line: 5631, col: 27, offset: 171946},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5592, col: 27, offset: 170716},
+							pos:        position{line: 5631, col: 27, offset: 171946},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5592, col: 35, offset: 170724},
+							pos:  position{line: 5631, col: 35, offset: 171954},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5592, col: 41, offset: 170730},
+							pos:   position{line: 5631, col: 41, offset: 171960},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5592, col: 48, offset: 170737},
+								pos:  position{line: 5631, col: 48, offset: 171967},
 								name: "PositiveInteger",
 							},
 						},
@@ -13903,28 +13954,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5601, col: 1, offset: 170928},
+			pos:  position{line: 5640, col: 1, offset: 172158},
 			expr: &actionExpr{
-				pos: position{line: 5601, col: 25, offset: 170952},
+				pos: position{line: 5640, col: 25, offset: 172182},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5601, col: 25, offset: 170952},
+					pos: position{line: 5640, col: 25, offset: 172182},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5601, col: 25, offset: 170952},
+							pos:        position{line: 5640, col: 25, offset: 172182},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5601, col: 31, offset: 170958},
+							pos:  position{line: 5640, col: 31, offset: 172188},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5601, col: 37, offset: 170964},
+							pos:   position{line: 5640, col: 37, offset: 172194},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5601, col: 44, offset: 170971},
+								pos:  position{line: 5640, col: 44, offset: 172201},
 								name: "PositiveInteger",
 							},
 						},
@@ -13934,30 +13985,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5610, col: 1, offset: 171158},
+			pos:  position{line: 5649, col: 1, offset: 172388},
 			expr: &actionExpr{
-				pos: position{line: 5610, col: 22, offset: 171179},
+				pos: position{line: 5649, col: 22, offset: 172409},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5610, col: 22, offset: 171179},
+					pos:   position{line: 5649, col: 22, offset: 172409},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5610, col: 41, offset: 171198},
+						pos: position{line: 5649, col: 41, offset: 172428},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5610, col: 41, offset: 171198},
+								pos:  position{line: 5649, col: 41, offset: 172428},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5610, col: 67, offset: 171224},
+								pos:  position{line: 5649, col: 67, offset: 172454},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5610, col: 93, offset: 171250},
+								pos:  position{line: 5649, col: 93, offset: 172480},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5610, col: 118, offset: 171275},
+								pos:  position{line: 5649, col: 118, offset: 172505},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13967,35 +14018,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5614, col: 1, offset: 171336},
+			pos:  position{line: 5653, col: 1, offset: 172566},
 			expr: &actionExpr{
-				pos: position{line: 5614, col: 26, offset: 171361},
+				pos: position{line: 5653, col: 26, offset: 172591},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5614, col: 26, offset: 171361},
+					pos: position{line: 5653, col: 26, offset: 172591},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5614, col: 26, offset: 171361},
+							pos:   position{line: 5653, col: 26, offset: 172591},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5614, col: 34, offset: 171369},
+								pos:  position{line: 5653, col: 34, offset: 172599},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5614, col: 53, offset: 171388},
+							pos:   position{line: 5653, col: 53, offset: 172618},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5614, col: 58, offset: 171393},
+								pos: position{line: 5653, col: 58, offset: 172623},
 								expr: &seqExpr{
-									pos: position{line: 5614, col: 59, offset: 171394},
+									pos: position{line: 5653, col: 59, offset: 172624},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5614, col: 59, offset: 171394},
+											pos:  position{line: 5653, col: 59, offset: 172624},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5614, col: 65, offset: 171400},
+											pos:  position{line: 5653, col: 65, offset: 172630},
 											name: "InputLookupOption",
 										},
 									},
@@ -14008,35 +14059,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5656, col: 1, offset: 172846},
+			pos:  position{line: 5695, col: 1, offset: 174076},
 			expr: &actionExpr{
-				pos: position{line: 5656, col: 21, offset: 172866},
+				pos: position{line: 5695, col: 21, offset: 174096},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5656, col: 21, offset: 172866},
+					pos: position{line: 5695, col: 21, offset: 174096},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5656, col: 21, offset: 172866},
+							pos:  position{line: 5695, col: 21, offset: 174096},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5656, col: 26, offset: 172871},
+							pos:  position{line: 5695, col: 26, offset: 174101},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 42, offset: 172887},
+							pos:   position{line: 5695, col: 42, offset: 174117},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5656, col: 60, offset: 172905},
+								pos: position{line: 5695, col: 60, offset: 174135},
 								expr: &seqExpr{
-									pos: position{line: 5656, col: 61, offset: 172906},
+									pos: position{line: 5695, col: 61, offset: 174136},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5656, col: 61, offset: 172906},
+											pos:  position{line: 5695, col: 61, offset: 174136},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5656, col: 83, offset: 172928},
+											pos:  position{line: 5695, col: 83, offset: 174158},
 											name: "SPACE",
 										},
 									},
@@ -14044,20 +14095,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 91, offset: 172936},
+							pos:   position{line: 5695, col: 91, offset: 174166},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5656, col: 101, offset: 172946},
+								pos:  position{line: 5695, col: 101, offset: 174176},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 109, offset: 172954},
+							pos:   position{line: 5695, col: 109, offset: 174184},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5656, col: 121, offset: 172966},
+								pos: position{line: 5695, col: 121, offset: 174196},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5656, col: 122, offset: 172967},
+									pos:  position{line: 5695, col: 122, offset: 174197},
 									name: "WhereClause",
 								},
 							},
@@ -14068,15 +14119,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5679, col: 1, offset: 173655},
+			pos:  position{line: 5718, col: 1, offset: 174885},
 			expr: &actionExpr{
-				pos: position{line: 5679, col: 24, offset: 173678},
+				pos: position{line: 5718, col: 24, offset: 174908},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5679, col: 24, offset: 173678},
+					pos:   position{line: 5718, col: 24, offset: 174908},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5679, col: 41, offset: 173695},
+						pos:  position{line: 5718, col: 41, offset: 174925},
 						name: "InputLookupBlock",
 					},
 				},
@@ -14084,26 +14135,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5690, col: 1, offset: 174094},
+			pos:  position{line: 5729, col: 1, offset: 175324},
 			expr: &actionExpr{
-				pos: position{line: 5690, col: 20, offset: 174113},
+				pos: position{line: 5729, col: 20, offset: 175343},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5690, col: 20, offset: 174113},
+					pos:   position{line: 5729, col: 20, offset: 175343},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5690, col: 28, offset: 174121},
+						pos: position{line: 5729, col: 28, offset: 175351},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5690, col: 28, offset: 174121},
+								pos:  position{line: 5729, col: 28, offset: 175351},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5690, col: 52, offset: 174145},
+								pos:  position{line: 5729, col: 52, offset: 175375},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5690, col: 68, offset: 174161},
+								pos:  position{line: 5729, col: 68, offset: 175391},
 								name: "MaxOutOption",
 							},
 						},
@@ -14113,28 +14164,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5695, col: 1, offset: 174259},
+			pos:  position{line: 5734, col: 1, offset: 175489},
 			expr: &actionExpr{
-				pos: position{line: 5695, col: 26, offset: 174284},
+				pos: position{line: 5734, col: 26, offset: 175514},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5695, col: 26, offset: 174284},
+					pos: position{line: 5734, col: 26, offset: 175514},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5695, col: 26, offset: 174284},
+							pos:        position{line: 5734, col: 26, offset: 175514},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5695, col: 44, offset: 174302},
+							pos:  position{line: 5734, col: 44, offset: 175532},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 50, offset: 174308},
+							pos:   position{line: 5734, col: 50, offset: 175538},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5695, col: 58, offset: 174316},
+								pos:  position{line: 5734, col: 58, offset: 175546},
 								name: "Boolean",
 							},
 						},
@@ -14144,28 +14195,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5702, col: 1, offset: 174455},
+			pos:  position{line: 5741, col: 1, offset: 175685},
 			expr: &actionExpr{
-				pos: position{line: 5702, col: 18, offset: 174472},
+				pos: position{line: 5741, col: 18, offset: 175702},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5702, col: 18, offset: 174472},
+					pos: position{line: 5741, col: 18, offset: 175702},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5702, col: 18, offset: 174472},
+							pos:        position{line: 5741, col: 18, offset: 175702},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5702, col: 28, offset: 174482},
+							pos:  position{line: 5741, col: 28, offset: 175712},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5702, col: 34, offset: 174488},
+							pos:   position{line: 5741, col: 34, offset: 175718},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5702, col: 39, offset: 174493},
+								pos:  position{line: 5741, col: 39, offset: 175723},
 								name: "IntegerAsString",
 							},
 						},
@@ -14175,28 +14226,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5713, col: 1, offset: 174794},
+			pos:  position{line: 5752, col: 1, offset: 176024},
 			expr: &actionExpr{
-				pos: position{line: 5713, col: 17, offset: 174810},
+				pos: position{line: 5752, col: 17, offset: 176040},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5713, col: 17, offset: 174810},
+					pos: position{line: 5752, col: 17, offset: 176040},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5713, col: 17, offset: 174810},
+							pos:        position{line: 5752, col: 17, offset: 176040},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5713, col: 26, offset: 174819},
+							pos:  position{line: 5752, col: 26, offset: 176049},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5713, col: 32, offset: 174825},
+							pos:   position{line: 5752, col: 32, offset: 176055},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5713, col: 36, offset: 174829},
+								pos:  position{line: 5752, col: 36, offset: 176059},
 								name: "IntegerAsString",
 							},
 						},
@@ -14206,43 +14257,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5725, col: 1, offset: 175184},
+			pos:  position{line: 5764, col: 1, offset: 176414},
 			expr: &actionExpr{
-				pos: position{line: 5725, col: 14, offset: 175197},
+				pos: position{line: 5764, col: 14, offset: 176427},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5725, col: 14, offset: 175197},
+					pos: position{line: 5764, col: 14, offset: 176427},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5725, col: 14, offset: 175197},
+							pos:        position{line: 5764, col: 14, offset: 176427},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5725, col: 18, offset: 175201},
+							pos: position{line: 5764, col: 18, offset: 176431},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5725, col: 18, offset: 175201},
+								pos:  position{line: 5764, col: 18, offset: 176431},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5725, col: 25, offset: 175208},
+							pos:   position{line: 5764, col: 25, offset: 176438},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5725, col: 32, offset: 175215},
+								pos:  position{line: 5764, col: 32, offset: 176445},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5725, col: 44, offset: 175227},
+							pos: position{line: 5764, col: 44, offset: 176457},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5725, col: 44, offset: 175227},
+								pos:  position{line: 5764, col: 44, offset: 176457},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5725, col: 51, offset: 175234},
+							pos:        position{line: 5764, col: 51, offset: 176464},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14253,35 +14304,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5730, col: 1, offset: 175323},
+			pos:  position{line: 5769, col: 1, offset: 176553},
 			expr: &actionExpr{
-				pos: position{line: 5730, col: 25, offset: 175347},
+				pos: position{line: 5769, col: 25, offset: 176577},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5730, col: 25, offset: 175347},
+					pos: position{line: 5769, col: 25, offset: 176577},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5730, col: 25, offset: 175347},
+							pos:   position{line: 5769, col: 25, offset: 176577},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5730, col: 31, offset: 175353},
+								pos:  position{line: 5769, col: 31, offset: 176583},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5730, col: 47, offset: 175369},
+							pos:   position{line: 5769, col: 47, offset: 176599},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5730, col: 52, offset: 175374},
+								pos: position{line: 5769, col: 52, offset: 176604},
 								expr: &seqExpr{
-									pos: position{line: 5730, col: 53, offset: 175375},
+									pos: position{line: 5769, col: 53, offset: 176605},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5730, col: 53, offset: 175375},
+											pos:  position{line: 5769, col: 53, offset: 176605},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5730, col: 59, offset: 175381},
+											pos:  position{line: 5769, col: 59, offset: 176611},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14294,37 +14345,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5757, col: 1, offset: 176191},
+			pos:  position{line: 5796, col: 1, offset: 177421},
 			expr: &actionExpr{
-				pos: position{line: 5757, col: 16, offset: 176206},
+				pos: position{line: 5796, col: 16, offset: 177436},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5757, col: 16, offset: 176206},
+					pos: position{line: 5796, col: 16, offset: 177436},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5757, col: 16, offset: 176206},
+							pos:  position{line: 5796, col: 16, offset: 177436},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5757, col: 21, offset: 176211},
+							pos:  position{line: 5796, col: 21, offset: 177441},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5757, col: 32, offset: 176222},
+							pos:   position{line: 5796, col: 32, offset: 177452},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5757, col: 40, offset: 176230},
+								pos: position{line: 5796, col: 40, offset: 177460},
 								expr: &seqExpr{
-									pos: position{line: 5757, col: 41, offset: 176231},
+									pos: position{line: 5796, col: 41, offset: 177461},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5757, col: 41, offset: 176231},
+											pos:  position{line: 5796, col: 41, offset: 177461},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5757, col: 57, offset: 176247},
+											pos: position{line: 5796, col: 57, offset: 177477},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5757, col: 57, offset: 176247},
+												pos:  position{line: 5796, col: 57, offset: 177477},
 												name: "SPACE",
 											},
 										},
@@ -14333,10 +14384,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5757, col: 66, offset: 176256},
+							pos:   position{line: 5796, col: 66, offset: 177486},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5757, col: 76, offset: 176266},
+								pos:  position{line: 5796, col: 76, offset: 177496},
 								name: "Subsearch",
 							},
 						},
@@ -14346,45 +14397,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5799, col: 1, offset: 177803},
+			pos:  position{line: 5838, col: 1, offset: 179033},
 			expr: &actionExpr{
-				pos: position{line: 5799, col: 17, offset: 177819},
+				pos: position{line: 5838, col: 17, offset: 179049},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5799, col: 17, offset: 177819},
+					pos: position{line: 5838, col: 17, offset: 179049},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5799, col: 17, offset: 177819},
+							pos:  position{line: 5838, col: 17, offset: 179049},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5799, col: 23, offset: 177825},
+							pos:   position{line: 5838, col: 23, offset: 179055},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5799, col: 31, offset: 177833},
+								pos: position{line: 5838, col: 31, offset: 179063},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 31, offset: 177833},
+										pos:  position{line: 5838, col: 31, offset: 179063},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 54, offset: 177856},
+										pos:  position{line: 5838, col: 54, offset: 179086},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 74, offset: 177876},
+										pos:  position{line: 5838, col: 74, offset: 179106},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 91, offset: 177893},
+										pos:  position{line: 5838, col: 91, offset: 179123},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 115, offset: 177917},
+										pos:  position{line: 5838, col: 115, offset: 179147},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5799, col: 135, offset: 177937},
+										pos:  position{line: 5838, col: 135, offset: 179167},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14396,51 +14447,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5803, col: 1, offset: 177992},
+			pos:  position{line: 5842, col: 1, offset: 179222},
 			expr: &actionExpr{
-				pos: position{line: 5803, col: 25, offset: 178016},
+				pos: position{line: 5842, col: 25, offset: 179246},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5803, col: 26, offset: 178017},
+					pos: position{line: 5842, col: 26, offset: 179247},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5803, col: 26, offset: 178017},
+							pos:   position{line: 5842, col: 26, offset: 179247},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5803, col: 33, offset: 178024},
+								pos: position{line: 5842, col: 33, offset: 179254},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5803, col: 33, offset: 178024},
+										pos:        position{line: 5842, col: 33, offset: 179254},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5803, col: 42, offset: 178033},
+										pos:        position{line: 5842, col: 42, offset: 179263},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5803, col: 51, offset: 178042},
+										pos:        position{line: 5842, col: 51, offset: 179272},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5803, col: 60, offset: 178051},
+										pos:        position{line: 5842, col: 60, offset: 179281},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5803, col: 68, offset: 178059},
+										pos:        position{line: 5842, col: 68, offset: 179289},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5803, col: 76, offset: 178067},
+										pos:        position{line: 5842, col: 76, offset: 179297},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14449,19 +14500,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5803, col: 84, offset: 178075},
+							pos:  position{line: 5842, col: 84, offset: 179305},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5803, col: 92, offset: 178083},
+							pos:   position{line: 5842, col: 92, offset: 179313},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5803, col: 105, offset: 178096},
+								pos:  position{line: 5842, col: 105, offset: 179326},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5803, col: 116, offset: 178107},
+							pos:  position{line: 5842, col: 116, offset: 179337},
 							name: "R_PAREN",
 						},
 					},
@@ -14470,15 +14521,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5829, col: 1, offset: 178865},
+			pos:  position{line: 5868, col: 1, offset: 180095},
 			expr: &actionExpr{
-				pos: position{line: 5829, col: 30, offset: 178894},
+				pos: position{line: 5868, col: 30, offset: 180124},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5829, col: 30, offset: 178894},
+					pos:   position{line: 5868, col: 30, offset: 180124},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5829, col: 43, offset: 178907},
+						pos:  position{line: 5868, col: 43, offset: 180137},
 						name: "StringExpr",
 					},
 				},
@@ -14486,61 +14537,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5854, col: 1, offset: 179615},
+			pos:  position{line: 5893, col: 1, offset: 180845},
 			expr: &actionExpr{
-				pos: position{line: 5854, col: 22, offset: 179636},
+				pos: position{line: 5893, col: 22, offset: 180866},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5854, col: 22, offset: 179636},
+					pos: position{line: 5893, col: 22, offset: 180866},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5854, col: 22, offset: 179636},
+							pos:        position{line: 5893, col: 22, offset: 180866},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5854, col: 37, offset: 179651},
+							pos:  position{line: 5893, col: 37, offset: 180881},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5854, col: 43, offset: 179657},
+							pos:   position{line: 5893, col: 43, offset: 180887},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5854, col: 50, offset: 179664},
+								pos: position{line: 5893, col: 50, offset: 180894},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5854, col: 50, offset: 179664},
+										pos:        position{line: 5893, col: 50, offset: 180894},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5854, col: 59, offset: 179673},
+										pos:        position{line: 5893, col: 59, offset: 180903},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5854, col: 68, offset: 179682},
+										pos:        position{line: 5893, col: 68, offset: 180912},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5854, col: 77, offset: 179691},
+										pos:        position{line: 5893, col: 77, offset: 180921},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5854, col: 85, offset: 179699},
+										pos:        position{line: 5893, col: 85, offset: 180929},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5854, col: 93, offset: 179707},
+										pos:        position{line: 5893, col: 93, offset: 180937},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14554,28 +14605,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5867, col: 1, offset: 180036},
+			pos:  position{line: 5906, col: 1, offset: 181266},
 			expr: &actionExpr{
-				pos: position{line: 5867, col: 19, offset: 180054},
+				pos: position{line: 5906, col: 19, offset: 181284},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5867, col: 19, offset: 180054},
+					pos: position{line: 5906, col: 19, offset: 181284},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5867, col: 19, offset: 180054},
+							pos:        position{line: 5906, col: 19, offset: 181284},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5867, col: 31, offset: 180066},
+							pos:  position{line: 5906, col: 31, offset: 181296},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5867, col: 37, offset: 180072},
+							pos:   position{line: 5906, col: 37, offset: 181302},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5867, col: 45, offset: 180080},
+								pos:  position{line: 5906, col: 45, offset: 181310},
 								name: "Boolean",
 							},
 						},
@@ -14585,28 +14636,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5874, col: 1, offset: 180203},
+			pos:  position{line: 5913, col: 1, offset: 181433},
 			expr: &actionExpr{
-				pos: position{line: 5874, col: 26, offset: 180228},
+				pos: position{line: 5913, col: 26, offset: 181458},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5874, col: 26, offset: 180228},
+					pos: position{line: 5913, col: 26, offset: 181458},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5874, col: 26, offset: 180228},
+							pos:        position{line: 5913, col: 26, offset: 181458},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5874, col: 45, offset: 180247},
+							pos:  position{line: 5913, col: 45, offset: 181477},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5874, col: 51, offset: 180253},
+							pos:   position{line: 5913, col: 51, offset: 181483},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5874, col: 59, offset: 180261},
+								pos:  position{line: 5913, col: 59, offset: 181491},
 								name: "Boolean",
 							},
 						},
@@ -14616,28 +14667,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5881, col: 1, offset: 180391},
+			pos:  position{line: 5920, col: 1, offset: 181621},
 			expr: &actionExpr{
-				pos: position{line: 5881, col: 22, offset: 180412},
+				pos: position{line: 5920, col: 22, offset: 181642},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5881, col: 22, offset: 180412},
+					pos: position{line: 5920, col: 22, offset: 181642},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5881, col: 22, offset: 180412},
+							pos:        position{line: 5920, col: 22, offset: 181642},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5881, col: 37, offset: 180427},
+							pos:  position{line: 5920, col: 37, offset: 181657},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5881, col: 43, offset: 180433},
+							pos:   position{line: 5920, col: 43, offset: 181663},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5881, col: 50, offset: 180440},
+								pos:  position{line: 5920, col: 50, offset: 181670},
 								name: "String",
 							},
 						},
@@ -14647,28 +14698,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5888, col: 1, offset: 180566},
+			pos:  position{line: 5927, col: 1, offset: 181796},
 			expr: &actionExpr{
-				pos: position{line: 5888, col: 16, offset: 180581},
+				pos: position{line: 5927, col: 16, offset: 181811},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5888, col: 16, offset: 180581},
+					pos: position{line: 5927, col: 16, offset: 181811},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5888, col: 16, offset: 180581},
+							pos:  position{line: 5927, col: 16, offset: 181811},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5888, col: 21, offset: 180586},
+							pos:  position{line: 5927, col: 21, offset: 181816},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5888, col: 32, offset: 180597},
+							pos:   position{line: 5927, col: 32, offset: 181827},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5888, col: 40, offset: 180605},
+								pos: position{line: 5927, col: 40, offset: 181835},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5888, col: 41, offset: 180606},
+									pos:  position{line: 5927, col: 41, offset: 181836},
 									name: "ToJsonOption",
 								},
 							},
@@ -14679,132 +14730,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5941, col: 1, offset: 182688},
+			pos:  position{line: 5980, col: 1, offset: 183918},
 			expr: &choiceExpr{
-				pos: position{line: 5941, col: 12, offset: 182699},
+				pos: position{line: 5980, col: 12, offset: 183929},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 12, offset: 182699},
+						pos:  position{line: 5980, col: 12, offset: 183929},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 24, offset: 182711},
+						pos:  position{line: 5980, col: 24, offset: 183941},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 36, offset: 182723},
+						pos:  position{line: 5980, col: 36, offset: 183953},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 49, offset: 182736},
+						pos:  position{line: 5980, col: 49, offset: 183966},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 61, offset: 182748},
+						pos:  position{line: 5980, col: 61, offset: 183978},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 81, offset: 182768},
+						pos:  position{line: 5980, col: 81, offset: 183998},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 92, offset: 182779},
+						pos:  position{line: 5980, col: 92, offset: 184009},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 112, offset: 182799},
+						pos:  position{line: 5980, col: 112, offset: 184029},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 123, offset: 182810},
+						pos:  position{line: 5980, col: 123, offset: 184040},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 134, offset: 182821},
+						pos:  position{line: 5980, col: 134, offset: 184051},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 144, offset: 182831},
+						pos:  position{line: 5980, col: 144, offset: 184061},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 154, offset: 182841},
+						pos:  position{line: 5980, col: 154, offset: 184071},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 165, offset: 182852},
+						pos:  position{line: 5980, col: 165, offset: 184082},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 178, offset: 182865},
+						pos:  position{line: 5980, col: 178, offset: 184095},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 194, offset: 182881},
+						pos:  position{line: 5980, col: 194, offset: 184111},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 212, offset: 182899},
+						pos:  position{line: 5980, col: 212, offset: 184129},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 224, offset: 182911},
+						pos:  position{line: 5980, col: 224, offset: 184141},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 235, offset: 182922},
+						pos:  position{line: 5980, col: 235, offset: 184152},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 248, offset: 182935},
+						pos:  position{line: 5980, col: 248, offset: 184165},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 260, offset: 182947},
+						pos:  position{line: 5980, col: 260, offset: 184177},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 273, offset: 182960},
+						pos:  position{line: 5980, col: 273, offset: 184190},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 288, offset: 182975},
+						pos:  position{line: 5980, col: 288, offset: 184205},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 301, offset: 182988},
+						pos:  position{line: 5980, col: 301, offset: 184218},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 318, offset: 183005},
+						pos:  position{line: 5980, col: 318, offset: 184235},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 328, offset: 183015},
+						pos:  position{line: 5980, col: 328, offset: 184245},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 346, offset: 183033},
+						pos:  position{line: 5980, col: 346, offset: 184263},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 361, offset: 183048},
+						pos:  position{line: 5980, col: 361, offset: 184278},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 376, offset: 183063},
+						pos:  position{line: 5980, col: 376, offset: 184293},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 391, offset: 183078},
+						pos:  position{line: 5980, col: 391, offset: 184308},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 409, offset: 183096},
+						pos:  position{line: 5980, col: 409, offset: 184326},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5941, col: 422, offset: 183109},
+						pos:  position{line: 5980, col: 422, offset: 184339},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14812,18 +14863,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5942, col: 1, offset: 183121},
+			pos:  position{line: 5981, col: 1, offset: 184351},
 			expr: &seqExpr{
-				pos: position{line: 5942, col: 15, offset: 183135},
+				pos: position{line: 5981, col: 15, offset: 184365},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5942, col: 15, offset: 183135},
+						pos:        position{line: 5981, col: 15, offset: 184365},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5942, col: 24, offset: 183144},
+						pos:  position{line: 5981, col: 24, offset: 184374},
 						name: "SPACE",
 					},
 				},
@@ -14831,18 +14882,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5943, col: 1, offset: 183150},
+			pos:  position{line: 5982, col: 1, offset: 184380},
 			expr: &seqExpr{
-				pos: position{line: 5943, col: 14, offset: 183163},
+				pos: position{line: 5982, col: 14, offset: 184393},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5943, col: 14, offset: 183163},
+						pos:        position{line: 5982, col: 14, offset: 184393},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5943, col: 22, offset: 183171},
+						pos:  position{line: 5982, col: 22, offset: 184401},
 						name: "SPACE",
 					},
 				},
@@ -14850,18 +14901,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5944, col: 1, offset: 183177},
+			pos:  position{line: 5983, col: 1, offset: 184407},
 			expr: &seqExpr{
-				pos: position{line: 5944, col: 14, offset: 183190},
+				pos: position{line: 5983, col: 14, offset: 184420},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5944, col: 14, offset: 183190},
+						pos:        position{line: 5983, col: 14, offset: 184420},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5944, col: 22, offset: 183198},
+						pos:  position{line: 5983, col: 22, offset: 184428},
 						name: "SPACE",
 					},
 				},
@@ -14869,18 +14920,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5945, col: 1, offset: 183204},
+			pos:  position{line: 5984, col: 1, offset: 184434},
 			expr: &seqExpr{
-				pos: position{line: 5945, col: 20, offset: 183223},
+				pos: position{line: 5984, col: 20, offset: 184453},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5945, col: 20, offset: 183223},
+						pos:        position{line: 5984, col: 20, offset: 184453},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5945, col: 34, offset: 183237},
+						pos:  position{line: 5984, col: 34, offset: 184467},
 						name: "SPACE",
 					},
 				},
@@ -14888,18 +14939,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5946, col: 1, offset: 183243},
+			pos:  position{line: 5985, col: 1, offset: 184473},
 			expr: &seqExpr{
-				pos: position{line: 5946, col: 15, offset: 183257},
+				pos: position{line: 5985, col: 15, offset: 184487},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5946, col: 15, offset: 183257},
+						pos:        position{line: 5985, col: 15, offset: 184487},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5946, col: 24, offset: 183266},
+						pos:  position{line: 5985, col: 24, offset: 184496},
 						name: "SPACE",
 					},
 				},
@@ -14907,18 +14958,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5947, col: 1, offset: 183272},
+			pos:  position{line: 5986, col: 1, offset: 184502},
 			expr: &seqExpr{
-				pos: position{line: 5947, col: 14, offset: 183285},
+				pos: position{line: 5986, col: 14, offset: 184515},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5947, col: 14, offset: 183285},
+						pos:        position{line: 5986, col: 14, offset: 184515},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5947, col: 22, offset: 183293},
+						pos:  position{line: 5986, col: 22, offset: 184523},
 						name: "SPACE",
 					},
 				},
@@ -14926,9 +14977,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5948, col: 1, offset: 183299},
+			pos:  position{line: 5987, col: 1, offset: 184529},
 			expr: &litMatcher{
-				pos:        position{line: 5948, col: 22, offset: 183320},
+				pos:        position{line: 5987, col: 22, offset: 184550},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14936,16 +14987,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5949, col: 1, offset: 183327},
+			pos:  position{line: 5988, col: 1, offset: 184557},
 			expr: &seqExpr{
-				pos: position{line: 5949, col: 13, offset: 183339},
+				pos: position{line: 5988, col: 13, offset: 184569},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5949, col: 13, offset: 183339},
+						pos:  position{line: 5988, col: 13, offset: 184569},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5949, col: 31, offset: 183357},
+						pos:  position{line: 5988, col: 31, offset: 184587},
 						name: "SPACE",
 					},
 				},
@@ -14953,9 +15004,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5950, col: 1, offset: 183363},
+			pos:  position{line: 5989, col: 1, offset: 184593},
 			expr: &litMatcher{
-				pos:        position{line: 5950, col: 22, offset: 183384},
+				pos:        position{line: 5989, col: 22, offset: 184614},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14963,16 +15014,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5951, col: 1, offset: 183391},
+			pos:  position{line: 5990, col: 1, offset: 184621},
 			expr: &seqExpr{
-				pos: position{line: 5951, col: 13, offset: 183403},
+				pos: position{line: 5990, col: 13, offset: 184633},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5951, col: 13, offset: 183403},
+						pos:  position{line: 5990, col: 13, offset: 184633},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5951, col: 31, offset: 183421},
+						pos:  position{line: 5990, col: 31, offset: 184651},
 						name: "SPACE",
 					},
 				},
@@ -14980,18 +15031,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5952, col: 1, offset: 183427},
+			pos:  position{line: 5991, col: 1, offset: 184657},
 			expr: &seqExpr{
-				pos: position{line: 5952, col: 13, offset: 183439},
+				pos: position{line: 5991, col: 13, offset: 184669},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5952, col: 13, offset: 183439},
+						pos:        position{line: 5991, col: 13, offset: 184669},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5952, col: 20, offset: 183446},
+						pos:  position{line: 5991, col: 20, offset: 184676},
 						name: "SPACE",
 					},
 				},
@@ -14999,18 +15050,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5953, col: 1, offset: 183452},
+			pos:  position{line: 5992, col: 1, offset: 184682},
 			expr: &seqExpr{
-				pos: position{line: 5953, col: 12, offset: 183463},
+				pos: position{line: 5992, col: 12, offset: 184693},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5953, col: 12, offset: 183463},
+						pos:        position{line: 5992, col: 12, offset: 184693},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5953, col: 18, offset: 183469},
+						pos:  position{line: 5992, col: 18, offset: 184699},
 						name: "SPACE",
 					},
 				},
@@ -15018,18 +15069,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5954, col: 1, offset: 183475},
+			pos:  position{line: 5993, col: 1, offset: 184705},
 			expr: &seqExpr{
-				pos: position{line: 5954, col: 13, offset: 183487},
+				pos: position{line: 5993, col: 13, offset: 184717},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5954, col: 13, offset: 183487},
+						pos:        position{line: 5993, col: 13, offset: 184717},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5954, col: 20, offset: 183494},
+						pos:  position{line: 5993, col: 20, offset: 184724},
 						name: "SPACE",
 					},
 				},
@@ -15037,9 +15088,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5955, col: 1, offset: 183500},
+			pos:  position{line: 5994, col: 1, offset: 184730},
 			expr: &litMatcher{
-				pos:        position{line: 5955, col: 12, offset: 183511},
+				pos:        position{line: 5994, col: 12, offset: 184741},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -15047,9 +15098,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5956, col: 1, offset: 183517},
+			pos:  position{line: 5995, col: 1, offset: 184747},
 			expr: &litMatcher{
-				pos:        position{line: 5956, col: 13, offset: 183529},
+				pos:        position{line: 5995, col: 13, offset: 184759},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -15057,18 +15108,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5957, col: 1, offset: 183536},
+			pos:  position{line: 5996, col: 1, offset: 184766},
 			expr: &seqExpr{
-				pos: position{line: 5957, col: 15, offset: 183550},
+				pos: position{line: 5996, col: 15, offset: 184780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5957, col: 15, offset: 183550},
+						pos:        position{line: 5996, col: 15, offset: 184780},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5957, col: 24, offset: 183559},
+						pos:  position{line: 5996, col: 24, offset: 184789},
 						name: "SPACE",
 					},
 				},
@@ -15076,18 +15127,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5958, col: 1, offset: 183565},
+			pos:  position{line: 5997, col: 1, offset: 184795},
 			expr: &seqExpr{
-				pos: position{line: 5958, col: 18, offset: 183582},
+				pos: position{line: 5997, col: 18, offset: 184812},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5958, col: 18, offset: 183582},
+						pos:        position{line: 5997, col: 18, offset: 184812},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5958, col: 30, offset: 183594},
+						pos:  position{line: 5997, col: 30, offset: 184824},
 						name: "SPACE",
 					},
 				},
@@ -15095,18 +15146,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5959, col: 1, offset: 183600},
+			pos:  position{line: 5998, col: 1, offset: 184830},
 			expr: &seqExpr{
-				pos: position{line: 5959, col: 12, offset: 183611},
+				pos: position{line: 5998, col: 12, offset: 184841},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5959, col: 12, offset: 183611},
+						pos:        position{line: 5998, col: 12, offset: 184841},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5959, col: 18, offset: 183617},
+						pos:  position{line: 5998, col: 18, offset: 184847},
 						name: "SPACE",
 					},
 				},
@@ -15114,9 +15165,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5960, col: 1, offset: 183623},
+			pos:  position{line: 5999, col: 1, offset: 184853},
 			expr: &litMatcher{
-				pos:        position{line: 5960, col: 13, offset: 183635},
+				pos:        position{line: 5999, col: 13, offset: 184865},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -15124,18 +15175,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5961, col: 1, offset: 183642},
+			pos:  position{line: 6000, col: 1, offset: 184872},
 			expr: &seqExpr{
-				pos: position{line: 5961, col: 20, offset: 183661},
+				pos: position{line: 6000, col: 20, offset: 184891},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5961, col: 20, offset: 183661},
+						pos:        position{line: 6000, col: 20, offset: 184891},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5961, col: 34, offset: 183675},
+						pos:  position{line: 6000, col: 34, offset: 184905},
 						name: "SPACE",
 					},
 				},
@@ -15143,9 +15194,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5962, col: 1, offset: 183681},
+			pos:  position{line: 6001, col: 1, offset: 184911},
 			expr: &litMatcher{
-				pos:        position{line: 5962, col: 14, offset: 183694},
+				pos:        position{line: 6001, col: 14, offset: 184924},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -15153,22 +15204,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5963, col: 1, offset: 183702},
+			pos:  position{line: 6002, col: 1, offset: 184932},
 			expr: &seqExpr{
-				pos: position{line: 5963, col: 21, offset: 183722},
+				pos: position{line: 6002, col: 21, offset: 184952},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5963, col: 21, offset: 183722},
+						pos:  position{line: 6002, col: 21, offset: 184952},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5963, col: 27, offset: 183728},
+						pos:        position{line: 6002, col: 27, offset: 184958},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5963, col: 36, offset: 183737},
+						pos:  position{line: 6002, col: 36, offset: 184967},
 						name: "SPACE",
 					},
 				},
@@ -15176,9 +15227,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5964, col: 1, offset: 183743},
+			pos:  position{line: 6003, col: 1, offset: 184973},
 			expr: &litMatcher{
-				pos:        position{line: 5964, col: 15, offset: 183757},
+				pos:        position{line: 6003, col: 15, offset: 184987},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -15186,9 +15237,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5965, col: 1, offset: 183766},
+			pos:  position{line: 6004, col: 1, offset: 184996},
 			expr: &litMatcher{
-				pos:        position{line: 5965, col: 14, offset: 183779},
+				pos:        position{line: 6004, col: 14, offset: 185009},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -15196,9 +15247,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5966, col: 1, offset: 183787},
+			pos:  position{line: 6005, col: 1, offset: 185017},
 			expr: &litMatcher{
-				pos:        position{line: 5966, col: 15, offset: 183801},
+				pos:        position{line: 6005, col: 15, offset: 185031},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -15206,9 +15257,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5967, col: 1, offset: 183810},
+			pos:  position{line: 6006, col: 1, offset: 185040},
 			expr: &litMatcher{
-				pos:        position{line: 5967, col: 17, offset: 183826},
+				pos:        position{line: 6006, col: 17, offset: 185056},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -15216,9 +15267,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5968, col: 1, offset: 183837},
+			pos:  position{line: 6007, col: 1, offset: 185067},
 			expr: &litMatcher{
-				pos:        position{line: 5968, col: 15, offset: 183851},
+				pos:        position{line: 6007, col: 15, offset: 185081},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -15226,9 +15277,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5969, col: 1, offset: 183860},
+			pos:  position{line: 6008, col: 1, offset: 185090},
 			expr: &litMatcher{
-				pos:        position{line: 5969, col: 19, offset: 183878},
+				pos:        position{line: 6008, col: 19, offset: 185108},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -15236,9 +15287,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5970, col: 1, offset: 183891},
+			pos:  position{line: 6009, col: 1, offset: 185121},
 			expr: &litMatcher{
-				pos:        position{line: 5970, col: 17, offset: 183907},
+				pos:        position{line: 6009, col: 17, offset: 185137},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -15246,9 +15297,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5971, col: 1, offset: 183918},
+			pos:  position{line: 6010, col: 1, offset: 185148},
 			expr: &litMatcher{
-				pos:        position{line: 5971, col: 17, offset: 183934},
+				pos:        position{line: 6010, col: 17, offset: 185164},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15256,18 +15307,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5972, col: 1, offset: 183945},
+			pos:  position{line: 6011, col: 1, offset: 185175},
 			expr: &seqExpr{
-				pos: position{line: 5972, col: 20, offset: 183964},
+				pos: position{line: 6011, col: 20, offset: 185194},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5972, col: 20, offset: 183964},
+						pos:        position{line: 6011, col: 20, offset: 185194},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5972, col: 34, offset: 183978},
+						pos:  position{line: 6011, col: 34, offset: 185208},
 						name: "SPACE",
 					},
 				},
@@ -15275,28 +15326,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5973, col: 1, offset: 183984},
+			pos:  position{line: 6012, col: 1, offset: 185214},
 			expr: &seqExpr{
-				pos: position{line: 5973, col: 16, offset: 183999},
+				pos: position{line: 6012, col: 16, offset: 185229},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5973, col: 16, offset: 183999},
+						pos: position{line: 6012, col: 16, offset: 185229},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5973, col: 16, offset: 183999},
+							pos:  position{line: 6012, col: 16, offset: 185229},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5973, col: 24, offset: 184007},
+						pos: position{line: 6012, col: 24, offset: 185237},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5973, col: 24, offset: 184007},
+								pos:        position{line: 6012, col: 24, offset: 185237},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5973, col: 30, offset: 184013},
+								pos:        position{line: 6012, col: 30, offset: 185243},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15304,9 +15355,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5973, col: 35, offset: 184018},
+						pos: position{line: 6012, col: 35, offset: 185248},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5973, col: 35, offset: 184018},
+							pos:  position{line: 6012, col: 35, offset: 185248},
 							name: "SPACE",
 						},
 					},
@@ -15315,9 +15366,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5974, col: 1, offset: 184025},
+			pos:  position{line: 6013, col: 1, offset: 185255},
 			expr: &litMatcher{
-				pos:        position{line: 5974, col: 17, offset: 184041},
+				pos:        position{line: 6013, col: 17, offset: 185271},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15325,18 +15376,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5975, col: 1, offset: 184052},
+			pos:  position{line: 6014, col: 1, offset: 185282},
 			expr: &seqExpr{
-				pos: position{line: 5975, col: 15, offset: 184066},
+				pos: position{line: 6014, col: 15, offset: 185296},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5975, col: 15, offset: 184066},
+						pos:        position{line: 6014, col: 15, offset: 185296},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5975, col: 24, offset: 184075},
+						pos:  position{line: 6014, col: 24, offset: 185305},
 						name: "SPACE",
 					},
 				},
@@ -15344,9 +15395,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5976, col: 1, offset: 184081},
+			pos:  position{line: 6015, col: 1, offset: 185311},
 			expr: &litMatcher{
-				pos:        position{line: 5976, col: 15, offset: 184095},
+				pos:        position{line: 6015, col: 15, offset: 185325},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15354,115 +15405,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5979, col: 1, offset: 184208},
+			pos:  position{line: 6018, col: 1, offset: 185438},
 			expr: &choiceExpr{
-				pos: position{line: 5979, col: 16, offset: 184223},
+				pos: position{line: 6018, col: 16, offset: 185453},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5979, col: 16, offset: 184223},
+						pos:        position{line: 6018, col: 16, offset: 185453},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5979, col: 47, offset: 184254},
+						pos:        position{line: 6018, col: 47, offset: 185484},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5979, col: 55, offset: 184262},
+						pos:        position{line: 6018, col: 55, offset: 185492},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 16, offset: 184285},
+						pos:        position{line: 6019, col: 16, offset: 185515},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 26, offset: 184295},
+						pos:        position{line: 6019, col: 26, offset: 185525},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 34, offset: 184303},
+						pos:        position{line: 6019, col: 34, offset: 185533},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 42, offset: 184311},
+						pos:        position{line: 6019, col: 42, offset: 185541},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 50, offset: 184319},
+						pos:        position{line: 6019, col: 50, offset: 185549},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 58, offset: 184327},
+						pos:        position{line: 6019, col: 58, offset: 185557},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5980, col: 66, offset: 184335},
+						pos:        position{line: 6019, col: 66, offset: 185565},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 16, offset: 184357},
+						pos:        position{line: 6020, col: 16, offset: 185587},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 26, offset: 184367},
+						pos:        position{line: 6020, col: 26, offset: 185597},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 34, offset: 184375},
+						pos:        position{line: 6020, col: 34, offset: 185605},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 42, offset: 184383},
+						pos:        position{line: 6020, col: 42, offset: 185613},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 50, offset: 184391},
+						pos:        position{line: 6020, col: 50, offset: 185621},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 58, offset: 184399},
+						pos:        position{line: 6020, col: 58, offset: 185629},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 66, offset: 184407},
+						pos:        position{line: 6020, col: 66, offset: 185637},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5981, col: 74, offset: 184415},
+						pos:        position{line: 6020, col: 74, offset: 185645},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15472,25 +15523,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5982, col: 1, offset: 184421},
+			pos:  position{line: 6021, col: 1, offset: 185651},
 			expr: &choiceExpr{
-				pos: position{line: 5982, col: 16, offset: 184436},
+				pos: position{line: 6021, col: 16, offset: 185666},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5982, col: 16, offset: 184436},
+						pos:        position{line: 6021, col: 16, offset: 185666},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5982, col: 30, offset: 184450},
+						pos:        position{line: 6021, col: 30, offset: 185680},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5982, col: 36, offset: 184456},
+						pos:        position{line: 6021, col: 36, offset: 185686},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15500,18 +15551,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5986, col: 1, offset: 184612},
+			pos:  position{line: 6025, col: 1, offset: 185842},
 			expr: &seqExpr{
-				pos: position{line: 5986, col: 8, offset: 184619},
+				pos: position{line: 6025, col: 8, offset: 185849},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5986, col: 8, offset: 184619},
+						pos:        position{line: 6025, col: 8, offset: 185849},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5986, col: 14, offset: 184625},
+						pos:  position{line: 6025, col: 14, offset: 185855},
 						name: "SPACE",
 					},
 				},
@@ -15519,22 +15570,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5987, col: 1, offset: 184631},
+			pos:  position{line: 6026, col: 1, offset: 185861},
 			expr: &seqExpr{
-				pos: position{line: 5987, col: 7, offset: 184637},
+				pos: position{line: 6026, col: 7, offset: 185867},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5987, col: 7, offset: 184637},
+						pos:  position{line: 6026, col: 7, offset: 185867},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5987, col: 13, offset: 184643},
+						pos:        position{line: 6026, col: 13, offset: 185873},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5987, col: 18, offset: 184648},
+						pos:  position{line: 6026, col: 18, offset: 185878},
 						name: "SPACE",
 					},
 				},
@@ -15542,22 +15593,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5988, col: 1, offset: 184654},
+			pos:  position{line: 6027, col: 1, offset: 185884},
 			expr: &seqExpr{
-				pos: position{line: 5988, col: 8, offset: 184661},
+				pos: position{line: 6027, col: 8, offset: 185891},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5988, col: 8, offset: 184661},
+						pos:  position{line: 6027, col: 8, offset: 185891},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5988, col: 14, offset: 184667},
+						pos:        position{line: 6027, col: 14, offset: 185897},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5988, col: 20, offset: 184673},
+						pos:  position{line: 6027, col: 20, offset: 185903},
 						name: "SPACE",
 					},
 				},
@@ -15565,22 +15616,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5989, col: 1, offset: 184679},
+			pos:  position{line: 6028, col: 1, offset: 185909},
 			expr: &seqExpr{
-				pos: position{line: 5989, col: 9, offset: 184687},
+				pos: position{line: 6028, col: 9, offset: 185917},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5989, col: 9, offset: 184687},
+						pos:  position{line: 6028, col: 9, offset: 185917},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5989, col: 24, offset: 184702},
+						pos:        position{line: 6028, col: 24, offset: 185932},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5989, col: 28, offset: 184706},
+						pos:  position{line: 6028, col: 28, offset: 185936},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15588,22 +15639,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5990, col: 1, offset: 184721},
+			pos:  position{line: 6029, col: 1, offset: 185951},
 			expr: &seqExpr{
-				pos: position{line: 5990, col: 7, offset: 184727},
+				pos: position{line: 6029, col: 7, offset: 185957},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5990, col: 7, offset: 184727},
+						pos:  position{line: 6029, col: 7, offset: 185957},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5990, col: 13, offset: 184733},
+						pos:        position{line: 6029, col: 13, offset: 185963},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5990, col: 19, offset: 184739},
+						pos:  position{line: 6029, col: 19, offset: 185969},
 						name: "SPACE",
 					},
 				},
@@ -15611,22 +15662,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5991, col: 1, offset: 184765},
+			pos:  position{line: 6030, col: 1, offset: 185995},
 			expr: &seqExpr{
-				pos: position{line: 5991, col: 7, offset: 184771},
+				pos: position{line: 6030, col: 7, offset: 186001},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5991, col: 7, offset: 184771},
+						pos:  position{line: 6030, col: 7, offset: 186001},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5991, col: 13, offset: 184777},
+						pos:        position{line: 6030, col: 13, offset: 186007},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5991, col: 19, offset: 184783},
+						pos:  position{line: 6030, col: 19, offset: 186013},
 						name: "SPACE",
 					},
 				},
@@ -15634,22 +15685,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5993, col: 1, offset: 184810},
+			pos:  position{line: 6032, col: 1, offset: 186040},
 			expr: &seqExpr{
-				pos: position{line: 5993, col: 10, offset: 184819},
+				pos: position{line: 6032, col: 10, offset: 186049},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5993, col: 10, offset: 184819},
+						pos:  position{line: 6032, col: 10, offset: 186049},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5993, col: 25, offset: 184834},
+						pos:        position{line: 6032, col: 25, offset: 186064},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5993, col: 29, offset: 184838},
+						pos:  position{line: 6032, col: 29, offset: 186068},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15657,22 +15708,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5994, col: 1, offset: 184853},
+			pos:  position{line: 6033, col: 1, offset: 186083},
 			expr: &seqExpr{
-				pos: position{line: 5994, col: 10, offset: 184862},
+				pos: position{line: 6033, col: 10, offset: 186092},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5994, col: 10, offset: 184862},
+						pos:  position{line: 6033, col: 10, offset: 186092},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5994, col: 25, offset: 184877},
+						pos:        position{line: 6033, col: 25, offset: 186107},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5994, col: 29, offset: 184881},
+						pos:  position{line: 6033, col: 29, offset: 186111},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15680,9 +15731,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5995, col: 1, offset: 184896},
+			pos:  position{line: 6034, col: 1, offset: 186126},
 			expr: &litMatcher{
-				pos:        position{line: 5995, col: 10, offset: 184905},
+				pos:        position{line: 6034, col: 10, offset: 186135},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15690,18 +15741,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5996, col: 1, offset: 184909},
+			pos:  position{line: 6035, col: 1, offset: 186139},
 			expr: &seqExpr{
-				pos: position{line: 5996, col: 12, offset: 184920},
+				pos: position{line: 6035, col: 12, offset: 186150},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5996, col: 12, offset: 184920},
+						pos:        position{line: 6035, col: 12, offset: 186150},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5996, col: 16, offset: 184924},
+						pos:  position{line: 6035, col: 16, offset: 186154},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15709,16 +15760,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5997, col: 1, offset: 184939},
+			pos:  position{line: 6036, col: 1, offset: 186169},
 			expr: &seqExpr{
-				pos: position{line: 5997, col: 12, offset: 184950},
+				pos: position{line: 6036, col: 12, offset: 186180},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5997, col: 12, offset: 184950},
+						pos:  position{line: 6036, col: 12, offset: 186180},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5997, col: 27, offset: 184965},
+						pos:        position{line: 6036, col: 27, offset: 186195},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15728,40 +15779,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5999, col: 1, offset: 184970},
+			pos:  position{line: 6038, col: 1, offset: 186200},
 			expr: &notExpr{
-				pos: position{line: 5999, col: 8, offset: 184977},
+				pos: position{line: 6038, col: 8, offset: 186207},
 				expr: &anyMatcher{
-					line: 5999, col: 9, offset: 184978,
+					line: 6038, col: 9, offset: 186208,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 6000, col: 1, offset: 184980},
+			pos:  position{line: 6039, col: 1, offset: 186210},
 			expr: &choiceExpr{
-				pos: position{line: 6000, col: 15, offset: 184994},
+				pos: position{line: 6039, col: 15, offset: 186224},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 6000, col: 15, offset: 184994},
+						pos:        position{line: 6039, col: 15, offset: 186224},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 6000, col: 21, offset: 185000},
+						pos:        position{line: 6039, col: 21, offset: 186230},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6000, col: 28, offset: 185007},
+						pos:        position{line: 6039, col: 28, offset: 186237},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6000, col: 35, offset: 185014},
+						pos:        position{line: 6039, col: 35, offset: 186244},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15771,37 +15822,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 6001, col: 1, offset: 185019},
+			pos:  position{line: 6040, col: 1, offset: 186249},
 			expr: &choiceExpr{
-				pos: position{line: 6001, col: 10, offset: 185028},
+				pos: position{line: 6040, col: 10, offset: 186258},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 6001, col: 11, offset: 185029},
+						pos: position{line: 6040, col: 11, offset: 186259},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 6001, col: 11, offset: 185029},
+								pos: position{line: 6040, col: 11, offset: 186259},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6001, col: 11, offset: 185029},
+									pos:  position{line: 6040, col: 11, offset: 186259},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 6001, col: 23, offset: 185041},
+								pos:  position{line: 6040, col: 23, offset: 186271},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 6001, col: 31, offset: 185049},
+								pos: position{line: 6040, col: 31, offset: 186279},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6001, col: 31, offset: 185049},
+									pos:  position{line: 6040, col: 31, offset: 186279},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 6001, col: 46, offset: 185064},
+						pos: position{line: 6040, col: 46, offset: 186294},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6001, col: 46, offset: 185064},
+							pos:  position{line: 6040, col: 46, offset: 186294},
 							name: "WHITESPACE",
 						},
 					},
@@ -15810,38 +15861,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 6002, col: 1, offset: 185076},
+			pos:  position{line: 6041, col: 1, offset: 186306},
 			expr: &seqExpr{
-				pos: position{line: 6002, col: 12, offset: 185087},
+				pos: position{line: 6041, col: 12, offset: 186317},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6002, col: 12, offset: 185087},
+						pos:        position{line: 6041, col: 12, offset: 186317},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 6002, col: 18, offset: 185093},
+						pos: position{line: 6041, col: 18, offset: 186323},
 						expr: &seqExpr{
-							pos: position{line: 6002, col: 19, offset: 185094},
+							pos: position{line: 6041, col: 19, offset: 186324},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 6002, col: 19, offset: 185094},
+									pos: position{line: 6041, col: 19, offset: 186324},
 									expr: &litMatcher{
-										pos:        position{line: 6002, col: 21, offset: 185096},
+										pos:        position{line: 6041, col: 21, offset: 186326},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 6002, col: 28, offset: 185103,
+									line: 6041, col: 28, offset: 186333,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 6002, col: 32, offset: 185107},
+						pos:        position{line: 6041, col: 32, offset: 186337},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15851,16 +15902,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 6003, col: 1, offset: 185113},
+			pos:  position{line: 6042, col: 1, offset: 186343},
 			expr: &choiceExpr{
-				pos: position{line: 6003, col: 20, offset: 185132},
+				pos: position{line: 6042, col: 20, offset: 186362},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6003, col: 20, offset: 185132},
+						pos:  position{line: 6042, col: 20, offset: 186362},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6003, col: 28, offset: 185140},
+						pos:        position{line: 6042, col: 28, offset: 186370},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15870,16 +15921,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 6004, col: 1, offset: 185143},
+			pos:  position{line: 6043, col: 1, offset: 186373},
 			expr: &choiceExpr{
-				pos: position{line: 6004, col: 19, offset: 185161},
+				pos: position{line: 6043, col: 19, offset: 186391},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6004, col: 19, offset: 185161},
+						pos:  position{line: 6043, col: 19, offset: 186391},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6004, col: 27, offset: 185169},
+						pos:  position{line: 6043, col: 27, offset: 186399},
 						name: "SPACE",
 					},
 				},
@@ -20467,6 +20518,52 @@ func (p *parser) callonJsonExpr27() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onJsonExpr27(stack["opName"], stack["json"], stack["path"], stack["value"], stack["rest"])
+}
+
+func (c *current) onJsonExpr48(value, rest any) (any, error) {
+	castedValue, ok := value.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
+	}
+
+	args := make([]*structs.JsonExpr, 1, 5)
+	args[0] = castedValue
+
+	if rest != nil {
+		var restValue *structs.JsonExpr
+		for idx, arg := range rest.([]any) {
+			restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+			}
+			args = append(args, restValue)
+		}
+	}
+
+	var result *structs.JsonExpr
+	var err error
+	if len(args) == 1 {
+		result, err = createJsonExprAst("json_array", args[0], nil, structs.JEMExpr)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		result = args[0]
+		for i := 1; i < len(args); i++ {
+			result, err = createJsonExprAst("json_array", result, args[i], structs.JEMExpr)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr48() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr48(stack["value"], stack["rest"])
 }
 
 func (c *current) onLenExpr2(str any) (any, error) {

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -308,6 +308,14 @@ func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs
 	}, nil
 }
 
+func getRawValJsonObjectKey(key *structs.JsonExpr) string {
+	if key.JsonExprMode == structs.JEMField {
+		return key.FieldValue
+	} else {
+		return key.InputString.RawString
+	}
+}
+
 func transferUint8ToString(opName interface{}) (string, error) {
 	strData, ok := opName.([]byte)
 	if !ok {
@@ -554,177 +562,177 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 542, col: 1, offset: 15307},
+			pos:  position{line: 550, col: 1, offset: 15507},
 			expr: &choiceExpr{
-				pos: position{line: 542, col: 10, offset: 15316},
+				pos: position{line: 550, col: 10, offset: 15516},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 542, col: 10, offset: 15316},
+						pos: position{line: 550, col: 10, offset: 15516},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 542, col: 10, offset: 15316},
+							pos: position{line: 550, col: 10, offset: 15516},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 542, col: 10, offset: 15316},
+									pos:   position{line: 550, col: 10, offset: 15516},
 									label: "indexBlock",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 542, col: 21, offset: 15327},
+										pos: position{line: 550, col: 21, offset: 15527},
 										expr: &ruleRefExpr{
-											pos:  position{line: 542, col: 22, offset: 15328},
+											pos:  position{line: 550, col: 22, offset: 15528},
 											name: "IndexBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 542, col: 35, offset: 15341},
+									pos: position{line: 550, col: 35, offset: 15541},
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 35, offset: 15341},
+										pos:  position{line: 550, col: 35, offset: 15541},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 542, col: 42, offset: 15348},
+									pos:   position{line: 550, col: 42, offset: 15548},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 57, offset: 15363},
+										pos:  position{line: 550, col: 57, offset: 15563},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 542, col: 77, offset: 15383},
+									pos:   position{line: 550, col: 77, offset: 15583},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 542, col: 90, offset: 15396},
+										pos: position{line: 550, col: 90, offset: 15596},
 										expr: &ruleRefExpr{
-											pos:  position{line: 542, col: 91, offset: 15397},
+											pos:  position{line: 550, col: 91, offset: 15597},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 542, col: 105, offset: 15411},
+									pos:   position{line: 550, col: 105, offset: 15611},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 542, col: 120, offset: 15426},
+										pos: position{line: 550, col: 120, offset: 15626},
 										expr: &ruleRefExpr{
-											pos:  position{line: 542, col: 121, offset: 15427},
+											pos:  position{line: 550, col: 121, offset: 15627},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 542, col: 144, offset: 15450},
+									pos: position{line: 550, col: 144, offset: 15650},
 									expr: &ruleRefExpr{
-										pos:  position{line: 542, col: 144, offset: 15450},
+										pos:  position{line: 550, col: 144, offset: 15650},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 542, col: 151, offset: 15457},
+									pos:  position{line: 550, col: 151, offset: 15657},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 608, col: 3, offset: 17380},
+						pos: position{line: 616, col: 3, offset: 17580},
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
-							pos: position{line: 608, col: 3, offset: 17380},
+							pos: position{line: 616, col: 3, offset: 17580},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 608, col: 3, offset: 17380},
+									pos: position{line: 616, col: 3, offset: 17580},
 									expr: &ruleRefExpr{
-										pos:  position{line: 608, col: 3, offset: 17380},
+										pos:  position{line: 616, col: 3, offset: 17580},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 10, offset: 17387},
+									pos:  position{line: 616, col: 10, offset: 17587},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 15, offset: 17392},
+									pos:  position{line: 616, col: 15, offset: 17592},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 28, offset: 17405},
+									pos:  position{line: 616, col: 28, offset: 17605},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 608, col: 34, offset: 17411},
+									pos:   position{line: 616, col: 34, offset: 17611},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 608, col: 50, offset: 17427},
+										pos:  position{line: 616, col: 50, offset: 17627},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 608, col: 70, offset: 17447},
+									pos:   position{line: 616, col: 70, offset: 17647},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 608, col: 85, offset: 17462},
+										pos: position{line: 616, col: 85, offset: 17662},
 										expr: &ruleRefExpr{
-											pos:  position{line: 608, col: 86, offset: 17463},
+											pos:  position{line: 616, col: 86, offset: 17663},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 608, col: 109, offset: 17486},
+									pos: position{line: 616, col: 109, offset: 17686},
 									expr: &ruleRefExpr{
-										pos:  position{line: 608, col: 109, offset: 17486},
+										pos:  position{line: 616, col: 109, offset: 17686},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 608, col: 116, offset: 17493},
+									pos:  position{line: 616, col: 116, offset: 17693},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 627, col: 3, offset: 18006},
+						pos: position{line: 635, col: 3, offset: 18206},
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
-							pos: position{line: 627, col: 3, offset: 18006},
+							pos: position{line: 635, col: 3, offset: 18206},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 627, col: 3, offset: 18006},
+									pos: position{line: 635, col: 3, offset: 18206},
 									expr: &ruleRefExpr{
-										pos:  position{line: 627, col: 3, offset: 18006},
+										pos:  position{line: 635, col: 3, offset: 18206},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 627, col: 10, offset: 18013},
+									pos:   position{line: 635, col: 10, offset: 18213},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 627, col: 22, offset: 18025},
+										pos:  position{line: 635, col: 22, offset: 18225},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 627, col: 39, offset: 18042},
+									pos:   position{line: 635, col: 39, offset: 18242},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 627, col: 54, offset: 18057},
+										pos: position{line: 635, col: 54, offset: 18257},
 										expr: &ruleRefExpr{
-											pos:  position{line: 627, col: 55, offset: 18058},
+											pos:  position{line: 635, col: 55, offset: 18258},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 627, col: 78, offset: 18081},
+									pos: position{line: 635, col: 78, offset: 18281},
 									expr: &ruleRefExpr{
-										pos:  position{line: 627, col: 78, offset: 18081},
+										pos:  position{line: 635, col: 78, offset: 18281},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 627, col: 85, offset: 18088},
+									pos:  position{line: 635, col: 85, offset: 18288},
 									name: "EOF",
 								},
 							},
@@ -735,32 +743,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexAssign",
-			pos:  position{line: 643, col: 1, offset: 18470},
+			pos:  position{line: 651, col: 1, offset: 18670},
 			expr: &actionExpr{
-				pos: position{line: 643, col: 16, offset: 18485},
+				pos: position{line: 651, col: 16, offset: 18685},
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
-					pos: position{line: 643, col: 16, offset: 18485},
+					pos: position{line: 651, col: 16, offset: 18685},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 643, col: 16, offset: 18485},
+							pos:   position{line: 651, col: 16, offset: 18685},
 							label: "index",
 							expr: &litMatcher{
-								pos:        position{line: 643, col: 23, offset: 18492},
+								pos:        position{line: 651, col: 23, offset: 18692},
 								val:        "_index",
 								ignoreCase: false,
 								want:       "\"_index\"",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 643, col: 33, offset: 18502},
+							pos:  position{line: 651, col: 33, offset: 18702},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 643, col: 39, offset: 18508},
+							pos:   position{line: 651, col: 39, offset: 18708},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 643, col: 49, offset: 18518},
+								pos:  position{line: 651, col: 49, offset: 18718},
 								name: "String",
 							},
 						},
@@ -770,35 +778,35 @@ var g = &grammar{
 		},
 		{
 			name: "IndexExpression",
-			pos:  position{line: 648, col: 1, offset: 18707},
+			pos:  position{line: 656, col: 1, offset: 18907},
 			expr: &actionExpr{
-				pos: position{line: 648, col: 20, offset: 18726},
+				pos: position{line: 656, col: 20, offset: 18926},
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
-					pos: position{line: 648, col: 20, offset: 18726},
+					pos: position{line: 656, col: 20, offset: 18926},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 648, col: 20, offset: 18726},
+							pos:   position{line: 656, col: 20, offset: 18926},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 648, col: 27, offset: 18733},
+								pos:  position{line: 656, col: 27, offset: 18933},
 								name: "IndexAssign",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 648, col: 40, offset: 18746},
+							pos:   position{line: 656, col: 40, offset: 18946},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 648, col: 45, offset: 18751},
+								pos: position{line: 656, col: 45, offset: 18951},
 								expr: &seqExpr{
-									pos: position{line: 648, col: 46, offset: 18752},
+									pos: position{line: 656, col: 46, offset: 18952},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 648, col: 46, offset: 18752},
+											pos:  position{line: 656, col: 46, offset: 18952},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 648, col: 49, offset: 18755},
+											pos:  position{line: 656, col: 49, offset: 18955},
 											name: "IndexAssign",
 										},
 									},
@@ -811,32 +819,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexBlock",
-			pos:  position{line: 673, col: 1, offset: 19336},
+			pos:  position{line: 681, col: 1, offset: 19536},
 			expr: &actionExpr{
-				pos: position{line: 673, col: 15, offset: 19350},
+				pos: position{line: 681, col: 15, offset: 19550},
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 673, col: 15, offset: 19350},
+					pos: position{line: 681, col: 15, offset: 19550},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 673, col: 15, offset: 19350},
+							pos: position{line: 681, col: 15, offset: 19550},
 							expr: &ruleRefExpr{
-								pos:  position{line: 673, col: 15, offset: 19350},
+								pos:  position{line: 681, col: 15, offset: 19550},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 673, col: 22, offset: 19357},
+							pos:   position{line: 681, col: 22, offset: 19557},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 673, col: 33, offset: 19368},
+								pos:  position{line: 681, col: 33, offset: 19568},
 								name: "IndexExpression",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 673, col: 50, offset: 19385},
+							pos: position{line: 681, col: 50, offset: 19585},
 							expr: &ruleRefExpr{
-								pos:  position{line: 673, col: 50, offset: 19385},
+								pos:  position{line: 681, col: 50, offset: 19585},
 								name: "PIPE",
 							},
 						},
@@ -846,76 +854,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 677, col: 1, offset: 19422},
+			pos:  position{line: 685, col: 1, offset: 19622},
 			expr: &actionExpr{
-				pos: position{line: 677, col: 21, offset: 19442},
+				pos: position{line: 685, col: 21, offset: 19642},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 677, col: 21, offset: 19442},
+					pos: position{line: 685, col: 21, offset: 19642},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 677, col: 21, offset: 19442},
+							pos:        position{line: 685, col: 21, offset: 19642},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 677, col: 26, offset: 19447},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 677, col: 32, offset: 19453},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 677, col: 36, offset: 19457},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 677, col: 41, offset: 19462},
+							pos:        position{line: 685, col: 26, offset: 19647},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 677, col: 47, offset: 19468},
+							pos:        position{line: 685, col: 32, offset: 19653},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 677, col: 51, offset: 19472},
+							pos:        position{line: 685, col: 36, offset: 19657},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 677, col: 56, offset: 19477},
+							pos:        position{line: 685, col: 41, offset: 19662},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 685, col: 47, offset: 19668},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 685, col: 51, offset: 19672},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 677, col: 61, offset: 19482},
+							pos:        position{line: 685, col: 56, offset: 19677},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 677, col: 66, offset: 19487},
+							pos:        position{line: 685, col: 61, offset: 19682},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 685, col: 66, offset: 19687},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -927,15 +935,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 684, col: 1, offset: 19628},
+			pos:  position{line: 692, col: 1, offset: 19828},
 			expr: &actionExpr{
-				pos: position{line: 684, col: 31, offset: 19658},
+				pos: position{line: 692, col: 31, offset: 19858},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 684, col: 31, offset: 19658},
+					pos:   position{line: 692, col: 31, offset: 19858},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 684, col: 38, offset: 19665},
+						pos:  position{line: 692, col: 38, offset: 19865},
 						name: "IntegerAsString",
 					},
 				},
@@ -943,22 +951,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 702, col: 1, offset: 20308},
+			pos:  position{line: 710, col: 1, offset: 20508},
 			expr: &actionExpr{
-				pos: position{line: 702, col: 26, offset: 20333},
+				pos: position{line: 710, col: 26, offset: 20533},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 702, col: 26, offset: 20333},
+					pos:   position{line: 710, col: 26, offset: 20533},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 702, col: 37, offset: 20344},
+						pos: position{line: 710, col: 37, offset: 20544},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 702, col: 37, offset: 20344},
+								pos:  position{line: 710, col: 37, offset: 20544},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 702, col: 53, offset: 20360},
+								pos:  position{line: 710, col: 53, offset: 20560},
 								name: "PartialTimestamp",
 							},
 						},
@@ -968,22 +976,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 711, col: 1, offset: 20618},
+			pos:  position{line: 719, col: 1, offset: 20818},
 			expr: &actionExpr{
-				pos: position{line: 711, col: 17, offset: 20634},
+				pos: position{line: 719, col: 17, offset: 20834},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 711, col: 17, offset: 20634},
+					pos:   position{line: 719, col: 17, offset: 20834},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 711, col: 31, offset: 20648},
+						pos: position{line: 719, col: 31, offset: 20848},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 711, col: 31, offset: 20648},
+								pos:  position{line: 719, col: 31, offset: 20848},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 711, col: 55, offset: 20672},
+								pos:  position{line: 719, col: 55, offset: 20872},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -993,28 +1001,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 715, col: 1, offset: 20734},
+			pos:  position{line: 723, col: 1, offset: 20934},
 			expr: &actionExpr{
-				pos: position{line: 715, col: 22, offset: 20755},
+				pos: position{line: 723, col: 22, offset: 20955},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 715, col: 22, offset: 20755},
+					pos: position{line: 723, col: 22, offset: 20955},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 715, col: 22, offset: 20755},
+							pos:        position{line: 723, col: 22, offset: 20955},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 715, col: 28, offset: 20761},
+							pos:  position{line: 723, col: 28, offset: 20961},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 715, col: 34, offset: 20767},
+							pos:   position{line: 723, col: 34, offset: 20967},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 715, col: 45, offset: 20778},
+								pos:  position{line: 723, col: 45, offset: 20978},
 								name: "GenTimestamp",
 							},
 						},
@@ -1024,28 +1032,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 724, col: 1, offset: 20968},
+			pos:  position{line: 732, col: 1, offset: 21168},
 			expr: &actionExpr{
-				pos: position{line: 724, col: 24, offset: 20991},
+				pos: position{line: 732, col: 24, offset: 21191},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 724, col: 24, offset: 20991},
+					pos: position{line: 732, col: 24, offset: 21191},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 724, col: 24, offset: 20991},
+							pos:        position{line: 732, col: 24, offset: 21191},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 724, col: 32, offset: 20999},
+							pos:  position{line: 732, col: 32, offset: 21199},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 724, col: 38, offset: 21005},
+							pos:   position{line: 732, col: 38, offset: 21205},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 724, col: 49, offset: 21016},
+								pos:  position{line: 732, col: 49, offset: 21216},
 								name: "GenTimestamp",
 							},
 						},
@@ -1055,59 +1063,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 733, col: 1, offset: 21210},
+			pos:  position{line: 741, col: 1, offset: 21410},
 			expr: &actionExpr{
-				pos: position{line: 733, col: 28, offset: 21237},
+				pos: position{line: 741, col: 28, offset: 21437},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 733, col: 28, offset: 21237},
+					pos: position{line: 741, col: 28, offset: 21437},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 733, col: 28, offset: 21237},
+							pos:        position{line: 741, col: 28, offset: 21437},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 733, col: 40, offset: 21249},
+							pos:  position{line: 741, col: 40, offset: 21449},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 733, col: 46, offset: 21255},
+							pos:   position{line: 741, col: 46, offset: 21455},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 733, col: 53, offset: 21262},
+								pos:  position{line: 741, col: 53, offset: 21462},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 733, col: 69, offset: 21278},
+							pos:   position{line: 741, col: 69, offset: 21478},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 733, col: 77, offset: 21286},
+								pos: position{line: 741, col: 77, offset: 21486},
 								expr: &choiceExpr{
-									pos: position{line: 733, col: 78, offset: 21287},
+									pos: position{line: 741, col: 78, offset: 21487},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 733, col: 78, offset: 21287},
+											pos:        position{line: 741, col: 78, offset: 21487},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 733, col: 84, offset: 21293},
+											pos:        position{line: 741, col: 84, offset: 21493},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 733, col: 90, offset: 21299},
+											pos:        position{line: 741, col: 90, offset: 21499},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 733, col: 96, offset: 21305},
+											pos:        position{line: 741, col: 96, offset: 21505},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -1122,26 +1130,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 774, col: 1, offset: 22457},
+			pos:  position{line: 782, col: 1, offset: 22657},
 			expr: &actionExpr{
-				pos: position{line: 774, col: 19, offset: 22475},
+				pos: position{line: 782, col: 19, offset: 22675},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 774, col: 19, offset: 22475},
+					pos:   position{line: 782, col: 19, offset: 22675},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 774, col: 35, offset: 22491},
+						pos: position{line: 782, col: 35, offset: 22691},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 774, col: 35, offset: 22491},
+								pos:  position{line: 782, col: 35, offset: 22691},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 774, col: 55, offset: 22511},
+								pos:  position{line: 782, col: 55, offset: 22711},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 774, col: 77, offset: 22533},
+								pos:  position{line: 782, col: 77, offset: 22733},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -1151,35 +1159,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 778, col: 1, offset: 22594},
+			pos:  position{line: 786, col: 1, offset: 22794},
 			expr: &actionExpr{
-				pos: position{line: 778, col: 23, offset: 22616},
+				pos: position{line: 786, col: 23, offset: 22816},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 778, col: 23, offset: 22616},
+					pos: position{line: 786, col: 23, offset: 22816},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 778, col: 23, offset: 22616},
+							pos:   position{line: 786, col: 23, offset: 22816},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 778, col: 29, offset: 22622},
+								pos:  position{line: 786, col: 29, offset: 22822},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 778, col: 44, offset: 22637},
+							pos:   position{line: 786, col: 44, offset: 22837},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 778, col: 49, offset: 22642},
+								pos: position{line: 786, col: 49, offset: 22842},
 								expr: &seqExpr{
-									pos: position{line: 778, col: 50, offset: 22643},
+									pos: position{line: 786, col: 50, offset: 22843},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 778, col: 50, offset: 22643},
+											pos:  position{line: 786, col: 50, offset: 22843},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 778, col: 56, offset: 22649},
+											pos:  position{line: 786, col: 56, offset: 22849},
 											name: "GenTimesOption",
 										},
 									},
@@ -1192,25 +1200,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 830, col: 1, offset: 24402},
+			pos:  position{line: 838, col: 1, offset: 24602},
 			expr: &actionExpr{
-				pos: position{line: 830, col: 23, offset: 24424},
+				pos: position{line: 838, col: 23, offset: 24624},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 830, col: 23, offset: 24424},
+					pos: position{line: 838, col: 23, offset: 24624},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 830, col: 23, offset: 24424},
+							pos: position{line: 838, col: 23, offset: 24624},
 							expr: &ruleRefExpr{
-								pos:  position{line: 830, col: 23, offset: 24424},
+								pos:  position{line: 838, col: 23, offset: 24624},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 830, col: 35, offset: 24436},
+							pos:   position{line: 838, col: 35, offset: 24636},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 830, col: 42, offset: 24443},
+								pos:  position{line: 838, col: 42, offset: 24643},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1220,32 +1228,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 834, col: 1, offset: 24484},
+			pos:  position{line: 842, col: 1, offset: 24684},
 			expr: &actionExpr{
-				pos: position{line: 834, col: 16, offset: 24499},
+				pos: position{line: 842, col: 16, offset: 24699},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 834, col: 16, offset: 24499},
+					pos: position{line: 842, col: 16, offset: 24699},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 834, col: 16, offset: 24499},
+							pos: position{line: 842, col: 16, offset: 24699},
 							expr: &ruleRefExpr{
-								pos:  position{line: 834, col: 18, offset: 24501},
+								pos:  position{line: 842, col: 18, offset: 24701},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 834, col: 26, offset: 24509},
+							pos: position{line: 842, col: 26, offset: 24709},
 							expr: &ruleRefExpr{
-								pos:  position{line: 834, col: 26, offset: 24509},
+								pos:  position{line: 842, col: 26, offset: 24709},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 834, col: 38, offset: 24521},
+							pos:   position{line: 842, col: 38, offset: 24721},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 834, col: 45, offset: 24528},
+								pos:  position{line: 842, col: 45, offset: 24728},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1255,33 +1263,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 838, col: 1, offset: 24569},
+			pos:  position{line: 846, col: 1, offset: 24769},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 16, offset: 24584},
+				pos: position{line: 846, col: 16, offset: 24784},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 16, offset: 24584},
+					pos: position{line: 846, col: 16, offset: 24784},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 838, col: 16, offset: 24584},
+							pos:  position{line: 846, col: 16, offset: 24784},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 21, offset: 24589},
+							pos:   position{line: 846, col: 21, offset: 24789},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 838, col: 28, offset: 24596},
+								pos: position{line: 846, col: 28, offset: 24796},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 838, col: 28, offset: 24596},
+										pos:  position{line: 846, col: 28, offset: 24796},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 838, col: 42, offset: 24610},
+										pos:  position{line: 846, col: 42, offset: 24810},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 838, col: 55, offset: 24623},
+										pos:  position{line: 846, col: 55, offset: 24823},
 										name: "TimeModifiers",
 									},
 								},
@@ -1293,114 +1301,114 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 843, col: 1, offset: 24702},
+			pos:  position{line: 851, col: 1, offset: 24902},
 			expr: &actionExpr{
-				pos: position{line: 843, col: 25, offset: 24726},
+				pos: position{line: 851, col: 25, offset: 24926},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 843, col: 25, offset: 24726},
+					pos:   position{line: 851, col: 25, offset: 24926},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 843, col: 32, offset: 24733},
+						pos: position{line: 851, col: 32, offset: 24933},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 32, offset: 24733},
+								pos:  position{line: 851, col: 32, offset: 24933},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 51, offset: 24752},
+								pos:  position{line: 851, col: 51, offset: 24952},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 69, offset: 24770},
+								pos:  position{line: 851, col: 69, offset: 24970},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 81, offset: 24782},
+								pos:  position{line: 851, col: 81, offset: 24982},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 94, offset: 24795},
+								pos:  position{line: 851, col: 94, offset: 24995},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 106, offset: 24807},
+								pos:  position{line: 851, col: 106, offset: 25007},
 								name: "RegexAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 122, offset: 24823},
+								pos:  position{line: 851, col: 122, offset: 25023},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 133, offset: 24834},
+								pos:  position{line: 851, col: 133, offset: 25034},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 150, offset: 24851},
+								pos:  position{line: 851, col: 150, offset: 25051},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 164, offset: 24865},
+								pos:  position{line: 851, col: 164, offset: 25065},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 181, offset: 24882},
+								pos:  position{line: 851, col: 181, offset: 25082},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 200, offset: 24901},
+								pos:  position{line: 851, col: 200, offset: 25101},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 213, offset: 24914},
+								pos:  position{line: 851, col: 213, offset: 25114},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 225, offset: 24926},
+								pos:  position{line: 851, col: 225, offset: 25126},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 243, offset: 24944},
+								pos:  position{line: 851, col: 243, offset: 25144},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 256, offset: 24957},
+								pos:  position{line: 851, col: 256, offset: 25157},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 270, offset: 24971},
+								pos:  position{line: 851, col: 270, offset: 25171},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 288, offset: 24989},
+								pos:  position{line: 851, col: 288, offset: 25189},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 300, offset: 25001},
+								pos:  position{line: 851, col: 300, offset: 25201},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 311, offset: 25012},
+								pos:  position{line: 851, col: 311, offset: 25212},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 330, offset: 25031},
+								pos:  position{line: 851, col: 330, offset: 25231},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 346, offset: 25047},
+								pos:  position{line: 851, col: 346, offset: 25247},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 362, offset: 25063},
+								pos:  position{line: 851, col: 362, offset: 25263},
 								name: "InputLookupAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 384, offset: 25085},
+								pos:  position{line: 851, col: 384, offset: 25285},
 								name: "AppendBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 843, col: 398, offset: 25099},
+								pos:  position{line: 851, col: 398, offset: 25299},
 								name: "ToJsonBlock",
 							},
 						},
@@ -1410,37 +1418,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 848, col: 1, offset: 25192},
+			pos:  position{line: 856, col: 1, offset: 25392},
 			expr: &actionExpr{
-				pos: position{line: 848, col: 21, offset: 25212},
+				pos: position{line: 856, col: 21, offset: 25412},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 848, col: 21, offset: 25212},
+					pos: position{line: 856, col: 21, offset: 25412},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 21, offset: 25212},
+							pos:  position{line: 856, col: 21, offset: 25412},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 26, offset: 25217},
+							pos:  position{line: 856, col: 26, offset: 25417},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 37, offset: 25228},
+							pos:   position{line: 856, col: 37, offset: 25428},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 848, col: 40, offset: 25231},
+								pos: position{line: 856, col: 40, offset: 25431},
 								expr: &choiceExpr{
-									pos: position{line: 848, col: 41, offset: 25232},
+									pos: position{line: 856, col: 41, offset: 25432},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 848, col: 41, offset: 25232},
+											pos:        position{line: 856, col: 41, offset: 25432},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 848, col: 47, offset: 25238},
+											pos:        position{line: 856, col: 47, offset: 25438},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1450,14 +1458,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 848, col: 53, offset: 25244},
+							pos:  position{line: 856, col: 53, offset: 25444},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 848, col: 68, offset: 25259},
+							pos:   position{line: 856, col: 68, offset: 25459},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 848, col: 75, offset: 25266},
+								pos:  position{line: 856, col: 75, offset: 25466},
 								name: "FieldNameList",
 							},
 						},
@@ -1467,28 +1475,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 867, col: 1, offset: 25806},
+			pos:  position{line: 875, col: 1, offset: 26006},
 			expr: &actionExpr{
-				pos: position{line: 867, col: 26, offset: 25831},
+				pos: position{line: 875, col: 26, offset: 26031},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 867, col: 26, offset: 25831},
+					pos: position{line: 875, col: 26, offset: 26031},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 867, col: 26, offset: 25831},
+							pos:   position{line: 875, col: 26, offset: 26031},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 867, col: 31, offset: 25836},
+								pos:  position{line: 875, col: 31, offset: 26036},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 867, col: 47, offset: 25852},
+							pos:   position{line: 875, col: 47, offset: 26052},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 867, col: 56, offset: 25861},
+								pos: position{line: 875, col: 56, offset: 26061},
 								expr: &ruleRefExpr{
-									pos:  position{line: 867, col: 57, offset: 25862},
+									pos:  position{line: 875, col: 57, offset: 26062},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1499,36 +1507,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 931, col: 1, offset: 28155},
+			pos:  position{line: 939, col: 1, offset: 28355},
 			expr: &actionExpr{
-				pos: position{line: 931, col: 20, offset: 28174},
+				pos: position{line: 939, col: 20, offset: 28374},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 931, col: 20, offset: 28174},
+					pos: position{line: 939, col: 20, offset: 28374},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 931, col: 20, offset: 28174},
+							pos:  position{line: 939, col: 20, offset: 28374},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 931, col: 25, offset: 28179},
+							pos:  position{line: 939, col: 25, offset: 28379},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 931, col: 35, offset: 28189},
+							pos:   position{line: 939, col: 35, offset: 28389},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 931, col: 41, offset: 28195},
+								pos:  position{line: 939, col: 41, offset: 28395},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 931, col: 64, offset: 28218},
+							pos:   position{line: 939, col: 64, offset: 28418},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 931, col: 72, offset: 28226},
+								pos: position{line: 939, col: 72, offset: 28426},
 								expr: &ruleRefExpr{
-									pos:  position{line: 931, col: 73, offset: 28227},
+									pos:  position{line: 939, col: 73, offset: 28427},
 									name: "StatsOptions",
 								},
 							},
@@ -1539,17 +1547,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 945, col: 1, offset: 28560},
+			pos:  position{line: 953, col: 1, offset: 28760},
 			expr: &actionExpr{
-				pos: position{line: 945, col: 17, offset: 28576},
+				pos: position{line: 953, col: 17, offset: 28776},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 945, col: 17, offset: 28576},
+					pos:   position{line: 953, col: 17, offset: 28776},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 945, col: 24, offset: 28583},
+						pos: position{line: 953, col: 24, offset: 28783},
 						expr: &ruleRefExpr{
-							pos:  position{line: 945, col: 25, offset: 28584},
+							pos:  position{line: 953, col: 25, offset: 28784},
 							name: "StatsOption",
 						},
 					},
@@ -1558,45 +1566,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 983, col: 1, offset: 30025},
+			pos:  position{line: 991, col: 1, offset: 30225},
 			expr: &actionExpr{
-				pos: position{line: 983, col: 16, offset: 30040},
+				pos: position{line: 991, col: 16, offset: 30240},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 983, col: 16, offset: 30040},
+					pos: position{line: 991, col: 16, offset: 30240},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 983, col: 16, offset: 30040},
+							pos:  position{line: 991, col: 16, offset: 30240},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 983, col: 22, offset: 30046},
+							pos:   position{line: 991, col: 22, offset: 30246},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 983, col: 32, offset: 30056},
+								pos:  position{line: 991, col: 32, offset: 30256},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 983, col: 47, offset: 30071},
+							pos:  position{line: 991, col: 47, offset: 30271},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 983, col: 53, offset: 30077},
+							pos:   position{line: 991, col: 53, offset: 30277},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 983, col: 58, offset: 30082},
+								pos: position{line: 991, col: 58, offset: 30282},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 983, col: 58, offset: 30082},
+										pos:  position{line: 991, col: 58, offset: 30282},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 983, col: 76, offset: 30100},
+										pos:  position{line: 991, col: 76, offset: 30300},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 983, col: 94, offset: 30118},
+										pos:  position{line: 991, col: 94, offset: 30318},
 										name: "QuotedString",
 									},
 								},
@@ -1608,36 +1616,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 988, col: 1, offset: 30223},
+			pos:  position{line: 996, col: 1, offset: 30423},
 			expr: &actionExpr{
-				pos: position{line: 988, col: 19, offset: 30241},
+				pos: position{line: 996, col: 19, offset: 30441},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 988, col: 19, offset: 30241},
+					pos:   position{line: 996, col: 19, offset: 30441},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 988, col: 27, offset: 30249},
+						pos: position{line: 996, col: 27, offset: 30449},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 988, col: 27, offset: 30249},
+								pos:        position{line: 996, col: 27, offset: 30449},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 988, col: 38, offset: 30260},
+								pos:        position{line: 996, col: 38, offset: 30460},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 988, col: 58, offset: 30280},
+								pos:        position{line: 996, col: 58, offset: 30480},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 988, col: 68, offset: 30290},
+								pos:        position{line: 996, col: 68, offset: 30490},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1649,22 +1657,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 996, col: 1, offset: 30480},
+			pos:  position{line: 1004, col: 1, offset: 30680},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 17, offset: 30496},
+				pos: position{line: 1004, col: 17, offset: 30696},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 996, col: 17, offset: 30496},
+					pos: position{line: 1004, col: 17, offset: 30696},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 996, col: 17, offset: 30496},
+							pos:  position{line: 1004, col: 17, offset: 30696},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 996, col: 20, offset: 30499},
+							pos:   position{line: 1004, col: 20, offset: 30699},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 996, col: 27, offset: 30506},
+								pos:  position{line: 1004, col: 27, offset: 30706},
 								name: "FieldNameList",
 							},
 						},
@@ -1674,28 +1682,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 1008, col: 1, offset: 30856},
+			pos:  position{line: 1016, col: 1, offset: 31056},
 			expr: &actionExpr{
-				pos: position{line: 1008, col: 35, offset: 30890},
+				pos: position{line: 1016, col: 35, offset: 31090},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 1008, col: 35, offset: 30890},
+					pos: position{line: 1016, col: 35, offset: 31090},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1008, col: 35, offset: 30890},
+							pos:        position{line: 1016, col: 35, offset: 31090},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1008, col: 53, offset: 30908},
+							pos:  position{line: 1016, col: 53, offset: 31108},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1008, col: 59, offset: 30914},
+							pos:   position{line: 1016, col: 59, offset: 31114},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 67, offset: 30922},
+								pos:  position{line: 1016, col: 67, offset: 31122},
 								name: "Boolean",
 							},
 						},
@@ -1705,28 +1713,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 1020, col: 1, offset: 31183},
+			pos:  position{line: 1028, col: 1, offset: 31383},
 			expr: &actionExpr{
-				pos: position{line: 1020, col: 29, offset: 31211},
+				pos: position{line: 1028, col: 29, offset: 31411},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 1020, col: 29, offset: 31211},
+					pos: position{line: 1028, col: 29, offset: 31411},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1020, col: 29, offset: 31211},
+							pos:        position{line: 1028, col: 29, offset: 31411},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1020, col: 39, offset: 31221},
+							pos:  position{line: 1028, col: 39, offset: 31421},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1020, col: 45, offset: 31227},
+							pos:   position{line: 1028, col: 45, offset: 31427},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1020, col: 53, offset: 31235},
+								pos:  position{line: 1028, col: 53, offset: 31435},
 								name: "Boolean",
 							},
 						},
@@ -1736,28 +1744,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 1032, col: 1, offset: 31482},
+			pos:  position{line: 1040, col: 1, offset: 31682},
 			expr: &actionExpr{
-				pos: position{line: 1032, col: 28, offset: 31509},
+				pos: position{line: 1040, col: 28, offset: 31709},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 1032, col: 28, offset: 31509},
+					pos: position{line: 1040, col: 28, offset: 31709},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1032, col: 28, offset: 31509},
+							pos:        position{line: 1040, col: 28, offset: 31709},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1032, col: 37, offset: 31518},
+							pos:  position{line: 1040, col: 37, offset: 31718},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1032, col: 43, offset: 31524},
+							pos:   position{line: 1040, col: 43, offset: 31724},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1032, col: 51, offset: 31532},
+								pos:  position{line: 1040, col: 51, offset: 31732},
 								name: "Boolean",
 							},
 						},
@@ -1767,28 +1775,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 1045, col: 1, offset: 31866},
+			pos:  position{line: 1053, col: 1, offset: 32066},
 			expr: &actionExpr{
-				pos: position{line: 1045, col: 28, offset: 31893},
+				pos: position{line: 1053, col: 28, offset: 32093},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 1045, col: 28, offset: 31893},
+					pos: position{line: 1053, col: 28, offset: 32093},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1045, col: 28, offset: 31893},
+							pos:        position{line: 1053, col: 28, offset: 32093},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1045, col: 37, offset: 31902},
+							pos:  position{line: 1053, col: 37, offset: 32102},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1045, col: 43, offset: 31908},
+							pos:   position{line: 1053, col: 43, offset: 32108},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1045, col: 51, offset: 31916},
+								pos:  position{line: 1053, col: 51, offset: 32116},
 								name: "Boolean",
 							},
 						},
@@ -1798,28 +1806,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 1058, col: 1, offset: 32250},
+			pos:  position{line: 1066, col: 1, offset: 32450},
 			expr: &actionExpr{
-				pos: position{line: 1058, col: 28, offset: 32277},
+				pos: position{line: 1066, col: 28, offset: 32477},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1058, col: 28, offset: 32277},
+					pos: position{line: 1066, col: 28, offset: 32477},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1058, col: 28, offset: 32277},
+							pos:        position{line: 1066, col: 28, offset: 32477},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1058, col: 37, offset: 32286},
+							pos:  position{line: 1066, col: 37, offset: 32486},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1058, col: 43, offset: 32292},
+							pos:   position{line: 1066, col: 43, offset: 32492},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1058, col: 54, offset: 32303},
+								pos:  position{line: 1066, col: 54, offset: 32503},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1829,37 +1837,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1078, col: 1, offset: 32907},
+			pos:  position{line: 1086, col: 1, offset: 33107},
 			expr: &actionExpr{
-				pos: position{line: 1078, col: 33, offset: 32939},
+				pos: position{line: 1086, col: 33, offset: 33139},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1078, col: 33, offset: 32939},
+					pos: position{line: 1086, col: 33, offset: 33139},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1078, col: 33, offset: 32939},
+							pos:        position{line: 1086, col: 33, offset: 33139},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1078, col: 48, offset: 32954},
+							pos:  position{line: 1086, col: 48, offset: 33154},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1078, col: 54, offset: 32960},
+							pos:  position{line: 1086, col: 54, offset: 33160},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1078, col: 62, offset: 32968},
+							pos:   position{line: 1086, col: 62, offset: 33168},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1078, col: 71, offset: 32977},
+								pos:  position{line: 1086, col: 71, offset: 33177},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1078, col: 80, offset: 32986},
+							pos:  position{line: 1086, col: 80, offset: 33186},
 							name: "R_PAREN",
 						},
 					},
@@ -1868,37 +1876,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1090, col: 1, offset: 33256},
+			pos:  position{line: 1098, col: 1, offset: 33456},
 			expr: &actionExpr{
-				pos: position{line: 1090, col: 32, offset: 33287},
+				pos: position{line: 1098, col: 32, offset: 33487},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1090, col: 32, offset: 33287},
+					pos: position{line: 1098, col: 32, offset: 33487},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1090, col: 32, offset: 33287},
+							pos:        position{line: 1098, col: 32, offset: 33487},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 46, offset: 33301},
+							pos:  position{line: 1098, col: 46, offset: 33501},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 52, offset: 33307},
+							pos:  position{line: 1098, col: 52, offset: 33507},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1090, col: 60, offset: 33315},
+							pos:   position{line: 1098, col: 60, offset: 33515},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1090, col: 69, offset: 33324},
+								pos:  position{line: 1098, col: 69, offset: 33524},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1090, col: 78, offset: 33333},
+							pos:  position{line: 1098, col: 78, offset: 33533},
 							name: "R_PAREN",
 						},
 					},
@@ -1907,28 +1915,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1102, col: 1, offset: 33601},
+			pos:  position{line: 1110, col: 1, offset: 33801},
 			expr: &actionExpr{
-				pos: position{line: 1102, col: 32, offset: 33632},
+				pos: position{line: 1110, col: 32, offset: 33832},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1102, col: 32, offset: 33632},
+					pos: position{line: 1110, col: 32, offset: 33832},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1102, col: 32, offset: 33632},
+							pos:        position{line: 1110, col: 32, offset: 33832},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1102, col: 46, offset: 33646},
+							pos:  position{line: 1110, col: 46, offset: 33846},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1102, col: 52, offset: 33652},
+							pos:   position{line: 1110, col: 52, offset: 33852},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1102, col: 63, offset: 33663},
+								pos:  position{line: 1110, col: 63, offset: 33863},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1938,46 +1946,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1118, col: 1, offset: 34126},
+			pos:  position{line: 1126, col: 1, offset: 34326},
 			expr: &actionExpr{
-				pos: position{line: 1118, col: 22, offset: 34147},
+				pos: position{line: 1126, col: 22, offset: 34347},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1118, col: 22, offset: 34147},
+					pos:   position{line: 1126, col: 22, offset: 34347},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1118, col: 32, offset: 34157},
+						pos: position{line: 1126, col: 32, offset: 34357},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 32, offset: 34157},
+								pos:  position{line: 1126, col: 32, offset: 34357},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 65, offset: 34190},
+								pos:  position{line: 1126, col: 65, offset: 34390},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 92, offset: 34217},
+								pos:  position{line: 1126, col: 92, offset: 34417},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 118, offset: 34243},
+								pos:  position{line: 1126, col: 118, offset: 34443},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 144, offset: 34269},
+								pos:  position{line: 1126, col: 144, offset: 34469},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 170, offset: 34295},
+								pos:  position{line: 1126, col: 170, offset: 34495},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 201, offset: 34326},
+								pos:  position{line: 1126, col: 201, offset: 34526},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1118, col: 231, offset: 34356},
+								pos:  position{line: 1126, col: 231, offset: 34556},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1987,35 +1995,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1122, col: 1, offset: 34415},
+			pos:  position{line: 1130, col: 1, offset: 34615},
 			expr: &actionExpr{
-				pos: position{line: 1122, col: 26, offset: 34440},
+				pos: position{line: 1130, col: 26, offset: 34640},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1122, col: 26, offset: 34440},
+					pos: position{line: 1130, col: 26, offset: 34640},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1122, col: 26, offset: 34440},
+							pos:   position{line: 1130, col: 26, offset: 34640},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1122, col: 32, offset: 34446},
+								pos:  position{line: 1130, col: 32, offset: 34646},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1122, col: 50, offset: 34464},
+							pos:   position{line: 1130, col: 50, offset: 34664},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1122, col: 55, offset: 34469},
+								pos: position{line: 1130, col: 55, offset: 34669},
 								expr: &seqExpr{
-									pos: position{line: 1122, col: 56, offset: 34470},
+									pos: position{line: 1130, col: 56, offset: 34670},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1122, col: 56, offset: 34470},
+											pos:  position{line: 1130, col: 56, offset: 34670},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1122, col: 62, offset: 34476},
+											pos:  position{line: 1130, col: 62, offset: 34676},
 											name: "StreamStatsOption",
 										},
 									},
@@ -2028,41 +2036,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1181, col: 1, offset: 36665},
+			pos:  position{line: 1189, col: 1, offset: 36865},
 			expr: &choiceExpr{
-				pos: position{line: 1181, col: 21, offset: 36685},
+				pos: position{line: 1189, col: 21, offset: 36885},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1181, col: 21, offset: 36685},
+						pos: position{line: 1189, col: 21, offset: 36885},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1181, col: 21, offset: 36685},
+							pos: position{line: 1189, col: 21, offset: 36885},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 21, offset: 36685},
+									pos:  position{line: 1189, col: 21, offset: 36885},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 26, offset: 36690},
+									pos:  position{line: 1189, col: 26, offset: 36890},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 42, offset: 36706},
+									pos:   position{line: 1189, col: 42, offset: 36906},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 56, offset: 36720},
+										pos:  position{line: 1189, col: 56, offset: 36920},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1181, col: 79, offset: 36743},
+									pos:  position{line: 1189, col: 79, offset: 36943},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1181, col: 85, offset: 36749},
+									pos:   position{line: 1189, col: 85, offset: 36949},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1181, col: 91, offset: 36755},
+										pos:  position{line: 1189, col: 91, offset: 36955},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2070,24 +2078,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1192, col: 3, offset: 37140},
+						pos: position{line: 1200, col: 3, offset: 37340},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1192, col: 3, offset: 37140},
+							pos: position{line: 1200, col: 3, offset: 37340},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 3, offset: 37140},
+									pos:  position{line: 1200, col: 3, offset: 37340},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1192, col: 8, offset: 37145},
+									pos:  position{line: 1200, col: 8, offset: 37345},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1192, col: 24, offset: 37161},
+									pos:   position{line: 1200, col: 24, offset: 37361},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1192, col: 30, offset: 37167},
+										pos:  position{line: 1200, col: 30, offset: 37367},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2099,31 +2107,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1204, col: 1, offset: 37539},
+			pos:  position{line: 1212, col: 1, offset: 37739},
 			expr: &actionExpr{
-				pos: position{line: 1204, col: 15, offset: 37553},
+				pos: position{line: 1212, col: 15, offset: 37753},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1204, col: 15, offset: 37553},
+					pos: position{line: 1212, col: 15, offset: 37753},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1204, col: 15, offset: 37553},
+							pos:  position{line: 1212, col: 15, offset: 37753},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1204, col: 25, offset: 37563},
+							pos:   position{line: 1212, col: 25, offset: 37763},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1204, col: 34, offset: 37572},
+								pos: position{line: 1212, col: 34, offset: 37772},
 								expr: &seqExpr{
-									pos: position{line: 1204, col: 35, offset: 37573},
+									pos: position{line: 1212, col: 35, offset: 37773},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1204, col: 35, offset: 37573},
+											pos:  position{line: 1212, col: 35, offset: 37773},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1204, col: 45, offset: 37583},
+											pos:  position{line: 1212, col: 45, offset: 37783},
 											name: "EqualityOperator",
 										},
 									},
@@ -2131,10 +2139,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1204, col: 64, offset: 37602},
+							pos:   position{line: 1212, col: 64, offset: 37802},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1204, col: 68, offset: 37606},
+								pos:  position{line: 1212, col: 68, offset: 37806},
 								name: "QuotedString",
 							},
 						},
@@ -2144,22 +2152,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1232, col: 1, offset: 38185},
+			pos:  position{line: 1240, col: 1, offset: 38385},
 			expr: &actionExpr{
-				pos: position{line: 1232, col: 18, offset: 38202},
+				pos: position{line: 1240, col: 18, offset: 38402},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1232, col: 18, offset: 38202},
+					pos: position{line: 1240, col: 18, offset: 38402},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1232, col: 18, offset: 38202},
+							pos:  position{line: 1240, col: 18, offset: 38402},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1232, col: 23, offset: 38207},
+							pos:   position{line: 1240, col: 23, offset: 38407},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1232, col: 28, offset: 38212},
+								pos:  position{line: 1240, col: 28, offset: 38412},
 								name: "RegexBlock",
 							},
 						},
@@ -2169,44 +2177,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1260, col: 1, offset: 38994},
+			pos:  position{line: 1268, col: 1, offset: 39194},
 			expr: &actionExpr{
-				pos: position{line: 1260, col: 17, offset: 39010},
+				pos: position{line: 1268, col: 17, offset: 39210},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1260, col: 17, offset: 39010},
+					pos: position{line: 1268, col: 17, offset: 39210},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1260, col: 17, offset: 39010},
+							pos:   position{line: 1268, col: 17, offset: 39210},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1260, col: 23, offset: 39016},
+								pos:  position{line: 1268, col: 23, offset: 39216},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1260, col: 36, offset: 39029},
+							pos:   position{line: 1268, col: 36, offset: 39229},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1260, col: 41, offset: 39034},
+								pos: position{line: 1268, col: 41, offset: 39234},
 								expr: &seqExpr{
-									pos: position{line: 1260, col: 42, offset: 39035},
+									pos: position{line: 1268, col: 42, offset: 39235},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1260, col: 43, offset: 39036},
+											pos: position{line: 1268, col: 43, offset: 39236},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1260, col: 43, offset: 39036},
+													pos:  position{line: 1268, col: 43, offset: 39236},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1260, col: 49, offset: 39042},
+													pos:  position{line: 1268, col: 49, offset: 39242},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1260, col: 56, offset: 39049},
+											pos:  position{line: 1268, col: 56, offset: 39249},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2219,35 +2227,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1278, col: 1, offset: 39426},
+			pos:  position{line: 1286, col: 1, offset: 39626},
 			expr: &actionExpr{
-				pos: position{line: 1278, col: 17, offset: 39442},
+				pos: position{line: 1286, col: 17, offset: 39642},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1278, col: 17, offset: 39442},
+					pos: position{line: 1286, col: 17, offset: 39642},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1278, col: 17, offset: 39442},
+							pos:   position{line: 1286, col: 17, offset: 39642},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1278, col: 23, offset: 39448},
+								pos:  position{line: 1286, col: 23, offset: 39648},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1278, col: 36, offset: 39461},
+							pos:   position{line: 1286, col: 36, offset: 39661},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1278, col: 41, offset: 39466},
+								pos: position{line: 1286, col: 41, offset: 39666},
 								expr: &seqExpr{
-									pos: position{line: 1278, col: 42, offset: 39467},
+									pos: position{line: 1286, col: 42, offset: 39667},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1278, col: 42, offset: 39467},
+											pos:  position{line: 1286, col: 42, offset: 39667},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1278, col: 45, offset: 39470},
+											pos:  position{line: 1286, col: 45, offset: 39670},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2260,32 +2268,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1296, col: 1, offset: 39835},
+			pos:  position{line: 1304, col: 1, offset: 40035},
 			expr: &choiceExpr{
-				pos: position{line: 1296, col: 17, offset: 39851},
+				pos: position{line: 1304, col: 17, offset: 40051},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1296, col: 17, offset: 39851},
+						pos: position{line: 1304, col: 17, offset: 40051},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 17, offset: 39851},
+							pos: position{line: 1304, col: 17, offset: 40051},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1296, col: 17, offset: 39851},
+									pos:   position{line: 1304, col: 17, offset: 40051},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1296, col: 25, offset: 39859},
+										pos: position{line: 1304, col: 25, offset: 40059},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1296, col: 25, offset: 39859},
+											pos:  position{line: 1304, col: 25, offset: 40059},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 30, offset: 39864},
+									pos:   position{line: 1304, col: 30, offset: 40064},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 36, offset: 39870},
+										pos:  position{line: 1304, col: 36, offset: 40070},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2293,13 +2301,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1307, col: 5, offset: 40166},
+						pos: position{line: 1315, col: 5, offset: 40366},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1307, col: 5, offset: 40166},
+							pos:   position{line: 1315, col: 5, offset: 40366},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1307, col: 12, offset: 40173},
+								pos:  position{line: 1315, col: 12, offset: 40373},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2309,43 +2317,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1311, col: 1, offset: 40214},
+			pos:  position{line: 1319, col: 1, offset: 40414},
 			expr: &choiceExpr{
-				pos: position{line: 1311, col: 17, offset: 40230},
+				pos: position{line: 1319, col: 17, offset: 40430},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1311, col: 17, offset: 40230},
+						pos: position{line: 1319, col: 17, offset: 40430},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1311, col: 17, offset: 40230},
+							pos: position{line: 1319, col: 17, offset: 40430},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1311, col: 17, offset: 40230},
+									pos:  position{line: 1319, col: 17, offset: 40430},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1311, col: 25, offset: 40238},
+									pos:   position{line: 1319, col: 25, offset: 40438},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1311, col: 32, offset: 40245},
+										pos:  position{line: 1319, col: 32, offset: 40445},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1311, col: 45, offset: 40258},
+									pos:  position{line: 1319, col: 45, offset: 40458},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1313, col: 5, offset: 40295},
+						pos: position{line: 1321, col: 5, offset: 40495},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1313, col: 5, offset: 40295},
+							pos:   position{line: 1321, col: 5, offset: 40495},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1313, col: 10, offset: 40300},
+								pos:  position{line: 1321, col: 10, offset: 40500},
 								name: "SearchTerm",
 							},
 						},
@@ -2355,26 +2363,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1319, col: 1, offset: 40458},
+			pos:  position{line: 1327, col: 1, offset: 40658},
 			expr: &actionExpr{
-				pos: position{line: 1319, col: 15, offset: 40472},
+				pos: position{line: 1327, col: 15, offset: 40672},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1319, col: 15, offset: 40472},
+					pos:   position{line: 1327, col: 15, offset: 40672},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1319, col: 21, offset: 40478},
+						pos: position{line: 1327, col: 21, offset: 40678},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1319, col: 21, offset: 40478},
+								pos:  position{line: 1327, col: 21, offset: 40678},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1319, col: 44, offset: 40501},
+								pos:  position{line: 1327, col: 44, offset: 40701},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1319, col: 68, offset: 40525},
+								pos:  position{line: 1327, col: 68, offset: 40725},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2384,36 +2392,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1324, col: 1, offset: 40666},
+			pos:  position{line: 1332, col: 1, offset: 40866},
 			expr: &actionExpr{
-				pos: position{line: 1324, col: 19, offset: 40684},
+				pos: position{line: 1332, col: 19, offset: 40884},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1324, col: 19, offset: 40684},
+					pos: position{line: 1332, col: 19, offset: 40884},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1324, col: 19, offset: 40684},
+							pos:  position{line: 1332, col: 19, offset: 40884},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1324, col: 24, offset: 40689},
+							pos:  position{line: 1332, col: 24, offset: 40889},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1324, col: 38, offset: 40703},
+							pos:   position{line: 1332, col: 38, offset: 40903},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1324, col: 45, offset: 40710},
+								pos:  position{line: 1332, col: 45, offset: 40910},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1324, col: 68, offset: 40733},
+							pos:   position{line: 1332, col: 68, offset: 40933},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1324, col: 78, offset: 40743},
+								pos: position{line: 1332, col: 78, offset: 40943},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1324, col: 79, offset: 40744},
+									pos:  position{line: 1332, col: 79, offset: 40944},
 									name: "LimitExpr",
 								},
 							},
@@ -2424,35 +2432,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1417, col: 1, offset: 43715},
+			pos:  position{line: 1425, col: 1, offset: 43915},
 			expr: &actionExpr{
-				pos: position{line: 1417, col: 27, offset: 43741},
+				pos: position{line: 1425, col: 27, offset: 43941},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1417, col: 27, offset: 43741},
+					pos: position{line: 1425, col: 27, offset: 43941},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1417, col: 27, offset: 43741},
+							pos:   position{line: 1425, col: 27, offset: 43941},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1417, col: 33, offset: 43747},
+								pos:  position{line: 1425, col: 33, offset: 43947},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1417, col: 51, offset: 43765},
+							pos:   position{line: 1425, col: 51, offset: 43965},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1417, col: 56, offset: 43770},
+								pos: position{line: 1425, col: 56, offset: 43970},
 								expr: &seqExpr{
-									pos: position{line: 1417, col: 57, offset: 43771},
+									pos: position{line: 1425, col: 57, offset: 43971},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1417, col: 57, offset: 43771},
+											pos:  position{line: 1425, col: 57, offset: 43971},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1417, col: 63, offset: 43777},
+											pos:  position{line: 1425, col: 63, offset: 43977},
 											name: "TimechartArgument",
 										},
 									},
@@ -2465,22 +2473,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1446, col: 1, offset: 44511},
+			pos:  position{line: 1454, col: 1, offset: 44711},
 			expr: &actionExpr{
-				pos: position{line: 1446, col: 22, offset: 44532},
+				pos: position{line: 1454, col: 22, offset: 44732},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1446, col: 22, offset: 44532},
+					pos:   position{line: 1454, col: 22, offset: 44732},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1446, col: 29, offset: 44539},
+						pos: position{line: 1454, col: 29, offset: 44739},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1446, col: 29, offset: 44539},
+								pos:  position{line: 1454, col: 29, offset: 44739},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1446, col: 45, offset: 44555},
+								pos:  position{line: 1454, col: 45, offset: 44755},
 								name: "TcOptions",
 							},
 						},
@@ -2490,28 +2498,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1450, col: 1, offset: 44593},
+			pos:  position{line: 1458, col: 1, offset: 44793},
 			expr: &actionExpr{
-				pos: position{line: 1450, col: 18, offset: 44610},
+				pos: position{line: 1458, col: 18, offset: 44810},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1450, col: 18, offset: 44610},
+					pos: position{line: 1458, col: 18, offset: 44810},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1450, col: 18, offset: 44610},
+							pos:   position{line: 1458, col: 18, offset: 44810},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1450, col: 23, offset: 44615},
+								pos:  position{line: 1458, col: 23, offset: 44815},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1450, col: 39, offset: 44631},
+							pos:   position{line: 1458, col: 39, offset: 44831},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1450, col: 53, offset: 44645},
+								pos: position{line: 1458, col: 53, offset: 44845},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1450, col: 53, offset: 44645},
+									pos:  position{line: 1458, col: 53, offset: 44845},
 									name: "SplitByClause",
 								},
 							},
@@ -2522,22 +2530,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1464, col: 1, offset: 44984},
+			pos:  position{line: 1472, col: 1, offset: 45184},
 			expr: &actionExpr{
-				pos: position{line: 1464, col: 18, offset: 45001},
+				pos: position{line: 1472, col: 18, offset: 45201},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1464, col: 18, offset: 45001},
+					pos: position{line: 1472, col: 18, offset: 45201},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1464, col: 18, offset: 45001},
+							pos:  position{line: 1472, col: 18, offset: 45201},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1464, col: 21, offset: 45004},
+							pos:   position{line: 1472, col: 21, offset: 45204},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1464, col: 27, offset: 45010},
+								pos:  position{line: 1472, col: 27, offset: 45210},
 								name: "FieldName",
 							},
 						},
@@ -2547,24 +2555,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1472, col: 1, offset: 45139},
+			pos:  position{line: 1480, col: 1, offset: 45339},
 			expr: &actionExpr{
-				pos: position{line: 1472, col: 14, offset: 45152},
+				pos: position{line: 1480, col: 14, offset: 45352},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1472, col: 14, offset: 45152},
+					pos:   position{line: 1480, col: 14, offset: 45352},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1472, col: 22, offset: 45160},
+						pos: position{line: 1480, col: 22, offset: 45360},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1472, col: 22, offset: 45160},
+								pos:  position{line: 1480, col: 22, offset: 45360},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1472, col: 35, offset: 45173},
+								pos: position{line: 1480, col: 35, offset: 45373},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1472, col: 36, offset: 45174},
+									pos:  position{line: 1480, col: 36, offset: 45374},
 									name: "TcOption",
 								},
 							},
@@ -2575,34 +2583,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1514, col: 1, offset: 46694},
+			pos:  position{line: 1522, col: 1, offset: 46894},
 			expr: &actionExpr{
-				pos: position{line: 1514, col: 13, offset: 46706},
+				pos: position{line: 1522, col: 13, offset: 46906},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1514, col: 13, offset: 46706},
+					pos: position{line: 1522, col: 13, offset: 46906},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1514, col: 13, offset: 46706},
+							pos:  position{line: 1522, col: 13, offset: 46906},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1514, col: 19, offset: 46712},
+							pos:   position{line: 1522, col: 19, offset: 46912},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1514, col: 31, offset: 46724},
+								pos:  position{line: 1522, col: 31, offset: 46924},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1514, col: 43, offset: 46736},
+							pos:  position{line: 1522, col: 43, offset: 46936},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1514, col: 49, offset: 46742},
+							pos:   position{line: 1522, col: 49, offset: 46942},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1514, col: 53, offset: 46746},
+								pos:  position{line: 1522, col: 53, offset: 46946},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2612,36 +2620,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1519, col: 1, offset: 46859},
+			pos:  position{line: 1527, col: 1, offset: 47059},
 			expr: &actionExpr{
-				pos: position{line: 1519, col: 16, offset: 46874},
+				pos: position{line: 1527, col: 16, offset: 47074},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1519, col: 16, offset: 46874},
+					pos:   position{line: 1527, col: 16, offset: 47074},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1519, col: 24, offset: 46882},
+						pos: position{line: 1527, col: 24, offset: 47082},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1519, col: 24, offset: 46882},
+								pos:        position{line: 1527, col: 24, offset: 47082},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1519, col: 36, offset: 46894},
+								pos:        position{line: 1527, col: 36, offset: 47094},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1519, col: 49, offset: 46907},
+								pos:        position{line: 1527, col: 49, offset: 47107},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1519, col: 61, offset: 46919},
+								pos:        position{line: 1527, col: 61, offset: 47119},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2653,50 +2661,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1527, col: 1, offset: 47115},
+			pos:  position{line: 1535, col: 1, offset: 47315},
 			expr: &actionExpr{
-				pos: position{line: 1527, col: 17, offset: 47131},
+				pos: position{line: 1535, col: 17, offset: 47331},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1527, col: 17, offset: 47131},
+					pos:   position{line: 1535, col: 17, offset: 47331},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1527, col: 27, offset: 47141},
+						pos: position{line: 1535, col: 27, offset: 47341},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 27, offset: 47141},
+								pos:  position{line: 1535, col: 27, offset: 47341},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 36, offset: 47150},
+								pos:  position{line: 1535, col: 36, offset: 47350},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 44, offset: 47158},
+								pos:  position{line: 1535, col: 44, offset: 47358},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 57, offset: 47171},
+								pos:  position{line: 1535, col: 57, offset: 47371},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 66, offset: 47180},
+								pos:  position{line: 1535, col: 66, offset: 47380},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 73, offset: 47187},
+								pos:  position{line: 1535, col: 73, offset: 47387},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 79, offset: 47193},
+								pos:  position{line: 1535, col: 79, offset: 47393},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 86, offset: 47200},
+								pos:  position{line: 1535, col: 86, offset: 47400},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1527, col: 96, offset: 47210},
+								pos:  position{line: 1535, col: 96, offset: 47410},
 								name: "Year",
 							},
 						},
@@ -2706,37 +2714,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1531, col: 1, offset: 47246},
+			pos:  position{line: 1539, col: 1, offset: 47446},
 			expr: &actionExpr{
-				pos: position{line: 1531, col: 21, offset: 47266},
+				pos: position{line: 1539, col: 21, offset: 47466},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1531, col: 21, offset: 47266},
+					pos: position{line: 1539, col: 21, offset: 47466},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1531, col: 21, offset: 47266},
+							pos:   position{line: 1539, col: 21, offset: 47466},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1531, col: 29, offset: 47274},
+								pos: position{line: 1539, col: 29, offset: 47474},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1531, col: 29, offset: 47274},
+										pos:  position{line: 1539, col: 29, offset: 47474},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1531, col: 45, offset: 47290},
+										pos:  position{line: 1539, col: 45, offset: 47490},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1531, col: 62, offset: 47307},
+							pos:   position{line: 1539, col: 62, offset: 47507},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1531, col: 72, offset: 47317},
+								pos: position{line: 1539, col: 72, offset: 47517},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1531, col: 73, offset: 47318},
+									pos:  position{line: 1539, col: 73, offset: 47518},
 									name: "AllTimeScale",
 								},
 							},
@@ -2747,28 +2755,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1590, col: 1, offset: 50009},
+			pos:  position{line: 1598, col: 1, offset: 50209},
 			expr: &actionExpr{
-				pos: position{line: 1590, col: 21, offset: 50029},
+				pos: position{line: 1598, col: 21, offset: 50229},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1590, col: 21, offset: 50029},
+					pos: position{line: 1598, col: 21, offset: 50229},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1590, col: 21, offset: 50029},
+							pos:        position{line: 1598, col: 21, offset: 50229},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1590, col: 31, offset: 50039},
+							pos:  position{line: 1598, col: 31, offset: 50239},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1590, col: 37, offset: 50045},
+							pos:   position{line: 1598, col: 37, offset: 50245},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1590, col: 48, offset: 50056},
+								pos:  position{line: 1598, col: 48, offset: 50256},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2778,28 +2786,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1601, col: 1, offset: 50297},
+			pos:  position{line: 1609, col: 1, offset: 50497},
 			expr: &actionExpr{
-				pos: position{line: 1601, col: 21, offset: 50317},
+				pos: position{line: 1609, col: 21, offset: 50517},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1601, col: 21, offset: 50317},
+					pos: position{line: 1609, col: 21, offset: 50517},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1601, col: 21, offset: 50317},
+							pos:        position{line: 1609, col: 21, offset: 50517},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1601, col: 28, offset: 50324},
+							pos:  position{line: 1609, col: 28, offset: 50524},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1601, col: 34, offset: 50330},
+							pos:   position{line: 1609, col: 34, offset: 50530},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1601, col: 43, offset: 50339},
+								pos:  position{line: 1609, col: 43, offset: 50539},
 								name: "IntegerAsString",
 							},
 						},
@@ -2809,31 +2817,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1622, col: 1, offset: 50918},
+			pos:  position{line: 1630, col: 1, offset: 51118},
 			expr: &choiceExpr{
-				pos: position{line: 1622, col: 23, offset: 50940},
+				pos: position{line: 1630, col: 23, offset: 51140},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1622, col: 23, offset: 50940},
+						pos: position{line: 1630, col: 23, offset: 51140},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1622, col: 23, offset: 50940},
+							pos: position{line: 1630, col: 23, offset: 51140},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1622, col: 23, offset: 50940},
+									pos:        position{line: 1630, col: 23, offset: 51140},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1622, col: 35, offset: 50952},
+									pos:  position{line: 1630, col: 35, offset: 51152},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1622, col: 41, offset: 50958},
+									pos:   position{line: 1630, col: 41, offset: 51158},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1622, col: 51, offset: 50968},
+										pos:  position{line: 1630, col: 51, offset: 51168},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2841,33 +2849,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1636, col: 3, offset: 51387},
+						pos: position{line: 1644, col: 3, offset: 51587},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1636, col: 3, offset: 51387},
+							pos: position{line: 1644, col: 3, offset: 51587},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1636, col: 3, offset: 51387},
+									pos:        position{line: 1644, col: 3, offset: 51587},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1636, col: 15, offset: 51399},
+									pos:  position{line: 1644, col: 15, offset: 51599},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1636, col: 21, offset: 51405},
+									pos:   position{line: 1644, col: 21, offset: 51605},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1636, col: 32, offset: 51416},
+										pos: position{line: 1644, col: 32, offset: 51616},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1636, col: 32, offset: 51416},
+												pos:  position{line: 1644, col: 32, offset: 51616},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1636, col: 52, offset: 51436},
+												pos:  position{line: 1644, col: 52, offset: 51636},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2881,35 +2889,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1656, col: 1, offset: 51905},
+			pos:  position{line: 1664, col: 1, offset: 52105},
 			expr: &actionExpr{
-				pos: position{line: 1656, col: 19, offset: 51923},
+				pos: position{line: 1664, col: 19, offset: 52123},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1656, col: 19, offset: 51923},
+					pos: position{line: 1664, col: 19, offset: 52123},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1656, col: 19, offset: 51923},
+							pos:        position{line: 1664, col: 19, offset: 52123},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1656, col: 27, offset: 51931},
+							pos:  position{line: 1664, col: 27, offset: 52131},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1656, col: 33, offset: 51937},
+							pos:   position{line: 1664, col: 33, offset: 52137},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1656, col: 41, offset: 51945},
+								pos: position{line: 1664, col: 41, offset: 52145},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1656, col: 41, offset: 51945},
+										pos:  position{line: 1664, col: 41, offset: 52145},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1656, col: 57, offset: 51961},
+										pos:  position{line: 1664, col: 57, offset: 52161},
 										name: "IntegerAsString",
 									},
 								},
@@ -2921,35 +2929,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1671, col: 1, offset: 52340},
+			pos:  position{line: 1679, col: 1, offset: 52540},
 			expr: &actionExpr{
-				pos: position{line: 1671, col: 17, offset: 52356},
+				pos: position{line: 1679, col: 17, offset: 52556},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1671, col: 17, offset: 52356},
+					pos: position{line: 1679, col: 17, offset: 52556},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1671, col: 17, offset: 52356},
+							pos:        position{line: 1679, col: 17, offset: 52556},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1671, col: 23, offset: 52362},
+							pos:  position{line: 1679, col: 23, offset: 52562},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1671, col: 29, offset: 52368},
+							pos:   position{line: 1679, col: 29, offset: 52568},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1671, col: 37, offset: 52376},
+								pos: position{line: 1679, col: 37, offset: 52576},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1671, col: 37, offset: 52376},
+										pos:  position{line: 1679, col: 37, offset: 52576},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1671, col: 53, offset: 52392},
+										pos:  position{line: 1679, col: 53, offset: 52592},
 										name: "IntegerAsString",
 									},
 								},
@@ -2961,40 +2969,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1686, col: 1, offset: 52763},
+			pos:  position{line: 1694, col: 1, offset: 52963},
 			expr: &choiceExpr{
-				pos: position{line: 1686, col: 18, offset: 52780},
+				pos: position{line: 1694, col: 18, offset: 52980},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1686, col: 18, offset: 52780},
+						pos: position{line: 1694, col: 18, offset: 52980},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1686, col: 18, offset: 52780},
+							pos: position{line: 1694, col: 18, offset: 52980},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1686, col: 18, offset: 52780},
+									pos:        position{line: 1694, col: 18, offset: 52980},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1686, col: 25, offset: 52787},
+									pos:  position{line: 1694, col: 25, offset: 52987},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1686, col: 31, offset: 52793},
+									pos:   position{line: 1694, col: 31, offset: 52993},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1686, col: 36, offset: 52798},
+										pos: position{line: 1694, col: 36, offset: 52998},
 										expr: &choiceExpr{
-											pos: position{line: 1686, col: 37, offset: 52799},
+											pos: position{line: 1694, col: 37, offset: 52999},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1686, col: 37, offset: 52799},
+													pos:  position{line: 1694, col: 37, offset: 52999},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1686, col: 53, offset: 52815},
+													pos:  position{line: 1694, col: 53, offset: 53015},
 													name: "IntegerAsString",
 												},
 											},
@@ -3002,25 +3010,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1686, col: 71, offset: 52833},
+									pos:        position{line: 1694, col: 71, offset: 53033},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1686, col: 77, offset: 52839},
+									pos:   position{line: 1694, col: 77, offset: 53039},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1686, col: 82, offset: 52844},
+										pos: position{line: 1694, col: 82, offset: 53044},
 										expr: &choiceExpr{
-											pos: position{line: 1686, col: 83, offset: 52845},
+											pos: position{line: 1694, col: 83, offset: 53045},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1686, col: 83, offset: 52845},
+													pos:  position{line: 1694, col: 83, offset: 53045},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1686, col: 99, offset: 52861},
+													pos:  position{line: 1694, col: 99, offset: 53061},
 													name: "IntegerAsString",
 												},
 											},
@@ -3031,26 +3039,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1729, col: 3, offset: 54297},
+						pos: position{line: 1737, col: 3, offset: 54497},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1729, col: 3, offset: 54297},
+							pos: position{line: 1737, col: 3, offset: 54497},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1729, col: 3, offset: 54297},
+									pos:        position{line: 1737, col: 3, offset: 54497},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1729, col: 10, offset: 54304},
+									pos:  position{line: 1737, col: 10, offset: 54504},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1729, col: 16, offset: 54310},
+									pos:   position{line: 1737, col: 16, offset: 54510},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1729, col: 24, offset: 54318},
+										pos:  position{line: 1737, col: 24, offset: 54518},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3062,38 +3070,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1744, col: 1, offset: 54649},
+			pos:  position{line: 1752, col: 1, offset: 54849},
 			expr: &actionExpr{
-				pos: position{line: 1744, col: 17, offset: 54665},
+				pos: position{line: 1752, col: 17, offset: 54865},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1744, col: 17, offset: 54665},
+					pos:   position{line: 1752, col: 17, offset: 54865},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1744, col: 25, offset: 54673},
+						pos: position{line: 1752, col: 25, offset: 54873},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 25, offset: 54673},
+								pos:  position{line: 1752, col: 25, offset: 54873},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 46, offset: 54694},
+								pos:  position{line: 1752, col: 46, offset: 54894},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 65, offset: 54713},
+								pos:  position{line: 1752, col: 65, offset: 54913},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 84, offset: 54732},
+								pos:  position{line: 1752, col: 84, offset: 54932},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 101, offset: 54749},
+								pos:  position{line: 1752, col: 101, offset: 54949},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1744, col: 116, offset: 54764},
+								pos:  position{line: 1752, col: 116, offset: 54964},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3103,35 +3111,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1748, col: 1, offset: 54807},
+			pos:  position{line: 1756, col: 1, offset: 55007},
 			expr: &actionExpr{
-				pos: position{line: 1748, col: 22, offset: 54828},
+				pos: position{line: 1756, col: 22, offset: 55028},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1748, col: 22, offset: 54828},
+					pos: position{line: 1756, col: 22, offset: 55028},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1748, col: 22, offset: 54828},
+							pos:   position{line: 1756, col: 22, offset: 55028},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1748, col: 29, offset: 54835},
+								pos:  position{line: 1756, col: 29, offset: 55035},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1748, col: 42, offset: 54848},
+							pos:   position{line: 1756, col: 42, offset: 55048},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1748, col: 48, offset: 54854},
+								pos: position{line: 1756, col: 48, offset: 55054},
 								expr: &seqExpr{
-									pos: position{line: 1748, col: 49, offset: 54855},
+									pos: position{line: 1756, col: 49, offset: 55055},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1748, col: 49, offset: 54855},
+											pos:  position{line: 1756, col: 49, offset: 55055},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1748, col: 55, offset: 54861},
+											pos:  position{line: 1756, col: 55, offset: 55061},
 											name: "BinCmdOption",
 										},
 									},
@@ -3144,51 +3152,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1794, col: 1, offset: 56345},
+			pos:  position{line: 1802, col: 1, offset: 56545},
 			expr: &choiceExpr{
-				pos: position{line: 1794, col: 13, offset: 56357},
+				pos: position{line: 1802, col: 13, offset: 56557},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1794, col: 13, offset: 56357},
+						pos: position{line: 1802, col: 13, offset: 56557},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1794, col: 13, offset: 56357},
+							pos: position{line: 1802, col: 13, offset: 56557},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1794, col: 13, offset: 56357},
+									pos:  position{line: 1802, col: 13, offset: 56557},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1794, col: 18, offset: 56362},
+									pos:  position{line: 1802, col: 18, offset: 56562},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1794, col: 26, offset: 56370},
+									pos:   position{line: 1802, col: 26, offset: 56570},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1794, col: 40, offset: 56384},
+										pos:  position{line: 1802, col: 40, offset: 56584},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1794, col: 59, offset: 56403},
+									pos:  position{line: 1802, col: 59, offset: 56603},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1794, col: 65, offset: 56409},
+									pos:   position{line: 1802, col: 65, offset: 56609},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1794, col: 71, offset: 56415},
+										pos:  position{line: 1802, col: 71, offset: 56615},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1794, col: 81, offset: 56425},
+									pos:   position{line: 1802, col: 81, offset: 56625},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1794, col: 94, offset: 56438},
+										pos: position{line: 1802, col: 94, offset: 56638},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1794, col: 95, offset: 56439},
+											pos:  position{line: 1802, col: 95, offset: 56639},
 											name: "AsField",
 										},
 									},
@@ -3197,34 +3205,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1821, col: 3, offset: 57265},
+						pos: position{line: 1829, col: 3, offset: 57465},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1821, col: 3, offset: 57265},
+							pos: position{line: 1829, col: 3, offset: 57465},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1821, col: 3, offset: 57265},
+									pos:  position{line: 1829, col: 3, offset: 57465},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1821, col: 8, offset: 57270},
+									pos:  position{line: 1829, col: 8, offset: 57470},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1821, col: 16, offset: 57278},
+									pos:   position{line: 1829, col: 16, offset: 57478},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1821, col: 22, offset: 57284},
+										pos:  position{line: 1829, col: 22, offset: 57484},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1821, col: 32, offset: 57294},
+									pos:   position{line: 1829, col: 32, offset: 57494},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1821, col: 45, offset: 57307},
+										pos: position{line: 1829, col: 45, offset: 57507},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1821, col: 46, offset: 57308},
+											pos:  position{line: 1829, col: 46, offset: 57508},
 											name: "AsField",
 										},
 									},
@@ -3237,15 +3245,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1852, col: 1, offset: 58165},
+			pos:  position{line: 1860, col: 1, offset: 58365},
 			expr: &actionExpr{
-				pos: position{line: 1852, col: 15, offset: 58179},
+				pos: position{line: 1860, col: 15, offset: 58379},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1852, col: 15, offset: 58179},
+					pos:   position{line: 1860, col: 15, offset: 58379},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1852, col: 27, offset: 58191},
+						pos:  position{line: 1860, col: 27, offset: 58391},
 						name: "SpanOptions",
 					},
 				},
@@ -3253,26 +3261,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1860, col: 1, offset: 58416},
+			pos:  position{line: 1868, col: 1, offset: 58616},
 			expr: &actionExpr{
-				pos: position{line: 1860, col: 16, offset: 58431},
+				pos: position{line: 1868, col: 16, offset: 58631},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1860, col: 16, offset: 58431},
+					pos: position{line: 1868, col: 16, offset: 58631},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1860, col: 16, offset: 58431},
+							pos:  position{line: 1868, col: 16, offset: 58631},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1860, col: 25, offset: 58440},
+							pos:  position{line: 1868, col: 25, offset: 58640},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1860, col: 31, offset: 58446},
+							pos:   position{line: 1868, col: 31, offset: 58646},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1860, col: 42, offset: 58457},
+								pos:  position{line: 1868, col: 42, offset: 58657},
 								name: "SpanLength",
 							},
 						},
@@ -3282,26 +3290,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1867, col: 1, offset: 58603},
+			pos:  position{line: 1875, col: 1, offset: 58803},
 			expr: &actionExpr{
-				pos: position{line: 1867, col: 15, offset: 58617},
+				pos: position{line: 1875, col: 15, offset: 58817},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1867, col: 15, offset: 58617},
+					pos: position{line: 1875, col: 15, offset: 58817},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1867, col: 15, offset: 58617},
+							pos:   position{line: 1875, col: 15, offset: 58817},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1867, col: 24, offset: 58626},
+								pos:  position{line: 1875, col: 24, offset: 58826},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1867, col: 40, offset: 58642},
+							pos:   position{line: 1875, col: 40, offset: 58842},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1867, col: 50, offset: 58652},
+								pos:  position{line: 1875, col: 50, offset: 58852},
 								name: "AllTimeScale",
 							},
 						},
@@ -3311,43 +3319,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1884, col: 1, offset: 59201},
+			pos:  position{line: 1892, col: 1, offset: 59401},
 			expr: &actionExpr{
-				pos: position{line: 1884, col: 14, offset: 59214},
+				pos: position{line: 1892, col: 14, offset: 59414},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1884, col: 14, offset: 59214},
+					pos: position{line: 1892, col: 14, offset: 59414},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1884, col: 14, offset: 59214},
+							pos:  position{line: 1892, col: 14, offset: 59414},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1884, col: 20, offset: 59220},
+							pos:        position{line: 1892, col: 20, offset: 59420},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1884, col: 28, offset: 59228},
+							pos:  position{line: 1892, col: 28, offset: 59428},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 34, offset: 59234},
+							pos:   position{line: 1892, col: 34, offset: 59434},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1884, col: 41, offset: 59241},
+								pos: position{line: 1892, col: 41, offset: 59441},
 								expr: &choiceExpr{
-									pos: position{line: 1884, col: 42, offset: 59242},
+									pos: position{line: 1892, col: 42, offset: 59442},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1884, col: 42, offset: 59242},
+											pos:        position{line: 1892, col: 42, offset: 59442},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1884, col: 50, offset: 59250},
+											pos:        position{line: 1892, col: 50, offset: 59450},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3357,14 +3365,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1884, col: 61, offset: 59261},
+							pos:  position{line: 1892, col: 61, offset: 59461},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1884, col: 76, offset: 59276},
+							pos:   position{line: 1892, col: 76, offset: 59476},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1884, col: 86, offset: 59286},
+								pos:  position{line: 1892, col: 86, offset: 59486},
 								name: "IntegerAsString",
 							},
 						},
@@ -3374,22 +3382,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1908, col: 1, offset: 59867},
+			pos:  position{line: 1916, col: 1, offset: 60067},
 			expr: &actionExpr{
-				pos: position{line: 1908, col: 19, offset: 59885},
+				pos: position{line: 1916, col: 19, offset: 60085},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1908, col: 19, offset: 59885},
+					pos: position{line: 1916, col: 19, offset: 60085},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1908, col: 19, offset: 59885},
+							pos:  position{line: 1916, col: 19, offset: 60085},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1908, col: 24, offset: 59890},
+							pos:   position{line: 1916, col: 24, offset: 60090},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1908, col: 38, offset: 59904},
+								pos:  position{line: 1916, col: 38, offset: 60104},
 								name: "StatisticExpr",
 							},
 						},
@@ -3399,76 +3407,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1945, col: 1, offset: 61042},
+			pos:  position{line: 1953, col: 1, offset: 61242},
 			expr: &actionExpr{
-				pos: position{line: 1945, col: 18, offset: 61059},
+				pos: position{line: 1953, col: 18, offset: 61259},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1945, col: 18, offset: 61059},
+					pos: position{line: 1953, col: 18, offset: 61259},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1945, col: 18, offset: 61059},
+							pos:   position{line: 1953, col: 18, offset: 61259},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1945, col: 23, offset: 61064},
+								pos: position{line: 1953, col: 23, offset: 61264},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1945, col: 23, offset: 61064},
+										pos:  position{line: 1953, col: 23, offset: 61264},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1945, col: 33, offset: 61074},
+										pos:  position{line: 1953, col: 33, offset: 61274},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1945, col: 43, offset: 61084},
+							pos:   position{line: 1953, col: 43, offset: 61284},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1945, col: 49, offset: 61090},
+								pos: position{line: 1953, col: 49, offset: 61290},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1945, col: 50, offset: 61091},
+									pos:  position{line: 1953, col: 50, offset: 61291},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1945, col: 67, offset: 61108},
+							pos:   position{line: 1953, col: 67, offset: 61308},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1945, col: 78, offset: 61119},
+								pos: position{line: 1953, col: 78, offset: 61319},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1945, col: 78, offset: 61119},
+										pos:  position{line: 1953, col: 78, offset: 61319},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1945, col: 84, offset: 61125},
+										pos:  position{line: 1953, col: 84, offset: 61325},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1945, col: 99, offset: 61140},
+							pos:   position{line: 1953, col: 99, offset: 61340},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1945, col: 108, offset: 61149},
+								pos: position{line: 1953, col: 108, offset: 61349},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1945, col: 109, offset: 61150},
+									pos:  position{line: 1953, col: 109, offset: 61350},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1945, col: 120, offset: 61161},
+							pos:   position{line: 1953, col: 120, offset: 61361},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1945, col: 128, offset: 61169},
+								pos: position{line: 1953, col: 128, offset: 61369},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1945, col: 129, offset: 61170},
+									pos:  position{line: 1953, col: 129, offset: 61370},
 									name: "StatisticOptions",
 								},
 							},
@@ -3479,25 +3487,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1987, col: 1, offset: 62255},
+			pos:  position{line: 1995, col: 1, offset: 62455},
 			expr: &choiceExpr{
-				pos: position{line: 1987, col: 19, offset: 62273},
+				pos: position{line: 1995, col: 19, offset: 62473},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1987, col: 19, offset: 62273},
+						pos: position{line: 1995, col: 19, offset: 62473},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1987, col: 19, offset: 62273},
+							pos: position{line: 1995, col: 19, offset: 62473},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1987, col: 19, offset: 62273},
+									pos:  position{line: 1995, col: 19, offset: 62473},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1987, col: 25, offset: 62279},
+									pos:   position{line: 1995, col: 25, offset: 62479},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1987, col: 32, offset: 62286},
+										pos:  position{line: 1995, col: 32, offset: 62486},
 										name: "IntegerAsString",
 									},
 								},
@@ -3505,30 +3513,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1990, col: 3, offset: 62340},
+						pos: position{line: 1998, col: 3, offset: 62540},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1990, col: 3, offset: 62340},
+							pos: position{line: 1998, col: 3, offset: 62540},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1990, col: 3, offset: 62340},
+									pos:  position{line: 1998, col: 3, offset: 62540},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1990, col: 9, offset: 62346},
+									pos:        position{line: 1998, col: 9, offset: 62546},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1990, col: 17, offset: 62354},
+									pos:  position{line: 1998, col: 17, offset: 62554},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1990, col: 23, offset: 62360},
+									pos:   position{line: 1998, col: 23, offset: 62560},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1990, col: 30, offset: 62367},
+										pos:  position{line: 1998, col: 30, offset: 62567},
 										name: "IntegerAsString",
 									},
 								},
@@ -3540,17 +3548,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1995, col: 1, offset: 62465},
+			pos:  position{line: 2003, col: 1, offset: 62665},
 			expr: &actionExpr{
-				pos: position{line: 1995, col: 21, offset: 62485},
+				pos: position{line: 2003, col: 21, offset: 62685},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1995, col: 21, offset: 62485},
+					pos:   position{line: 2003, col: 21, offset: 62685},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1995, col: 28, offset: 62492},
+						pos: position{line: 2003, col: 28, offset: 62692},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1995, col: 29, offset: 62493},
+							pos:  position{line: 2003, col: 29, offset: 62693},
 							name: "StatisticOption",
 						},
 					},
@@ -3559,34 +3567,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 2044, col: 1, offset: 64055},
+			pos:  position{line: 2052, col: 1, offset: 64255},
 			expr: &actionExpr{
-				pos: position{line: 2044, col: 20, offset: 64074},
+				pos: position{line: 2052, col: 20, offset: 64274},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 2044, col: 20, offset: 64074},
+					pos: position{line: 2052, col: 20, offset: 64274},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2044, col: 20, offset: 64074},
+							pos:  position{line: 2052, col: 20, offset: 64274},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2044, col: 26, offset: 64080},
+							pos:   position{line: 2052, col: 26, offset: 64280},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2044, col: 36, offset: 64090},
+								pos:  position{line: 2052, col: 36, offset: 64290},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2044, col: 55, offset: 64109},
+							pos:  position{line: 2052, col: 55, offset: 64309},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2044, col: 61, offset: 64115},
+							pos:   position{line: 2052, col: 61, offset: 64315},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2044, col: 67, offset: 64121},
+								pos:  position{line: 2052, col: 67, offset: 64321},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3596,48 +3604,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 2049, col: 1, offset: 64230},
+			pos:  position{line: 2057, col: 1, offset: 64430},
 			expr: &actionExpr{
-				pos: position{line: 2049, col: 23, offset: 64252},
+				pos: position{line: 2057, col: 23, offset: 64452},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2049, col: 23, offset: 64252},
+					pos:   position{line: 2057, col: 23, offset: 64452},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2049, col: 31, offset: 64260},
+						pos: position{line: 2057, col: 31, offset: 64460},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2049, col: 31, offset: 64260},
+								pos:        position{line: 2057, col: 31, offset: 64460},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2049, col: 46, offset: 64275},
+								pos:        position{line: 2057, col: 46, offset: 64475},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2049, col: 60, offset: 64289},
+								pos:        position{line: 2057, col: 60, offset: 64489},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2049, col: 73, offset: 64302},
+								pos:        position{line: 2057, col: 73, offset: 64502},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2049, col: 85, offset: 64314},
+								pos:        position{line: 2057, col: 85, offset: 64514},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2049, col: 102, offset: 64331},
+								pos:        position{line: 2057, col: 102, offset: 64531},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3649,25 +3657,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2057, col: 1, offset: 64518},
+			pos:  position{line: 2065, col: 1, offset: 64718},
 			expr: &choiceExpr{
-				pos: position{line: 2057, col: 13, offset: 64530},
+				pos: position{line: 2065, col: 13, offset: 64730},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2057, col: 13, offset: 64530},
+						pos: position{line: 2065, col: 13, offset: 64730},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2057, col: 13, offset: 64530},
+							pos: position{line: 2065, col: 13, offset: 64730},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2057, col: 13, offset: 64530},
+									pos:  position{line: 2065, col: 13, offset: 64730},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2057, col: 16, offset: 64533},
+									pos:   position{line: 2065, col: 16, offset: 64733},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2057, col: 26, offset: 64543},
+										pos:  position{line: 2065, col: 26, offset: 64743},
 										name: "FieldNameList",
 									},
 								},
@@ -3675,13 +3683,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2060, col: 3, offset: 64600},
+						pos: position{line: 2068, col: 3, offset: 64800},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2060, col: 3, offset: 64600},
+							pos:   position{line: 2068, col: 3, offset: 64800},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2060, col: 16, offset: 64613},
+								pos:  position{line: 2068, col: 16, offset: 64813},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3691,26 +3699,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2064, col: 1, offset: 64671},
+			pos:  position{line: 2072, col: 1, offset: 64871},
 			expr: &actionExpr{
-				pos: position{line: 2064, col: 15, offset: 64685},
+				pos: position{line: 2072, col: 15, offset: 64885},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2064, col: 15, offset: 64685},
+					pos: position{line: 2072, col: 15, offset: 64885},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2064, col: 15, offset: 64685},
+							pos:  position{line: 2072, col: 15, offset: 64885},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2064, col: 20, offset: 64690},
+							pos:  position{line: 2072, col: 20, offset: 64890},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2064, col: 30, offset: 64700},
+							pos:   position{line: 2072, col: 30, offset: 64900},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2064, col: 40, offset: 64710},
+								pos:  position{line: 2072, col: 40, offset: 64910},
 								name: "DedupExpr",
 							},
 						},
@@ -3720,27 +3728,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2110, col: 1, offset: 66039},
+			pos:  position{line: 2118, col: 1, offset: 66239},
 			expr: &actionExpr{
-				pos: position{line: 2110, col: 14, offset: 66052},
+				pos: position{line: 2118, col: 14, offset: 66252},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2110, col: 14, offset: 66052},
+					pos: position{line: 2118, col: 14, offset: 66252},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2110, col: 14, offset: 66052},
+							pos:   position{line: 2118, col: 14, offset: 66252},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2110, col: 23, offset: 66061},
+								pos: position{line: 2118, col: 23, offset: 66261},
 								expr: &seqExpr{
-									pos: position{line: 2110, col: 24, offset: 66062},
+									pos: position{line: 2118, col: 24, offset: 66262},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2110, col: 24, offset: 66062},
+											pos:  position{line: 2118, col: 24, offset: 66262},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2110, col: 30, offset: 66068},
+											pos:  position{line: 2118, col: 30, offset: 66268},
 											name: "IntegerAsString",
 										},
 									},
@@ -3748,45 +3756,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2110, col: 48, offset: 66086},
+							pos:   position{line: 2118, col: 48, offset: 66286},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2110, col: 57, offset: 66095},
+								pos: position{line: 2118, col: 57, offset: 66295},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2110, col: 58, offset: 66096},
+									pos:  position{line: 2118, col: 58, offset: 66296},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2110, col: 73, offset: 66111},
+							pos:   position{line: 2118, col: 73, offset: 66311},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2110, col: 83, offset: 66121},
+								pos: position{line: 2118, col: 83, offset: 66321},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2110, col: 84, offset: 66122},
+									pos:  position{line: 2118, col: 84, offset: 66322},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2110, col: 101, offset: 66139},
+							pos:   position{line: 2118, col: 101, offset: 66339},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2110, col: 110, offset: 66148},
+								pos: position{line: 2118, col: 110, offset: 66348},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2110, col: 111, offset: 66149},
+									pos:  position{line: 2118, col: 111, offset: 66349},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2110, col: 126, offset: 66164},
+							pos:   position{line: 2118, col: 126, offset: 66364},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2110, col: 139, offset: 66177},
+								pos: position{line: 2118, col: 139, offset: 66377},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2110, col: 140, offset: 66178},
+									pos:  position{line: 2118, col: 140, offset: 66378},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3797,27 +3805,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2167, col: 1, offset: 67916},
+			pos:  position{line: 2175, col: 1, offset: 68116},
 			expr: &actionExpr{
-				pos: position{line: 2167, col: 19, offset: 67934},
+				pos: position{line: 2175, col: 19, offset: 68134},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2167, col: 19, offset: 67934},
+					pos: position{line: 2175, col: 19, offset: 68134},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2167, col: 19, offset: 67934},
+							pos: position{line: 2175, col: 19, offset: 68134},
 							expr: &litMatcher{
-								pos:        position{line: 2167, col: 21, offset: 67936},
+								pos:        position{line: 2175, col: 21, offset: 68136},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2167, col: 31, offset: 67946},
+							pos:   position{line: 2175, col: 31, offset: 68146},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2167, col: 37, offset: 67952},
+								pos:  position{line: 2175, col: 37, offset: 68152},
 								name: "FieldName",
 							},
 						},
@@ -3827,48 +3835,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2173, col: 1, offset: 68091},
+			pos:  position{line: 2181, col: 1, offset: 68291},
 			expr: &actionExpr{
-				pos: position{line: 2173, col: 32, offset: 68122},
+				pos: position{line: 2181, col: 32, offset: 68322},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2173, col: 32, offset: 68122},
+					pos: position{line: 2181, col: 32, offset: 68322},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2173, col: 32, offset: 68122},
+							pos:   position{line: 2181, col: 32, offset: 68322},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2173, col: 38, offset: 68128},
+								pos:  position{line: 2181, col: 38, offset: 68328},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2173, col: 48, offset: 68138},
+							pos: position{line: 2181, col: 48, offset: 68338},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2173, col: 50, offset: 68140},
+								pos:  position{line: 2181, col: 50, offset: 68340},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2173, col: 57, offset: 68147},
+							pos:   position{line: 2181, col: 57, offset: 68347},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2173, col: 62, offset: 68152},
+								pos: position{line: 2181, col: 62, offset: 68352},
 								expr: &seqExpr{
-									pos: position{line: 2173, col: 63, offset: 68153},
+									pos: position{line: 2181, col: 63, offset: 68353},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2173, col: 63, offset: 68153},
+											pos:  position{line: 2181, col: 63, offset: 68353},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2173, col: 69, offset: 68159},
+											pos:  position{line: 2181, col: 69, offset: 68359},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2173, col: 79, offset: 68169},
+											pos: position{line: 2181, col: 79, offset: 68369},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2173, col: 81, offset: 68171},
+												pos:  position{line: 2181, col: 81, offset: 68371},
 												name: "EQUAL",
 											},
 										},
@@ -3882,45 +3890,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2184, col: 1, offset: 68446},
+			pos:  position{line: 2192, col: 1, offset: 68646},
 			expr: &actionExpr{
-				pos: position{line: 2184, col: 19, offset: 68464},
+				pos: position{line: 2192, col: 19, offset: 68664},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2184, col: 19, offset: 68464},
+					pos: position{line: 2192, col: 19, offset: 68664},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 19, offset: 68464},
+							pos:  position{line: 2192, col: 19, offset: 68664},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 25, offset: 68470},
+							pos:   position{line: 2192, col: 25, offset: 68670},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 31, offset: 68476},
+								pos:  position{line: 2192, col: 31, offset: 68676},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 46, offset: 68491},
+							pos:   position{line: 2192, col: 46, offset: 68691},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2184, col: 51, offset: 68496},
+								pos: position{line: 2192, col: 51, offset: 68696},
 								expr: &seqExpr{
-									pos: position{line: 2184, col: 52, offset: 68497},
+									pos: position{line: 2192, col: 52, offset: 68697},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2184, col: 52, offset: 68497},
+											pos:  position{line: 2192, col: 52, offset: 68697},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2184, col: 58, offset: 68503},
+											pos:  position{line: 2192, col: 58, offset: 68703},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2184, col: 73, offset: 68518},
+											pos: position{line: 2192, col: 73, offset: 68718},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2184, col: 74, offset: 68519},
+												pos:  position{line: 2192, col: 74, offset: 68719},
 												name: "EQUAL",
 											},
 										},
@@ -3934,17 +3942,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2202, col: 1, offset: 69047},
+			pos:  position{line: 2210, col: 1, offset: 69247},
 			expr: &actionExpr{
-				pos: position{line: 2202, col: 17, offset: 69063},
+				pos: position{line: 2210, col: 17, offset: 69263},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2202, col: 17, offset: 69063},
+					pos:   position{line: 2210, col: 17, offset: 69263},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2202, col: 24, offset: 69070},
+						pos: position{line: 2210, col: 24, offset: 69270},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2202, col: 25, offset: 69071},
+							pos:  position{line: 2210, col: 25, offset: 69271},
 							name: "DedupOption",
 						},
 					},
@@ -3953,36 +3961,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2242, col: 1, offset: 70337},
+			pos:  position{line: 2250, col: 1, offset: 70537},
 			expr: &actionExpr{
-				pos: position{line: 2242, col: 16, offset: 70352},
+				pos: position{line: 2250, col: 16, offset: 70552},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2242, col: 16, offset: 70352},
+					pos: position{line: 2250, col: 16, offset: 70552},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2242, col: 16, offset: 70352},
+							pos:  position{line: 2250, col: 16, offset: 70552},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2242, col: 22, offset: 70358},
+							pos:   position{line: 2250, col: 22, offset: 70558},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2242, col: 32, offset: 70368},
+								pos:  position{line: 2250, col: 32, offset: 70568},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2242, col: 47, offset: 70383},
+							pos:        position{line: 2250, col: 47, offset: 70583},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2242, col: 51, offset: 70387},
+							pos:   position{line: 2250, col: 51, offset: 70587},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2242, col: 57, offset: 70393},
+								pos:  position{line: 2250, col: 57, offset: 70593},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3992,30 +4000,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2247, col: 1, offset: 70502},
+			pos:  position{line: 2255, col: 1, offset: 70702},
 			expr: &actionExpr{
-				pos: position{line: 2247, col: 19, offset: 70520},
+				pos: position{line: 2255, col: 19, offset: 70720},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2247, col: 19, offset: 70520},
+					pos:   position{line: 2255, col: 19, offset: 70720},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2247, col: 27, offset: 70528},
+						pos: position{line: 2255, col: 27, offset: 70728},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2247, col: 27, offset: 70528},
+								pos:        position{line: 2255, col: 27, offset: 70728},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2247, col: 43, offset: 70544},
+								pos:        position{line: 2255, col: 43, offset: 70744},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2247, col: 57, offset: 70558},
+								pos:        position{line: 2255, col: 57, offset: 70758},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -4027,22 +4035,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2255, col: 1, offset: 70743},
+			pos:  position{line: 2263, col: 1, offset: 70943},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 22, offset: 70764},
+				pos: position{line: 2263, col: 22, offset: 70964},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2255, col: 22, offset: 70764},
+					pos: position{line: 2263, col: 22, offset: 70964},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2255, col: 22, offset: 70764},
+							pos:  position{line: 2263, col: 22, offset: 70964},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2255, col: 39, offset: 70781},
+							pos:   position{line: 2263, col: 39, offset: 70981},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2255, col: 53, offset: 70795},
+								pos:  position{line: 2263, col: 53, offset: 70995},
 								name: "SortElements",
 							},
 						},
@@ -4052,35 +4060,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2260, col: 1, offset: 70903},
+			pos:  position{line: 2268, col: 1, offset: 71103},
 			expr: &actionExpr{
-				pos: position{line: 2260, col: 17, offset: 70919},
+				pos: position{line: 2268, col: 17, offset: 71119},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2260, col: 17, offset: 70919},
+					pos: position{line: 2268, col: 17, offset: 71119},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2260, col: 17, offset: 70919},
+							pos:   position{line: 2268, col: 17, offset: 71119},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2260, col: 23, offset: 70925},
+								pos:  position{line: 2268, col: 23, offset: 71125},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2260, col: 41, offset: 70943},
+							pos:   position{line: 2268, col: 41, offset: 71143},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2260, col: 46, offset: 70948},
+								pos: position{line: 2268, col: 46, offset: 71148},
 								expr: &seqExpr{
-									pos: position{line: 2260, col: 47, offset: 70949},
+									pos: position{line: 2268, col: 47, offset: 71149},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2260, col: 47, offset: 70949},
+											pos:  position{line: 2268, col: 47, offset: 71149},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2260, col: 62, offset: 70964},
+											pos:  position{line: 2268, col: 62, offset: 71164},
 											name: "SingleSortElement",
 										},
 									},
@@ -4093,22 +4101,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2275, col: 1, offset: 71322},
+			pos:  position{line: 2283, col: 1, offset: 71522},
 			expr: &actionExpr{
-				pos: position{line: 2275, col: 22, offset: 71343},
+				pos: position{line: 2283, col: 22, offset: 71543},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2275, col: 22, offset: 71343},
+					pos:   position{line: 2283, col: 22, offset: 71543},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2275, col: 31, offset: 71352},
+						pos: position{line: 2283, col: 31, offset: 71552},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2275, col: 31, offset: 71352},
+								pos:  position{line: 2283, col: 31, offset: 71552},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2275, col: 59, offset: 71380},
+								pos:  position{line: 2283, col: 59, offset: 71580},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4118,33 +4126,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2279, col: 1, offset: 71439},
+			pos:  position{line: 2287, col: 1, offset: 71639},
 			expr: &actionExpr{
-				pos: position{line: 2279, col: 33, offset: 71471},
+				pos: position{line: 2287, col: 33, offset: 71671},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2279, col: 33, offset: 71471},
+					pos: position{line: 2287, col: 33, offset: 71671},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2279, col: 33, offset: 71471},
+							pos:   position{line: 2287, col: 33, offset: 71671},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2279, col: 47, offset: 71485},
+								pos: position{line: 2287, col: 47, offset: 71685},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2279, col: 47, offset: 71485},
+										pos:        position{line: 2287, col: 47, offset: 71685},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 53, offset: 71491},
+										pos:        position{line: 2287, col: 53, offset: 71691},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 59, offset: 71497},
+										pos:        position{line: 2287, col: 59, offset: 71697},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4153,10 +4161,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2279, col: 63, offset: 71501},
+							pos:   position{line: 2287, col: 63, offset: 71701},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2279, col: 69, offset: 71507},
+								pos:  position{line: 2287, col: 69, offset: 71707},
 								name: "FieldName",
 							},
 						},
@@ -4166,33 +4174,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2294, col: 1, offset: 71782},
+			pos:  position{line: 2302, col: 1, offset: 71982},
 			expr: &actionExpr{
-				pos: position{line: 2294, col: 30, offset: 71811},
+				pos: position{line: 2302, col: 30, offset: 72011},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2294, col: 30, offset: 71811},
+					pos: position{line: 2302, col: 30, offset: 72011},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2294, col: 30, offset: 71811},
+							pos:   position{line: 2302, col: 30, offset: 72011},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2294, col: 44, offset: 71825},
+								pos: position{line: 2302, col: 44, offset: 72025},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2294, col: 44, offset: 71825},
+										pos:        position{line: 2302, col: 44, offset: 72025},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2294, col: 50, offset: 71831},
+										pos:        position{line: 2302, col: 50, offset: 72031},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2294, col: 56, offset: 71837},
+										pos:        position{line: 2302, col: 56, offset: 72037},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4201,31 +4209,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2294, col: 60, offset: 71841},
+							pos:   position{line: 2302, col: 60, offset: 72041},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2294, col: 64, offset: 71845},
+								pos: position{line: 2302, col: 64, offset: 72045},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2294, col: 64, offset: 71845},
+										pos:        position{line: 2302, col: 64, offset: 72045},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2294, col: 73, offset: 71854},
+										pos:        position{line: 2302, col: 73, offset: 72054},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2294, col: 81, offset: 71862},
+										pos:        position{line: 2302, col: 81, offset: 72062},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2294, col: 88, offset: 71869},
+										pos:        position{line: 2302, col: 88, offset: 72069},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4234,19 +4242,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2294, col: 95, offset: 71876},
+							pos:  position{line: 2302, col: 95, offset: 72076},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2294, col: 103, offset: 71884},
+							pos:   position{line: 2302, col: 103, offset: 72084},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2294, col: 109, offset: 71890},
+								pos:  position{line: 2302, col: 109, offset: 72090},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2294, col: 119, offset: 71900},
+							pos:  position{line: 2302, col: 119, offset: 72100},
 							name: "R_PAREN",
 						},
 					},
@@ -4255,26 +4263,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2314, col: 1, offset: 72325},
+			pos:  position{line: 2322, col: 1, offset: 72525},
 			expr: &actionExpr{
-				pos: position{line: 2314, col: 16, offset: 72340},
+				pos: position{line: 2322, col: 16, offset: 72540},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2314, col: 16, offset: 72340},
+					pos: position{line: 2322, col: 16, offset: 72540},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 16, offset: 72340},
+							pos:  position{line: 2322, col: 16, offset: 72540},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2314, col: 21, offset: 72345},
+							pos:  position{line: 2322, col: 21, offset: 72545},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2314, col: 32, offset: 72356},
+							pos:   position{line: 2322, col: 32, offset: 72556},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2314, col: 43, offset: 72367},
+								pos:  position{line: 2322, col: 43, offset: 72567},
 								name: "RenameExpr",
 							},
 						},
@@ -4284,33 +4292,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2337, col: 1, offset: 73031},
+			pos:  position{line: 2345, col: 1, offset: 73231},
 			expr: &choiceExpr{
-				pos: position{line: 2337, col: 15, offset: 73045},
+				pos: position{line: 2345, col: 15, offset: 73245},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2337, col: 15, offset: 73045},
+						pos: position{line: 2345, col: 15, offset: 73245},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2337, col: 15, offset: 73045},
+							pos: position{line: 2345, col: 15, offset: 73245},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2337, col: 15, offset: 73045},
+									pos:   position{line: 2345, col: 15, offset: 73245},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2337, col: 31, offset: 73061},
+										pos:  position{line: 2345, col: 31, offset: 73261},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2337, col: 41, offset: 73071},
+									pos:  position{line: 2345, col: 41, offset: 73271},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2337, col: 44, offset: 73074},
+									pos:   position{line: 2345, col: 44, offset: 73274},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2337, col: 55, offset: 73085},
+										pos:  position{line: 2345, col: 55, offset: 73285},
 										name: "QuotedString",
 									},
 								},
@@ -4318,28 +4326,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2348, col: 3, offset: 73404},
+						pos: position{line: 2356, col: 3, offset: 73604},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2348, col: 3, offset: 73404},
+							pos: position{line: 2356, col: 3, offset: 73604},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2348, col: 3, offset: 73404},
+									pos:   position{line: 2356, col: 3, offset: 73604},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2348, col: 19, offset: 73420},
+										pos:  position{line: 2356, col: 19, offset: 73620},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2348, col: 29, offset: 73430},
+									pos:  position{line: 2356, col: 29, offset: 73630},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2348, col: 32, offset: 73433},
+									pos:   position{line: 2356, col: 32, offset: 73633},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2348, col: 43, offset: 73444},
+										pos:  position{line: 2356, col: 43, offset: 73644},
 										name: "RenamePattern",
 									},
 								},
@@ -4351,48 +4359,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2370, col: 1, offset: 74010},
+			pos:  position{line: 2378, col: 1, offset: 74210},
 			expr: &actionExpr{
-				pos: position{line: 2370, col: 13, offset: 74022},
+				pos: position{line: 2378, col: 13, offset: 74222},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2370, col: 13, offset: 74022},
+					pos: position{line: 2378, col: 13, offset: 74222},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2370, col: 13, offset: 74022},
+							pos:  position{line: 2378, col: 13, offset: 74222},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2370, col: 18, offset: 74027},
+							pos:  position{line: 2378, col: 18, offset: 74227},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2370, col: 26, offset: 74035},
+							pos:        position{line: 2378, col: 26, offset: 74235},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2370, col: 34, offset: 74043},
+							pos:  position{line: 2378, col: 34, offset: 74243},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2370, col: 40, offset: 74049},
+							pos:   position{line: 2378, col: 40, offset: 74249},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2370, col: 46, offset: 74055},
+								pos:  position{line: 2378, col: 46, offset: 74255},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2370, col: 62, offset: 74071},
+							pos:  position{line: 2378, col: 62, offset: 74271},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2370, col: 68, offset: 74077},
+							pos:   position{line: 2378, col: 68, offset: 74277},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2370, col: 72, offset: 74081},
+								pos:  position{line: 2378, col: 72, offset: 74281},
 								name: "QuotedString",
 							},
 						},
@@ -4402,37 +4410,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2399, col: 1, offset: 74810},
+			pos:  position{line: 2407, col: 1, offset: 75010},
 			expr: &actionExpr{
-				pos: position{line: 2399, col: 14, offset: 74823},
+				pos: position{line: 2407, col: 14, offset: 75023},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2399, col: 14, offset: 74823},
+					pos: position{line: 2407, col: 14, offset: 75023},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2399, col: 14, offset: 74823},
+							pos:  position{line: 2407, col: 14, offset: 75023},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2399, col: 19, offset: 74828},
+							pos:  position{line: 2407, col: 19, offset: 75028},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2399, col: 28, offset: 74837},
+							pos:   position{line: 2407, col: 28, offset: 75037},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2399, col: 34, offset: 74843},
+								pos: position{line: 2407, col: 34, offset: 75043},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2399, col: 35, offset: 74844},
+									pos:  position{line: 2407, col: 35, offset: 75044},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2399, col: 47, offset: 74856},
+							pos:   position{line: 2407, col: 47, offset: 75056},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2399, col: 58, offset: 74867},
+								pos:  position{line: 2407, col: 58, offset: 75067},
 								name: "SortElements",
 							},
 						},
@@ -4442,41 +4450,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2437, col: 1, offset: 75746},
+			pos:  position{line: 2445, col: 1, offset: 75946},
 			expr: &actionExpr{
-				pos: position{line: 2437, col: 14, offset: 75759},
+				pos: position{line: 2445, col: 14, offset: 75959},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2437, col: 14, offset: 75759},
+					pos: position{line: 2445, col: 14, offset: 75959},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2437, col: 14, offset: 75759},
+							pos: position{line: 2445, col: 14, offset: 75959},
 							expr: &seqExpr{
-								pos: position{line: 2437, col: 15, offset: 75760},
+								pos: position{line: 2445, col: 15, offset: 75960},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2437, col: 15, offset: 75760},
+										pos:        position{line: 2445, col: 15, offset: 75960},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2437, col: 23, offset: 75768},
+										pos:  position{line: 2445, col: 23, offset: 75968},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2437, col: 31, offset: 75776},
+							pos:   position{line: 2445, col: 31, offset: 75976},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2437, col: 40, offset: 75785},
+								pos:  position{line: 2445, col: 40, offset: 75985},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2437, col: 56, offset: 75801},
+							pos:  position{line: 2445, col: 56, offset: 76001},
 							name: "SPACE",
 						},
 					},
@@ -4485,43 +4493,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2451, col: 1, offset: 76100},
+			pos:  position{line: 2459, col: 1, offset: 76300},
 			expr: &actionExpr{
-				pos: position{line: 2451, col: 14, offset: 76113},
+				pos: position{line: 2459, col: 14, offset: 76313},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2451, col: 14, offset: 76113},
+					pos: position{line: 2459, col: 14, offset: 76313},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2451, col: 14, offset: 76113},
+							pos:  position{line: 2459, col: 14, offset: 76313},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2451, col: 19, offset: 76118},
+							pos:  position{line: 2459, col: 19, offset: 76318},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2451, col: 28, offset: 76127},
+							pos:   position{line: 2459, col: 28, offset: 76327},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2451, col: 34, offset: 76133},
+								pos:  position{line: 2459, col: 34, offset: 76333},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2451, col: 45, offset: 76144},
+							pos:   position{line: 2459, col: 45, offset: 76344},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2451, col: 50, offset: 76149},
+								pos: position{line: 2459, col: 50, offset: 76349},
 								expr: &seqExpr{
-									pos: position{line: 2451, col: 51, offset: 76150},
+									pos: position{line: 2459, col: 51, offset: 76350},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2451, col: 51, offset: 76150},
+											pos:  position{line: 2459, col: 51, offset: 76350},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2451, col: 57, offset: 76156},
+											pos:  position{line: 2459, col: 57, offset: 76356},
 											name: "SingleEval",
 										},
 									},
@@ -4534,30 +4542,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2486, col: 1, offset: 77389},
+			pos:  position{line: 2494, col: 1, offset: 77589},
 			expr: &actionExpr{
-				pos: position{line: 2486, col: 15, offset: 77403},
+				pos: position{line: 2494, col: 15, offset: 77603},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2486, col: 15, offset: 77403},
+					pos: position{line: 2494, col: 15, offset: 77603},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2486, col: 15, offset: 77403},
+							pos:   position{line: 2494, col: 15, offset: 77603},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2486, col: 21, offset: 77409},
+								pos:  position{line: 2494, col: 21, offset: 77609},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2486, col: 31, offset: 77419},
+							pos:  position{line: 2494, col: 31, offset: 77619},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2486, col: 37, offset: 77425},
+							pos:   position{line: 2494, col: 37, offset: 77625},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2486, col: 42, offset: 77430},
+								pos:  position{line: 2494, col: 42, offset: 77630},
 								name: "EvalExpression",
 							},
 						},
@@ -4567,15 +4575,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2499, col: 1, offset: 77831},
+			pos:  position{line: 2507, col: 1, offset: 78031},
 			expr: &actionExpr{
-				pos: position{line: 2499, col: 19, offset: 77849},
+				pos: position{line: 2507, col: 19, offset: 78049},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2499, col: 19, offset: 77849},
+					pos:   position{line: 2507, col: 19, offset: 78049},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2499, col: 25, offset: 77855},
+						pos:  position{line: 2507, col: 25, offset: 78055},
 						name: "ValueExpr",
 					},
 				},
@@ -4583,85 +4591,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2511, col: 1, offset: 78243},
+			pos:  position{line: 2519, col: 1, offset: 78443},
 			expr: &choiceExpr{
-				pos: position{line: 2511, col: 18, offset: 78260},
+				pos: position{line: 2519, col: 18, offset: 78460},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2511, col: 18, offset: 78260},
+						pos: position{line: 2519, col: 18, offset: 78460},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2511, col: 18, offset: 78260},
+							pos: position{line: 2519, col: 18, offset: 78460},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2511, col: 18, offset: 78260},
+									pos:        position{line: 2519, col: 18, offset: 78460},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 23, offset: 78265},
+									pos:  position{line: 2519, col: 23, offset: 78465},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 31, offset: 78273},
+									pos:   position{line: 2519, col: 31, offset: 78473},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 41, offset: 78283},
+										pos:  position{line: 2519, col: 41, offset: 78483},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 50, offset: 78292},
+									pos:  position{line: 2519, col: 50, offset: 78492},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 56, offset: 78298},
+									pos:   position{line: 2519, col: 56, offset: 78498},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 66, offset: 78308},
+										pos:  position{line: 2519, col: 66, offset: 78508},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 76, offset: 78318},
+									pos:  position{line: 2519, col: 76, offset: 78518},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 82, offset: 78324},
+									pos:   position{line: 2519, col: 82, offset: 78524},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 93, offset: 78335},
+										pos:  position{line: 2519, col: 93, offset: 78535},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 103, offset: 78345},
+									pos:  position{line: 2519, col: 103, offset: 78545},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2522, col: 3, offset: 78596},
+						pos: position{line: 2530, col: 3, offset: 78796},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2522, col: 3, offset: 78596},
+							pos: position{line: 2530, col: 3, offset: 78796},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2522, col: 3, offset: 78596},
+									pos:   position{line: 2530, col: 3, offset: 78796},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2522, col: 11, offset: 78604},
+										pos: position{line: 2530, col: 11, offset: 78804},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2522, col: 11, offset: 78604},
+												pos:        position{line: 2530, col: 11, offset: 78804},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2522, col: 20, offset: 78613},
+												pos:        position{line: 2530, col: 20, offset: 78813},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4670,31 +4678,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2522, col: 32, offset: 78625},
+									pos:  position{line: 2530, col: 32, offset: 78825},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2522, col: 40, offset: 78633},
+									pos:   position{line: 2530, col: 40, offset: 78833},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2522, col: 45, offset: 78638},
+										pos:  position{line: 2530, col: 45, offset: 78838},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2522, col: 64, offset: 78657},
+									pos:   position{line: 2530, col: 64, offset: 78857},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2522, col: 69, offset: 78662},
+										pos: position{line: 2530, col: 69, offset: 78862},
 										expr: &seqExpr{
-											pos: position{line: 2522, col: 70, offset: 78663},
+											pos: position{line: 2530, col: 70, offset: 78863},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2522, col: 70, offset: 78663},
+													pos:  position{line: 2530, col: 70, offset: 78863},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2522, col: 76, offset: 78669},
+													pos:  position{line: 2530, col: 76, offset: 78869},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4702,50 +4710,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2522, col: 97, offset: 78690},
+									pos:  position{line: 2530, col: 97, offset: 78890},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2545, col: 3, offset: 79294},
+						pos: position{line: 2553, col: 3, offset: 79494},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2545, col: 3, offset: 79294},
+							pos: position{line: 2553, col: 3, offset: 79494},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2545, col: 3, offset: 79294},
+									pos:        position{line: 2553, col: 3, offset: 79494},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2545, col: 14, offset: 79305},
+									pos:  position{line: 2553, col: 14, offset: 79505},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2545, col: 22, offset: 79313},
+									pos:   position{line: 2553, col: 22, offset: 79513},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2545, col: 32, offset: 79323},
+										pos:  position{line: 2553, col: 32, offset: 79523},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2545, col: 42, offset: 79333},
+									pos:   position{line: 2553, col: 42, offset: 79533},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2545, col: 47, offset: 79338},
+										pos: position{line: 2553, col: 47, offset: 79538},
 										expr: &seqExpr{
-											pos: position{line: 2545, col: 48, offset: 79339},
+											pos: position{line: 2553, col: 48, offset: 79539},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2545, col: 48, offset: 79339},
+													pos:  position{line: 2553, col: 48, offset: 79539},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2545, col: 54, offset: 79345},
+													pos:  position{line: 2553, col: 54, offset: 79545},
 													name: "ValueExpr",
 												},
 											},
@@ -4753,73 +4761,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2545, col: 66, offset: 79357},
+									pos:  position{line: 2553, col: 66, offset: 79557},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2562, col: 3, offset: 79776},
+						pos: position{line: 2570, col: 3, offset: 79976},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2562, col: 3, offset: 79776},
+							pos: position{line: 2570, col: 3, offset: 79976},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2562, col: 3, offset: 79776},
+									pos:        position{line: 2570, col: 3, offset: 79976},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2562, col: 12, offset: 79785},
+									pos:  position{line: 2570, col: 12, offset: 79985},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2562, col: 20, offset: 79793},
+									pos:   position{line: 2570, col: 20, offset: 79993},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2562, col: 30, offset: 79803},
+										pos:  position{line: 2570, col: 30, offset: 80003},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2562, col: 40, offset: 79813},
+									pos:  position{line: 2570, col: 40, offset: 80013},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2562, col: 46, offset: 79819},
+									pos:   position{line: 2570, col: 46, offset: 80019},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2562, col: 57, offset: 79830},
+										pos:  position{line: 2570, col: 57, offset: 80030},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2562, col: 67, offset: 79840},
+									pos:  position{line: 2570, col: 67, offset: 80040},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2574, col: 3, offset: 80120},
+						pos: position{line: 2582, col: 3, offset: 80320},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2574, col: 3, offset: 80120},
+							pos: position{line: 2582, col: 3, offset: 80320},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2574, col: 3, offset: 80120},
+									pos:        position{line: 2582, col: 3, offset: 80320},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2574, col: 10, offset: 80127},
+									pos:  position{line: 2582, col: 10, offset: 80327},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2574, col: 18, offset: 80135},
+									pos:  position{line: 2582, col: 18, offset: 80335},
 									name: "R_PAREN",
 								},
 							},
@@ -4830,30 +4838,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2581, col: 1, offset: 80232},
+			pos:  position{line: 2589, col: 1, offset: 80432},
 			expr: &actionExpr{
-				pos: position{line: 2581, col: 23, offset: 80254},
+				pos: position{line: 2589, col: 23, offset: 80454},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2581, col: 23, offset: 80254},
+					pos: position{line: 2589, col: 23, offset: 80454},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2581, col: 23, offset: 80254},
+							pos:   position{line: 2589, col: 23, offset: 80454},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2581, col: 33, offset: 80264},
+								pos:  position{line: 2589, col: 33, offset: 80464},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2581, col: 42, offset: 80273},
+							pos:  position{line: 2589, col: 42, offset: 80473},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2581, col: 48, offset: 80279},
+							pos:   position{line: 2589, col: 48, offset: 80479},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2581, col: 54, offset: 80285},
+								pos:  position{line: 2589, col: 54, offset: 80485},
 								name: "ValueExpr",
 							},
 						},
@@ -4863,15 +4871,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2589, col: 1, offset: 80490},
+			pos:  position{line: 2597, col: 1, offset: 80690},
 			expr: &actionExpr{
-				pos: position{line: 2589, col: 26, offset: 80515},
+				pos: position{line: 2597, col: 26, offset: 80715},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2589, col: 26, offset: 80515},
+					pos:   position{line: 2597, col: 26, offset: 80715},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2589, col: 37, offset: 80526},
+						pos:  position{line: 2597, col: 37, offset: 80726},
 						name: "StringExpr",
 					},
 				},
@@ -4879,15 +4887,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2599, col: 1, offset: 80735},
+			pos:  position{line: 2607, col: 1, offset: 80935},
 			expr: &actionExpr{
-				pos: position{line: 2599, col: 30, offset: 80764},
+				pos: position{line: 2607, col: 30, offset: 80964},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2599, col: 30, offset: 80764},
+					pos:   position{line: 2607, col: 30, offset: 80964},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2599, col: 45, offset: 80779},
+						pos:  position{line: 2607, col: 45, offset: 80979},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4895,22 +4903,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2608, col: 1, offset: 80985},
+			pos:  position{line: 2616, col: 1, offset: 81185},
 			expr: &actionExpr{
-				pos: position{line: 2608, col: 27, offset: 81011},
+				pos: position{line: 2616, col: 27, offset: 81211},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2608, col: 27, offset: 81011},
+					pos:   position{line: 2616, col: 27, offset: 81211},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2608, col: 40, offset: 81024},
+						pos: position{line: 2616, col: 40, offset: 81224},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2608, col: 40, offset: 81024},
+								pos:  position{line: 2616, col: 40, offset: 81224},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2608, col: 68, offset: 81052},
+								pos:  position{line: 2616, col: 68, offset: 81252},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4920,182 +4928,182 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2612, col: 1, offset: 81129},
+			pos:  position{line: 2620, col: 1, offset: 81329},
 			expr: &choiceExpr{
-				pos: position{line: 2612, col: 19, offset: 81147},
+				pos: position{line: 2620, col: 19, offset: 81347},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2612, col: 19, offset: 81147},
+						pos: position{line: 2620, col: 19, offset: 81347},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2612, col: 20, offset: 81148},
+							pos: position{line: 2620, col: 20, offset: 81348},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2612, col: 20, offset: 81148},
+									pos:   position{line: 2620, col: 20, offset: 81348},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2612, col: 28, offset: 81156},
+										pos:        position{line: 2620, col: 28, offset: 81356},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2612, col: 37, offset: 81165},
+									pos:  position{line: 2620, col: 37, offset: 81365},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2612, col: 45, offset: 81173},
+									pos:   position{line: 2620, col: 45, offset: 81373},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2612, col: 56, offset: 81184},
+										pos:  position{line: 2620, col: 56, offset: 81384},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2612, col: 67, offset: 81195},
+									pos:  position{line: 2620, col: 67, offset: 81395},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2612, col: 73, offset: 81201},
+									pos:   position{line: 2620, col: 73, offset: 81401},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2612, col: 79, offset: 81207},
+										pos:  position{line: 2620, col: 79, offset: 81407},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2612, col: 90, offset: 81218},
+									pos:  position{line: 2620, col: 90, offset: 81418},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2624, col: 3, offset: 81579},
+						pos: position{line: 2632, col: 3, offset: 81779},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2624, col: 4, offset: 81580},
+							pos: position{line: 2632, col: 4, offset: 81780},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2624, col: 4, offset: 81580},
+									pos:   position{line: 2632, col: 4, offset: 81780},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2624, col: 12, offset: 81588},
+										pos:        position{line: 2632, col: 12, offset: 81788},
 										val:        "spath",
 										ignoreCase: false,
 										want:       "\"spath\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 21, offset: 81597},
+									pos:  position{line: 2632, col: 21, offset: 81797},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 29, offset: 81605},
+									pos:   position{line: 2632, col: 29, offset: 81805},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 35, offset: 81611},
+										pos:  position{line: 2632, col: 35, offset: 81811},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 46, offset: 81622},
+									pos:  position{line: 2632, col: 46, offset: 81822},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2624, col: 52, offset: 81628},
+									pos:   position{line: 2632, col: 52, offset: 81828},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2624, col: 57, offset: 81633},
+										pos:  position{line: 2632, col: 57, offset: 81833},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2624, col: 68, offset: 81644},
+									pos:  position{line: 2632, col: 68, offset: 81844},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2636, col: 3, offset: 81999},
+						pos: position{line: 2644, col: 3, offset: 82199},
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
-							pos: position{line: 2636, col: 4, offset: 82000},
+							pos: position{line: 2644, col: 4, offset: 82200},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2636, col: 4, offset: 82000},
+									pos:   position{line: 2644, col: 4, offset: 82200},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2636, col: 12, offset: 82008},
+										pos:        position{line: 2644, col: 12, offset: 82208},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 23, offset: 82019},
+									pos:  position{line: 2644, col: 23, offset: 82219},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2636, col: 31, offset: 82027},
+									pos:   position{line: 2644, col: 31, offset: 82227},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2636, col: 46, offset: 82042},
+										pos:  position{line: 2644, col: 46, offset: 82242},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 61, offset: 82057},
+									pos:  position{line: 2644, col: 61, offset: 82257},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2636, col: 67, offset: 82063},
+									pos:   position{line: 2644, col: 67, offset: 82263},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2636, col: 78, offset: 82074},
+										pos:  position{line: 2644, col: 78, offset: 82274},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2636, col: 90, offset: 82086},
+									pos:   position{line: 2644, col: 90, offset: 82286},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2636, col: 99, offset: 82095},
+										pos: position{line: 2644, col: 99, offset: 82295},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2636, col: 100, offset: 82096},
+											pos:  position{line: 2644, col: 100, offset: 82296},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2636, col: 119, offset: 82115},
+									pos:  position{line: 2644, col: 119, offset: 82315},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2652, col: 3, offset: 82677},
+						pos: position{line: 2660, col: 3, offset: 82877},
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
-							pos: position{line: 2652, col: 4, offset: 82678},
+							pos: position{line: 2660, col: 4, offset: 82878},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2652, col: 4, offset: 82678},
+									pos:   position{line: 2660, col: 4, offset: 82878},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2652, col: 12, offset: 82686},
+										pos: position{line: 2660, col: 12, offset: 82886},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2652, col: 12, offset: 82686},
+												pos:        position{line: 2660, col: 12, offset: 82886},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2652, col: 24, offset: 82698},
+												pos:        position{line: 2660, col: 24, offset: 82898},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -5104,222 +5112,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2652, col: 34, offset: 82708},
+									pos:  position{line: 2660, col: 34, offset: 82908},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2652, col: 42, offset: 82716},
+									pos:   position{line: 2660, col: 42, offset: 82916},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2652, col: 57, offset: 82731},
+										pos:  position{line: 2660, col: 57, offset: 82931},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2652, col: 72, offset: 82746},
+									pos:  position{line: 2660, col: 72, offset: 82946},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2664, col: 3, offset: 83094},
+						pos: position{line: 2672, col: 3, offset: 83294},
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
-							pos: position{line: 2664, col: 4, offset: 83095},
+							pos: position{line: 2672, col: 4, offset: 83295},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2664, col: 4, offset: 83095},
+									pos:   position{line: 2672, col: 4, offset: 83295},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2664, col: 12, offset: 83103},
+										pos:        position{line: 2672, col: 12, offset: 83303},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2664, col: 24, offset: 83115},
+									pos:  position{line: 2672, col: 24, offset: 83315},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2664, col: 32, offset: 83123},
+									pos:   position{line: 2672, col: 32, offset: 83323},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2664, col: 42, offset: 83133},
+										pos:  position{line: 2672, col: 42, offset: 83333},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2664, col: 51, offset: 83142},
+									pos:  position{line: 2672, col: 51, offset: 83342},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2677, col: 3, offset: 83489},
+						pos: position{line: 2685, col: 3, offset: 83689},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2677, col: 4, offset: 83490},
+							pos: position{line: 2685, col: 4, offset: 83690},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2677, col: 4, offset: 83490},
+									pos:   position{line: 2685, col: 4, offset: 83690},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2677, col: 12, offset: 83498},
+										pos:        position{line: 2685, col: 12, offset: 83698},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2677, col: 21, offset: 83507},
+									pos:  position{line: 2685, col: 21, offset: 83707},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2677, col: 29, offset: 83515},
+									pos:   position{line: 2685, col: 29, offset: 83715},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2677, col: 44, offset: 83530},
+										pos:  position{line: 2685, col: 44, offset: 83730},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2677, col: 59, offset: 83545},
+									pos:  position{line: 2685, col: 59, offset: 83745},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2677, col: 65, offset: 83551},
+									pos:   position{line: 2685, col: 65, offset: 83751},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2677, col: 70, offset: 83556},
+										pos:  position{line: 2685, col: 70, offset: 83756},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2677, col: 80, offset: 83566},
+									pos:  position{line: 2685, col: 80, offset: 83766},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2690, col: 3, offset: 83988},
+						pos: position{line: 2698, col: 3, offset: 84188},
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
-							pos: position{line: 2690, col: 4, offset: 83989},
+							pos: position{line: 2698, col: 4, offset: 84189},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2690, col: 4, offset: 83989},
+									pos:   position{line: 2698, col: 4, offset: 84189},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2690, col: 12, offset: 83997},
+										pos:        position{line: 2698, col: 12, offset: 84197},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2690, col: 23, offset: 84008},
+									pos:  position{line: 2698, col: 23, offset: 84208},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2690, col: 31, offset: 84016},
+									pos:   position{line: 2698, col: 31, offset: 84216},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2690, col: 42, offset: 84027},
+										pos:  position{line: 2698, col: 42, offset: 84227},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2690, col: 54, offset: 84039},
+									pos:  position{line: 2698, col: 54, offset: 84239},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2690, col: 60, offset: 84045},
+									pos:   position{line: 2698, col: 60, offset: 84245},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2690, col: 69, offset: 84054},
+										pos:  position{line: 2698, col: 69, offset: 84254},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2690, col: 81, offset: 84066},
+									pos:  position{line: 2698, col: 81, offset: 84266},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2690, col: 87, offset: 84072},
+									pos:   position{line: 2698, col: 87, offset: 84272},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2690, col: 98, offset: 84083},
+										pos: position{line: 2698, col: 98, offset: 84283},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2690, col: 99, offset: 84084},
+											pos:  position{line: 2698, col: 99, offset: 84284},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2690, col: 112, offset: 84097},
+									pos:  position{line: 2698, col: 112, offset: 84297},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2703, col: 3, offset: 84548},
+						pos: position{line: 2711, col: 3, offset: 84748},
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
-							pos: position{line: 2703, col: 4, offset: 84549},
+							pos: position{line: 2711, col: 4, offset: 84749},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2703, col: 4, offset: 84549},
+									pos:   position{line: 2711, col: 4, offset: 84749},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2703, col: 12, offset: 84557},
+										pos:        position{line: 2711, col: 12, offset: 84757},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2703, col: 21, offset: 84566},
+									pos:  position{line: 2711, col: 21, offset: 84766},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2703, col: 29, offset: 84574},
+									pos:   position{line: 2711, col: 29, offset: 84774},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2703, col: 36, offset: 84581},
+										pos:  position{line: 2711, col: 36, offset: 84781},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2703, col: 51, offset: 84596},
+									pos:  position{line: 2711, col: 51, offset: 84796},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2703, col: 57, offset: 84602},
+									pos:   position{line: 2711, col: 57, offset: 84802},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2703, col: 65, offset: 84610},
+										pos:  position{line: 2711, col: 65, offset: 84810},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2703, col: 80, offset: 84625},
+									pos:   position{line: 2711, col: 80, offset: 84825},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2703, col: 85, offset: 84630},
+										pos: position{line: 2711, col: 85, offset: 84830},
 										expr: &seqExpr{
-											pos: position{line: 2703, col: 86, offset: 84631},
+											pos: position{line: 2711, col: 86, offset: 84831},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2703, col: 86, offset: 84631},
+													pos:  position{line: 2711, col: 86, offset: 84831},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2703, col: 92, offset: 84637},
+													pos:  position{line: 2711, col: 92, offset: 84837},
 													name: "StringExpr",
 												},
 											},
@@ -5327,63 +5335,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2703, col: 105, offset: 84650},
+									pos:  position{line: 2711, col: 105, offset: 84850},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2720, col: 3, offset: 85178},
+						pos: position{line: 2728, col: 3, offset: 85378},
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
-							pos: position{line: 2720, col: 4, offset: 85179},
+							pos: position{line: 2728, col: 4, offset: 85379},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2720, col: 4, offset: 85179},
+									pos:   position{line: 2728, col: 4, offset: 85379},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2720, col: 12, offset: 85187},
+										pos:        position{line: 2728, col: 12, offset: 85387},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2720, col: 32, offset: 85207},
+									pos:  position{line: 2728, col: 32, offset: 85407},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2720, col: 40, offset: 85215},
+									pos:   position{line: 2728, col: 40, offset: 85415},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2720, col: 55, offset: 85230},
+										pos:  position{line: 2728, col: 55, offset: 85430},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2720, col: 70, offset: 85245},
+									pos:   position{line: 2728, col: 70, offset: 85445},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2720, col: 75, offset: 85250},
+										pos: position{line: 2728, col: 75, offset: 85450},
 										expr: &seqExpr{
-											pos: position{line: 2720, col: 76, offset: 85251},
+											pos: position{line: 2728, col: 76, offset: 85451},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2720, col: 76, offset: 85251},
+													pos:  position{line: 2728, col: 76, offset: 85451},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2720, col: 83, offset: 85258},
+													pos: position{line: 2728, col: 83, offset: 85458},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2720, col: 83, offset: 85258},
+															pos:        position{line: 2728, col: 83, offset: 85458},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2720, col: 92, offset: 85267},
+															pos:        position{line: 2728, col: 92, offset: 85467},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5391,7 +5399,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2720, col: 101, offset: 85276},
+													pos:        position{line: 2728, col: 101, offset: 85476},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5401,54 +5409,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2720, col: 108, offset: 85283},
+									pos:  position{line: 2728, col: 108, offset: 85483},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2745, col: 3, offset: 85986},
+						pos: position{line: 2753, col: 3, offset: 86186},
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
-							pos: position{line: 2745, col: 4, offset: 85987},
+							pos: position{line: 2753, col: 4, offset: 86187},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2745, col: 4, offset: 85987},
+									pos:   position{line: 2753, col: 4, offset: 86187},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2745, col: 12, offset: 85995},
+										pos:        position{line: 2753, col: 12, offset: 86195},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2745, col: 24, offset: 86007},
+									pos:  position{line: 2753, col: 24, offset: 86207},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 32, offset: 86015},
+									pos:   position{line: 2753, col: 32, offset: 86215},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2745, col: 41, offset: 86024},
+										pos:  position{line: 2753, col: 41, offset: 86224},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2745, col: 64, offset: 86047},
+									pos:   position{line: 2753, col: 64, offset: 86247},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2745, col: 69, offset: 86052},
+										pos: position{line: 2753, col: 69, offset: 86252},
 										expr: &seqExpr{
-											pos: position{line: 2745, col: 70, offset: 86053},
+											pos: position{line: 2753, col: 70, offset: 86253},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 70, offset: 86053},
+													pos:  position{line: 2753, col: 70, offset: 86253},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2745, col: 76, offset: 86059},
+													pos:  position{line: 2753, col: 76, offset: 86259},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5456,57 +5464,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2745, col: 101, offset: 86084},
+									pos:  position{line: 2753, col: 101, offset: 86284},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2765, col: 3, offset: 86672},
+						pos: position{line: 2773, col: 3, offset: 86872},
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
-							pos: position{line: 2765, col: 3, offset: 86672},
+							pos: position{line: 2773, col: 3, offset: 86872},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2765, col: 3, offset: 86672},
+									pos:   position{line: 2773, col: 3, offset: 86872},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2765, col: 9, offset: 86678},
+										pos:  position{line: 2773, col: 9, offset: 86878},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2765, col: 25, offset: 86694},
+									pos: position{line: 2773, col: 25, offset: 86894},
 									expr: &choiceExpr{
-										pos: position{line: 2765, col: 27, offset: 86696},
+										pos: position{line: 2773, col: 27, offset: 86896},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 27, offset: 86696},
+												pos:  position{line: 2773, col: 27, offset: 86896},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 36, offset: 86705},
+												pos:  position{line: 2773, col: 36, offset: 86905},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 46, offset: 86715},
+												pos:  position{line: 2773, col: 46, offset: 86915},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 54, offset: 86723},
+												pos:  position{line: 2773, col: 54, offset: 86923},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 62, offset: 86731},
+												pos:  position{line: 2773, col: 62, offset: 86931},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2765, col: 70, offset: 86739},
+												pos:  position{line: 2773, col: 70, offset: 86939},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2765, col: 84, offset: 86753},
+												pos:        position{line: 2773, col: 84, offset: 86953},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5522,36 +5530,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2777, col: 1, offset: 87148},
+			pos:  position{line: 2785, col: 1, offset: 87348},
 			expr: &choiceExpr{
-				pos: position{line: 2777, col: 13, offset: 87160},
+				pos: position{line: 2785, col: 13, offset: 87360},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2777, col: 13, offset: 87160},
+						pos: position{line: 2785, col: 13, offset: 87360},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2777, col: 14, offset: 87161},
+							pos: position{line: 2785, col: 14, offset: 87361},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2777, col: 14, offset: 87161},
+									pos:   position{line: 2785, col: 14, offset: 87361},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2777, col: 22, offset: 87169},
+										pos: position{line: 2785, col: 22, offset: 87369},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2777, col: 22, offset: 87169},
+												pos:        position{line: 2785, col: 22, offset: 87369},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2777, col: 32, offset: 87179},
+												pos:        position{line: 2785, col: 32, offset: 87379},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2777, col: 42, offset: 87189},
+												pos:        position{line: 2785, col: 42, offset: 87389},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5560,44 +5568,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2777, col: 55, offset: 87202},
+									pos:  position{line: 2785, col: 55, offset: 87402},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2777, col: 63, offset: 87210},
+									pos:   position{line: 2785, col: 63, offset: 87410},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2777, col: 74, offset: 87221},
+										pos:  position{line: 2785, col: 74, offset: 87421},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2777, col: 85, offset: 87232},
+									pos:  position{line: 2785, col: 85, offset: 87432},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2789, col: 3, offset: 87546},
+						pos: position{line: 2797, col: 3, offset: 87746},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2789, col: 4, offset: 87547},
+							pos: position{line: 2797, col: 4, offset: 87747},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2789, col: 4, offset: 87547},
+									pos:   position{line: 2797, col: 4, offset: 87747},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2789, col: 12, offset: 87555},
+										pos: position{line: 2797, col: 12, offset: 87755},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2789, col: 12, offset: 87555},
+												pos:        position{line: 2797, col: 12, offset: 87755},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2789, col: 20, offset: 87563},
+												pos:        position{line: 2797, col: 20, offset: 87763},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5606,31 +5614,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2789, col: 27, offset: 87570},
+									pos:  position{line: 2797, col: 27, offset: 87770},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2789, col: 35, offset: 87578},
+									pos:   position{line: 2797, col: 35, offset: 87778},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2789, col: 44, offset: 87587},
+										pos:  position{line: 2797, col: 44, offset: 87787},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2789, col: 55, offset: 87598},
+									pos:   position{line: 2797, col: 55, offset: 87798},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2789, col: 60, offset: 87603},
+										pos: position{line: 2797, col: 60, offset: 87803},
 										expr: &seqExpr{
-											pos: position{line: 2789, col: 61, offset: 87604},
+											pos: position{line: 2797, col: 61, offset: 87804},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2789, col: 61, offset: 87604},
+													pos:  position{line: 2797, col: 61, offset: 87804},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2789, col: 67, offset: 87610},
+													pos:  position{line: 2797, col: 67, offset: 87810},
 													name: "StringExpr",
 												},
 											},
@@ -5638,195 +5646,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2789, col: 80, offset: 87623},
+									pos:  position{line: 2797, col: 80, offset: 87823},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2811, col: 3, offset: 88223},
+						pos: position{line: 2819, col: 3, offset: 88423},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2811, col: 4, offset: 88224},
+							pos: position{line: 2819, col: 4, offset: 88424},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2811, col: 4, offset: 88224},
+									pos:   position{line: 2819, col: 4, offset: 88424},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2811, col: 12, offset: 88232},
+										pos:        position{line: 2819, col: 12, offset: 88432},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2811, col: 23, offset: 88243},
+									pos:  position{line: 2819, col: 23, offset: 88443},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2811, col: 31, offset: 88251},
+									pos:   position{line: 2819, col: 31, offset: 88451},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2811, col: 46, offset: 88266},
+										pos:  position{line: 2819, col: 46, offset: 88466},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2811, col: 61, offset: 88281},
+									pos:  position{line: 2819, col: 61, offset: 88481},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2822, col: 3, offset: 88583},
+						pos: position{line: 2830, col: 3, offset: 88783},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2822, col: 4, offset: 88584},
+							pos: position{line: 2830, col: 4, offset: 88784},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2822, col: 4, offset: 88584},
+									pos:   position{line: 2830, col: 4, offset: 88784},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2822, col: 12, offset: 88592},
+										pos:        position{line: 2830, col: 12, offset: 88792},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 22, offset: 88602},
+									pos:  position{line: 2830, col: 22, offset: 88802},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 30, offset: 88610},
+									pos:   position{line: 2830, col: 30, offset: 88810},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 45, offset: 88625},
+										pos:  position{line: 2830, col: 45, offset: 88825},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 60, offset: 88640},
+									pos:  position{line: 2830, col: 60, offset: 88840},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2822, col: 66, offset: 88646},
+									pos:   position{line: 2830, col: 66, offset: 88846},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2822, col: 72, offset: 88652},
+										pos:  position{line: 2830, col: 72, offset: 88852},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2822, col: 83, offset: 88663},
+									pos:  position{line: 2830, col: 83, offset: 88863},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2834, col: 3, offset: 89013},
+						pos: position{line: 2842, col: 3, offset: 89213},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2834, col: 4, offset: 89014},
+							pos: position{line: 2842, col: 4, offset: 89214},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2834, col: 4, offset: 89014},
+									pos:   position{line: 2842, col: 4, offset: 89214},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2834, col: 12, offset: 89022},
+										pos:        position{line: 2842, col: 12, offset: 89222},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2834, col: 22, offset: 89032},
+									pos:  position{line: 2842, col: 22, offset: 89232},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2834, col: 30, offset: 89040},
+									pos:   position{line: 2842, col: 30, offset: 89240},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2834, col: 45, offset: 89055},
+										pos:  position{line: 2842, col: 45, offset: 89255},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2834, col: 60, offset: 89070},
+									pos:  position{line: 2842, col: 60, offset: 89270},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2834, col: 66, offset: 89076},
+									pos:   position{line: 2842, col: 66, offset: 89276},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2834, col: 79, offset: 89089},
+										pos:  position{line: 2842, col: 79, offset: 89289},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2834, col: 90, offset: 89100},
+									pos:  position{line: 2842, col: 90, offset: 89300},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2858, col: 3, offset: 89766},
+						pos: position{line: 2866, col: 3, offset: 89966},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2858, col: 4, offset: 89767},
+							pos: position{line: 2866, col: 4, offset: 89967},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2858, col: 4, offset: 89767},
+									pos:   position{line: 2866, col: 4, offset: 89967},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2858, col: 12, offset: 89775},
+										pos:        position{line: 2866, col: 12, offset: 89975},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 22, offset: 89785},
+									pos:  position{line: 2866, col: 22, offset: 89985},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 30, offset: 89793},
+									pos:   position{line: 2866, col: 30, offset: 89993},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2858, col: 41, offset: 89804},
+										pos:  position{line: 2866, col: 41, offset: 90004},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 52, offset: 89815},
+									pos:  position{line: 2866, col: 52, offset: 90015},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 58, offset: 89821},
+									pos:   position{line: 2866, col: 58, offset: 90021},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2858, col: 69, offset: 89832},
+										pos:  position{line: 2866, col: 69, offset: 90032},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2858, col: 81, offset: 89844},
+									pos:   position{line: 2866, col: 81, offset: 90044},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2858, col: 93, offset: 89856},
+										pos: position{line: 2866, col: 93, offset: 90056},
 										expr: &seqExpr{
-											pos: position{line: 2858, col: 94, offset: 89857},
+											pos: position{line: 2866, col: 94, offset: 90057},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 94, offset: 89857},
+													pos:  position{line: 2866, col: 94, offset: 90057},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2858, col: 100, offset: 89863},
+													pos:  position{line: 2866, col: 100, offset: 90063},
 													name: "NumericExpr",
 												},
 											},
@@ -5834,50 +5842,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2858, col: 114, offset: 89877},
+									pos:  position{line: 2866, col: 114, offset: 90077},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2883, col: 3, offset: 90707},
+						pos: position{line: 2891, col: 3, offset: 90907},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2883, col: 3, offset: 90707},
+							pos: position{line: 2891, col: 3, offset: 90907},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2883, col: 3, offset: 90707},
+									pos:        position{line: 2891, col: 3, offset: 90907},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2883, col: 14, offset: 90718},
+									pos:  position{line: 2891, col: 14, offset: 90918},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2883, col: 22, offset: 90726},
+									pos:   position{line: 2891, col: 22, offset: 90926},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2883, col: 28, offset: 90732},
+										pos:  position{line: 2891, col: 28, offset: 90932},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2883, col: 38, offset: 90742},
+									pos:   position{line: 2891, col: 38, offset: 90942},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2883, col: 45, offset: 90749},
+										pos: position{line: 2891, col: 45, offset: 90949},
 										expr: &seqExpr{
-											pos: position{line: 2883, col: 46, offset: 90750},
+											pos: position{line: 2891, col: 46, offset: 90950},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2883, col: 46, offset: 90750},
+													pos:  position{line: 2891, col: 46, offset: 90950},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2883, col: 52, offset: 90756},
+													pos:  position{line: 2891, col: 52, offset: 90956},
 													name: "StringExpr",
 												},
 											},
@@ -5885,38 +5893,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2883, col: 65, offset: 90769},
+									pos:  position{line: 2891, col: 65, offset: 90969},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2896, col: 3, offset: 91137},
+						pos: position{line: 2904, col: 3, offset: 91337},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2896, col: 4, offset: 91138},
+							pos: position{line: 2904, col: 4, offset: 91338},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2896, col: 4, offset: 91138},
+									pos:   position{line: 2904, col: 4, offset: 91338},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2896, col: 12, offset: 91146},
+										pos: position{line: 2904, col: 12, offset: 91346},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2896, col: 12, offset: 91146},
+												pos:        position{line: 2904, col: 12, offset: 91346},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2896, col: 22, offset: 91156},
+												pos:        position{line: 2904, col: 22, offset: 91356},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2896, col: 32, offset: 91166},
+												pos:        position{line: 2904, col: 32, offset: 91366},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5925,171 +5933,171 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2896, col: 40, offset: 91174},
+									pos:  position{line: 2904, col: 40, offset: 91374},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2896, col: 48, offset: 91182},
+									pos:   position{line: 2904, col: 48, offset: 91382},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2896, col: 54, offset: 91188},
+										pos:  position{line: 2904, col: 54, offset: 91388},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2896, col: 66, offset: 91200},
+									pos:   position{line: 2904, col: 66, offset: 91400},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2896, col: 82, offset: 91216},
+										pos: position{line: 2904, col: 82, offset: 91416},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2896, col: 83, offset: 91217},
+											pos:  position{line: 2904, col: 83, offset: 91417},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2896, col: 101, offset: 91235},
+									pos:  position{line: 2904, col: 101, offset: 91435},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2915, col: 3, offset: 91675},
+						pos: position{line: 2923, col: 3, offset: 91875},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2915, col: 3, offset: 91675},
+							pos: position{line: 2923, col: 3, offset: 91875},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2915, col: 3, offset: 91675},
+									pos:        position{line: 2923, col: 3, offset: 91875},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 12, offset: 91684},
+									pos:  position{line: 2923, col: 12, offset: 91884},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 20, offset: 91692},
+									pos:   position{line: 2923, col: 20, offset: 91892},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 25, offset: 91697},
+										pos:  position{line: 2923, col: 25, offset: 91897},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 36, offset: 91708},
+									pos:  position{line: 2923, col: 36, offset: 91908},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2915, col: 42, offset: 91714},
+									pos:   position{line: 2923, col: 42, offset: 91914},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2915, col: 45, offset: 91717},
+										pos:  position{line: 2923, col: 45, offset: 91917},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2915, col: 55, offset: 91727},
+									pos:  position{line: 2923, col: 55, offset: 91927},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2922, col: 3, offset: 91885},
+						pos: position{line: 2930, col: 3, offset: 92085},
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
-							pos: position{line: 2922, col: 3, offset: 91885},
+							pos: position{line: 2930, col: 3, offset: 92085},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2922, col: 3, offset: 91885},
+									pos:        position{line: 2930, col: 3, offset: 92085},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 21, offset: 91903},
+									pos:  position{line: 2930, col: 21, offset: 92103},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2922, col: 29, offset: 91911},
+									pos:   position{line: 2930, col: 29, offset: 92111},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2922, col: 33, offset: 91915},
+										pos:  position{line: 2930, col: 33, offset: 92115},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 43, offset: 91925},
+									pos:  position{line: 2930, col: 43, offset: 92125},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2922, col: 49, offset: 91931},
+									pos:   position{line: 2930, col: 49, offset: 92131},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2922, col: 53, offset: 91935},
+										pos:  position{line: 2930, col: 53, offset: 92135},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 66, offset: 91948},
+									pos:  position{line: 2930, col: 66, offset: 92148},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2922, col: 72, offset: 91954},
+									pos:   position{line: 2930, col: 72, offset: 92154},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2922, col: 78, offset: 91960},
+										pos:  position{line: 2930, col: 78, offset: 92160},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2922, col: 91, offset: 91973},
+									pos:  position{line: 2930, col: 91, offset: 92173},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2933, col: 3, offset: 92281},
+						pos: position{line: 2941, col: 3, offset: 92481},
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
-							pos: position{line: 2933, col: 3, offset: 92281},
+							pos: position{line: 2941, col: 3, offset: 92481},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2933, col: 3, offset: 92281},
+									pos:        position{line: 2941, col: 3, offset: 92481},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2933, col: 12, offset: 92290},
+									pos:  position{line: 2941, col: 12, offset: 92490},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2933, col: 20, offset: 92298},
+									pos:   position{line: 2941, col: 20, offset: 92498},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2933, col: 27, offset: 92305},
+										pos:  position{line: 2941, col: 27, offset: 92505},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2933, col: 38, offset: 92316},
+									pos:   position{line: 2941, col: 38, offset: 92516},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2933, col: 43, offset: 92321},
+										pos: position{line: 2941, col: 43, offset: 92521},
 										expr: &seqExpr{
-											pos: position{line: 2933, col: 44, offset: 92322},
+											pos: position{line: 2941, col: 44, offset: 92522},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2933, col: 44, offset: 92322},
+													pos:  position{line: 2941, col: 44, offset: 92522},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2933, col: 50, offset: 92328},
+													pos:  position{line: 2941, col: 50, offset: 92528},
 													name: "StringExpr",
 												},
 											},
@@ -6097,47 +6105,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2933, col: 63, offset: 92341},
+									pos:  position{line: 2941, col: 63, offset: 92541},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2951, col: 3, offset: 92808},
+						pos: position{line: 2959, col: 3, offset: 93008},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2951, col: 3, offset: 92808},
+							pos: position{line: 2959, col: 3, offset: 93008},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2951, col: 3, offset: 92808},
+									pos:        position{line: 2959, col: 3, offset: 93008},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 12, offset: 92817},
+									pos:  position{line: 2959, col: 12, offset: 93017},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2951, col: 20, offset: 92825},
+									pos:   position{line: 2959, col: 20, offset: 93025},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2951, col: 42, offset: 92847},
+										pos: position{line: 2959, col: 42, offset: 93047},
 										expr: &seqExpr{
-											pos: position{line: 2951, col: 43, offset: 92848},
+											pos: position{line: 2959, col: 43, offset: 93048},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2951, col: 44, offset: 92849},
+													pos: position{line: 2959, col: 44, offset: 93049},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2951, col: 44, offset: 92849},
+															pos:        position{line: 2959, col: 44, offset: 93049},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2951, col: 53, offset: 92858},
+															pos:        position{line: 2959, col: 53, offset: 93058},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6145,7 +6153,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2951, col: 62, offset: 92867},
+													pos:        position{line: 2959, col: 62, offset: 93067},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6155,56 +6163,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 69, offset: 92874},
+									pos:  position{line: 2959, col: 69, offset: 93074},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2973, col: 3, offset: 93471},
+						pos: position{line: 2981, col: 3, offset: 93671},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2973, col: 3, offset: 93471},
+							pos: position{line: 2981, col: 3, offset: 93671},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2973, col: 3, offset: 93471},
+									pos:        position{line: 2981, col: 3, offset: 93671},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2973, col: 13, offset: 93481},
+									pos:  position{line: 2981, col: 13, offset: 93681},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2973, col: 21, offset: 93489},
+									pos:   position{line: 2981, col: 21, offset: 93689},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2973, col: 27, offset: 93495},
+										pos:  position{line: 2981, col: 27, offset: 93695},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2973, col: 43, offset: 93511},
+									pos:   position{line: 2981, col: 43, offset: 93711},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2973, col: 53, offset: 93521},
+										pos: position{line: 2981, col: 53, offset: 93721},
 										expr: &seqExpr{
-											pos: position{line: 2973, col: 54, offset: 93522},
+											pos: position{line: 2981, col: 54, offset: 93722},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2973, col: 54, offset: 93522},
+													pos:  position{line: 2981, col: 54, offset: 93722},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2973, col: 60, offset: 93528},
+													pos:        position{line: 2981, col: 60, offset: 93728},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2973, col: 73, offset: 93541},
+													pos:  position{line: 2981, col: 73, offset: 93741},
 													name: "FloatAsString",
 												},
 											},
@@ -6212,40 +6220,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2973, col: 89, offset: 93557},
+									pos:   position{line: 2981, col: 89, offset: 93757},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2973, col: 95, offset: 93563},
+										pos: position{line: 2981, col: 95, offset: 93763},
 										expr: &seqExpr{
-											pos: position{line: 2973, col: 96, offset: 93564},
+											pos: position{line: 2981, col: 96, offset: 93764},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2973, col: 96, offset: 93564},
+													pos:  position{line: 2981, col: 96, offset: 93764},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2973, col: 102, offset: 93570},
+													pos:        position{line: 2981, col: 102, offset: 93770},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2973, col: 112, offset: 93580},
+													pos: position{line: 2981, col: 112, offset: 93780},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2973, col: 112, offset: 93580},
+															pos:        position{line: 2981, col: 112, offset: 93780},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2973, col: 125, offset: 93593},
+															pos:        position{line: 2981, col: 125, offset: 93793},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2973, col: 137, offset: 93605},
+															pos:        position{line: 2981, col: 137, offset: 93805},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6257,25 +6265,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2973, col: 151, offset: 93619},
+									pos:   position{line: 2981, col: 151, offset: 93819},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2973, col: 158, offset: 93626},
+										pos: position{line: 2981, col: 158, offset: 93826},
 										expr: &seqExpr{
-											pos: position{line: 2973, col: 159, offset: 93627},
+											pos: position{line: 2981, col: 159, offset: 93827},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2973, col: 159, offset: 93627},
+													pos:  position{line: 2981, col: 159, offset: 93827},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2973, col: 165, offset: 93633},
+													pos:        position{line: 2981, col: 165, offset: 93833},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2973, col: 175, offset: 93643},
+													pos:  position{line: 2981, col: 175, offset: 93843},
 													name: "QuotedString",
 												},
 											},
@@ -6283,213 +6291,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2973, col: 190, offset: 93658},
+									pos:  position{line: 2981, col: 190, offset: 93858},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3013, col: 3, offset: 94653},
+						pos: position{line: 3021, col: 3, offset: 94853},
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
-							pos: position{line: 3013, col: 3, offset: 94653},
+							pos: position{line: 3021, col: 3, offset: 94853},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3013, col: 3, offset: 94653},
+									pos:        position{line: 3021, col: 3, offset: 94853},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3013, col: 15, offset: 94665},
+									pos:  position{line: 3021, col: 15, offset: 94865},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3013, col: 23, offset: 94673},
+									pos:   position{line: 3021, col: 23, offset: 94873},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3013, col: 30, offset: 94680},
+										pos: position{line: 3021, col: 30, offset: 94880},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3013, col: 31, offset: 94681},
+											pos:  position{line: 3021, col: 31, offset: 94881},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3013, col: 44, offset: 94694},
+									pos:  position{line: 3021, col: 44, offset: 94894},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3024, col: 3, offset: 94885},
+						pos: position{line: 3032, col: 3, offset: 95085},
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
-							pos: position{line: 3024, col: 3, offset: 94885},
+							pos: position{line: 3032, col: 3, offset: 95085},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3024, col: 3, offset: 94885},
+									pos:        position{line: 3032, col: 3, offset: 95085},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3024, col: 12, offset: 94894},
+									pos:  position{line: 3032, col: 12, offset: 95094},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3024, col: 20, offset: 94902},
+									pos:   position{line: 3032, col: 20, offset: 95102},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3024, col: 30, offset: 94912},
+										pos:  position{line: 3032, col: 30, offset: 95112},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3024, col: 40, offset: 94922},
+									pos:  position{line: 3032, col: 40, offset: 95122},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3030, col: 3, offset: 95045},
+						pos: position{line: 3038, col: 3, offset: 95245},
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
-							pos: position{line: 3030, col: 3, offset: 95045},
+							pos: position{line: 3038, col: 3, offset: 95245},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3030, col: 3, offset: 95045},
+									pos:        position{line: 3038, col: 3, offset: 95245},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 13, offset: 95055},
+									pos:  position{line: 3038, col: 13, offset: 95255},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 21, offset: 95063},
+									pos:   position{line: 3038, col: 21, offset: 95263},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 25, offset: 95067},
+										pos:  position{line: 3038, col: 25, offset: 95267},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 35, offset: 95077},
+									pos:  position{line: 3038, col: 35, offset: 95277},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 41, offset: 95083},
+									pos:   position{line: 3038, col: 41, offset: 95283},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 47, offset: 95089},
+										pos:  position{line: 3038, col: 47, offset: 95289},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 58, offset: 95100},
+									pos:  position{line: 3038, col: 58, offset: 95300},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 64, offset: 95106},
+									pos:   position{line: 3038, col: 64, offset: 95306},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 76, offset: 95118},
+										pos:  position{line: 3038, col: 76, offset: 95318},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 87, offset: 95129},
+									pos:  position{line: 3038, col: 87, offset: 95329},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3037, col: 3, offset: 95353},
+						pos: position{line: 3045, col: 3, offset: 95553},
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
-							pos: position{line: 3037, col: 3, offset: 95353},
+							pos: position{line: 3045, col: 3, offset: 95553},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3037, col: 3, offset: 95353},
+									pos:        position{line: 3045, col: 3, offset: 95553},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3037, col: 14, offset: 95364},
+									pos:  position{line: 3045, col: 14, offset: 95564},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3037, col: 22, offset: 95372},
+									pos:   position{line: 3045, col: 22, offset: 95572},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3037, col: 26, offset: 95376},
+										pos:  position{line: 3045, col: 26, offset: 95576},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3037, col: 36, offset: 95386},
+									pos:  position{line: 3045, col: 36, offset: 95586},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3037, col: 42, offset: 95392},
+									pos:   position{line: 3045, col: 42, offset: 95592},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3037, col: 49, offset: 95399},
+										pos:  position{line: 3045, col: 49, offset: 95599},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3037, col: 60, offset: 95410},
+									pos:  position{line: 3045, col: 60, offset: 95610},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3045, col: 3, offset: 95574},
+						pos: position{line: 3053, col: 3, offset: 95774},
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
-							pos: position{line: 3045, col: 3, offset: 95574},
+							pos: position{line: 3053, col: 3, offset: 95774},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3045, col: 3, offset: 95574},
+									pos:        position{line: 3053, col: 3, offset: 95774},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 14, offset: 95585},
+									pos:  position{line: 3053, col: 14, offset: 95785},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 22, offset: 95593},
+									pos:   position{line: 3053, col: 22, offset: 95793},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 26, offset: 95597},
+										pos:  position{line: 3053, col: 26, offset: 95797},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 36, offset: 95607},
+									pos:  position{line: 3053, col: 36, offset: 95807},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 42, offset: 95613},
+									pos:   position{line: 3053, col: 42, offset: 95813},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 49, offset: 95620},
+										pos:  position{line: 3053, col: 49, offset: 95820},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 60, offset: 95631},
+									pos:  position{line: 3053, col: 60, offset: 95831},
 									name: "R_PAREN",
 								},
 							},
@@ -6500,15 +6508,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 3053, col: 1, offset: 95793},
+			pos:  position{line: 3061, col: 1, offset: 95993},
 			expr: &actionExpr{
-				pos: position{line: 3053, col: 21, offset: 95813},
+				pos: position{line: 3061, col: 21, offset: 96013},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3053, col: 21, offset: 95813},
+					pos:   position{line: 3061, col: 21, offset: 96013},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3053, col: 25, offset: 95817},
+						pos:  position{line: 3061, col: 25, offset: 96017},
 						name: "QuotedString",
 					},
 				},
@@ -6516,15 +6524,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3060, col: 1, offset: 95944},
+			pos:  position{line: 3068, col: 1, offset: 96144},
 			expr: &actionExpr{
-				pos: position{line: 3060, col: 22, offset: 95965},
+				pos: position{line: 3068, col: 22, offset: 96165},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3060, col: 22, offset: 95965},
+					pos:   position{line: 3068, col: 22, offset: 96165},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3060, col: 26, offset: 95969},
+						pos:  position{line: 3068, col: 26, offset: 96169},
 						name: "UnquotedString",
 					},
 				},
@@ -6532,22 +6540,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3067, col: 1, offset: 96097},
+			pos:  position{line: 3075, col: 1, offset: 96297},
 			expr: &actionExpr{
-				pos: position{line: 3067, col: 20, offset: 96116},
+				pos: position{line: 3075, col: 20, offset: 96316},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3067, col: 20, offset: 96116},
+					pos: position{line: 3075, col: 20, offset: 96316},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3067, col: 20, offset: 96116},
+							pos:  position{line: 3075, col: 20, offset: 96316},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3067, col: 26, offset: 96122},
+							pos:   position{line: 3075, col: 26, offset: 96322},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3067, col: 38, offset: 96134},
+								pos:  position{line: 3075, col: 38, offset: 96334},
 								name: "String",
 							},
 						},
@@ -6557,27 +6565,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3073, col: 1, offset: 96319},
+			pos:  position{line: 3081, col: 1, offset: 96519},
 			expr: &choiceExpr{
-				pos: position{line: 3073, col: 20, offset: 96338},
+				pos: position{line: 3081, col: 20, offset: 96538},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3073, col: 20, offset: 96338},
+						pos: position{line: 3081, col: 20, offset: 96538},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3073, col: 20, offset: 96338},
+							pos: position{line: 3081, col: 20, offset: 96538},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3073, col: 20, offset: 96338},
+									pos:        position{line: 3081, col: 20, offset: 96538},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3073, col: 28, offset: 96346},
+									pos: position{line: 3081, col: 28, offset: 96546},
 									expr: &charClassMatcher{
-										pos:        position{line: 3073, col: 28, offset: 96346},
+										pos:        position{line: 3081, col: 28, offset: 96546},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6586,9 +6594,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3073, col: 42, offset: 96360},
+									pos: position{line: 3081, col: 42, offset: 96560},
 									expr: &litMatcher{
-										pos:        position{line: 3073, col: 44, offset: 96362},
+										pos:        position{line: 3081, col: 44, offset: 96562},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6598,27 +6606,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3076, col: 3, offset: 96404},
+						pos: position{line: 3084, col: 3, offset: 96604},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3076, col: 3, offset: 96404},
+							pos: position{line: 3084, col: 3, offset: 96604},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3076, col: 3, offset: 96404},
+									pos:        position{line: 3084, col: 3, offset: 96604},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3076, col: 7, offset: 96408},
+									pos:   position{line: 3084, col: 7, offset: 96608},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3076, col: 13, offset: 96414},
+										pos:  position{line: 3084, col: 13, offset: 96614},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3076, col: 23, offset: 96424},
+									pos:        position{line: 3084, col: 23, offset: 96624},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6631,26 +6639,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3081, col: 1, offset: 96492},
+			pos:  position{line: 3089, col: 1, offset: 96692},
 			expr: &actionExpr{
-				pos: position{line: 3081, col: 15, offset: 96506},
+				pos: position{line: 3089, col: 15, offset: 96706},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3081, col: 15, offset: 96506},
+					pos: position{line: 3089, col: 15, offset: 96706},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3081, col: 15, offset: 96506},
+							pos:  position{line: 3089, col: 15, offset: 96706},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3081, col: 20, offset: 96511},
+							pos:  position{line: 3089, col: 20, offset: 96711},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3081, col: 30, offset: 96521},
+							pos:   position{line: 3089, col: 30, offset: 96721},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3081, col: 40, offset: 96531},
+								pos:  position{line: 3089, col: 40, offset: 96731},
 								name: "BoolExpr",
 							},
 						},
@@ -6660,15 +6668,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3094, col: 1, offset: 96874},
+			pos:  position{line: 3102, col: 1, offset: 97074},
 			expr: &actionExpr{
-				pos: position{line: 3094, col: 13, offset: 96886},
+				pos: position{line: 3102, col: 13, offset: 97086},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3094, col: 13, offset: 96886},
+					pos:   position{line: 3102, col: 13, offset: 97086},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3094, col: 18, offset: 96891},
+						pos:  position{line: 3102, col: 18, offset: 97091},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6676,35 +6684,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3099, col: 1, offset: 96961},
+			pos:  position{line: 3107, col: 1, offset: 97161},
 			expr: &actionExpr{
-				pos: position{line: 3099, col: 19, offset: 96979},
+				pos: position{line: 3107, col: 19, offset: 97179},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3099, col: 19, offset: 96979},
+					pos: position{line: 3107, col: 19, offset: 97179},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3099, col: 19, offset: 96979},
+							pos:   position{line: 3107, col: 19, offset: 97179},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3099, col: 25, offset: 96985},
+								pos:  position{line: 3107, col: 25, offset: 97185},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3099, col: 40, offset: 97000},
+							pos:   position{line: 3107, col: 40, offset: 97200},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3099, col: 45, offset: 97005},
+								pos: position{line: 3107, col: 45, offset: 97205},
 								expr: &seqExpr{
-									pos: position{line: 3099, col: 46, offset: 97006},
+									pos: position{line: 3107, col: 46, offset: 97206},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3099, col: 46, offset: 97006},
+											pos:  position{line: 3107, col: 46, offset: 97206},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3099, col: 49, offset: 97009},
+											pos:  position{line: 3107, col: 49, offset: 97209},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6717,35 +6725,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3119, col: 1, offset: 97447},
+			pos:  position{line: 3127, col: 1, offset: 97647},
 			expr: &actionExpr{
-				pos: position{line: 3119, col: 19, offset: 97465},
+				pos: position{line: 3127, col: 19, offset: 97665},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3119, col: 19, offset: 97465},
+					pos: position{line: 3127, col: 19, offset: 97665},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3119, col: 19, offset: 97465},
+							pos:   position{line: 3127, col: 19, offset: 97665},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3119, col: 25, offset: 97471},
+								pos:  position{line: 3127, col: 25, offset: 97671},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3119, col: 40, offset: 97486},
+							pos:   position{line: 3127, col: 40, offset: 97686},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3119, col: 45, offset: 97491},
+								pos: position{line: 3127, col: 45, offset: 97691},
 								expr: &seqExpr{
-									pos: position{line: 3119, col: 46, offset: 97492},
+									pos: position{line: 3127, col: 46, offset: 97692},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3119, col: 46, offset: 97492},
+											pos:  position{line: 3127, col: 46, offset: 97692},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3119, col: 50, offset: 97496},
+											pos:  position{line: 3127, col: 50, offset: 97696},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6758,47 +6766,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3139, col: 1, offset: 97935},
+			pos:  position{line: 3147, col: 1, offset: 98135},
 			expr: &choiceExpr{
-				pos: position{line: 3139, col: 19, offset: 97953},
+				pos: position{line: 3147, col: 19, offset: 98153},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3139, col: 19, offset: 97953},
+						pos: position{line: 3147, col: 19, offset: 98153},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3139, col: 19, offset: 97953},
+							pos: position{line: 3147, col: 19, offset: 98153},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3139, col: 19, offset: 97953},
+									pos:  position{line: 3147, col: 19, offset: 98153},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3139, col: 23, offset: 97957},
+									pos:  position{line: 3147, col: 23, offset: 98157},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3139, col: 31, offset: 97965},
+									pos:   position{line: 3147, col: 31, offset: 98165},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3139, col: 37, offset: 97971},
+										pos:  position{line: 3147, col: 37, offset: 98171},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3139, col: 52, offset: 97986},
+									pos:  position{line: 3147, col: 52, offset: 98186},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3149, col: 3, offset: 98189},
+						pos: position{line: 3157, col: 3, offset: 98389},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3149, col: 3, offset: 98189},
+							pos:   position{line: 3157, col: 3, offset: 98389},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3149, col: 9, offset: 98195},
+								pos:  position{line: 3157, col: 9, offset: 98395},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6808,50 +6816,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3154, col: 1, offset: 98266},
+			pos:  position{line: 3162, col: 1, offset: 98466},
 			expr: &choiceExpr{
-				pos: position{line: 3154, col: 19, offset: 98284},
+				pos: position{line: 3162, col: 19, offset: 98484},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3154, col: 19, offset: 98284},
+						pos: position{line: 3162, col: 19, offset: 98484},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3154, col: 19, offset: 98284},
+							pos: position{line: 3162, col: 19, offset: 98484},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3154, col: 19, offset: 98284},
+									pos:  position{line: 3162, col: 19, offset: 98484},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3154, col: 27, offset: 98292},
+									pos:   position{line: 3162, col: 27, offset: 98492},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3154, col: 33, offset: 98298},
+										pos:  position{line: 3162, col: 33, offset: 98498},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3154, col: 48, offset: 98313},
+									pos:  position{line: 3162, col: 48, offset: 98513},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3157, col: 3, offset: 98349},
+						pos: position{line: 3165, col: 3, offset: 98549},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3157, col: 3, offset: 98349},
+							pos:   position{line: 3165, col: 3, offset: 98549},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3157, col: 10, offset: 98356},
+								pos: position{line: 3165, col: 10, offset: 98556},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3157, col: 10, offset: 98356},
+										pos:  position{line: 3165, col: 10, offset: 98556},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3157, col: 31, offset: 98377},
+										pos:  position{line: 3165, col: 31, offset: 98577},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6863,72 +6871,72 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3162, col: 1, offset: 98497},
+			pos:  position{line: 3170, col: 1, offset: 98697},
 			expr: &choiceExpr{
-				pos: position{line: 3162, col: 23, offset: 98519},
+				pos: position{line: 3170, col: 23, offset: 98719},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3162, col: 23, offset: 98519},
+						pos: position{line: 3170, col: 23, offset: 98719},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3162, col: 24, offset: 98520},
+							pos: position{line: 3170, col: 24, offset: 98720},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3162, col: 24, offset: 98520},
+									pos:   position{line: 3170, col: 24, offset: 98720},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3162, col: 28, offset: 98524},
+										pos: position{line: 3170, col: 28, offset: 98724},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3162, col: 28, offset: 98524},
+												pos:        position{line: 3170, col: 28, offset: 98724},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 39, offset: 98535},
+												pos:        position{line: 3170, col: 39, offset: 98735},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 49, offset: 98545},
+												pos:        position{line: 3170, col: 49, offset: 98745},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 59, offset: 98555},
+												pos:        position{line: 3170, col: 59, offset: 98755},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 70, offset: 98566},
+												pos:        position{line: 3170, col: 70, offset: 98766},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 84, offset: 98580},
+												pos:        position{line: 3170, col: 84, offset: 98780},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 94, offset: 98590},
+												pos:        position{line: 3170, col: 94, offset: 98790},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 110, offset: 98606},
+												pos:        position{line: 3170, col: 110, offset: 98806},
 												val:        "ismv",
 												ignoreCase: false,
 												want:       "\"ismv\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3162, col: 119, offset: 98615},
+												pos:        position{line: 3170, col: 119, offset: 98815},
 												val:        "isobject",
 												ignoreCase: false,
 												want:       "\"isobject\"",
@@ -6937,56 +6945,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 131, offset: 98627},
+									pos:  position{line: 3170, col: 131, offset: 98827},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3162, col: 139, offset: 98635},
+									pos:   position{line: 3170, col: 139, offset: 98835},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3162, col: 145, offset: 98641},
+										pos:  position{line: 3170, col: 145, offset: 98841},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 155, offset: 98651},
+									pos:  position{line: 3170, col: 155, offset: 98851},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3192, col: 3, offset: 99522},
+						pos: position{line: 3200, col: 3, offset: 99722},
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3192, col: 3, offset: 99522},
+							pos: position{line: 3200, col: 3, offset: 99722},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3192, col: 3, offset: 99522},
+									pos:   position{line: 3200, col: 3, offset: 99722},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3192, col: 11, offset: 99530},
+										pos: position{line: 3200, col: 11, offset: 99730},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3192, col: 11, offset: 99530},
+												pos:        position{line: 3200, col: 11, offset: 99730},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3192, col: 20, offset: 99539},
+												pos:        position{line: 3200, col: 20, offset: 99739},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3192, col: 29, offset: 99548},
+												pos:        position{line: 3200, col: 29, offset: 99748},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3192, col: 39, offset: 99558},
+												pos:        position{line: 3200, col: 39, offset: 99758},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6995,86 +7003,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3192, col: 52, offset: 99571},
+									pos:  position{line: 3200, col: 52, offset: 99771},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3192, col: 60, offset: 99579},
+									pos:   position{line: 3200, col: 60, offset: 99779},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3192, col: 70, offset: 99589},
+										pos:  position{line: 3200, col: 70, offset: 99789},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3192, col: 80, offset: 99599},
+									pos:  position{line: 3200, col: 80, offset: 99799},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3192, col: 86, offset: 99605},
+									pos:   position{line: 3200, col: 86, offset: 99805},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3192, col: 97, offset: 99616},
+										pos:  position{line: 3200, col: 97, offset: 99816},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3192, col: 107, offset: 99626},
+									pos:  position{line: 3200, col: 107, offset: 99826},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3205, col: 3, offset: 99996},
+						pos: position{line: 3213, col: 3, offset: 100196},
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
-							pos: position{line: 3205, col: 3, offset: 99996},
+							pos: position{line: 3213, col: 3, offset: 100196},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3205, col: 3, offset: 99996},
+									pos:   position{line: 3213, col: 3, offset: 100196},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3205, col: 8, offset: 100001},
+										pos:  position{line: 3213, col: 8, offset: 100201},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3205, col: 18, offset: 100011},
+									pos:  position{line: 3213, col: 18, offset: 100211},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3205, col: 24, offset: 100017},
+									pos:        position{line: 3213, col: 24, offset: 100217},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3205, col: 29, offset: 100022},
+									pos:  position{line: 3213, col: 29, offset: 100222},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3205, col: 37, offset: 100030},
+									pos:   position{line: 3213, col: 37, offset: 100230},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3205, col: 50, offset: 100043},
+										pos:  position{line: 3213, col: 50, offset: 100243},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3205, col: 60, offset: 100053},
+									pos:   position{line: 3213, col: 60, offset: 100253},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3205, col: 65, offset: 100058},
+										pos: position{line: 3213, col: 65, offset: 100258},
 										expr: &seqExpr{
-											pos: position{line: 3205, col: 66, offset: 100059},
+											pos: position{line: 3213, col: 66, offset: 100259},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3205, col: 66, offset: 100059},
+													pos:  position{line: 3213, col: 66, offset: 100259},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3205, col: 72, offset: 100065},
+													pos:  position{line: 3213, col: 72, offset: 100265},
 													name: "ValueExpr",
 												},
 											},
@@ -7082,50 +7090,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3205, col: 84, offset: 100077},
+									pos:  position{line: 3213, col: 84, offset: 100277},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3224, col: 3, offset: 100628},
+						pos: position{line: 3232, col: 3, offset: 100828},
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
-							pos: position{line: 3224, col: 3, offset: 100628},
+							pos: position{line: 3232, col: 3, offset: 100828},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3224, col: 3, offset: 100628},
+									pos:        position{line: 3232, col: 3, offset: 100828},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3224, col: 8, offset: 100633},
+									pos:  position{line: 3232, col: 8, offset: 100833},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3224, col: 16, offset: 100641},
+									pos:   position{line: 3232, col: 16, offset: 100841},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3224, col: 29, offset: 100654},
+										pos:  position{line: 3232, col: 29, offset: 100854},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3224, col: 39, offset: 100664},
+									pos:   position{line: 3232, col: 39, offset: 100864},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3224, col: 44, offset: 100669},
+										pos: position{line: 3232, col: 44, offset: 100869},
 										expr: &seqExpr{
-											pos: position{line: 3224, col: 45, offset: 100670},
+											pos: position{line: 3232, col: 45, offset: 100870},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3224, col: 45, offset: 100670},
+													pos:  position{line: 3232, col: 45, offset: 100870},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3224, col: 51, offset: 100676},
+													pos:  position{line: 3232, col: 51, offset: 100876},
 													name: "ValueExpr",
 												},
 											},
@@ -7133,7 +7141,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3224, col: 63, offset: 100688},
+									pos:  position{line: 3232, col: 63, offset: 100888},
 									name: "R_PAREN",
 								},
 							},
@@ -7144,34 +7152,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3242, col: 1, offset: 101109},
+			pos:  position{line: 3250, col: 1, offset: 101309},
 			expr: &actionExpr{
-				pos: position{line: 3242, col: 23, offset: 101131},
+				pos: position{line: 3250, col: 23, offset: 101331},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3242, col: 23, offset: 101131},
+					pos: position{line: 3250, col: 23, offset: 101331},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3242, col: 23, offset: 101131},
+							pos:   position{line: 3250, col: 23, offset: 101331},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3242, col: 28, offset: 101136},
+								pos:  position{line: 3250, col: 28, offset: 101336},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3242, col: 38, offset: 101146},
+							pos:   position{line: 3250, col: 38, offset: 101346},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3242, col: 41, offset: 101149},
+								pos:  position{line: 3250, col: 41, offset: 101349},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3242, col: 62, offset: 101170},
+							pos:   position{line: 3250, col: 62, offset: 101370},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3242, col: 68, offset: 101176},
+								pos:  position{line: 3250, col: 68, offset: 101376},
 								name: "ValueExpr",
 							},
 						},
@@ -7181,141 +7189,141 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3260, col: 1, offset: 101770},
+			pos:  position{line: 3268, col: 1, offset: 101970},
 			expr: &choiceExpr{
-				pos: position{line: 3260, col: 14, offset: 101783},
+				pos: position{line: 3268, col: 14, offset: 101983},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3260, col: 14, offset: 101783},
+						pos: position{line: 3268, col: 14, offset: 101983},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3260, col: 14, offset: 101783},
+							pos:   position{line: 3268, col: 14, offset: 101983},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3260, col: 24, offset: 101793},
+								pos:  position{line: 3268, col: 24, offset: 101993},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3269, col: 3, offset: 101983},
+						pos: position{line: 3277, col: 3, offset: 102183},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3269, col: 3, offset: 101983},
+							pos: position{line: 3277, col: 3, offset: 102183},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3269, col: 3, offset: 101983},
+									pos:  position{line: 3277, col: 3, offset: 102183},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3269, col: 12, offset: 101992},
+									pos:   position{line: 3277, col: 12, offset: 102192},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3269, col: 22, offset: 102002},
+										pos:  position{line: 3277, col: 22, offset: 102202},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3269, col: 37, offset: 102017},
+									pos:  position{line: 3277, col: 37, offset: 102217},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3278, col: 3, offset: 102201},
+						pos: position{line: 3286, col: 3, offset: 102401},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3278, col: 3, offset: 102201},
+							pos:   position{line: 3286, col: 3, offset: 102401},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3278, col: 11, offset: 102209},
+								pos:  position{line: 3286, col: 11, offset: 102409},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3287, col: 3, offset: 102389},
+						pos: position{line: 3295, col: 3, offset: 102589},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3287, col: 3, offset: 102389},
+							pos:   position{line: 3295, col: 3, offset: 102589},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3287, col: 7, offset: 102393},
+								pos:  position{line: 3295, col: 7, offset: 102593},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3296, col: 3, offset: 102565},
+						pos: position{line: 3304, col: 3, offset: 102765},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3296, col: 3, offset: 102565},
+							pos: position{line: 3304, col: 3, offset: 102765},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3296, col: 3, offset: 102565},
+									pos:  position{line: 3304, col: 3, offset: 102765},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3296, col: 12, offset: 102574},
+									pos:   position{line: 3304, col: 12, offset: 102774},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3296, col: 16, offset: 102578},
+										pos:  position{line: 3304, col: 16, offset: 102778},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3296, col: 28, offset: 102590},
+									pos:  position{line: 3304, col: 28, offset: 102790},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3305, col: 3, offset: 102759},
+						pos: position{line: 3313, col: 3, offset: 102959},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3305, col: 3, offset: 102759},
+							pos: position{line: 3313, col: 3, offset: 102959},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3305, col: 3, offset: 102759},
+									pos:  position{line: 3313, col: 3, offset: 102959},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3305, col: 11, offset: 102767},
+									pos:   position{line: 3313, col: 11, offset: 102967},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3305, col: 19, offset: 102775},
+										pos:  position{line: 3313, col: 19, offset: 102975},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3305, col: 28, offset: 102784},
+									pos:  position{line: 3313, col: 28, offset: 102984},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3314, col: 3, offset: 102956},
+						pos: position{line: 3322, col: 3, offset: 103156},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3314, col: 3, offset: 102956},
+							pos:   position{line: 3322, col: 3, offset: 103156},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3314, col: 18, offset: 102971},
+								pos:  position{line: 3322, col: 18, offset: 103171},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3323, col: 3, offset: 103169},
+						pos: position{line: 3331, col: 3, offset: 103369},
 						run: (*parser).callonValueExpr32,
 						expr: &labeledExpr{
-							pos:   position{line: 3323, col: 3, offset: 103169},
+							pos:   position{line: 3331, col: 3, offset: 103369},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3323, col: 12, offset: 103178},
+								pos:  position{line: 3331, col: 12, offset: 103378},
 								name: "JsonExpr",
 							},
 						},
@@ -7325,28 +7333,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3332, col: 1, offset: 103345},
+			pos:  position{line: 3340, col: 1, offset: 103545},
 			expr: &choiceExpr{
-				pos: position{line: 3332, col: 15, offset: 103359},
+				pos: position{line: 3340, col: 15, offset: 103559},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3332, col: 15, offset: 103359},
+						pos: position{line: 3340, col: 15, offset: 103559},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3332, col: 15, offset: 103359},
+							pos: position{line: 3340, col: 15, offset: 103559},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3332, col: 15, offset: 103359},
+									pos:   position{line: 3340, col: 15, offset: 103559},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3332, col: 20, offset: 103364},
+										pos:  position{line: 3340, col: 20, offset: 103564},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3332, col: 29, offset: 103373},
+									pos: position{line: 3340, col: 29, offset: 103573},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3332, col: 31, offset: 103375},
+										pos:  position{line: 3340, col: 31, offset: 103575},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7354,23 +7362,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3340, col: 3, offset: 103545},
+						pos: position{line: 3348, col: 3, offset: 103745},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3340, col: 3, offset: 103545},
+							pos: position{line: 3348, col: 3, offset: 103745},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3340, col: 3, offset: 103545},
+									pos:   position{line: 3348, col: 3, offset: 103745},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3340, col: 7, offset: 103549},
+										pos:  position{line: 3348, col: 7, offset: 103749},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3340, col: 20, offset: 103562},
+									pos: position{line: 3348, col: 20, offset: 103762},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3340, col: 22, offset: 103564},
+										pos:  position{line: 3348, col: 22, offset: 103764},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7378,50 +7386,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3348, col: 3, offset: 103729},
+						pos: position{line: 3356, col: 3, offset: 103929},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3348, col: 3, offset: 103729},
+							pos: position{line: 3356, col: 3, offset: 103929},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3348, col: 3, offset: 103729},
+									pos:   position{line: 3356, col: 3, offset: 103929},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3348, col: 9, offset: 103735},
+										pos:  position{line: 3356, col: 9, offset: 103935},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3348, col: 25, offset: 103751},
+									pos: position{line: 3356, col: 25, offset: 103951},
 									expr: &choiceExpr{
-										pos: position{line: 3348, col: 27, offset: 103753},
+										pos: position{line: 3356, col: 27, offset: 103953},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 27, offset: 103753},
+												pos:  position{line: 3356, col: 27, offset: 103953},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 36, offset: 103762},
+												pos:  position{line: 3356, col: 36, offset: 103962},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 46, offset: 103772},
+												pos:  position{line: 3356, col: 46, offset: 103972},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 54, offset: 103780},
+												pos:  position{line: 3356, col: 54, offset: 103980},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 62, offset: 103788},
+												pos:  position{line: 3356, col: 62, offset: 103988},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3348, col: 70, offset: 103796},
+												pos:  position{line: 3356, col: 70, offset: 103996},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3348, col: 84, offset: 103810},
+												pos:        position{line: 3356, col: 84, offset: 104010},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7433,13 +7441,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3356, col: 3, offset: 103960},
+						pos: position{line: 3364, col: 3, offset: 104160},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3356, col: 3, offset: 103960},
+							pos:   position{line: 3364, col: 3, offset: 104160},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3356, col: 10, offset: 103967},
+								pos:  position{line: 3364, col: 10, offset: 104167},
 								name: "ConcatExpr",
 							},
 						},
@@ -7449,35 +7457,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3366, col: 1, offset: 104173},
+			pos:  position{line: 3374, col: 1, offset: 104373},
 			expr: &actionExpr{
-				pos: position{line: 3366, col: 15, offset: 104187},
+				pos: position{line: 3374, col: 15, offset: 104387},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3366, col: 15, offset: 104187},
+					pos: position{line: 3374, col: 15, offset: 104387},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3366, col: 15, offset: 104187},
+							pos:   position{line: 3374, col: 15, offset: 104387},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3366, col: 21, offset: 104193},
+								pos:  position{line: 3374, col: 21, offset: 104393},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3366, col: 32, offset: 104204},
+							pos:   position{line: 3374, col: 32, offset: 104404},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3366, col: 37, offset: 104209},
+								pos: position{line: 3374, col: 37, offset: 104409},
 								expr: &seqExpr{
-									pos: position{line: 3366, col: 38, offset: 104210},
+									pos: position{line: 3374, col: 38, offset: 104410},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3366, col: 38, offset: 104210},
+											pos:  position{line: 3374, col: 38, offset: 104410},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3366, col: 50, offset: 104222},
+											pos:  position{line: 3374, col: 50, offset: 104422},
 											name: "ConcatAtom",
 										},
 									},
@@ -7485,28 +7493,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3366, col: 63, offset: 104235},
+							pos: position{line: 3374, col: 63, offset: 104435},
 							expr: &choiceExpr{
-								pos: position{line: 3366, col: 65, offset: 104237},
+								pos: position{line: 3374, col: 65, offset: 104437},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3366, col: 65, offset: 104237},
+										pos:  position{line: 3374, col: 65, offset: 104437},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3366, col: 74, offset: 104246},
+										pos:  position{line: 3374, col: 74, offset: 104446},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3366, col: 84, offset: 104256},
+										pos:  position{line: 3374, col: 84, offset: 104456},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3366, col: 92, offset: 104264},
+										pos:  position{line: 3374, col: 92, offset: 104464},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3366, col: 100, offset: 104272},
+										pos:        position{line: 3374, col: 100, offset: 104472},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7520,54 +7528,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3384, col: 1, offset: 104678},
+			pos:  position{line: 3392, col: 1, offset: 104878},
 			expr: &choiceExpr{
-				pos: position{line: 3384, col: 15, offset: 104692},
+				pos: position{line: 3392, col: 15, offset: 104892},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3384, col: 15, offset: 104692},
+						pos: position{line: 3392, col: 15, offset: 104892},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3384, col: 15, offset: 104692},
+							pos:   position{line: 3392, col: 15, offset: 104892},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3384, col: 20, offset: 104697},
+								pos:  position{line: 3392, col: 20, offset: 104897},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3393, col: 3, offset: 104861},
+						pos: position{line: 3401, col: 3, offset: 105061},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3393, col: 3, offset: 104861},
+							pos:   position{line: 3401, col: 3, offset: 105061},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3393, col: 7, offset: 104865},
+								pos:  position{line: 3401, col: 7, offset: 105065},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3401, col: 3, offset: 105004},
+						pos: position{line: 3409, col: 3, offset: 105204},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3401, col: 3, offset: 105004},
+							pos:   position{line: 3409, col: 3, offset: 105204},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3401, col: 10, offset: 105011},
+								pos:  position{line: 3409, col: 10, offset: 105211},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3409, col: 3, offset: 105150},
+						pos: position{line: 3417, col: 3, offset: 105350},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3409, col: 3, offset: 105150},
+							pos:   position{line: 3417, col: 3, offset: 105350},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3409, col: 9, offset: 105156},
+								pos:  position{line: 3417, col: 9, offset: 105356},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7577,32 +7585,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3419, col: 1, offset: 105325},
+			pos:  position{line: 3427, col: 1, offset: 105525},
 			expr: &actionExpr{
-				pos: position{line: 3419, col: 16, offset: 105340},
+				pos: position{line: 3427, col: 16, offset: 105540},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3419, col: 16, offset: 105340},
+					pos: position{line: 3427, col: 16, offset: 105540},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3419, col: 16, offset: 105340},
+							pos:   position{line: 3427, col: 16, offset: 105540},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3419, col: 21, offset: 105345},
+								pos:  position{line: 3427, col: 21, offset: 105545},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3419, col: 39, offset: 105363},
+							pos: position{line: 3427, col: 39, offset: 105563},
 							expr: &choiceExpr{
-								pos: position{line: 3419, col: 41, offset: 105365},
+								pos: position{line: 3427, col: 41, offset: 105565},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3419, col: 41, offset: 105365},
+										pos:  position{line: 3427, col: 41, offset: 105565},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3419, col: 55, offset: 105379},
+										pos:        position{line: 3427, col: 55, offset: 105579},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7616,44 +7624,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3424, col: 1, offset: 105444},
+			pos:  position{line: 3432, col: 1, offset: 105644},
 			expr: &actionExpr{
-				pos: position{line: 3424, col: 22, offset: 105465},
+				pos: position{line: 3432, col: 22, offset: 105665},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3424, col: 22, offset: 105465},
+					pos: position{line: 3432, col: 22, offset: 105665},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3424, col: 22, offset: 105465},
+							pos:   position{line: 3432, col: 22, offset: 105665},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3424, col: 28, offset: 105471},
+								pos:  position{line: 3432, col: 28, offset: 105671},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3424, col: 46, offset: 105489},
+							pos:   position{line: 3432, col: 46, offset: 105689},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3424, col: 51, offset: 105494},
+								pos: position{line: 3432, col: 51, offset: 105694},
 								expr: &seqExpr{
-									pos: position{line: 3424, col: 52, offset: 105495},
+									pos: position{line: 3432, col: 52, offset: 105695},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3424, col: 53, offset: 105496},
+											pos: position{line: 3432, col: 53, offset: 105696},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3424, col: 53, offset: 105496},
+													pos:  position{line: 3432, col: 53, offset: 105696},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3424, col: 62, offset: 105505},
+													pos:  position{line: 3432, col: 62, offset: 105705},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3424, col: 71, offset: 105514},
+											pos:  position{line: 3432, col: 71, offset: 105714},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7666,48 +7674,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3445, col: 1, offset: 106015},
+			pos:  position{line: 3453, col: 1, offset: 106215},
 			expr: &actionExpr{
-				pos: position{line: 3445, col: 22, offset: 106036},
+				pos: position{line: 3453, col: 22, offset: 106236},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3445, col: 22, offset: 106036},
+					pos: position{line: 3453, col: 22, offset: 106236},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3445, col: 22, offset: 106036},
+							pos:   position{line: 3453, col: 22, offset: 106236},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3445, col: 28, offset: 106042},
+								pos:  position{line: 3453, col: 28, offset: 106242},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3445, col: 46, offset: 106060},
+							pos:   position{line: 3453, col: 46, offset: 106260},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3445, col: 51, offset: 106065},
+								pos: position{line: 3453, col: 51, offset: 106265},
 								expr: &seqExpr{
-									pos: position{line: 3445, col: 52, offset: 106066},
+									pos: position{line: 3453, col: 52, offset: 106266},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3445, col: 53, offset: 106067},
+											pos: position{line: 3453, col: 53, offset: 106267},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3445, col: 53, offset: 106067},
+													pos:  position{line: 3453, col: 53, offset: 106267},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3445, col: 61, offset: 106075},
+													pos:  position{line: 3453, col: 61, offset: 106275},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3445, col: 69, offset: 106083},
+													pos:  position{line: 3453, col: 69, offset: 106283},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3445, col: 76, offset: 106090},
+											pos:  position{line: 3453, col: 76, offset: 106290},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7720,22 +7728,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3465, col: 1, offset: 106559},
+			pos:  position{line: 3473, col: 1, offset: 106759},
 			expr: &actionExpr{
-				pos: position{line: 3465, col: 21, offset: 106579},
+				pos: position{line: 3473, col: 21, offset: 106779},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3465, col: 21, offset: 106579},
+					pos: position{line: 3473, col: 21, offset: 106779},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3465, col: 21, offset: 106579},
+							pos:  position{line: 3473, col: 21, offset: 106779},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3465, col: 27, offset: 106585},
+							pos:   position{line: 3473, col: 27, offset: 106785},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3465, col: 32, offset: 106590},
+								pos:  position{line: 3473, col: 32, offset: 106790},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7745,67 +7753,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3475, col: 1, offset: 106834},
+			pos:  position{line: 3483, col: 1, offset: 107034},
 			expr: &choiceExpr{
-				pos: position{line: 3475, col: 22, offset: 106855},
+				pos: position{line: 3483, col: 22, offset: 107055},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3475, col: 22, offset: 106855},
+						pos: position{line: 3483, col: 22, offset: 107055},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3475, col: 22, offset: 106855},
+							pos: position{line: 3483, col: 22, offset: 107055},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 22, offset: 106855},
+									pos:  position{line: 3483, col: 22, offset: 107055},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3475, col: 30, offset: 106863},
+									pos:   position{line: 3483, col: 30, offset: 107063},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3475, col: 35, offset: 106868},
+										pos:  position{line: 3483, col: 35, offset: 107068},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3475, col: 53, offset: 106886},
+									pos:  position{line: 3483, col: 53, offset: 107086},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3478, col: 3, offset: 106921},
+						pos: position{line: 3486, col: 3, offset: 107121},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3478, col: 3, offset: 106921},
+							pos:   position{line: 3486, col: 3, offset: 107121},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3478, col: 20, offset: 106938},
+								pos:  position{line: 3486, col: 20, offset: 107138},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3481, col: 3, offset: 106992},
+						pos: position{line: 3489, col: 3, offset: 107192},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3481, col: 3, offset: 106992},
+							pos:   position{line: 3489, col: 3, offset: 107192},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3481, col: 9, offset: 106998},
+								pos:  position{line: 3489, col: 9, offset: 107198},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3491, col: 3, offset: 107217},
+						pos: position{line: 3499, col: 3, offset: 107417},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3491, col: 3, offset: 107217},
+							pos:   position{line: 3499, col: 3, offset: 107417},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3491, col: 10, offset: 107224},
+								pos:  position{line: 3499, col: 10, offset: 107424},
 								name: "NumberAsString",
 							},
 						},
@@ -7815,144 +7823,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3504, col: 1, offset: 107602},
+			pos:  position{line: 3512, col: 1, offset: 107802},
 			expr: &choiceExpr{
-				pos: position{line: 3504, col: 20, offset: 107621},
+				pos: position{line: 3512, col: 20, offset: 107821},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3504, col: 20, offset: 107621},
+						pos: position{line: 3512, col: 20, offset: 107821},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3504, col: 21, offset: 107622},
+							pos: position{line: 3512, col: 21, offset: 107822},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3504, col: 21, offset: 107622},
+									pos:   position{line: 3512, col: 21, offset: 107822},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3504, col: 29, offset: 107630},
+										pos: position{line: 3512, col: 29, offset: 107830},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3504, col: 29, offset: 107630},
+												pos:        position{line: 3512, col: 29, offset: 107830},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 37, offset: 107638},
+												pos:        position{line: 3512, col: 37, offset: 107838},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 46, offset: 107647},
+												pos:        position{line: 3512, col: 46, offset: 107847},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 58, offset: 107659},
+												pos:        position{line: 3512, col: 58, offset: 107859},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 67, offset: 107668},
+												pos:        position{line: 3512, col: 67, offset: 107868},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 77, offset: 107678},
+												pos:        position{line: 3512, col: 77, offset: 107878},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 85, offset: 107686},
+												pos:        position{line: 3512, col: 85, offset: 107886},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 95, offset: 107696},
+												pos:        position{line: 3512, col: 95, offset: 107896},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 102, offset: 107703},
+												pos:        position{line: 3512, col: 102, offset: 107903},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 113, offset: 107714},
+												pos:        position{line: 3512, col: 113, offset: 107914},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 123, offset: 107724},
+												pos:        position{line: 3512, col: 123, offset: 107924},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 132, offset: 107733},
+												pos:        position{line: 3512, col: 132, offset: 107933},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 142, offset: 107743},
+												pos:        position{line: 3512, col: 142, offset: 107943},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 151, offset: 107752},
+												pos:        position{line: 3512, col: 151, offset: 107952},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 161, offset: 107762},
+												pos:        position{line: 3512, col: 161, offset: 107962},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 170, offset: 107771},
+												pos:        position{line: 3512, col: 170, offset: 107971},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 179, offset: 107780},
+												pos:        position{line: 3512, col: 179, offset: 107980},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 187, offset: 107788},
+												pos:        position{line: 3512, col: 187, offset: 107988},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 196, offset: 107797},
+												pos:        position{line: 3512, col: 196, offset: 107997},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 204, offset: 107805},
+												pos:        position{line: 3512, col: 204, offset: 108005},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3504, col: 213, offset: 107814},
+												pos:        position{line: 3512, col: 213, offset: 108014},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7961,102 +7969,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3504, col: 220, offset: 107821},
+									pos:  position{line: 3512, col: 220, offset: 108021},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3504, col: 228, offset: 107829},
+									pos:   position{line: 3512, col: 228, offset: 108029},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3504, col: 234, offset: 107835},
+										pos:  position{line: 3512, col: 234, offset: 108035},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3504, col: 253, offset: 107854},
+									pos:  position{line: 3512, col: 253, offset: 108054},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3524, col: 3, offset: 108366},
+						pos: position{line: 3532, col: 3, offset: 108566},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3524, col: 3, offset: 108366},
+							pos: position{line: 3532, col: 3, offset: 108566},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3524, col: 3, offset: 108366},
+									pos:   position{line: 3532, col: 3, offset: 108566},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3524, col: 13, offset: 108376},
+										pos:        position{line: 3532, col: 13, offset: 108576},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3524, col: 21, offset: 108384},
+									pos:  position{line: 3532, col: 21, offset: 108584},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3524, col: 29, offset: 108392},
+									pos:   position{line: 3532, col: 29, offset: 108592},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3524, col: 35, offset: 108398},
+										pos:  position{line: 3532, col: 35, offset: 108598},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3524, col: 54, offset: 108417},
+									pos:   position{line: 3532, col: 54, offset: 108617},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3524, col: 69, offset: 108432},
+										pos: position{line: 3532, col: 69, offset: 108632},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3524, col: 70, offset: 108433},
+											pos:  position{line: 3532, col: 70, offset: 108633},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3524, col: 89, offset: 108452},
+									pos:  position{line: 3532, col: 89, offset: 108652},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3545, col: 3, offset: 109070},
+						pos: position{line: 3553, col: 3, offset: 109270},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3545, col: 4, offset: 109071},
+							pos: position{line: 3553, col: 4, offset: 109271},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3545, col: 4, offset: 109071},
+									pos:   position{line: 3553, col: 4, offset: 109271},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3545, col: 12, offset: 109079},
+										pos: position{line: 3553, col: 12, offset: 109279},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3545, col: 12, offset: 109079},
+												pos:        position{line: 3553, col: 12, offset: 109279},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3545, col: 20, offset: 109087},
+												pos:        position{line: 3553, col: 20, offset: 109287},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3545, col: 27, offset: 109094},
+												pos:        position{line: 3553, col: 27, offset: 109294},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3545, col: 38, offset: 109105},
+												pos:        position{line: 3553, col: 38, offset: 109305},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -8065,54 +8073,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3545, col: 46, offset: 109113},
+									pos:  position{line: 3553, col: 46, offset: 109313},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3545, col: 54, offset: 109121},
+									pos:  position{line: 3553, col: 54, offset: 109321},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3558, col: 3, offset: 109407},
+						pos: position{line: 3566, col: 3, offset: 109607},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3558, col: 3, offset: 109407},
+							pos: position{line: 3566, col: 3, offset: 109607},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3558, col: 3, offset: 109407},
+									pos:        position{line: 3566, col: 3, offset: 109607},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3558, col: 14, offset: 109418},
+									pos:  position{line: 3566, col: 14, offset: 109618},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3558, col: 22, offset: 109426},
+									pos:   position{line: 3566, col: 22, offset: 109626},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3558, col: 33, offset: 109437},
+										pos:  position{line: 3566, col: 33, offset: 109637},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3558, col: 44, offset: 109448},
+									pos:   position{line: 3566, col: 44, offset: 109648},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3558, col: 53, offset: 109457},
+										pos: position{line: 3566, col: 53, offset: 109657},
 										expr: &seqExpr{
-											pos: position{line: 3558, col: 54, offset: 109458},
+											pos: position{line: 3566, col: 54, offset: 109658},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3558, col: 54, offset: 109458},
+													pos:  position{line: 3566, col: 54, offset: 109658},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3558, col: 60, offset: 109464},
+													pos:  position{line: 3566, col: 60, offset: 109664},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8120,38 +8128,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3558, col: 80, offset: 109484},
+									pos:  position{line: 3566, col: 80, offset: 109684},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3586, col: 3, offset: 110327},
+						pos: position{line: 3594, col: 3, offset: 110527},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3586, col: 4, offset: 110328},
+							pos: position{line: 3594, col: 4, offset: 110528},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3586, col: 4, offset: 110328},
+									pos:   position{line: 3594, col: 4, offset: 110528},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3586, col: 12, offset: 110336},
+										pos: position{line: 3594, col: 12, offset: 110536},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3586, col: 12, offset: 110336},
+												pos:        position{line: 3594, col: 12, offset: 110536},
 												val:        "bit_and",
 												ignoreCase: false,
 												want:       "\"bit_and\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3586, col: 24, offset: 110348},
+												pos:        position{line: 3594, col: 24, offset: 110548},
 												val:        "bit_or",
 												ignoreCase: false,
 												want:       "\"bit_or\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3586, col: 35, offset: 110359},
+												pos:        position{line: 3594, col: 35, offset: 110559},
 												val:        "bit_xor",
 												ignoreCase: false,
 												want:       "\"bit_xor\"",
@@ -8160,43 +8168,43 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3586, col: 46, offset: 110370},
+									pos:  position{line: 3594, col: 46, offset: 110570},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3586, col: 54, offset: 110378},
+									pos:   position{line: 3594, col: 54, offset: 110578},
 									label: "firstArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3586, col: 63, offset: 110387},
+										pos:  position{line: 3594, col: 63, offset: 110587},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3586, col: 81, offset: 110405},
+									pos:  position{line: 3594, col: 81, offset: 110605},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3586, col: 87, offset: 110411},
+									pos:   position{line: 3594, col: 87, offset: 110611},
 									label: "secondArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3586, col: 97, offset: 110421},
+										pos:  position{line: 3594, col: 97, offset: 110621},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3586, col: 115, offset: 110439},
+									pos:   position{line: 3594, col: 115, offset: 110639},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3586, col: 120, offset: 110444},
+										pos: position{line: 3594, col: 120, offset: 110644},
 										expr: &seqExpr{
-											pos: position{line: 3586, col: 121, offset: 110445},
+											pos: position{line: 3594, col: 121, offset: 110645},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3586, col: 121, offset: 110445},
+													pos:  position{line: 3594, col: 121, offset: 110645},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3586, col: 127, offset: 110451},
+													pos:  position{line: 3594, col: 127, offset: 110651},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8204,38 +8212,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3586, col: 147, offset: 110471},
+									pos:  position{line: 3594, col: 147, offset: 110671},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3622, col: 3, offset: 111568},
+						pos: position{line: 3630, col: 3, offset: 111768},
 						run: (*parser).callonNumericEvalExpr83,
 						expr: &seqExpr{
-							pos: position{line: 3622, col: 4, offset: 111569},
+							pos: position{line: 3630, col: 4, offset: 111769},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3622, col: 4, offset: 111569},
+									pos:   position{line: 3630, col: 4, offset: 111769},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3622, col: 12, offset: 111577},
+										pos: position{line: 3630, col: 12, offset: 111777},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3622, col: 12, offset: 111577},
+												pos:        position{line: 3630, col: 12, offset: 111777},
 												val:        "bit_not",
 												ignoreCase: false,
 												want:       "\"bit_not\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3622, col: 24, offset: 111589},
+												pos:        position{line: 3630, col: 24, offset: 111789},
 												val:        "bit_shift_left",
 												ignoreCase: false,
 												want:       "\"bit_shift_left\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3622, col: 43, offset: 111608},
+												pos:        position{line: 3630, col: 43, offset: 111808},
 												val:        "bit_shift_right",
 												ignoreCase: false,
 												want:       "\"bit_shift_right\"",
@@ -8244,31 +8252,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3622, col: 62, offset: 111627},
+									pos:  position{line: 3630, col: 62, offset: 111827},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3622, col: 70, offset: 111635},
+									pos:   position{line: 3630, col: 70, offset: 111835},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3622, col: 75, offset: 111640},
+										pos:  position{line: 3630, col: 75, offset: 111840},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3622, col: 93, offset: 111658},
+									pos:   position{line: 3630, col: 93, offset: 111858},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3622, col: 99, offset: 111664},
+										pos: position{line: 3630, col: 99, offset: 111864},
 										expr: &seqExpr{
-											pos: position{line: 3622, col: 100, offset: 111665},
+											pos: position{line: 3630, col: 100, offset: 111865},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3622, col: 100, offset: 111665},
+													pos:  position{line: 3630, col: 100, offset: 111865},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3622, col: 106, offset: 111671},
+													pos:  position{line: 3630, col: 106, offset: 111871},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8276,73 +8284,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3622, col: 126, offset: 111691},
+									pos:  position{line: 3630, col: 126, offset: 111891},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3649, col: 3, offset: 112615},
+						pos: position{line: 3657, col: 3, offset: 112815},
 						run: (*parser).callonNumericEvalExpr99,
 						expr: &seqExpr{
-							pos: position{line: 3649, col: 3, offset: 112615},
+							pos: position{line: 3657, col: 3, offset: 112815},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3649, col: 3, offset: 112615},
+									pos:   position{line: 3657, col: 3, offset: 112815},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3649, col: 12, offset: 112624},
+										pos:        position{line: 3657, col: 12, offset: 112824},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3649, col: 18, offset: 112630},
+									pos:  position{line: 3657, col: 18, offset: 112830},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3649, col: 26, offset: 112638},
+									pos:   position{line: 3657, col: 26, offset: 112838},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3649, col: 31, offset: 112643},
+										pos:  position{line: 3657, col: 31, offset: 112843},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3649, col: 39, offset: 112651},
+									pos:  position{line: 3657, col: 39, offset: 112851},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3652, col: 3, offset: 112686},
+						pos: position{line: 3660, col: 3, offset: 112886},
 						run: (*parser).callonNumericEvalExpr107,
 						expr: &seqExpr{
-							pos: position{line: 3652, col: 4, offset: 112687},
+							pos: position{line: 3660, col: 4, offset: 112887},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3652, col: 4, offset: 112687},
+									pos:   position{line: 3660, col: 4, offset: 112887},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3652, col: 12, offset: 112695},
+										pos: position{line: 3660, col: 12, offset: 112895},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3652, col: 12, offset: 112695},
+												pos:        position{line: 3660, col: 12, offset: 112895},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3652, col: 20, offset: 112703},
+												pos:        position{line: 3660, col: 20, offset: 112903},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3652, col: 30, offset: 112713},
+												pos:        position{line: 3660, col: 30, offset: 112913},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8351,128 +8359,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3652, col: 39, offset: 112722},
+									pos:  position{line: 3660, col: 39, offset: 112922},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3652, col: 47, offset: 112730},
+									pos:   position{line: 3660, col: 47, offset: 112930},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3652, col: 53, offset: 112736},
+										pos:  position{line: 3660, col: 53, offset: 112936},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3652, col: 72, offset: 112755},
+									pos:   position{line: 3660, col: 72, offset: 112955},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3652, col: 79, offset: 112762},
+										pos:  position{line: 3660, col: 79, offset: 112962},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3652, col: 97, offset: 112780},
+									pos:  position{line: 3660, col: 97, offset: 112980},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3682, col: 3, offset: 113619},
+						pos: position{line: 3690, col: 3, offset: 113819},
 						run: (*parser).callonNumericEvalExpr120,
 						expr: &seqExpr{
-							pos: position{line: 3682, col: 4, offset: 113620},
+							pos: position{line: 3690, col: 4, offset: 113820},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3682, col: 4, offset: 113620},
+									pos:   position{line: 3690, col: 4, offset: 113820},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3682, col: 11, offset: 113627},
+										pos:        position{line: 3690, col: 11, offset: 113827},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3682, col: 17, offset: 113633},
+									pos:  position{line: 3690, col: 17, offset: 113833},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3682, col: 25, offset: 113641},
+									pos:   position{line: 3690, col: 25, offset: 113841},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3682, col: 31, offset: 113647},
+										pos:  position{line: 3690, col: 31, offset: 113847},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3682, col: 50, offset: 113666},
+									pos:   position{line: 3690, col: 50, offset: 113866},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3682, col: 56, offset: 113672},
+										pos: position{line: 3690, col: 56, offset: 113872},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3682, col: 57, offset: 113673},
+											pos:  position{line: 3690, col: 57, offset: 113873},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3682, col: 76, offset: 113692},
+									pos:  position{line: 3690, col: 76, offset: 113892},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3711, col: 3, offset: 114465},
+						pos: position{line: 3719, col: 3, offset: 114665},
 						run: (*parser).callonNumericEvalExpr131,
 						expr: &seqExpr{
-							pos: position{line: 3711, col: 3, offset: 114465},
+							pos: position{line: 3719, col: 3, offset: 114665},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3711, col: 3, offset: 114465},
+									pos:   position{line: 3719, col: 3, offset: 114665},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3711, col: 11, offset: 114473},
+										pos:        position{line: 3719, col: 11, offset: 114673},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3711, col: 28, offset: 114490},
+									pos:  position{line: 3719, col: 28, offset: 114690},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3711, col: 36, offset: 114498},
+									pos:   position{line: 3719, col: 36, offset: 114698},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3711, col: 42, offset: 114504},
+										pos:  position{line: 3719, col: 42, offset: 114704},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3711, col: 61, offset: 114523},
+									pos:  position{line: 3719, col: 61, offset: 114723},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3711, col: 67, offset: 114529},
+									pos:  position{line: 3719, col: 67, offset: 114729},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3711, col: 73, offset: 114535},
+									pos:   position{line: 3719, col: 73, offset: 114735},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3711, col: 84, offset: 114546},
+										pos:  position{line: 3719, col: 84, offset: 114746},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3711, col: 120, offset: 114582},
+									pos:  position{line: 3719, col: 120, offset: 114782},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3711, col: 126, offset: 114588},
+									pos:  position{line: 3719, col: 126, offset: 114788},
 									name: "R_PAREN",
 								},
 							},
@@ -8483,103 +8491,103 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExprLevel1",
-			pos:  position{line: 3728, col: 1, offset: 115118},
+			pos:  position{line: 3736, col: 1, offset: 115318},
 			expr: &choiceExpr{
-				pos: position{line: 3728, col: 19, offset: 115136},
+				pos: position{line: 3736, col: 19, offset: 115336},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3728, col: 19, offset: 115136},
+						pos: position{line: 3736, col: 19, offset: 115336},
 						run: (*parser).callonJsonExprLevel12,
 						expr: &labeledExpr{
-							pos:   position{line: 3728, col: 19, offset: 115136},
+							pos:   position{line: 3736, col: 19, offset: 115336},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3728, col: 28, offset: 115145},
+								pos:  position{line: 3736, col: 28, offset: 115345},
 								name: "JsonExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3731, col: 3, offset: 115185},
+						pos: position{line: 3739, col: 3, offset: 115385},
 						run: (*parser).callonJsonExprLevel15,
 						expr: &labeledExpr{
-							pos:   position{line: 3731, col: 3, offset: 115185},
+							pos:   position{line: 3739, col: 3, offset: 115385},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3731, col: 9, offset: 115191},
+								pos:  position{line: 3739, col: 9, offset: 115391},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3745, col: 3, offset: 115537},
+						pos: position{line: 3753, col: 3, offset: 115737},
 						run: (*parser).callonJsonExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3745, col: 3, offset: 115537},
+							pos:   position{line: 3753, col: 3, offset: 115737},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3745, col: 9, offset: 115543},
+								pos:  position{line: 3753, col: 9, offset: 115743},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3759, col: 3, offset: 115907},
+						pos: position{line: 3767, col: 3, offset: 116107},
 						run: (*parser).callonJsonExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3759, col: 3, offset: 115907},
+							pos:   position{line: 3767, col: 3, offset: 116107},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3759, col: 9, offset: 115913},
+								pos:  position{line: 3767, col: 9, offset: 116113},
 								name: "NumericExprLevel3",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3773, col: 3, offset: 116279},
+						pos: position{line: 3781, col: 3, offset: 116479},
 						run: (*parser).callonJsonExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3773, col: 3, offset: 116279},
+							pos:   position{line: 3781, col: 3, offset: 116479},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3773, col: 9, offset: 116285},
+								pos:  position{line: 3781, col: 9, offset: 116485},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3787, col: 3, offset: 116662},
+						pos: position{line: 3795, col: 3, offset: 116862},
 						run: (*parser).callonJsonExprLevel117,
 						expr: &labeledExpr{
-							pos:   position{line: 3787, col: 3, offset: 116662},
+							pos:   position{line: 3795, col: 3, offset: 116862},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3787, col: 9, offset: 116668},
+								pos:  position{line: 3795, col: 9, offset: 116868},
 								name: "BoolExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3801, col: 3, offset: 117023},
+						pos: position{line: 3809, col: 3, offset: 117223},
 						run: (*parser).callonJsonExprLevel120,
 						expr: &labeledExpr{
-							pos:   position{line: 3801, col: 3, offset: 117023},
+							pos:   position{line: 3809, col: 3, offset: 117223},
 							label: "value",
 							expr: &seqExpr{
-								pos: position{line: 3801, col: 10, offset: 117030},
+								pos: position{line: 3809, col: 10, offset: 117230},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 3801, col: 10, offset: 117030},
+										pos:        position{line: 3809, col: 10, offset: 117230},
 										val:        "null",
 										ignoreCase: false,
 										want:       "\"null\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3801, col: 17, offset: 117037},
+										pos:  position{line: 3809, col: 17, offset: 117237},
 										name: "L_PAREN",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3801, col: 25, offset: 117045},
+										pos:  position{line: 3809, col: 25, offset: 117245},
 										name: "R_PAREN",
 									},
 								},
@@ -8587,13 +8595,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3811, col: 3, offset: 117240},
+						pos: position{line: 3819, col: 3, offset: 117440},
 						run: (*parser).callonJsonExprLevel126,
 						expr: &labeledExpr{
-							pos:   position{line: 3811, col: 3, offset: 117240},
+							pos:   position{line: 3819, col: 3, offset: 117440},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3811, col: 9, offset: 117246},
+								pos:  position{line: 3819, col: 9, offset: 117446},
 								name: "StringExpr",
 							},
 						},
@@ -8603,65 +8611,65 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExpr",
-			pos:  position{line: 3826, col: 1, offset: 117609},
+			pos:  position{line: 3834, col: 1, offset: 117809},
 			expr: &actionExpr{
-				pos: position{line: 3826, col: 13, offset: 117621},
+				pos: position{line: 3834, col: 13, offset: 117821},
 				run: (*parser).callonJsonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3826, col: 13, offset: 117621},
+					pos: position{line: 3834, col: 13, offset: 117821},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3826, col: 13, offset: 117621},
+							pos:        position{line: 3834, col: 13, offset: 117821},
 							val:        "json_object",
 							ignoreCase: false,
 							want:       "\"json_object\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3826, col: 27, offset: 117635},
+							pos:  position{line: 3834, col: 27, offset: 117835},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 3826, col: 35, offset: 117643},
+							pos:   position{line: 3834, col: 35, offset: 117843},
 							label: "firstKey",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3826, col: 45, offset: 117653},
+								pos:  position{line: 3834, col: 45, offset: 117853},
 								name: "JsonExprLevel1",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3826, col: 61, offset: 117669},
+							pos:  position{line: 3834, col: 61, offset: 117869},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3826, col: 67, offset: 117675},
+							pos:   position{line: 3834, col: 67, offset: 117875},
 							label: "firstValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3826, col: 79, offset: 117687},
+								pos:  position{line: 3834, col: 79, offset: 117887},
 								name: "JsonExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3826, col: 95, offset: 117703},
+							pos:   position{line: 3834, col: 95, offset: 117903},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3826, col: 100, offset: 117708},
+								pos: position{line: 3834, col: 100, offset: 117908},
 								expr: &seqExpr{
-									pos: position{line: 3826, col: 101, offset: 117709},
+									pos: position{line: 3834, col: 101, offset: 117909},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 101, offset: 117709},
+											pos:  position{line: 3834, col: 101, offset: 117909},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 107, offset: 117715},
+											pos:  position{line: 3834, col: 107, offset: 117915},
 											name: "JsonExprLevel1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 122, offset: 117730},
+											pos:  position{line: 3834, col: 122, offset: 117930},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 128, offset: 117736},
+											pos:  position{line: 3834, col: 128, offset: 117936},
 											name: "JsonExprLevel1",
 										},
 									},
@@ -8669,7 +8677,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3826, col: 145, offset: 117753},
+							pos:  position{line: 3834, col: 145, offset: 117953},
 							name: "R_PAREN",
 						},
 					},
@@ -8678,28 +8686,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3902, col: 1, offset: 120272},
+			pos:  position{line: 3927, col: 1, offset: 120957},
 			expr: &choiceExpr{
-				pos: position{line: 3902, col: 12, offset: 120283},
+				pos: position{line: 3927, col: 12, offset: 120968},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3902, col: 12, offset: 120283},
+						pos: position{line: 3927, col: 12, offset: 120968},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3902, col: 12, offset: 120283},
+							pos: position{line: 3927, col: 12, offset: 120968},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3902, col: 12, offset: 120283},
+									pos:   position{line: 3927, col: 12, offset: 120968},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3902, col: 16, offset: 120287},
+										pos:  position{line: 3927, col: 16, offset: 120972},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3902, col: 29, offset: 120300},
+									pos: position{line: 3927, col: 29, offset: 120985},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3902, col: 31, offset: 120302},
+										pos:  position{line: 3927, col: 31, offset: 120987},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8707,50 +8715,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3918, col: 3, offset: 120677},
+						pos: position{line: 3943, col: 3, offset: 121362},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3918, col: 3, offset: 120677},
+							pos: position{line: 3943, col: 3, offset: 121362},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3918, col: 3, offset: 120677},
+									pos:   position{line: 3943, col: 3, offset: 121362},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3918, col: 9, offset: 120683},
+										pos:  position{line: 3943, col: 9, offset: 121368},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3918, col: 25, offset: 120699},
+									pos: position{line: 3943, col: 25, offset: 121384},
 									expr: &choiceExpr{
-										pos: position{line: 3918, col: 27, offset: 120701},
+										pos: position{line: 3943, col: 27, offset: 121386},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 27, offset: 120701},
+												pos:  position{line: 3943, col: 27, offset: 121386},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 36, offset: 120710},
+												pos:  position{line: 3943, col: 36, offset: 121395},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 46, offset: 120720},
+												pos:  position{line: 3943, col: 46, offset: 121405},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 54, offset: 120728},
+												pos:  position{line: 3943, col: 54, offset: 121413},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 62, offset: 120736},
+												pos:  position{line: 3943, col: 62, offset: 121421},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3918, col: 70, offset: 120744},
+												pos:  position{line: 3943, col: 70, offset: 121429},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3918, col: 84, offset: 120758},
+												pos:        position{line: 3943, col: 84, offset: 121443},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8766,28 +8774,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3935, col: 1, offset: 121109},
+			pos:  position{line: 3960, col: 1, offset: 121794},
 			expr: &actionExpr{
-				pos: position{line: 3935, col: 19, offset: 121127},
+				pos: position{line: 3960, col: 19, offset: 121812},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3935, col: 19, offset: 121127},
+					pos: position{line: 3960, col: 19, offset: 121812},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3935, col: 19, offset: 121127},
+							pos:        position{line: 3960, col: 19, offset: 121812},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3935, col: 26, offset: 121134},
+							pos:  position{line: 3960, col: 26, offset: 121819},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3935, col: 32, offset: 121140},
+							pos:   position{line: 3960, col: 32, offset: 121825},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3935, col: 40, offset: 121148},
+								pos:  position{line: 3960, col: 40, offset: 121833},
 								name: "Boolean",
 							},
 						},
@@ -8797,28 +8805,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3946, col: 1, offset: 121337},
+			pos:  position{line: 3971, col: 1, offset: 122022},
 			expr: &actionExpr{
-				pos: position{line: 3946, col: 23, offset: 121359},
+				pos: position{line: 3971, col: 23, offset: 122044},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3946, col: 23, offset: 121359},
+					pos: position{line: 3971, col: 23, offset: 122044},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3946, col: 23, offset: 121359},
+							pos:        position{line: 3971, col: 23, offset: 122044},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3946, col: 34, offset: 121370},
+							pos:  position{line: 3971, col: 34, offset: 122055},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3946, col: 40, offset: 121376},
+							pos:   position{line: 3971, col: 40, offset: 122061},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3946, col: 48, offset: 121384},
+								pos:  position{line: 3971, col: 48, offset: 122069},
 								name: "Boolean",
 							},
 						},
@@ -8828,28 +8836,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3957, col: 1, offset: 121581},
+			pos:  position{line: 3982, col: 1, offset: 122266},
 			expr: &actionExpr{
-				pos: position{line: 3957, col: 20, offset: 121600},
+				pos: position{line: 3982, col: 20, offset: 122285},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3957, col: 20, offset: 121600},
+					pos: position{line: 3982, col: 20, offset: 122285},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3957, col: 20, offset: 121600},
+							pos:        position{line: 3982, col: 20, offset: 122285},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3957, col: 28, offset: 121608},
+							pos:  position{line: 3982, col: 28, offset: 122293},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3957, col: 34, offset: 121614},
+							pos:   position{line: 3982, col: 34, offset: 122299},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3957, col: 43, offset: 121623},
+								pos:  position{line: 3982, col: 43, offset: 122308},
 								name: "IntegerAsString",
 							},
 						},
@@ -8859,15 +8867,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3972, col: 1, offset: 121985},
+			pos:  position{line: 3997, col: 1, offset: 122670},
 			expr: &actionExpr{
-				pos: position{line: 3972, col: 19, offset: 122003},
+				pos: position{line: 3997, col: 19, offset: 122688},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3972, col: 19, offset: 122003},
+					pos:   position{line: 3997, col: 19, offset: 122688},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3972, col: 28, offset: 122012},
+						pos:  position{line: 3997, col: 28, offset: 122697},
 						name: "BoolExpr",
 					},
 				},
@@ -8875,30 +8883,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3983, col: 1, offset: 122224},
+			pos:  position{line: 4008, col: 1, offset: 122909},
 			expr: &actionExpr{
-				pos: position{line: 3983, col: 15, offset: 122238},
+				pos: position{line: 4008, col: 15, offset: 122923},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3983, col: 15, offset: 122238},
+					pos:   position{line: 4008, col: 15, offset: 122923},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3983, col: 23, offset: 122246},
+						pos: position{line: 4008, col: 23, offset: 122931},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3983, col: 23, offset: 122246},
+								pos:  position{line: 4008, col: 23, offset: 122931},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3983, col: 44, offset: 122267},
+								pos:  position{line: 4008, col: 44, offset: 122952},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3983, col: 61, offset: 122284},
+								pos:  position{line: 4008, col: 61, offset: 122969},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3983, col: 79, offset: 122302},
+								pos:  position{line: 4008, col: 79, offset: 122987},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8908,35 +8916,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3987, col: 1, offset: 122346},
+			pos:  position{line: 4012, col: 1, offset: 123031},
 			expr: &actionExpr{
-				pos: position{line: 3987, col: 19, offset: 122364},
+				pos: position{line: 4012, col: 19, offset: 123049},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3987, col: 19, offset: 122364},
+					pos: position{line: 4012, col: 19, offset: 123049},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3987, col: 19, offset: 122364},
+							pos:   position{line: 4012, col: 19, offset: 123049},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3987, col: 26, offset: 122371},
+								pos:  position{line: 4012, col: 26, offset: 123056},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3987, col: 37, offset: 122382},
+							pos:   position{line: 4012, col: 37, offset: 123067},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3987, col: 43, offset: 122388},
+								pos: position{line: 4012, col: 43, offset: 123073},
 								expr: &seqExpr{
-									pos: position{line: 3987, col: 44, offset: 122389},
+									pos: position{line: 4012, col: 44, offset: 123074},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3987, col: 44, offset: 122389},
+											pos:  position{line: 4012, col: 44, offset: 123074},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3987, col: 50, offset: 122395},
+											pos:  position{line: 4012, col: 50, offset: 123080},
 											name: "HeadOption",
 										},
 									},
@@ -8949,29 +8957,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4044, col: 1, offset: 124195},
+			pos:  position{line: 4069, col: 1, offset: 124880},
 			expr: &choiceExpr{
-				pos: position{line: 4044, col: 14, offset: 124208},
+				pos: position{line: 4069, col: 14, offset: 124893},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4044, col: 14, offset: 124208},
+						pos: position{line: 4069, col: 14, offset: 124893},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4044, col: 14, offset: 124208},
+							pos: position{line: 4069, col: 14, offset: 124893},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4044, col: 14, offset: 124208},
+									pos:  position{line: 4069, col: 14, offset: 124893},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4044, col: 19, offset: 124213},
+									pos:  position{line: 4069, col: 19, offset: 124898},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4044, col: 28, offset: 124222},
+									pos:   position{line: 4069, col: 28, offset: 124907},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4044, col: 37, offset: 124231},
+										pos:  position{line: 4069, col: 37, offset: 124916},
 										name: "HeadOptionList",
 									},
 								},
@@ -8979,24 +8987,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4055, col: 3, offset: 124550},
+						pos: position{line: 4080, col: 3, offset: 125235},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4055, col: 3, offset: 124550},
+							pos: position{line: 4080, col: 3, offset: 125235},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4055, col: 3, offset: 124550},
+									pos:  position{line: 4080, col: 3, offset: 125235},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4055, col: 8, offset: 124555},
+									pos:  position{line: 4080, col: 8, offset: 125240},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4055, col: 17, offset: 124564},
+									pos:   position{line: 4080, col: 17, offset: 125249},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4055, col: 26, offset: 124573},
+										pos:  position{line: 4080, col: 26, offset: 125258},
 										name: "IntegerAsString",
 									},
 								},
@@ -9004,17 +9012,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4075, col: 3, offset: 125090},
+						pos: position{line: 4100, col: 3, offset: 125775},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4075, col: 3, offset: 125090},
+							pos: position{line: 4100, col: 3, offset: 125775},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4075, col: 3, offset: 125090},
+									pos:  position{line: 4100, col: 3, offset: 125775},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4075, col: 8, offset: 125095},
+									pos:  position{line: 4100, col: 8, offset: 125780},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9025,29 +9033,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4093, col: 1, offset: 125565},
+			pos:  position{line: 4118, col: 1, offset: 126250},
 			expr: &choiceExpr{
-				pos: position{line: 4093, col: 14, offset: 125578},
+				pos: position{line: 4118, col: 14, offset: 126263},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4093, col: 14, offset: 125578},
+						pos: position{line: 4118, col: 14, offset: 126263},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4093, col: 14, offset: 125578},
+							pos: position{line: 4118, col: 14, offset: 126263},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4093, col: 14, offset: 125578},
+									pos:  position{line: 4118, col: 14, offset: 126263},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4093, col: 19, offset: 125583},
+									pos:  position{line: 4118, col: 19, offset: 126268},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4093, col: 28, offset: 125592},
+									pos:   position{line: 4118, col: 28, offset: 126277},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4093, col: 37, offset: 125601},
+										pos:  position{line: 4118, col: 37, offset: 126286},
 										name: "IntegerAsString",
 									},
 								},
@@ -9055,17 +9063,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4114, col: 3, offset: 126175},
+						pos: position{line: 4139, col: 3, offset: 126860},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4114, col: 3, offset: 126175},
+							pos: position{line: 4139, col: 3, offset: 126860},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4114, col: 3, offset: 126175},
+									pos:  position{line: 4139, col: 3, offset: 126860},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4114, col: 8, offset: 126180},
+									pos:  position{line: 4139, col: 8, offset: 126865},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9076,44 +9084,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4135, col: 1, offset: 126798},
+			pos:  position{line: 4160, col: 1, offset: 127483},
 			expr: &actionExpr{
-				pos: position{line: 4135, col: 20, offset: 126817},
+				pos: position{line: 4160, col: 20, offset: 127502},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4135, col: 20, offset: 126817},
+					pos: position{line: 4160, col: 20, offset: 127502},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4135, col: 20, offset: 126817},
+							pos:   position{line: 4160, col: 20, offset: 127502},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4135, col: 26, offset: 126823},
+								pos:  position{line: 4160, col: 26, offset: 127508},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4135, col: 37, offset: 126834},
+							pos:   position{line: 4160, col: 37, offset: 127519},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4135, col: 42, offset: 126839},
+								pos: position{line: 4160, col: 42, offset: 127524},
 								expr: &seqExpr{
-									pos: position{line: 4135, col: 43, offset: 126840},
+									pos: position{line: 4160, col: 43, offset: 127525},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4135, col: 44, offset: 126841},
+											pos: position{line: 4160, col: 44, offset: 127526},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4135, col: 44, offset: 126841},
+													pos:  position{line: 4160, col: 44, offset: 127526},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4135, col: 52, offset: 126849},
+													pos:  position{line: 4160, col: 52, offset: 127534},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4135, col: 59, offset: 126856},
+											pos:  position{line: 4160, col: 59, offset: 127541},
 											name: "Aggregator",
 										},
 									},
@@ -9126,28 +9134,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4152, col: 1, offset: 127359},
+			pos:  position{line: 4177, col: 1, offset: 128044},
 			expr: &actionExpr{
-				pos: position{line: 4152, col: 15, offset: 127373},
+				pos: position{line: 4177, col: 15, offset: 128058},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4152, col: 15, offset: 127373},
+					pos: position{line: 4177, col: 15, offset: 128058},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4152, col: 15, offset: 127373},
+							pos:   position{line: 4177, col: 15, offset: 128058},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4152, col: 23, offset: 127381},
+								pos:  position{line: 4177, col: 23, offset: 128066},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4152, col: 35, offset: 127393},
+							pos:   position{line: 4177, col: 35, offset: 128078},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4152, col: 43, offset: 127401},
+								pos: position{line: 4177, col: 43, offset: 128086},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4152, col: 43, offset: 127401},
+									pos:  position{line: 4177, col: 43, offset: 128086},
 									name: "AsField",
 								},
 							},
@@ -9158,26 +9166,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4168, col: 1, offset: 128242},
+			pos:  position{line: 4193, col: 1, offset: 128927},
 			expr: &actionExpr{
-				pos: position{line: 4168, col: 16, offset: 128257},
+				pos: position{line: 4193, col: 16, offset: 128942},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4168, col: 16, offset: 128257},
+					pos:   position{line: 4193, col: 16, offset: 128942},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4168, col: 21, offset: 128262},
+						pos: position{line: 4193, col: 21, offset: 128947},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 21, offset: 128262},
+								pos:  position{line: 4193, col: 21, offset: 128947},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 32, offset: 128273},
+								pos:  position{line: 4193, col: 32, offset: 128958},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4168, col: 48, offset: 128289},
+								pos:  position{line: 4193, col: 48, offset: 128974},
 								name: "AggCommon",
 							},
 						},
@@ -9187,165 +9195,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4173, col: 1, offset: 128457},
+			pos:  position{line: 4198, col: 1, offset: 129142},
 			expr: &actionExpr{
-				pos: position{line: 4173, col: 18, offset: 128474},
+				pos: position{line: 4198, col: 18, offset: 129159},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4173, col: 19, offset: 128475},
+					pos: position{line: 4198, col: 19, offset: 129160},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4173, col: 19, offset: 128475},
+							pos:        position{line: 4198, col: 19, offset: 129160},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 30, offset: 128486},
+							pos:        position{line: 4198, col: 30, offset: 129171},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 39, offset: 128495},
+							pos:        position{line: 4198, col: 39, offset: 129180},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 47, offset: 128503},
+							pos:        position{line: 4198, col: 47, offset: 129188},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 57, offset: 128513},
+							pos:        position{line: 4198, col: 57, offset: 129198},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 65, offset: 128521},
+							pos:        position{line: 4198, col: 65, offset: 129206},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 76, offset: 128532},
+							pos:        position{line: 4198, col: 76, offset: 129217},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 86, offset: 128542},
+							pos:        position{line: 4198, col: 86, offset: 129227},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 95, offset: 128551},
+							pos:        position{line: 4198, col: 95, offset: 129236},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 105, offset: 128561},
+							pos:        position{line: 4198, col: 105, offset: 129246},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 114, offset: 128570},
+							pos:        position{line: 4198, col: 114, offset: 129255},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 122, offset: 128578},
+							pos:        position{line: 4198, col: 122, offset: 129263},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 133, offset: 128589},
+							pos:        position{line: 4198, col: 133, offset: 129274},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4173, col: 142, offset: 128598},
+							pos:        position{line: 4198, col: 142, offset: 129283},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 1, offset: 128607},
+							pos:        position{line: 4199, col: 1, offset: 129292},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 10, offset: 128616},
+							pos:        position{line: 4199, col: 10, offset: 129301},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 26, offset: 128632},
+							pos:        position{line: 4199, col: 26, offset: 129317},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 37, offset: 128643},
+							pos:        position{line: 4199, col: 37, offset: 129328},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 46, offset: 128652},
+							pos:        position{line: 4199, col: 46, offset: 129337},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 56, offset: 128662},
+							pos:        position{line: 4199, col: 56, offset: 129347},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 72, offset: 128678},
+							pos:        position{line: 4199, col: 72, offset: 129363},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 82, offset: 128688},
+							pos:        position{line: 4199, col: 82, offset: 129373},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 100, offset: 128706},
+							pos:        position{line: 4199, col: 100, offset: 129391},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 113, offset: 128719},
+							pos:        position{line: 4199, col: 113, offset: 129404},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 132, offset: 128738},
+							pos:        position{line: 4199, col: 132, offset: 129423},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4174, col: 139, offset: 128745},
+							pos:        position{line: 4199, col: 139, offset: 129430},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9356,33 +9364,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4178, col: 1, offset: 128788},
+			pos:  position{line: 4203, col: 1, offset: 129473},
 			expr: &actionExpr{
-				pos: position{line: 4178, col: 22, offset: 128809},
+				pos: position{line: 4203, col: 22, offset: 129494},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4178, col: 23, offset: 128810},
+					pos: position{line: 4203, col: 23, offset: 129495},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4178, col: 23, offset: 128810},
+							pos:        position{line: 4203, col: 23, offset: 129495},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4178, col: 37, offset: 128824},
+							pos:        position{line: 4203, col: 37, offset: 129509},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4178, col: 51, offset: 128838},
+							pos:        position{line: 4203, col: 51, offset: 129523},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4178, col: 60, offset: 128847},
+							pos:        position{line: 4203, col: 60, offset: 129532},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9393,29 +9401,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4182, col: 1, offset: 128888},
+			pos:  position{line: 4207, col: 1, offset: 129573},
 			expr: &actionExpr{
-				pos: position{line: 4182, col: 12, offset: 128899},
+				pos: position{line: 4207, col: 12, offset: 129584},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4182, col: 12, offset: 128899},
+					pos: position{line: 4207, col: 12, offset: 129584},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4182, col: 12, offset: 128899},
+							pos:  position{line: 4207, col: 12, offset: 129584},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4182, col: 15, offset: 128902},
+							pos:   position{line: 4207, col: 15, offset: 129587},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4182, col: 23, offset: 128910},
+								pos: position{line: 4207, col: 23, offset: 129595},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4182, col: 23, offset: 128910},
+										pos:  position{line: 4207, col: 23, offset: 129595},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4182, col: 35, offset: 128922},
+										pos:  position{line: 4207, col: 35, offset: 129607},
 										name: "String",
 									},
 								},
@@ -9427,27 +9435,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4196, col: 1, offset: 129251},
+			pos:  position{line: 4221, col: 1, offset: 129936},
 			expr: &choiceExpr{
-				pos: position{line: 4196, col: 13, offset: 129263},
+				pos: position{line: 4221, col: 13, offset: 129948},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4196, col: 13, offset: 129263},
+						pos: position{line: 4221, col: 13, offset: 129948},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4196, col: 13, offset: 129263},
+							pos: position{line: 4221, col: 13, offset: 129948},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4196, col: 14, offset: 129264},
+									pos: position{line: 4221, col: 14, offset: 129949},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4196, col: 14, offset: 129264},
+											pos:        position{line: 4221, col: 14, offset: 129949},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4196, col: 24, offset: 129274},
+											pos:        position{line: 4221, col: 24, offset: 129959},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9455,47 +9463,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4196, col: 29, offset: 129279},
+									pos:  position{line: 4221, col: 29, offset: 129964},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4196, col: 37, offset: 129287},
+									pos:        position{line: 4221, col: 37, offset: 129972},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4196, col: 44, offset: 129294},
+									pos:   position{line: 4221, col: 44, offset: 129979},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4196, col: 54, offset: 129304},
+										pos:  position{line: 4221, col: 54, offset: 129989},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4196, col: 64, offset: 129314},
+									pos:  position{line: 4221, col: 64, offset: 129999},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4206, col: 3, offset: 129543},
+						pos: position{line: 4231, col: 3, offset: 130228},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4206, col: 3, offset: 129543},
+							pos: position{line: 4231, col: 3, offset: 130228},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4206, col: 4, offset: 129544},
+									pos: position{line: 4231, col: 4, offset: 130229},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4206, col: 4, offset: 129544},
+											pos:        position{line: 4231, col: 4, offset: 130229},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4206, col: 14, offset: 129554},
+											pos:        position{line: 4231, col: 14, offset: 130239},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9503,38 +9511,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4206, col: 19, offset: 129559},
+									pos:  position{line: 4231, col: 19, offset: 130244},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4206, col: 27, offset: 129567},
+									pos:   position{line: 4231, col: 27, offset: 130252},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4206, col: 33, offset: 129573},
+										pos:  position{line: 4231, col: 33, offset: 130258},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4206, col: 43, offset: 129583},
+									pos:  position{line: 4231, col: 43, offset: 130268},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4213, col: 5, offset: 129735},
+						pos: position{line: 4238, col: 5, offset: 130420},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4213, col: 6, offset: 129736},
+							pos: position{line: 4238, col: 6, offset: 130421},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4213, col: 6, offset: 129736},
+									pos:        position{line: 4238, col: 6, offset: 130421},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4213, col: 16, offset: 129746},
+									pos:        position{line: 4238, col: 16, offset: 130431},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9547,77 +9555,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4222, col: 1, offset: 129883},
+			pos:  position{line: 4247, col: 1, offset: 130568},
 			expr: &choiceExpr{
-				pos: position{line: 4222, col: 14, offset: 129896},
+				pos: position{line: 4247, col: 14, offset: 130581},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4222, col: 14, offset: 129896},
+						pos: position{line: 4247, col: 14, offset: 130581},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4222, col: 14, offset: 129896},
+							pos: position{line: 4247, col: 14, offset: 130581},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4222, col: 14, offset: 129896},
+									pos:   position{line: 4247, col: 14, offset: 130581},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4222, col: 22, offset: 129904},
+										pos:  position{line: 4247, col: 22, offset: 130589},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4222, col: 36, offset: 129918},
+									pos:  position{line: 4247, col: 36, offset: 130603},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4222, col: 44, offset: 129926},
+									pos:        position{line: 4247, col: 44, offset: 130611},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4222, col: 51, offset: 129933},
+									pos:   position{line: 4247, col: 51, offset: 130618},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4222, col: 61, offset: 129943},
+										pos:  position{line: 4247, col: 61, offset: 130628},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4222, col: 71, offset: 129953},
+									pos:  position{line: 4247, col: 71, offset: 130638},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4237, col: 3, offset: 130364},
+						pos: position{line: 4262, col: 3, offset: 131049},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4237, col: 3, offset: 130364},
+							pos: position{line: 4262, col: 3, offset: 131049},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4237, col: 3, offset: 130364},
+									pos:   position{line: 4262, col: 3, offset: 131049},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4237, col: 11, offset: 130372},
+										pos:  position{line: 4262, col: 11, offset: 131057},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4237, col: 25, offset: 130386},
+									pos:  position{line: 4262, col: 25, offset: 131071},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4237, col: 33, offset: 130394},
+									pos:   position{line: 4262, col: 33, offset: 131079},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4237, col: 39, offset: 130400},
+										pos:  position{line: 4262, col: 39, offset: 131085},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4237, col: 49, offset: 130410},
+									pos:  position{line: 4262, col: 49, offset: 131095},
 									name: "R_PAREN",
 								},
 							},
@@ -9628,22 +9636,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4267, col: 1, offset: 131391},
+			pos:  position{line: 4292, col: 1, offset: 132076},
 			expr: &actionExpr{
-				pos: position{line: 4267, col: 18, offset: 131408},
+				pos: position{line: 4292, col: 18, offset: 132093},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4267, col: 18, offset: 131408},
+					pos:   position{line: 4292, col: 18, offset: 132093},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4267, col: 26, offset: 131416},
+						pos: position{line: 4292, col: 26, offset: 132101},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4267, col: 26, offset: 131416},
+								pos:  position{line: 4292, col: 26, offset: 132101},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4267, col: 42, offset: 131432},
+								pos:  position{line: 4292, col: 42, offset: 132117},
 								name: "IntegerAsString",
 							},
 						},
@@ -9653,161 +9661,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4279, col: 1, offset: 131799},
+			pos:  position{line: 4304, col: 1, offset: 132484},
 			expr: &choiceExpr{
-				pos: position{line: 4279, col: 18, offset: 131816},
+				pos: position{line: 4304, col: 18, offset: 132501},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4279, col: 18, offset: 131816},
+						pos: position{line: 4304, col: 18, offset: 132501},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4279, col: 18, offset: 131816},
+							pos: position{line: 4304, col: 18, offset: 132501},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4279, col: 18, offset: 131816},
+									pos:   position{line: 4304, col: 18, offset: 132501},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4279, col: 26, offset: 131824},
+										pos:  position{line: 4304, col: 26, offset: 132509},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4279, col: 44, offset: 131842},
+									pos:   position{line: 4304, col: 44, offset: 132527},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4279, col: 58, offset: 131856},
+										pos:  position{line: 4304, col: 58, offset: 132541},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4279, col: 72, offset: 131870},
+									pos:  position{line: 4304, col: 72, offset: 132555},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4279, col: 80, offset: 131878},
+									pos:        position{line: 4304, col: 80, offset: 132563},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4279, col: 87, offset: 131885},
+									pos:   position{line: 4304, col: 87, offset: 132570},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4279, col: 97, offset: 131895},
+										pos:  position{line: 4304, col: 97, offset: 132580},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4279, col: 107, offset: 131905},
+									pos:  position{line: 4304, col: 107, offset: 132590},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4295, col: 3, offset: 132429},
+						pos: position{line: 4320, col: 3, offset: 133114},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4295, col: 3, offset: 132429},
+							pos: position{line: 4320, col: 3, offset: 133114},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4295, col: 3, offset: 132429},
+									pos:   position{line: 4320, col: 3, offset: 133114},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4295, col: 11, offset: 132437},
+										pos:  position{line: 4320, col: 11, offset: 133122},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4295, col: 29, offset: 132455},
+									pos:   position{line: 4320, col: 29, offset: 133140},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4295, col: 43, offset: 132469},
+										pos:  position{line: 4320, col: 43, offset: 133154},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4295, col: 57, offset: 132483},
+									pos:  position{line: 4320, col: 57, offset: 133168},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4295, col: 65, offset: 132491},
+									pos:   position{line: 4320, col: 65, offset: 133176},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4295, col: 71, offset: 132497},
+										pos:  position{line: 4320, col: 71, offset: 133182},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4295, col: 81, offset: 132507},
+									pos:  position{line: 4320, col: 81, offset: 133192},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4310, col: 3, offset: 132987},
+						pos: position{line: 4335, col: 3, offset: 133672},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4310, col: 3, offset: 132987},
+							pos: position{line: 4335, col: 3, offset: 133672},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4310, col: 4, offset: 132988},
+									pos:        position{line: 4335, col: 4, offset: 133673},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4310, col: 14, offset: 132998},
+									pos:  position{line: 4335, col: 14, offset: 133683},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4310, col: 22, offset: 133006},
+									pos:   position{line: 4335, col: 22, offset: 133691},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4310, col: 28, offset: 133012},
+										pos:  position{line: 4335, col: 28, offset: 133697},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4310, col: 38, offset: 133022},
+									pos:  position{line: 4335, col: 38, offset: 133707},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4325, col: 3, offset: 133409},
+						pos: position{line: 4350, col: 3, offset: 134094},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4325, col: 3, offset: 133409},
+							pos: position{line: 4350, col: 3, offset: 134094},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4325, col: 4, offset: 133410},
+									pos:        position{line: 4350, col: 4, offset: 134095},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4325, col: 14, offset: 133420},
+									pos:  position{line: 4350, col: 14, offset: 134105},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4325, col: 22, offset: 133428},
+									pos:        position{line: 4350, col: 22, offset: 134113},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4325, col: 29, offset: 133435},
+									pos:   position{line: 4350, col: 29, offset: 134120},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4325, col: 39, offset: 133445},
+										pos:  position{line: 4350, col: 39, offset: 134130},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4325, col: 49, offset: 133455},
+									pos:  position{line: 4350, col: 49, offset: 134140},
 									name: "R_PAREN",
 								},
 							},
@@ -9818,22 +9826,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4343, col: 1, offset: 133886},
+			pos:  position{line: 4368, col: 1, offset: 134571},
 			expr: &actionExpr{
-				pos: position{line: 4343, col: 25, offset: 133910},
+				pos: position{line: 4368, col: 25, offset: 134595},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4343, col: 25, offset: 133910},
+					pos:   position{line: 4368, col: 25, offset: 134595},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4343, col: 39, offset: 133924},
+						pos: position{line: 4368, col: 39, offset: 134609},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4343, col: 39, offset: 133924},
+								pos:  position{line: 4368, col: 39, offset: 134609},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4343, col: 67, offset: 133952},
+								pos:  position{line: 4368, col: 67, offset: 134637},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9843,43 +9851,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4347, col: 1, offset: 134015},
+			pos:  position{line: 4372, col: 1, offset: 134700},
 			expr: &actionExpr{
-				pos: position{line: 4347, col: 30, offset: 134044},
+				pos: position{line: 4372, col: 30, offset: 134729},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4347, col: 30, offset: 134044},
+					pos: position{line: 4372, col: 30, offset: 134729},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4347, col: 30, offset: 134044},
+							pos:   position{line: 4372, col: 30, offset: 134729},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4347, col: 34, offset: 134048},
+								pos:  position{line: 4372, col: 34, offset: 134733},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4347, col: 44, offset: 134058},
+							pos:   position{line: 4372, col: 44, offset: 134743},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4347, col: 48, offset: 134062},
+								pos: position{line: 4372, col: 48, offset: 134747},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4347, col: 48, offset: 134062},
+										pos:  position{line: 4372, col: 48, offset: 134747},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4347, col: 67, offset: 134081},
+										pos:  position{line: 4372, col: 67, offset: 134766},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4347, col: 87, offset: 134101},
+							pos:   position{line: 4372, col: 87, offset: 134786},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4347, col: 93, offset: 134107},
+								pos:  position{line: 4372, col: 93, offset: 134792},
 								name: "Number",
 							},
 						},
@@ -9889,15 +9897,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4360, col: 1, offset: 134341},
+			pos:  position{line: 4385, col: 1, offset: 135026},
 			expr: &actionExpr{
-				pos: position{line: 4360, col: 32, offset: 134372},
+				pos: position{line: 4385, col: 32, offset: 135057},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4360, col: 32, offset: 134372},
+					pos:   position{line: 4385, col: 32, offset: 135057},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4360, col: 38, offset: 134378},
+						pos:  position{line: 4385, col: 38, offset: 135063},
 						name: "Number",
 					},
 				},
@@ -9905,34 +9913,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4373, col: 1, offset: 134595},
+			pos:  position{line: 4398, col: 1, offset: 135280},
 			expr: &actionExpr{
-				pos: position{line: 4373, col: 26, offset: 134620},
+				pos: position{line: 4398, col: 26, offset: 135305},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4373, col: 26, offset: 134620},
+					pos: position{line: 4398, col: 26, offset: 135305},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4373, col: 26, offset: 134620},
+							pos:   position{line: 4398, col: 26, offset: 135305},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4373, col: 30, offset: 134624},
+								pos:  position{line: 4398, col: 30, offset: 135309},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4373, col: 40, offset: 134634},
+							pos:   position{line: 4398, col: 40, offset: 135319},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4373, col: 43, offset: 134637},
+								pos:  position{line: 4398, col: 43, offset: 135322},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4373, col: 60, offset: 134654},
+							pos:   position{line: 4398, col: 60, offset: 135339},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4373, col: 66, offset: 134660},
+								pos:  position{line: 4398, col: 66, offset: 135345},
 								name: "Boolean",
 							},
 						},
@@ -9942,22 +9950,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4386, col: 1, offset: 134895},
+			pos:  position{line: 4411, col: 1, offset: 135580},
 			expr: &actionExpr{
-				pos: position{line: 4386, col: 25, offset: 134919},
+				pos: position{line: 4411, col: 25, offset: 135604},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4386, col: 25, offset: 134919},
+					pos:   position{line: 4411, col: 25, offset: 135604},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4386, col: 39, offset: 134933},
+						pos: position{line: 4411, col: 39, offset: 135618},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4386, col: 39, offset: 134933},
+								pos:  position{line: 4411, col: 39, offset: 135618},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4386, col: 67, offset: 134961},
+								pos:  position{line: 4411, col: 67, offset: 135646},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9967,41 +9975,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4390, col: 1, offset: 135024},
+			pos:  position{line: 4415, col: 1, offset: 135709},
 			expr: &actionExpr{
-				pos: position{line: 4390, col: 30, offset: 135053},
+				pos: position{line: 4415, col: 30, offset: 135738},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4390, col: 30, offset: 135053},
+					pos: position{line: 4415, col: 30, offset: 135738},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4390, col: 30, offset: 135053},
+							pos:   position{line: 4415, col: 30, offset: 135738},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4390, col: 34, offset: 135057},
+								pos:  position{line: 4415, col: 34, offset: 135742},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4390, col: 44, offset: 135067},
+							pos:   position{line: 4415, col: 44, offset: 135752},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4390, col: 47, offset: 135070},
+								pos:  position{line: 4415, col: 47, offset: 135755},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4390, col: 64, offset: 135087},
+							pos:   position{line: 4415, col: 64, offset: 135772},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4390, col: 81, offset: 135104},
+								pos: position{line: 4415, col: 81, offset: 135789},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4390, col: 81, offset: 135104},
+										pos:  position{line: 4415, col: 81, offset: 135789},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4390, col: 103, offset: 135126},
+										pos:  position{line: 4415, col: 103, offset: 135811},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10013,22 +10021,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4406, col: 1, offset: 135558},
+			pos:  position{line: 4431, col: 1, offset: 136243},
 			expr: &actionExpr{
-				pos: position{line: 4406, col: 32, offset: 135589},
+				pos: position{line: 4431, col: 32, offset: 136274},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4406, col: 32, offset: 135589},
+					pos:   position{line: 4431, col: 32, offset: 136274},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4406, col: 49, offset: 135606},
+						pos: position{line: 4431, col: 49, offset: 136291},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4406, col: 49, offset: 135606},
+								pos:  position{line: 4431, col: 49, offset: 136291},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4406, col: 71, offset: 135628},
+								pos:  position{line: 4431, col: 71, offset: 136313},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10038,33 +10046,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4423, col: 1, offset: 136139},
+			pos:  position{line: 4448, col: 1, offset: 136824},
 			expr: &actionExpr{
-				pos: position{line: 4423, col: 24, offset: 136162},
+				pos: position{line: 4448, col: 24, offset: 136847},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4423, col: 24, offset: 136162},
+					pos: position{line: 4448, col: 24, offset: 136847},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4423, col: 24, offset: 136162},
+							pos:        position{line: 4448, col: 24, offset: 136847},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4423, col: 31, offset: 136169},
+							pos:  position{line: 4448, col: 31, offset: 136854},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4423, col: 39, offset: 136177},
+							pos:   position{line: 4448, col: 39, offset: 136862},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4423, col: 45, offset: 136183},
+								pos:  position{line: 4448, col: 45, offset: 136868},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4423, col: 52, offset: 136190},
+							pos:  position{line: 4448, col: 52, offset: 136875},
 							name: "R_PAREN",
 						},
 					},
@@ -10073,49 +10081,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4432, col: 1, offset: 136427},
+			pos:  position{line: 4457, col: 1, offset: 137112},
 			expr: &choiceExpr{
-				pos: position{line: 4432, col: 26, offset: 136452},
+				pos: position{line: 4457, col: 26, offset: 137137},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4432, col: 26, offset: 136452},
+						pos: position{line: 4457, col: 26, offset: 137137},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4432, col: 26, offset: 136452},
+							pos: position{line: 4457, col: 26, offset: 137137},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4432, col: 26, offset: 136452},
+									pos:        position{line: 4457, col: 26, offset: 137137},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4432, col: 33, offset: 136459},
+									pos:  position{line: 4457, col: 33, offset: 137144},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4432, col: 41, offset: 136467},
+									pos:   position{line: 4457, col: 41, offset: 137152},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4432, col: 47, offset: 136473},
+										pos:  position{line: 4457, col: 47, offset: 137158},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4432, col: 54, offset: 136480},
+									pos:  position{line: 4457, col: 54, offset: 137165},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4441, col: 3, offset: 136670},
+						pos: position{line: 4466, col: 3, offset: 137355},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4441, col: 3, offset: 136670},
+							pos:   position{line: 4466, col: 3, offset: 137355},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4441, col: 9, offset: 136676},
+								pos:  position{line: 4466, col: 9, offset: 137361},
 								name: "String",
 							},
 						},
@@ -10125,35 +10133,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4451, col: 1, offset: 136956},
+			pos:  position{line: 4476, col: 1, offset: 137641},
 			expr: &actionExpr{
-				pos: position{line: 4451, col: 18, offset: 136973},
+				pos: position{line: 4476, col: 18, offset: 137658},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4451, col: 18, offset: 136973},
+					pos: position{line: 4476, col: 18, offset: 137658},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4451, col: 18, offset: 136973},
+							pos:   position{line: 4476, col: 18, offset: 137658},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4451, col: 24, offset: 136979},
+								pos:  position{line: 4476, col: 24, offset: 137664},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4451, col: 34, offset: 136989},
+							pos:   position{line: 4476, col: 34, offset: 137674},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4451, col: 39, offset: 136994},
+								pos: position{line: 4476, col: 39, offset: 137679},
 								expr: &seqExpr{
-									pos: position{line: 4451, col: 40, offset: 136995},
+									pos: position{line: 4476, col: 40, offset: 137680},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4451, col: 40, offset: 136995},
+											pos:  position{line: 4476, col: 40, offset: 137680},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4451, col: 46, offset: 137001},
+											pos:  position{line: 4476, col: 46, offset: 137686},
 											name: "FieldName",
 										},
 									},
@@ -10166,16 +10174,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4468, col: 1, offset: 137496},
+			pos:  position{line: 4493, col: 1, offset: 138181},
 			expr: &choiceExpr{
-				pos: position{line: 4468, col: 18, offset: 137513},
+				pos: position{line: 4493, col: 18, offset: 138198},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4468, col: 18, offset: 137513},
+						pos:  position{line: 4493, col: 18, offset: 138198},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4468, col: 38, offset: 137533},
+						pos:  position{line: 4493, col: 38, offset: 138218},
 						name: "EarliestOnly",
 					},
 				},
@@ -10183,62 +10191,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4470, col: 1, offset: 137547},
+			pos:  position{line: 4495, col: 1, offset: 138232},
 			expr: &actionExpr{
-				pos: position{line: 4470, col: 22, offset: 137568},
+				pos: position{line: 4495, col: 22, offset: 138253},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4470, col: 22, offset: 137568},
+					pos: position{line: 4495, col: 22, offset: 138253},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4470, col: 22, offset: 137568},
+							pos:  position{line: 4495, col: 22, offset: 138253},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4470, col: 35, offset: 137581},
+							pos:  position{line: 4495, col: 35, offset: 138266},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4470, col: 41, offset: 137587},
+							pos:   position{line: 4495, col: 41, offset: 138272},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4470, col: 55, offset: 137601},
+								pos: position{line: 4495, col: 55, offset: 138286},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4470, col: 55, offset: 137601},
+										pos:  position{line: 4495, col: 55, offset: 138286},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4470, col: 75, offset: 137621},
+										pos:  position{line: 4495, col: 75, offset: 138306},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4470, col: 94, offset: 137640},
+							pos:  position{line: 4495, col: 94, offset: 138325},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4470, col: 100, offset: 137646},
+							pos:  position{line: 4495, col: 100, offset: 138331},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4470, col: 111, offset: 137657},
+							pos:  position{line: 4495, col: 111, offset: 138342},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4470, col: 117, offset: 137663},
+							pos:   position{line: 4495, col: 117, offset: 138348},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4470, col: 129, offset: 137675},
+								pos: position{line: 4495, col: 129, offset: 138360},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4470, col: 129, offset: 137675},
+										pos:  position{line: 4495, col: 129, offset: 138360},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4470, col: 149, offset: 137695},
+										pos:  position{line: 4495, col: 149, offset: 138380},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10250,33 +10258,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4511, col: 1, offset: 138834},
+			pos:  position{line: 4536, col: 1, offset: 139519},
 			expr: &actionExpr{
-				pos: position{line: 4511, col: 17, offset: 138850},
+				pos: position{line: 4536, col: 17, offset: 139535},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4511, col: 17, offset: 138850},
+					pos: position{line: 4536, col: 17, offset: 139535},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4511, col: 17, offset: 138850},
+							pos:  position{line: 4536, col: 17, offset: 139535},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4511, col: 30, offset: 138863},
+							pos:  position{line: 4536, col: 30, offset: 139548},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4511, col: 36, offset: 138869},
+							pos:   position{line: 4536, col: 36, offset: 139554},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4511, col: 50, offset: 138883},
+								pos: position{line: 4536, col: 50, offset: 139568},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4511, col: 50, offset: 138883},
+										pos:  position{line: 4536, col: 50, offset: 139568},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4511, col: 70, offset: 138903},
+										pos:  position{line: 4536, col: 70, offset: 139588},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10288,24 +10296,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4539, col: 1, offset: 139611},
+			pos:  position{line: 4564, col: 1, offset: 140296},
 			expr: &actionExpr{
-				pos: position{line: 4539, col: 23, offset: 139633},
+				pos: position{line: 4564, col: 23, offset: 140318},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4539, col: 23, offset: 139633},
+					pos: position{line: 4564, col: 23, offset: 140318},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4539, col: 23, offset: 139633},
+							pos:        position{line: 4564, col: 23, offset: 140318},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4539, col: 27, offset: 139637},
+							pos: position{line: 4564, col: 27, offset: 140322},
 							expr: &charClassMatcher{
-								pos:        position{line: 4539, col: 27, offset: 139637},
+								pos:        position{line: 4564, col: 27, offset: 140322},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10318,21 +10326,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4543, col: 1, offset: 139680},
+			pos:  position{line: 4568, col: 1, offset: 140365},
 			expr: &actionExpr{
-				pos: position{line: 4543, col: 13, offset: 139692},
+				pos: position{line: 4568, col: 13, offset: 140377},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4543, col: 14, offset: 139693},
+					pos: position{line: 4568, col: 14, offset: 140378},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4543, col: 14, offset: 139693},
+							pos:        position{line: 4568, col: 14, offset: 140378},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4543, col: 17, offset: 139696},
+							pos:        position{line: 4568, col: 17, offset: 140381},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10344,15 +10352,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4547, col: 1, offset: 139739},
+			pos:  position{line: 4572, col: 1, offset: 140424},
 			expr: &actionExpr{
-				pos: position{line: 4547, col: 16, offset: 139754},
+				pos: position{line: 4572, col: 16, offset: 140439},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4547, col: 16, offset: 139754},
+					pos:   position{line: 4572, col: 16, offset: 140439},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4547, col: 26, offset: 139764},
+						pos:  position{line: 4572, col: 26, offset: 140449},
 						name: "AllTimeScale",
 					},
 				},
@@ -10360,31 +10368,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4554, col: 1, offset: 139991},
+			pos:  position{line: 4579, col: 1, offset: 140676},
 			expr: &actionExpr{
-				pos: position{line: 4554, col: 9, offset: 139999},
+				pos: position{line: 4579, col: 9, offset: 140684},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4554, col: 9, offset: 139999},
+					pos: position{line: 4579, col: 9, offset: 140684},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4554, col: 9, offset: 139999},
+							pos:        position{line: 4579, col: 9, offset: 140684},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4554, col: 13, offset: 140003},
+							pos:   position{line: 4579, col: 13, offset: 140688},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4554, col: 19, offset: 140009},
+								pos: position{line: 4579, col: 19, offset: 140694},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4554, col: 19, offset: 140009},
+										pos:  position{line: 4579, col: 19, offset: 140694},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4554, col: 30, offset: 140020},
+										pos:  position{line: 4579, col: 30, offset: 140705},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10396,26 +10404,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4558, col: 1, offset: 140068},
+			pos:  position{line: 4583, col: 1, offset: 140753},
 			expr: &actionExpr{
-				pos: position{line: 4558, col: 11, offset: 140078},
+				pos: position{line: 4583, col: 11, offset: 140763},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4558, col: 11, offset: 140078},
+					pos: position{line: 4583, col: 11, offset: 140763},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4558, col: 11, offset: 140078},
+							pos:   position{line: 4583, col: 11, offset: 140763},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4558, col: 16, offset: 140083},
+								pos:  position{line: 4583, col: 16, offset: 140768},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4558, col: 36, offset: 140103},
+							pos:   position{line: 4583, col: 36, offset: 140788},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4558, col: 43, offset: 140110},
+								pos:  position{line: 4583, col: 43, offset: 140795},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10425,44 +10433,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4586, col: 1, offset: 140849},
+			pos:  position{line: 4611, col: 1, offset: 141534},
 			expr: &actionExpr{
-				pos: position{line: 4586, col: 29, offset: 140877},
+				pos: position{line: 4611, col: 29, offset: 141562},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4586, col: 29, offset: 140877},
+					pos: position{line: 4611, col: 29, offset: 141562},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4586, col: 29, offset: 140877},
+							pos:   position{line: 4611, col: 29, offset: 141562},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4586, col: 36, offset: 140884},
+								pos: position{line: 4611, col: 36, offset: 141569},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4586, col: 36, offset: 140884},
+										pos:  position{line: 4611, col: 36, offset: 141569},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4586, col: 45, offset: 140893},
+										pos:  position{line: 4611, col: 45, offset: 141578},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4586, col: 51, offset: 140899},
+							pos:   position{line: 4611, col: 51, offset: 141584},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4586, col: 57, offset: 140905},
+								pos: position{line: 4611, col: 57, offset: 141590},
 								expr: &choiceExpr{
-									pos: position{line: 4586, col: 58, offset: 140906},
+									pos: position{line: 4611, col: 58, offset: 141591},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4586, col: 58, offset: 140906},
+											pos:  position{line: 4611, col: 58, offset: 141591},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4586, col: 67, offset: 140915},
+											pos:  position{line: 4611, col: 67, offset: 141600},
 											name: "Snap",
 										},
 									},
@@ -10475,29 +10483,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4633, col: 1, offset: 142347},
+			pos:  position{line: 4658, col: 1, offset: 143032},
 			expr: &actionExpr{
-				pos: position{line: 4633, col: 22, offset: 142368},
+				pos: position{line: 4658, col: 22, offset: 143053},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4633, col: 22, offset: 142368},
+					pos: position{line: 4658, col: 22, offset: 143053},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4633, col: 22, offset: 142368},
+							pos:   position{line: 4658, col: 22, offset: 143053},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4633, col: 34, offset: 142380},
+								pos: position{line: 4658, col: 34, offset: 143065},
 								expr: &choiceExpr{
-									pos: position{line: 4633, col: 35, offset: 142381},
+									pos: position{line: 4658, col: 35, offset: 143066},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4633, col: 35, offset: 142381},
+											pos:        position{line: 4658, col: 35, offset: 143066},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4633, col: 43, offset: 142389},
+											pos:        position{line: 4658, col: 43, offset: 143074},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10507,12 +10515,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4633, col: 49, offset: 142395},
+							pos:   position{line: 4658, col: 49, offset: 143080},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4633, col: 57, offset: 142403},
+								pos: position{line: 4658, col: 57, offset: 143088},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4633, col: 58, offset: 142404},
+									pos:  position{line: 4658, col: 58, offset: 143089},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10523,31 +10531,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4658, col: 1, offset: 143087},
+			pos:  position{line: 4683, col: 1, offset: 143772},
 			expr: &actionExpr{
-				pos: position{line: 4658, col: 39, offset: 143125},
+				pos: position{line: 4683, col: 39, offset: 143810},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4658, col: 39, offset: 143125},
+					pos: position{line: 4683, col: 39, offset: 143810},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4658, col: 39, offset: 143125},
+							pos:   position{line: 4683, col: 39, offset: 143810},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4658, col: 46, offset: 143132},
+								pos: position{line: 4683, col: 46, offset: 143817},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4658, col: 47, offset: 143133},
+									pos:  position{line: 4683, col: 47, offset: 143818},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4658, col: 56, offset: 143142},
+							pos:   position{line: 4683, col: 56, offset: 143827},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4658, col: 66, offset: 143152},
+								pos: position{line: 4683, col: 66, offset: 143837},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4658, col: 67, offset: 143153},
+									pos:  position{line: 4683, col: 67, offset: 143838},
 									name: "Snap",
 								},
 							},
@@ -10558,136 +10566,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4685, col: 1, offset: 143783},
+			pos:  position{line: 4710, col: 1, offset: 144468},
 			expr: &actionExpr{
-				pos: position{line: 4685, col: 18, offset: 143800},
+				pos: position{line: 4710, col: 18, offset: 144485},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4685, col: 18, offset: 143800},
+					pos: position{line: 4710, col: 18, offset: 144485},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 18, offset: 143800},
+							pos:        position{line: 4710, col: 18, offset: 144485},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 23, offset: 143805},
+							pos:        position{line: 4710, col: 23, offset: 144490},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4685, col: 29, offset: 143811},
+							pos:        position{line: 4710, col: 29, offset: 144496},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 33, offset: 143815},
+							pos:        position{line: 4710, col: 33, offset: 144500},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 38, offset: 143820},
+							pos:        position{line: 4710, col: 38, offset: 144505},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4685, col: 44, offset: 143826},
+							pos:        position{line: 4710, col: 44, offset: 144511},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 48, offset: 143830},
+							pos:        position{line: 4710, col: 48, offset: 144515},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 53, offset: 143835},
+							pos:        position{line: 4710, col: 53, offset: 144520},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 58, offset: 143840},
+							pos:        position{line: 4710, col: 58, offset: 144525},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 63, offset: 143845},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4685, col: 69, offset: 143851},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4685, col: 73, offset: 143855},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4685, col: 78, offset: 143860},
+							pos:        position{line: 4710, col: 63, offset: 144530},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4685, col: 84, offset: 143866},
+							pos:        position{line: 4710, col: 69, offset: 144536},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 88, offset: 143870},
+							pos:        position{line: 4710, col: 73, offset: 144540},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 93, offset: 143875},
+							pos:        position{line: 4710, col: 78, offset: 144545},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4685, col: 99, offset: 143881},
+							pos:        position{line: 4710, col: 84, offset: 144551},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 103, offset: 143885},
+							pos:        position{line: 4710, col: 88, offset: 144555},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4685, col: 108, offset: 143890},
+							pos:        position{line: 4710, col: 93, offset: 144560},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4710, col: 99, offset: 144566},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4710, col: 103, offset: 144570},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4710, col: 108, offset: 144575},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10699,15 +10707,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4689, col: 1, offset: 143932},
+			pos:  position{line: 4714, col: 1, offset: 144617},
 			expr: &actionExpr{
-				pos: position{line: 4689, col: 22, offset: 143953},
+				pos: position{line: 4714, col: 22, offset: 144638},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4689, col: 22, offset: 143953},
+					pos:   position{line: 4714, col: 22, offset: 144638},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4689, col: 32, offset: 143963},
+						pos:  position{line: 4714, col: 32, offset: 144648},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10715,18 +10723,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4700, col: 1, offset: 144406},
+			pos:  position{line: 4725, col: 1, offset: 145091},
 			expr: &choiceExpr{
-				pos: position{line: 4700, col: 14, offset: 144419},
+				pos: position{line: 4725, col: 14, offset: 145104},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4700, col: 14, offset: 144419},
+						pos: position{line: 4725, col: 14, offset: 145104},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4700, col: 14, offset: 144419},
+							pos: position{line: 4725, col: 14, offset: 145104},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4700, col: 14, offset: 144419},
+									pos:        position{line: 4725, col: 14, offset: 145104},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10734,9 +10742,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4700, col: 29, offset: 144434},
+									pos: position{line: 4725, col: 29, offset: 145119},
 									expr: &charClassMatcher{
-										pos:        position{line: 4700, col: 29, offset: 144434},
+										pos:        position{line: 4725, col: 29, offset: 145119},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10748,10 +10756,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4703, col: 3, offset: 144490},
+						pos: position{line: 4728, col: 3, offset: 145175},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4703, col: 3, offset: 144490},
+							pos:  position{line: 4728, col: 3, offset: 145175},
 							name: "QuotedString",
 						},
 					},
@@ -10760,15 +10768,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4707, col: 1, offset: 144553},
+			pos:  position{line: 4732, col: 1, offset: 145238},
 			expr: &actionExpr{
-				pos: position{line: 4707, col: 24, offset: 144576},
+				pos: position{line: 4732, col: 24, offset: 145261},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4707, col: 24, offset: 144576},
+					pos: position{line: 4732, col: 24, offset: 145261},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4707, col: 24, offset: 144576},
+							pos:        position{line: 4732, col: 24, offset: 145261},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10776,9 +10784,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4707, col: 39, offset: 144591},
+							pos: position{line: 4732, col: 39, offset: 145276},
 							expr: &charClassMatcher{
-								pos:        position{line: 4707, col: 39, offset: 144591},
+								pos:        position{line: 4732, col: 39, offset: 145276},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10792,22 +10800,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4711, col: 1, offset: 144644},
+			pos:  position{line: 4736, col: 1, offset: 145329},
 			expr: &actionExpr{
-				pos: position{line: 4711, col: 11, offset: 144654},
+				pos: position{line: 4736, col: 11, offset: 145339},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4711, col: 11, offset: 144654},
+					pos:   position{line: 4736, col: 11, offset: 145339},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4711, col: 16, offset: 144659},
+						pos: position{line: 4736, col: 16, offset: 145344},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4711, col: 16, offset: 144659},
+								pos:  position{line: 4736, col: 16, offset: 145344},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4711, col: 31, offset: 144674},
+								pos:  position{line: 4736, col: 31, offset: 145359},
 								name: "UnquotedString",
 							},
 						},
@@ -10817,38 +10825,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4715, col: 1, offset: 144715},
+			pos:  position{line: 4740, col: 1, offset: 145400},
 			expr: &actionExpr{
-				pos: position{line: 4715, col: 17, offset: 144731},
+				pos: position{line: 4740, col: 17, offset: 145416},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4715, col: 17, offset: 144731},
+					pos: position{line: 4740, col: 17, offset: 145416},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4715, col: 17, offset: 144731},
+							pos:        position{line: 4740, col: 17, offset: 145416},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4715, col: 21, offset: 144735},
+							pos: position{line: 4740, col: 21, offset: 145420},
 							expr: &choiceExpr{
-								pos: position{line: 4715, col: 22, offset: 144736},
+								pos: position{line: 4740, col: 22, offset: 145421},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4715, col: 22, offset: 144736},
+										pos: position{line: 4740, col: 22, offset: 145421},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4715, col: 22, offset: 144736},
+												pos: position{line: 4740, col: 22, offset: 145421},
 												expr: &litMatcher{
-													pos:        position{line: 4715, col: 23, offset: 144737},
+													pos:        position{line: 4740, col: 23, offset: 145422},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4715, col: 28, offset: 144742},
+												pos:        position{line: 4740, col: 28, offset: 145427},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -10857,16 +10865,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4715, col: 35, offset: 144749},
+										pos: position{line: 4740, col: 35, offset: 145434},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4715, col: 35, offset: 144749},
+												pos:        position{line: 4740, col: 35, offset: 145434},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4715, col: 40, offset: 144754,
+												line: 4740, col: 40, offset: 145439,
 											},
 										},
 									},
@@ -10874,7 +10882,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4715, col: 44, offset: 144758},
+							pos:        position{line: 4740, col: 44, offset: 145443},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10885,48 +10893,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4720, col: 1, offset: 144869},
+			pos:  position{line: 4745, col: 1, offset: 145554},
 			expr: &actionExpr{
-				pos: position{line: 4720, col: 19, offset: 144887},
+				pos: position{line: 4745, col: 19, offset: 145572},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4720, col: 19, offset: 144887},
+					pos: position{line: 4745, col: 19, offset: 145572},
 					expr: &choiceExpr{
-						pos: position{line: 4720, col: 20, offset: 144888},
+						pos: position{line: 4745, col: 20, offset: 145573},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4720, col: 20, offset: 144888},
+								pos:        position{line: 4745, col: 20, offset: 145573},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4720, col: 27, offset: 144895},
+								pos: position{line: 4745, col: 27, offset: 145580},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4720, col: 27, offset: 144895},
+										pos: position{line: 4745, col: 27, offset: 145580},
 										expr: &choiceExpr{
-											pos: position{line: 4720, col: 29, offset: 144897},
+											pos: position{line: 4745, col: 29, offset: 145582},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4720, col: 29, offset: 144897},
+													pos:  position{line: 4745, col: 29, offset: 145582},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4720, col: 43, offset: 144911},
+													pos:        position{line: 4745, col: 43, offset: 145596},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4720, col: 49, offset: 144917},
+													pos:  position{line: 4745, col: 49, offset: 145602},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4720, col: 54, offset: 144922,
+										line: 4745, col: 54, offset: 145607,
 									},
 								},
 							},
@@ -10937,12 +10945,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4727, col: 1, offset: 145037},
+			pos:  position{line: 4752, col: 1, offset: 145722},
 			expr: &choiceExpr{
-				pos: position{line: 4727, col: 16, offset: 145052},
+				pos: position{line: 4752, col: 16, offset: 145737},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4727, col: 16, offset: 145052},
+						pos:        position{line: 4752, col: 16, offset: 145737},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10950,18 +10958,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4727, col: 37, offset: 145073},
+						pos: position{line: 4752, col: 37, offset: 145758},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4727, col: 37, offset: 145073},
+								pos:        position{line: 4752, col: 37, offset: 145758},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4727, col: 41, offset: 145077},
+								pos: position{line: 4752, col: 41, offset: 145762},
 								expr: &charClassMatcher{
-									pos:        position{line: 4727, col: 41, offset: 145077},
+									pos:        position{line: 4752, col: 41, offset: 145762},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10969,7 +10977,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4727, col: 48, offset: 145084},
+								pos:        position{line: 4752, col: 48, offset: 145769},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10981,46 +10989,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4729, col: 1, offset: 145090},
+			pos:  position{line: 4754, col: 1, offset: 145775},
 			expr: &actionExpr{
-				pos: position{line: 4729, col: 39, offset: 145128},
+				pos: position{line: 4754, col: 39, offset: 145813},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4729, col: 39, offset: 145128},
+					pos: position{line: 4754, col: 39, offset: 145813},
 					expr: &choiceExpr{
-						pos: position{line: 4729, col: 40, offset: 145129},
+						pos: position{line: 4754, col: 40, offset: 145814},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4729, col: 40, offset: 145129},
+								pos:  position{line: 4754, col: 40, offset: 145814},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4729, col: 54, offset: 145143},
+								pos: position{line: 4754, col: 54, offset: 145828},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4729, col: 54, offset: 145143},
+										pos: position{line: 4754, col: 54, offset: 145828},
 										expr: &choiceExpr{
-											pos: position{line: 4729, col: 56, offset: 145145},
+											pos: position{line: 4754, col: 56, offset: 145830},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4729, col: 56, offset: 145145},
+													pos:  position{line: 4754, col: 56, offset: 145830},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4729, col: 70, offset: 145159},
+													pos:        position{line: 4754, col: 70, offset: 145844},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4729, col: 76, offset: 145165},
+													pos:  position{line: 4754, col: 76, offset: 145850},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4729, col: 81, offset: 145170,
+										line: 4754, col: 81, offset: 145855,
 									},
 								},
 							},
@@ -11031,21 +11039,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4733, col: 1, offset: 145210},
+			pos:  position{line: 4758, col: 1, offset: 145895},
 			expr: &actionExpr{
-				pos: position{line: 4733, col: 12, offset: 145221},
+				pos: position{line: 4758, col: 12, offset: 145906},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4733, col: 13, offset: 145222},
+					pos: position{line: 4758, col: 13, offset: 145907},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4733, col: 13, offset: 145222},
+							pos:        position{line: 4758, col: 13, offset: 145907},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4733, col: 22, offset: 145231},
+							pos:        position{line: 4758, col: 22, offset: 145916},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11056,14 +11064,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4739, col: 1, offset: 145385},
+			pos:  position{line: 4764, col: 1, offset: 146070},
 			expr: &actionExpr{
-				pos: position{line: 4739, col: 18, offset: 145402},
+				pos: position{line: 4764, col: 18, offset: 146087},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4739, col: 18, offset: 145402},
+					pos: position{line: 4764, col: 18, offset: 146087},
 					expr: &charClassMatcher{
-						pos:        position{line: 4739, col: 18, offset: 145402},
+						pos:        position{line: 4764, col: 18, offset: 146087},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11075,15 +11083,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4743, col: 1, offset: 145453},
+			pos:  position{line: 4768, col: 1, offset: 146138},
 			expr: &actionExpr{
-				pos: position{line: 4743, col: 11, offset: 145463},
+				pos: position{line: 4768, col: 11, offset: 146148},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4743, col: 11, offset: 145463},
+					pos:   position{line: 4768, col: 11, offset: 146148},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4743, col: 18, offset: 145470},
+						pos:  position{line: 4768, col: 18, offset: 146155},
 						name: "NumberAsString",
 					},
 				},
@@ -11091,59 +11099,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4749, col: 1, offset: 145659},
+			pos:  position{line: 4774, col: 1, offset: 146344},
 			expr: &actionExpr{
-				pos: position{line: 4749, col: 19, offset: 145677},
+				pos: position{line: 4774, col: 19, offset: 146362},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4749, col: 19, offset: 145677},
+					pos: position{line: 4774, col: 19, offset: 146362},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4749, col: 19, offset: 145677},
+							pos:   position{line: 4774, col: 19, offset: 146362},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4749, col: 27, offset: 145685},
+								pos: position{line: 4774, col: 27, offset: 146370},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4749, col: 27, offset: 145685},
+										pos:  position{line: 4774, col: 27, offset: 146370},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4749, col: 43, offset: 145701},
+										pos:  position{line: 4774, col: 43, offset: 146386},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4749, col: 60, offset: 145718},
+							pos: position{line: 4774, col: 60, offset: 146403},
 							expr: &choiceExpr{
-								pos: position{line: 4749, col: 62, offset: 145720},
+								pos: position{line: 4774, col: 62, offset: 146405},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4749, col: 62, offset: 145720},
+										pos:  position{line: 4774, col: 62, offset: 146405},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4749, col: 70, offset: 145728},
+										pos:        position{line: 4774, col: 70, offset: 146413},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4749, col: 76, offset: 145734},
+										pos:        position{line: 4774, col: 76, offset: 146419},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4749, col: 82, offset: 145740},
+										pos:        position{line: 4774, col: 82, offset: 146425},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4749, col: 88, offset: 145746},
+										pos:  position{line: 4774, col: 88, offset: 146431},
 										name: "EOF",
 									},
 								},
@@ -11155,17 +11163,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4755, col: 1, offset: 145875},
+			pos:  position{line: 4780, col: 1, offset: 146560},
 			expr: &actionExpr{
-				pos: position{line: 4755, col: 18, offset: 145892},
+				pos: position{line: 4780, col: 18, offset: 146577},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4755, col: 18, offset: 145892},
+					pos: position{line: 4780, col: 18, offset: 146577},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4755, col: 18, offset: 145892},
+							pos: position{line: 4780, col: 18, offset: 146577},
 							expr: &charClassMatcher{
-								pos:        position{line: 4755, col: 18, offset: 145892},
+								pos:        position{line: 4780, col: 18, offset: 146577},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11173,9 +11181,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4755, col: 24, offset: 145898},
+							pos: position{line: 4780, col: 24, offset: 146583},
 							expr: &charClassMatcher{
-								pos:        position{line: 4755, col: 24, offset: 145898},
+								pos:        position{line: 4780, col: 24, offset: 146583},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11183,15 +11191,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4755, col: 31, offset: 145905},
+							pos:        position{line: 4780, col: 31, offset: 146590},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4755, col: 35, offset: 145909},
+							pos: position{line: 4780, col: 35, offset: 146594},
 							expr: &charClassMatcher{
-								pos:        position{line: 4755, col: 35, offset: 145909},
+								pos:        position{line: 4780, col: 35, offset: 146594},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11204,17 +11212,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4760, col: 1, offset: 146004},
+			pos:  position{line: 4785, col: 1, offset: 146689},
 			expr: &actionExpr{
-				pos: position{line: 4760, col: 20, offset: 146023},
+				pos: position{line: 4785, col: 20, offset: 146708},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4760, col: 20, offset: 146023},
+					pos: position{line: 4785, col: 20, offset: 146708},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4760, col: 20, offset: 146023},
+							pos: position{line: 4785, col: 20, offset: 146708},
 							expr: &charClassMatcher{
-								pos:        position{line: 4760, col: 20, offset: 146023},
+								pos:        position{line: 4785, col: 20, offset: 146708},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11222,9 +11230,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4760, col: 26, offset: 146029},
+							pos: position{line: 4785, col: 26, offset: 146714},
 							expr: &charClassMatcher{
-								pos:        position{line: 4760, col: 26, offset: 146029},
+								pos:        position{line: 4785, col: 26, offset: 146714},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11237,14 +11245,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4764, col: 1, offset: 146072},
+			pos:  position{line: 4789, col: 1, offset: 146757},
 			expr: &actionExpr{
-				pos: position{line: 4764, col: 28, offset: 146099},
+				pos: position{line: 4789, col: 28, offset: 146784},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4764, col: 28, offset: 146099},
+					pos: position{line: 4789, col: 28, offset: 146784},
 					expr: &charClassMatcher{
-						pos:        position{line: 4764, col: 28, offset: 146099},
+						pos:        position{line: 4789, col: 28, offset: 146784},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11255,15 +11263,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4768, col: 1, offset: 146142},
+			pos:  position{line: 4793, col: 1, offset: 146827},
 			expr: &actionExpr{
-				pos: position{line: 4768, col: 20, offset: 146161},
+				pos: position{line: 4793, col: 20, offset: 146846},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4768, col: 20, offset: 146161},
+					pos:   position{line: 4793, col: 20, offset: 146846},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4768, col: 27, offset: 146168},
+						pos:  position{line: 4793, col: 27, offset: 146853},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11271,37 +11279,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4776, col: 1, offset: 146415},
+			pos:  position{line: 4801, col: 1, offset: 147100},
 			expr: &actionExpr{
-				pos: position{line: 4776, col: 21, offset: 146435},
+				pos: position{line: 4801, col: 21, offset: 147120},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4776, col: 21, offset: 146435},
+					pos: position{line: 4801, col: 21, offset: 147120},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4776, col: 21, offset: 146435},
+							pos:  position{line: 4801, col: 21, offset: 147120},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4776, col: 36, offset: 146450},
+							pos:   position{line: 4801, col: 36, offset: 147135},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4776, col: 40, offset: 146454},
+								pos: position{line: 4801, col: 40, offset: 147139},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4776, col: 40, offset: 146454},
+										pos:        position{line: 4801, col: 40, offset: 147139},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4776, col: 47, offset: 146461},
+										pos:        position{line: 4801, col: 47, offset: 147146},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4776, col: 53, offset: 146467},
+										pos:        position{line: 4801, col: 53, offset: 147152},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11310,7 +11318,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4776, col: 59, offset: 146473},
+							pos:  position{line: 4801, col: 59, offset: 147158},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11319,43 +11327,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4787, col: 1, offset: 146703},
+			pos:  position{line: 4812, col: 1, offset: 147388},
 			expr: &actionExpr{
-				pos: position{line: 4787, col: 23, offset: 146725},
+				pos: position{line: 4812, col: 23, offset: 147410},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4787, col: 23, offset: 146725},
+					pos: position{line: 4812, col: 23, offset: 147410},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4787, col: 23, offset: 146725},
+							pos:  position{line: 4812, col: 23, offset: 147410},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4787, col: 38, offset: 146740},
+							pos:   position{line: 4812, col: 38, offset: 147425},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4787, col: 42, offset: 146744},
+								pos: position{line: 4812, col: 42, offset: 147429},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4787, col: 42, offset: 146744},
+										pos:        position{line: 4812, col: 42, offset: 147429},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4787, col: 49, offset: 146751},
+										pos:        position{line: 4812, col: 49, offset: 147436},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4787, col: 55, offset: 146757},
+										pos:        position{line: 4812, col: 55, offset: 147442},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4787, col: 62, offset: 146764},
+										pos:        position{line: 4812, col: 62, offset: 147449},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11364,7 +11372,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4787, col: 67, offset: 146769},
+							pos:  position{line: 4812, col: 67, offset: 147454},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11373,30 +11381,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4795, col: 1, offset: 146952},
+			pos:  position{line: 4820, col: 1, offset: 147637},
 			expr: &choiceExpr{
-				pos: position{line: 4795, col: 25, offset: 146976},
+				pos: position{line: 4820, col: 25, offset: 147661},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4795, col: 25, offset: 146976},
+						pos: position{line: 4820, col: 25, offset: 147661},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4795, col: 25, offset: 146976},
+							pos:   position{line: 4820, col: 25, offset: 147661},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4795, col: 28, offset: 146979},
+								pos:  position{line: 4820, col: 28, offset: 147664},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4798, col: 3, offset: 147021},
+						pos: position{line: 4823, col: 3, offset: 147706},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4798, col: 3, offset: 147021},
+							pos:   position{line: 4823, col: 3, offset: 147706},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4798, col: 6, offset: 147024},
+								pos:  position{line: 4823, col: 6, offset: 147709},
 								name: "InequalityOperator",
 							},
 						},
@@ -11406,25 +11414,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4802, col: 1, offset: 147067},
+			pos:  position{line: 4827, col: 1, offset: 147752},
 			expr: &actionExpr{
-				pos: position{line: 4802, col: 11, offset: 147077},
+				pos: position{line: 4827, col: 11, offset: 147762},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4802, col: 11, offset: 147077},
+					pos: position{line: 4827, col: 11, offset: 147762},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4802, col: 11, offset: 147077},
+							pos:  position{line: 4827, col: 11, offset: 147762},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4802, col: 26, offset: 147092},
+							pos:        position{line: 4827, col: 26, offset: 147777},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4802, col: 30, offset: 147096},
+							pos:  position{line: 4827, col: 30, offset: 147781},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11433,25 +11441,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4806, col: 1, offset: 147136},
+			pos:  position{line: 4831, col: 1, offset: 147821},
 			expr: &actionExpr{
-				pos: position{line: 4806, col: 12, offset: 147147},
+				pos: position{line: 4831, col: 12, offset: 147832},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4806, col: 12, offset: 147147},
+					pos: position{line: 4831, col: 12, offset: 147832},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4806, col: 12, offset: 147147},
+							pos:  position{line: 4831, col: 12, offset: 147832},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4806, col: 27, offset: 147162},
+							pos:        position{line: 4831, col: 27, offset: 147847},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4806, col: 31, offset: 147166},
+							pos:  position{line: 4831, col: 31, offset: 147851},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11460,25 +11468,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4810, col: 1, offset: 147206},
+			pos:  position{line: 4835, col: 1, offset: 147891},
 			expr: &actionExpr{
-				pos: position{line: 4810, col: 10, offset: 147215},
+				pos: position{line: 4835, col: 10, offset: 147900},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4810, col: 10, offset: 147215},
+					pos: position{line: 4835, col: 10, offset: 147900},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4810, col: 10, offset: 147215},
+							pos:  position{line: 4835, col: 10, offset: 147900},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4810, col: 25, offset: 147230},
+							pos:        position{line: 4835, col: 25, offset: 147915},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4810, col: 29, offset: 147234},
+							pos:  position{line: 4835, col: 29, offset: 147919},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11487,25 +11495,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4814, col: 1, offset: 147274},
+			pos:  position{line: 4839, col: 1, offset: 147959},
 			expr: &actionExpr{
-				pos: position{line: 4814, col: 10, offset: 147283},
+				pos: position{line: 4839, col: 10, offset: 147968},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4814, col: 10, offset: 147283},
+					pos: position{line: 4839, col: 10, offset: 147968},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4814, col: 10, offset: 147283},
+							pos:  position{line: 4839, col: 10, offset: 147968},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4814, col: 25, offset: 147298},
+							pos:        position{line: 4839, col: 25, offset: 147983},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4814, col: 29, offset: 147302},
+							pos:  position{line: 4839, col: 29, offset: 147987},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11514,25 +11522,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4818, col: 1, offset: 147342},
+			pos:  position{line: 4843, col: 1, offset: 148027},
 			expr: &actionExpr{
-				pos: position{line: 4818, col: 10, offset: 147351},
+				pos: position{line: 4843, col: 10, offset: 148036},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4818, col: 10, offset: 147351},
+					pos: position{line: 4843, col: 10, offset: 148036},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4818, col: 10, offset: 147351},
+							pos:  position{line: 4843, col: 10, offset: 148036},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4818, col: 25, offset: 147366},
+							pos:        position{line: 4843, col: 25, offset: 148051},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4818, col: 29, offset: 147370},
+							pos:  position{line: 4843, col: 29, offset: 148055},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11541,39 +11549,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4823, col: 1, offset: 147434},
+			pos:  position{line: 4848, col: 1, offset: 148119},
 			expr: &actionExpr{
-				pos: position{line: 4823, col: 11, offset: 147444},
+				pos: position{line: 4848, col: 11, offset: 148129},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4823, col: 12, offset: 147445},
+					pos: position{line: 4848, col: 12, offset: 148130},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4823, col: 12, offset: 147445},
+							pos:        position{line: 4848, col: 12, offset: 148130},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 24, offset: 147457},
+							pos:        position{line: 4848, col: 24, offset: 148142},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 35, offset: 147468},
+							pos:        position{line: 4848, col: 35, offset: 148153},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 44, offset: 147477},
+							pos:        position{line: 4848, col: 44, offset: 148162},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 52, offset: 147485},
+							pos:        position{line: 4848, col: 52, offset: 148170},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11584,39 +11592,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4827, col: 1, offset: 147527},
+			pos:  position{line: 4852, col: 1, offset: 148212},
 			expr: &actionExpr{
-				pos: position{line: 4827, col: 11, offset: 147537},
+				pos: position{line: 4852, col: 11, offset: 148222},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4827, col: 12, offset: 147538},
+					pos: position{line: 4852, col: 12, offset: 148223},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4827, col: 12, offset: 147538},
+							pos:        position{line: 4852, col: 12, offset: 148223},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4827, col: 24, offset: 147550},
+							pos:        position{line: 4852, col: 24, offset: 148235},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4827, col: 35, offset: 147561},
+							pos:        position{line: 4852, col: 35, offset: 148246},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4827, col: 44, offset: 147570},
+							pos:        position{line: 4852, col: 44, offset: 148255},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4827, col: 52, offset: 147578},
+							pos:        position{line: 4852, col: 52, offset: 148263},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11627,39 +11635,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4831, col: 1, offset: 147620},
+			pos:  position{line: 4856, col: 1, offset: 148305},
 			expr: &actionExpr{
-				pos: position{line: 4831, col: 9, offset: 147628},
+				pos: position{line: 4856, col: 9, offset: 148313},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4831, col: 10, offset: 147629},
+					pos: position{line: 4856, col: 10, offset: 148314},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4831, col: 10, offset: 147629},
+							pos:        position{line: 4856, col: 10, offset: 148314},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4831, col: 20, offset: 147639},
+							pos:        position{line: 4856, col: 20, offset: 148324},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4831, col: 29, offset: 147648},
+							pos:        position{line: 4856, col: 29, offset: 148333},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4831, col: 37, offset: 147656},
+							pos:        position{line: 4856, col: 37, offset: 148341},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4831, col: 44, offset: 147663},
+							pos:        position{line: 4856, col: 44, offset: 148348},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11670,27 +11678,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4835, col: 1, offset: 147703},
+			pos:  position{line: 4860, col: 1, offset: 148388},
 			expr: &actionExpr{
-				pos: position{line: 4835, col: 8, offset: 147710},
+				pos: position{line: 4860, col: 8, offset: 148395},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4835, col: 9, offset: 147711},
+					pos: position{line: 4860, col: 9, offset: 148396},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4835, col: 9, offset: 147711},
+							pos:        position{line: 4860, col: 9, offset: 148396},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4835, col: 18, offset: 147720},
+							pos:        position{line: 4860, col: 18, offset: 148405},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4835, col: 26, offset: 147728},
+							pos:        position{line: 4860, col: 26, offset: 148413},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11701,27 +11709,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4839, col: 1, offset: 147767},
+			pos:  position{line: 4864, col: 1, offset: 148452},
 			expr: &actionExpr{
-				pos: position{line: 4839, col: 9, offset: 147775},
+				pos: position{line: 4864, col: 9, offset: 148460},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4839, col: 10, offset: 147776},
+					pos: position{line: 4864, col: 10, offset: 148461},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4839, col: 10, offset: 147776},
+							pos:        position{line: 4864, col: 10, offset: 148461},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4839, col: 20, offset: 147786},
+							pos:        position{line: 4864, col: 20, offset: 148471},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4839, col: 29, offset: 147795},
+							pos:        position{line: 4864, col: 29, offset: 148480},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11732,27 +11740,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4843, col: 1, offset: 147835},
+			pos:  position{line: 4868, col: 1, offset: 148520},
 			expr: &actionExpr{
-				pos: position{line: 4843, col: 10, offset: 147844},
+				pos: position{line: 4868, col: 10, offset: 148529},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4843, col: 11, offset: 147845},
+					pos: position{line: 4868, col: 11, offset: 148530},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4843, col: 11, offset: 147845},
+							pos:        position{line: 4868, col: 11, offset: 148530},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4843, col: 22, offset: 147856},
+							pos:        position{line: 4868, col: 22, offset: 148541},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4843, col: 32, offset: 147866},
+							pos:        position{line: 4868, col: 32, offset: 148551},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11763,39 +11771,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4847, col: 1, offset: 147909},
+			pos:  position{line: 4872, col: 1, offset: 148594},
 			expr: &actionExpr{
-				pos: position{line: 4847, col: 12, offset: 147920},
+				pos: position{line: 4872, col: 12, offset: 148605},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4847, col: 13, offset: 147921},
+					pos: position{line: 4872, col: 13, offset: 148606},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4847, col: 13, offset: 147921},
+							pos:        position{line: 4872, col: 13, offset: 148606},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4847, col: 26, offset: 147934},
+							pos:        position{line: 4872, col: 26, offset: 148619},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4847, col: 38, offset: 147946},
+							pos:        position{line: 4872, col: 38, offset: 148631},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4847, col: 47, offset: 147955},
+							pos:        position{line: 4872, col: 47, offset: 148640},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4847, col: 55, offset: 147963},
+							pos:        position{line: 4872, col: 55, offset: 148648},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11806,39 +11814,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4851, col: 1, offset: 148006},
+			pos:  position{line: 4876, col: 1, offset: 148691},
 			expr: &actionExpr{
-				pos: position{line: 4851, col: 9, offset: 148014},
+				pos: position{line: 4876, col: 9, offset: 148699},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4851, col: 10, offset: 148015},
+					pos: position{line: 4876, col: 10, offset: 148700},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4851, col: 10, offset: 148015},
+							pos:        position{line: 4876, col: 10, offset: 148700},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4851, col: 20, offset: 148025},
+							pos:        position{line: 4876, col: 20, offset: 148710},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4851, col: 29, offset: 148034},
+							pos:        position{line: 4876, col: 29, offset: 148719},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4851, col: 37, offset: 148042},
+							pos:        position{line: 4876, col: 37, offset: 148727},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4851, col: 44, offset: 148049},
+							pos:        position{line: 4876, col: 44, offset: 148734},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11849,33 +11857,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4856, col: 1, offset: 148181},
+			pos:  position{line: 4881, col: 1, offset: 148866},
 			expr: &actionExpr{
-				pos: position{line: 4856, col: 15, offset: 148195},
+				pos: position{line: 4881, col: 15, offset: 148880},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4856, col: 16, offset: 148196},
+					pos: position{line: 4881, col: 16, offset: 148881},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4856, col: 16, offset: 148196},
+							pos:        position{line: 4881, col: 16, offset: 148881},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 23, offset: 148203},
+							pos:        position{line: 4881, col: 23, offset: 148888},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 30, offset: 148210},
+							pos:        position{line: 4881, col: 30, offset: 148895},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 37, offset: 148217},
+							pos:        position{line: 4881, col: 37, offset: 148902},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11886,26 +11894,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4865, col: 1, offset: 148441},
+			pos:  position{line: 4890, col: 1, offset: 149126},
 			expr: &actionExpr{
-				pos: position{line: 4865, col: 21, offset: 148461},
+				pos: position{line: 4890, col: 21, offset: 149146},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4865, col: 21, offset: 148461},
+					pos: position{line: 4890, col: 21, offset: 149146},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4865, col: 21, offset: 148461},
+							pos:  position{line: 4890, col: 21, offset: 149146},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4865, col: 26, offset: 148466},
+							pos:  position{line: 4890, col: 26, offset: 149151},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4865, col: 42, offset: 148482},
+							pos:   position{line: 4890, col: 42, offset: 149167},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4865, col: 53, offset: 148493},
+								pos:  position{line: 4890, col: 53, offset: 149178},
 								name: "TransactionOptions",
 							},
 						},
@@ -11915,17 +11923,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4875, col: 1, offset: 148868},
+			pos:  position{line: 4900, col: 1, offset: 149553},
 			expr: &actionExpr{
-				pos: position{line: 4875, col: 23, offset: 148890},
+				pos: position{line: 4900, col: 23, offset: 149575},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4875, col: 23, offset: 148890},
+					pos:   position{line: 4900, col: 23, offset: 149575},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4875, col: 34, offset: 148901},
+						pos: position{line: 4900, col: 34, offset: 149586},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4875, col: 34, offset: 148901},
+							pos:  position{line: 4900, col: 34, offset: 149586},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11934,35 +11942,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4890, col: 1, offset: 149292},
+			pos:  position{line: 4915, col: 1, offset: 149977},
 			expr: &actionExpr{
-				pos: position{line: 4890, col: 37, offset: 149328},
+				pos: position{line: 4915, col: 37, offset: 150013},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4890, col: 37, offset: 149328},
+					pos: position{line: 4915, col: 37, offset: 150013},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4890, col: 37, offset: 149328},
+							pos:   position{line: 4915, col: 37, offset: 150013},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4890, col: 43, offset: 149334},
+								pos:  position{line: 4915, col: 43, offset: 150019},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4890, col: 71, offset: 149362},
+							pos:   position{line: 4915, col: 71, offset: 150047},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4890, col: 76, offset: 149367},
+								pos: position{line: 4915, col: 76, offset: 150052},
 								expr: &seqExpr{
-									pos: position{line: 4890, col: 77, offset: 149368},
+									pos: position{line: 4915, col: 77, offset: 150053},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4890, col: 77, offset: 149368},
+											pos:  position{line: 4915, col: 77, offset: 150053},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4890, col: 83, offset: 149374},
+											pos:  position{line: 4915, col: 83, offset: 150059},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11975,26 +11983,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4925, col: 1, offset: 150363},
+			pos:  position{line: 4950, col: 1, offset: 151048},
 			expr: &actionExpr{
-				pos: position{line: 4925, col: 32, offset: 150394},
+				pos: position{line: 4950, col: 32, offset: 151079},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4925, col: 32, offset: 150394},
+					pos:   position{line: 4950, col: 32, offset: 151079},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4925, col: 40, offset: 150402},
+						pos: position{line: 4950, col: 40, offset: 151087},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4925, col: 40, offset: 150402},
+								pos:  position{line: 4950, col: 40, offset: 151087},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4925, col: 77, offset: 150439},
+								pos:  position{line: 4950, col: 77, offset: 151124},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4925, col: 96, offset: 150458},
+								pos:  position{line: 4950, col: 96, offset: 151143},
 								name: "EndsWithOption",
 							},
 						},
@@ -12004,15 +12012,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4929, col: 1, offset: 150502},
+			pos:  position{line: 4954, col: 1, offset: 151187},
 			expr: &actionExpr{
-				pos: position{line: 4929, col: 39, offset: 150540},
+				pos: position{line: 4954, col: 39, offset: 151225},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4929, col: 39, offset: 150540},
+					pos:   position{line: 4954, col: 39, offset: 151225},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4929, col: 46, offset: 150547},
+						pos:  position{line: 4954, col: 46, offset: 151232},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12020,28 +12028,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4940, col: 1, offset: 150763},
+			pos:  position{line: 4965, col: 1, offset: 151448},
 			expr: &actionExpr{
-				pos: position{line: 4940, col: 21, offset: 150783},
+				pos: position{line: 4965, col: 21, offset: 151468},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4940, col: 21, offset: 150783},
+					pos: position{line: 4965, col: 21, offset: 151468},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4940, col: 21, offset: 150783},
+							pos:        position{line: 4965, col: 21, offset: 151468},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4940, col: 34, offset: 150796},
+							pos:  position{line: 4965, col: 34, offset: 151481},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4940, col: 40, offset: 150802},
+							pos:   position{line: 4965, col: 40, offset: 151487},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4940, col: 48, offset: 150810},
+								pos:  position{line: 4965, col: 48, offset: 151495},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12051,28 +12059,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4950, col: 1, offset: 151048},
+			pos:  position{line: 4975, col: 1, offset: 151733},
 			expr: &actionExpr{
-				pos: position{line: 4950, col: 19, offset: 151066},
+				pos: position{line: 4975, col: 19, offset: 151751},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4950, col: 19, offset: 151066},
+					pos: position{line: 4975, col: 19, offset: 151751},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4950, col: 19, offset: 151066},
+							pos:        position{line: 4975, col: 19, offset: 151751},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4950, col: 30, offset: 151077},
+							pos:  position{line: 4975, col: 30, offset: 151762},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4950, col: 36, offset: 151083},
+							pos:   position{line: 4975, col: 36, offset: 151768},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4950, col: 44, offset: 151091},
+								pos:  position{line: 4975, col: 44, offset: 151776},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12082,26 +12090,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4961, col: 1, offset: 151360},
+			pos:  position{line: 4986, col: 1, offset: 152045},
 			expr: &actionExpr{
-				pos: position{line: 4961, col: 28, offset: 151387},
+				pos: position{line: 4986, col: 28, offset: 152072},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4961, col: 28, offset: 151387},
+					pos:   position{line: 4986, col: 28, offset: 152072},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4961, col: 37, offset: 151396},
+						pos: position{line: 4986, col: 37, offset: 152081},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4961, col: 37, offset: 151396},
+								pos:  position{line: 4986, col: 37, offset: 152081},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4961, col: 63, offset: 151422},
+								pos:  position{line: 4986, col: 63, offset: 152107},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4961, col: 81, offset: 151440},
+								pos:  position{line: 4986, col: 81, offset: 152125},
 								name: "TransactionSearch",
 							},
 						},
@@ -12111,22 +12119,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4965, col: 1, offset: 151488},
+			pos:  position{line: 4990, col: 1, offset: 152173},
 			expr: &actionExpr{
-				pos: position{line: 4965, col: 28, offset: 151515},
+				pos: position{line: 4990, col: 28, offset: 152200},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4965, col: 28, offset: 151515},
+					pos:   position{line: 4990, col: 28, offset: 152200},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4965, col: 33, offset: 151520},
+						pos: position{line: 4990, col: 33, offset: 152205},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4965, col: 33, offset: 151520},
+								pos:  position{line: 4990, col: 33, offset: 152205},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4965, col: 64, offset: 151551},
+								pos:  position{line: 4990, col: 64, offset: 152236},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12136,29 +12144,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4969, col: 1, offset: 151611},
+			pos:  position{line: 4994, col: 1, offset: 152296},
 			expr: &actionExpr{
-				pos: position{line: 4969, col: 38, offset: 151648},
+				pos: position{line: 4994, col: 38, offset: 152333},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4969, col: 38, offset: 151648},
+					pos: position{line: 4994, col: 38, offset: 152333},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4969, col: 38, offset: 151648},
+							pos:        position{line: 4994, col: 38, offset: 152333},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4969, col: 42, offset: 151652},
+							pos:   position{line: 4994, col: 42, offset: 152337},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4969, col: 55, offset: 151665},
+								pos:  position{line: 4994, col: 55, offset: 152350},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4969, col: 68, offset: 151678},
+							pos:        position{line: 4994, col: 68, offset: 152363},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12169,23 +12177,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4977, col: 1, offset: 151817},
+			pos:  position{line: 5002, col: 1, offset: 152502},
 			expr: &actionExpr{
-				pos: position{line: 4977, col: 21, offset: 151837},
+				pos: position{line: 5002, col: 21, offset: 152522},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4977, col: 21, offset: 151837},
+					pos: position{line: 5002, col: 21, offset: 152522},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4977, col: 21, offset: 151837},
+							pos:        position{line: 5002, col: 21, offset: 152522},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4977, col: 25, offset: 151841},
+							pos: position{line: 5002, col: 25, offset: 152526},
 							expr: &charClassMatcher{
-								pos:        position{line: 4977, col: 25, offset: 151841},
+								pos:        position{line: 5002, col: 25, offset: 152526},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12193,7 +12201,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4977, col: 44, offset: 151860},
+							pos:        position{line: 5002, col: 44, offset: 152545},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12204,15 +12212,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4982, col: 1, offset: 151971},
+			pos:  position{line: 5007, col: 1, offset: 152656},
 			expr: &actionExpr{
-				pos: position{line: 4982, col: 33, offset: 152003},
+				pos: position{line: 5007, col: 33, offset: 152688},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4982, col: 33, offset: 152003},
+					pos:   position{line: 5007, col: 33, offset: 152688},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4982, col: 37, offset: 152007},
+						pos:  position{line: 5007, col: 37, offset: 152692},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12220,15 +12228,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4990, col: 1, offset: 152162},
+			pos:  position{line: 5015, col: 1, offset: 152847},
 			expr: &actionExpr{
-				pos: position{line: 4990, col: 22, offset: 152183},
+				pos: position{line: 5015, col: 22, offset: 152868},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4990, col: 22, offset: 152183},
+					pos:   position{line: 5015, col: 22, offset: 152868},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4990, col: 27, offset: 152188},
+						pos:  position{line: 5015, col: 27, offset: 152873},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12236,37 +12244,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 5000, col: 1, offset: 152360},
+			pos:  position{line: 5025, col: 1, offset: 153045},
 			expr: &actionExpr{
-				pos: position{line: 5000, col: 20, offset: 152379},
+				pos: position{line: 5025, col: 20, offset: 153064},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 5000, col: 20, offset: 152379},
+					pos: position{line: 5025, col: 20, offset: 153064},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5000, col: 20, offset: 152379},
+							pos:        position{line: 5025, col: 20, offset: 153064},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5000, col: 27, offset: 152386},
+							pos:  position{line: 5025, col: 27, offset: 153071},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5000, col: 42, offset: 152401},
+							pos:  position{line: 5025, col: 42, offset: 153086},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5000, col: 50, offset: 152409},
+							pos:   position{line: 5025, col: 50, offset: 153094},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5000, col: 60, offset: 152419},
+								pos:  position{line: 5025, col: 60, offset: 153104},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5000, col: 69, offset: 152428},
+							pos:  position{line: 5025, col: 69, offset: 153113},
 							name: "R_PAREN",
 						},
 					},
@@ -12275,22 +12283,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5010, col: 1, offset: 152731},
+			pos:  position{line: 5035, col: 1, offset: 153416},
 			expr: &actionExpr{
-				pos: position{line: 5010, col: 20, offset: 152750},
+				pos: position{line: 5035, col: 20, offset: 153435},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5010, col: 20, offset: 152750},
+					pos: position{line: 5035, col: 20, offset: 153435},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5010, col: 20, offset: 152750},
+							pos:  position{line: 5035, col: 20, offset: 153435},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5010, col: 25, offset: 152755},
+							pos:   position{line: 5035, col: 25, offset: 153440},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5010, col: 42, offset: 152772},
+								pos:  position{line: 5035, col: 42, offset: 153457},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12300,41 +12308,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5014, col: 1, offset: 152821},
+			pos:  position{line: 5039, col: 1, offset: 153506},
 			expr: &actionExpr{
-				pos: position{line: 5014, col: 16, offset: 152836},
+				pos: position{line: 5039, col: 16, offset: 153521},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5014, col: 16, offset: 152836},
+					pos: position{line: 5039, col: 16, offset: 153521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 16, offset: 152836},
+							pos:  position{line: 5039, col: 16, offset: 153521},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 27, offset: 152847},
+							pos:  position{line: 5039, col: 27, offset: 153532},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 33, offset: 152853},
+							pos:   position{line: 5039, col: 33, offset: 153538},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5014, col: 50, offset: 152870},
+								pos: position{line: 5039, col: 50, offset: 153555},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5014, col: 50, offset: 152870},
+									pos:  position{line: 5039, col: 50, offset: 153555},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5014, col: 70, offset: 152890},
+							pos:  position{line: 5039, col: 70, offset: 153575},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5014, col: 85, offset: 152905},
+							pos:   position{line: 5039, col: 85, offset: 153590},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5014, col: 91, offset: 152911},
+								pos:  position{line: 5039, col: 91, offset: 153596},
 								name: "FieldName",
 							},
 						},
@@ -12344,35 +12352,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5043, col: 1, offset: 153682},
+			pos:  position{line: 5068, col: 1, offset: 154367},
 			expr: &actionExpr{
-				pos: position{line: 5043, col: 23, offset: 153704},
+				pos: position{line: 5068, col: 23, offset: 154389},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5043, col: 23, offset: 153704},
+					pos: position{line: 5068, col: 23, offset: 154389},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5043, col: 23, offset: 153704},
+							pos:   position{line: 5068, col: 23, offset: 154389},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5043, col: 31, offset: 153712},
+								pos:  position{line: 5068, col: 31, offset: 154397},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5043, col: 46, offset: 153727},
+							pos:   position{line: 5068, col: 46, offset: 154412},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5043, col: 52, offset: 153733},
+								pos: position{line: 5068, col: 52, offset: 154418},
 								expr: &seqExpr{
-									pos: position{line: 5043, col: 53, offset: 153734},
+									pos: position{line: 5068, col: 53, offset: 154419},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5043, col: 53, offset: 153734},
+											pos:  position{line: 5068, col: 53, offset: 154419},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5043, col: 59, offset: 153740},
+											pos:  position{line: 5068, col: 59, offset: 154425},
 											name: "MVBlockOption",
 										},
 									},
@@ -12385,26 +12393,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5077, col: 1, offset: 154796},
+			pos:  position{line: 5102, col: 1, offset: 155481},
 			expr: &actionExpr{
-				pos: position{line: 5077, col: 18, offset: 154813},
+				pos: position{line: 5102, col: 18, offset: 155498},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5077, col: 18, offset: 154813},
+					pos:   position{line: 5102, col: 18, offset: 155498},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5077, col: 27, offset: 154822},
+						pos: position{line: 5102, col: 27, offset: 155507},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5077, col: 27, offset: 154822},
+								pos:  position{line: 5102, col: 27, offset: 155507},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5077, col: 41, offset: 154836},
+								pos:  position{line: 5102, col: 41, offset: 155521},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5077, col: 60, offset: 154855},
+								pos:  position{line: 5102, col: 60, offset: 155540},
 								name: "SetSvOption",
 							},
 						},
@@ -12414,22 +12422,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5081, col: 1, offset: 154896},
+			pos:  position{line: 5106, col: 1, offset: 155581},
 			expr: &actionExpr{
-				pos: position{line: 5081, col: 16, offset: 154911},
+				pos: position{line: 5106, col: 16, offset: 155596},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5081, col: 16, offset: 154911},
+					pos:   position{line: 5106, col: 16, offset: 155596},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5081, col: 28, offset: 154923},
+						pos: position{line: 5106, col: 28, offset: 155608},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5081, col: 28, offset: 154923},
+								pos:  position{line: 5106, col: 28, offset: 155608},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5081, col: 46, offset: 154941},
+								pos:  position{line: 5106, col: 46, offset: 155626},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12439,28 +12447,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5085, col: 1, offset: 154988},
+			pos:  position{line: 5110, col: 1, offset: 155673},
 			expr: &actionExpr{
-				pos: position{line: 5085, col: 20, offset: 155007},
+				pos: position{line: 5110, col: 20, offset: 155692},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5085, col: 20, offset: 155007},
+					pos: position{line: 5110, col: 20, offset: 155692},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5085, col: 20, offset: 155007},
+							pos:        position{line: 5110, col: 20, offset: 155692},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5085, col: 28, offset: 155015},
+							pos:  position{line: 5110, col: 28, offset: 155700},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5085, col: 34, offset: 155021},
+							pos:   position{line: 5110, col: 34, offset: 155706},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5085, col: 38, offset: 155025},
+								pos:  position{line: 5110, col: 38, offset: 155710},
 								name: "QuotedString",
 							},
 						},
@@ -12470,28 +12478,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5096, col: 1, offset: 155276},
+			pos:  position{line: 5121, col: 1, offset: 155961},
 			expr: &actionExpr{
-				pos: position{line: 5096, col: 19, offset: 155294},
+				pos: position{line: 5121, col: 19, offset: 155979},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5096, col: 19, offset: 155294},
+					pos: position{line: 5121, col: 19, offset: 155979},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5096, col: 19, offset: 155294},
+							pos:        position{line: 5121, col: 19, offset: 155979},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5096, col: 31, offset: 155306},
+							pos:  position{line: 5121, col: 31, offset: 155991},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5096, col: 37, offset: 155312},
+							pos:   position{line: 5121, col: 37, offset: 155997},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5096, col: 41, offset: 155316},
+								pos:  position{line: 5121, col: 41, offset: 156001},
 								name: "QuotedString",
 							},
 						},
@@ -12501,28 +12509,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5114, col: 1, offset: 155787},
+			pos:  position{line: 5139, col: 1, offset: 156472},
 			expr: &actionExpr{
-				pos: position{line: 5114, col: 21, offset: 155807},
+				pos: position{line: 5139, col: 21, offset: 156492},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5114, col: 21, offset: 155807},
+					pos: position{line: 5139, col: 21, offset: 156492},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5114, col: 21, offset: 155807},
+							pos:        position{line: 5139, col: 21, offset: 156492},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5114, col: 34, offset: 155820},
+							pos:  position{line: 5139, col: 34, offset: 156505},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5114, col: 40, offset: 155826},
+							pos:   position{line: 5139, col: 40, offset: 156511},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5114, col: 48, offset: 155834},
+								pos:  position{line: 5139, col: 48, offset: 156519},
 								name: "Boolean",
 							},
 						},
@@ -12532,28 +12540,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5126, col: 1, offset: 156074},
+			pos:  position{line: 5151, col: 1, offset: 156759},
 			expr: &actionExpr{
-				pos: position{line: 5126, col: 16, offset: 156089},
+				pos: position{line: 5151, col: 16, offset: 156774},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5126, col: 16, offset: 156089},
+					pos: position{line: 5151, col: 16, offset: 156774},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5126, col: 16, offset: 156089},
+							pos:        position{line: 5151, col: 16, offset: 156774},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5126, col: 24, offset: 156097},
+							pos:  position{line: 5151, col: 24, offset: 156782},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5126, col: 30, offset: 156103},
+							pos:   position{line: 5151, col: 30, offset: 156788},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5126, col: 38, offset: 156111},
+								pos:  position{line: 5151, col: 38, offset: 156796},
 								name: "Boolean",
 							},
 						},
@@ -12563,28 +12571,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5138, col: 1, offset: 156376},
+			pos:  position{line: 5163, col: 1, offset: 157061},
 			expr: &actionExpr{
-				pos: position{line: 5138, col: 15, offset: 156390},
+				pos: position{line: 5163, col: 15, offset: 157075},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5138, col: 15, offset: 156390},
+					pos: position{line: 5163, col: 15, offset: 157075},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 15, offset: 156390},
+							pos:  position{line: 5163, col: 15, offset: 157075},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 20, offset: 156395},
+							pos:  position{line: 5163, col: 20, offset: 157080},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5138, col: 30, offset: 156405},
+							pos:   position{line: 5163, col: 30, offset: 157090},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5138, col: 40, offset: 156415},
+								pos: position{line: 5163, col: 40, offset: 157100},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5138, col: 40, offset: 156415},
+									pos:  position{line: 5163, col: 40, offset: 157100},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12595,39 +12603,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5145, col: 1, offset: 156541},
+			pos:  position{line: 5170, col: 1, offset: 157226},
 			expr: &actionExpr{
-				pos: position{line: 5145, col: 23, offset: 156563},
+				pos: position{line: 5170, col: 23, offset: 157248},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5145, col: 23, offset: 156563},
+					pos: position{line: 5170, col: 23, offset: 157248},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5145, col: 23, offset: 156563},
+							pos:  position{line: 5170, col: 23, offset: 157248},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5145, col: 29, offset: 156569},
+							pos:   position{line: 5170, col: 29, offset: 157254},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5145, col: 35, offset: 156575},
+								pos:  position{line: 5170, col: 35, offset: 157260},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5145, col: 49, offset: 156589},
+							pos:   position{line: 5170, col: 49, offset: 157274},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5145, col: 54, offset: 156594},
+								pos: position{line: 5170, col: 54, offset: 157279},
 								expr: &seqExpr{
-									pos: position{line: 5145, col: 55, offset: 156595},
+									pos: position{line: 5170, col: 55, offset: 157280},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5145, col: 55, offset: 156595},
+											pos:  position{line: 5170, col: 55, offset: 157280},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5145, col: 61, offset: 156601},
+											pos:  position{line: 5170, col: 61, offset: 157286},
 											name: "SPathArgument",
 										},
 									},
@@ -12640,26 +12648,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5177, col: 1, offset: 157494},
+			pos:  position{line: 5202, col: 1, offset: 158179},
 			expr: &actionExpr{
-				pos: position{line: 5177, col: 18, offset: 157511},
+				pos: position{line: 5202, col: 18, offset: 158196},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5177, col: 18, offset: 157511},
+					pos:   position{line: 5202, col: 18, offset: 158196},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5177, col: 23, offset: 157516},
+						pos: position{line: 5202, col: 23, offset: 158201},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5177, col: 23, offset: 157516},
+								pos:  position{line: 5202, col: 23, offset: 158201},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5177, col: 36, offset: 157529},
+								pos:  position{line: 5202, col: 36, offset: 158214},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5177, col: 50, offset: 157543},
+								pos:  position{line: 5202, col: 50, offset: 158228},
 								name: "PathField",
 							},
 						},
@@ -12669,28 +12677,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5181, col: 1, offset: 157579},
+			pos:  position{line: 5206, col: 1, offset: 158264},
 			expr: &actionExpr{
-				pos: position{line: 5181, col: 15, offset: 157593},
+				pos: position{line: 5206, col: 15, offset: 158278},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5181, col: 15, offset: 157593},
+					pos: position{line: 5206, col: 15, offset: 158278},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5181, col: 15, offset: 157593},
+							pos:        position{line: 5206, col: 15, offset: 158278},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5181, col: 23, offset: 157601},
+							pos:  position{line: 5206, col: 23, offset: 158286},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5181, col: 29, offset: 157607},
+							pos:   position{line: 5206, col: 29, offset: 158292},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5181, col: 35, offset: 157613},
+								pos:  position{line: 5206, col: 35, offset: 158298},
 								name: "FieldName",
 							},
 						},
@@ -12700,28 +12708,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5184, col: 1, offset: 157669},
+			pos:  position{line: 5209, col: 1, offset: 158354},
 			expr: &actionExpr{
-				pos: position{line: 5184, col: 16, offset: 157684},
+				pos: position{line: 5209, col: 16, offset: 158369},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5184, col: 16, offset: 157684},
+					pos: position{line: 5209, col: 16, offset: 158369},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5184, col: 16, offset: 157684},
+							pos:        position{line: 5209, col: 16, offset: 158369},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5184, col: 25, offset: 157693},
+							pos:  position{line: 5209, col: 25, offset: 158378},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5184, col: 31, offset: 157699},
+							pos:   position{line: 5209, col: 31, offset: 158384},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5184, col: 37, offset: 157705},
+								pos:  position{line: 5209, col: 37, offset: 158390},
 								name: "FieldName",
 							},
 						},
@@ -12731,34 +12739,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5187, col: 1, offset: 157762},
+			pos:  position{line: 5212, col: 1, offset: 158447},
 			expr: &actionExpr{
-				pos: position{line: 5187, col: 14, offset: 157775},
+				pos: position{line: 5212, col: 14, offset: 158460},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5187, col: 15, offset: 157776},
+					pos: position{line: 5212, col: 15, offset: 158461},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5187, col: 15, offset: 157776},
+							pos: position{line: 5212, col: 15, offset: 158461},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5187, col: 15, offset: 157776},
+									pos:        position{line: 5212, col: 15, offset: 158461},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5187, col: 22, offset: 157783},
+									pos:  position{line: 5212, col: 22, offset: 158468},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5187, col: 28, offset: 157789},
+									pos:  position{line: 5212, col: 28, offset: 158474},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5187, col: 47, offset: 157808},
+							pos:  position{line: 5212, col: 47, offset: 158493},
 							name: "SPathFieldString",
 						},
 					},
@@ -12767,16 +12775,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5199, col: 1, offset: 158220},
+			pos:  position{line: 5224, col: 1, offset: 158905},
 			expr: &choiceExpr{
-				pos: position{line: 5199, col: 21, offset: 158240},
+				pos: position{line: 5224, col: 21, offset: 158925},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5199, col: 21, offset: 158240},
+						pos:  position{line: 5224, col: 21, offset: 158925},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5199, col: 36, offset: 158255},
+						pos:  position{line: 5224, col: 36, offset: 158940},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12784,28 +12792,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5202, col: 1, offset: 158328},
+			pos:  position{line: 5227, col: 1, offset: 159013},
 			expr: &actionExpr{
-				pos: position{line: 5202, col: 16, offset: 158343},
+				pos: position{line: 5227, col: 16, offset: 159028},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5202, col: 16, offset: 158343},
+					pos: position{line: 5227, col: 16, offset: 159028},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5202, col: 16, offset: 158343},
+							pos:  position{line: 5227, col: 16, offset: 159028},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5202, col: 21, offset: 158348},
+							pos:  position{line: 5227, col: 21, offset: 159033},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5202, col: 32, offset: 158359},
+							pos:   position{line: 5227, col: 32, offset: 159044},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5202, col: 46, offset: 158373},
+								pos: position{line: 5227, col: 46, offset: 159058},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5202, col: 46, offset: 158373},
+									pos:  position{line: 5227, col: 46, offset: 159058},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12816,39 +12824,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5224, col: 1, offset: 158982},
+			pos:  position{line: 5249, col: 1, offset: 159667},
 			expr: &actionExpr{
-				pos: position{line: 5224, col: 24, offset: 159005},
+				pos: position{line: 5249, col: 24, offset: 159690},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5224, col: 24, offset: 159005},
+					pos: position{line: 5249, col: 24, offset: 159690},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5224, col: 24, offset: 159005},
+							pos:  position{line: 5249, col: 24, offset: 159690},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5224, col: 30, offset: 159011},
+							pos:   position{line: 5249, col: 30, offset: 159696},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5224, col: 37, offset: 159018},
+								pos:  position{line: 5249, col: 37, offset: 159703},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5224, col: 52, offset: 159033},
+							pos:   position{line: 5249, col: 52, offset: 159718},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5224, col: 57, offset: 159038},
+								pos: position{line: 5249, col: 57, offset: 159723},
 								expr: &seqExpr{
-									pos: position{line: 5224, col: 58, offset: 159039},
+									pos: position{line: 5249, col: 58, offset: 159724},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5224, col: 58, offset: 159039},
+											pos:  position{line: 5249, col: 58, offset: 159724},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5224, col: 64, offset: 159045},
+											pos:  position{line: 5249, col: 64, offset: 159730},
 											name: "FormatArgument",
 										},
 									},
@@ -12861,30 +12869,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5258, col: 1, offset: 160234},
+			pos:  position{line: 5283, col: 1, offset: 160919},
 			expr: &actionExpr{
-				pos: position{line: 5258, col: 19, offset: 160252},
+				pos: position{line: 5283, col: 19, offset: 160937},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5258, col: 19, offset: 160252},
+					pos:   position{line: 5283, col: 19, offset: 160937},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5258, col: 28, offset: 160261},
+						pos: position{line: 5283, col: 28, offset: 160946},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5258, col: 28, offset: 160261},
+								pos:  position{line: 5283, col: 28, offset: 160946},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5258, col: 46, offset: 160279},
+								pos:  position{line: 5283, col: 46, offset: 160964},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5258, col: 65, offset: 160298},
+								pos:  position{line: 5283, col: 65, offset: 160983},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5258, col: 82, offset: 160315},
+								pos:  position{line: 5283, col: 82, offset: 161000},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12894,28 +12902,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5262, col: 1, offset: 160365},
+			pos:  position{line: 5287, col: 1, offset: 161050},
 			expr: &actionExpr{
-				pos: position{line: 5262, col: 20, offset: 160384},
+				pos: position{line: 5287, col: 20, offset: 161069},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5262, col: 20, offset: 160384},
+					pos: position{line: 5287, col: 20, offset: 161069},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5262, col: 20, offset: 160384},
+							pos:        position{line: 5287, col: 20, offset: 161069},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5262, col: 28, offset: 160392},
+							pos:  position{line: 5287, col: 28, offset: 161077},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5262, col: 34, offset: 160398},
+							pos:   position{line: 5287, col: 34, offset: 161083},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5262, col: 38, offset: 160402},
+								pos:  position{line: 5287, col: 38, offset: 161087},
 								name: "QuotedString",
 							},
 						},
@@ -12925,28 +12933,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5271, col: 1, offset: 160614},
+			pos:  position{line: 5296, col: 1, offset: 161299},
 			expr: &actionExpr{
-				pos: position{line: 5271, col: 21, offset: 160634},
+				pos: position{line: 5296, col: 21, offset: 161319},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5271, col: 21, offset: 160634},
+					pos: position{line: 5296, col: 21, offset: 161319},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5271, col: 21, offset: 160634},
+							pos:        position{line: 5296, col: 21, offset: 161319},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5271, col: 34, offset: 160647},
+							pos:  position{line: 5296, col: 34, offset: 161332},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5271, col: 40, offset: 160653},
+							pos:   position{line: 5296, col: 40, offset: 161338},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5271, col: 47, offset: 160660},
+								pos:  position{line: 5296, col: 47, offset: 161345},
 								name: "IntegerAsString",
 							},
 						},
@@ -12956,28 +12964,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5284, col: 1, offset: 161066},
+			pos:  position{line: 5309, col: 1, offset: 161751},
 			expr: &actionExpr{
-				pos: position{line: 5284, col: 19, offset: 161084},
+				pos: position{line: 5309, col: 19, offset: 161769},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5284, col: 19, offset: 161084},
+					pos: position{line: 5309, col: 19, offset: 161769},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5284, col: 19, offset: 161084},
+							pos:        position{line: 5309, col: 19, offset: 161769},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5284, col: 30, offset: 161095},
+							pos:  position{line: 5309, col: 30, offset: 161780},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5284, col: 36, offset: 161101},
+							pos:   position{line: 5309, col: 36, offset: 161786},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5284, col: 40, offset: 161105},
+								pos:  position{line: 5309, col: 40, offset: 161790},
 								name: "QuotedString",
 							},
 						},
@@ -12987,78 +12995,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5293, col: 1, offset: 161320},
+			pos:  position{line: 5318, col: 1, offset: 162005},
 			expr: &actionExpr{
-				pos: position{line: 5293, col: 24, offset: 161343},
+				pos: position{line: 5318, col: 24, offset: 162028},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5293, col: 24, offset: 161343},
+					pos: position{line: 5318, col: 24, offset: 162028},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5293, col: 24, offset: 161343},
+							pos:   position{line: 5318, col: 24, offset: 162028},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 34, offset: 161353},
+								pos:  position{line: 5318, col: 34, offset: 162038},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5293, col: 47, offset: 161366},
+							pos:  position{line: 5318, col: 47, offset: 162051},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5293, col: 53, offset: 161372},
+							pos:   position{line: 5318, col: 53, offset: 162057},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 63, offset: 161382},
+								pos:  position{line: 5318, col: 63, offset: 162067},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5293, col: 76, offset: 161395},
+							pos:  position{line: 5318, col: 76, offset: 162080},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5293, col: 82, offset: 161401},
+							pos:   position{line: 5318, col: 82, offset: 162086},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 95, offset: 161414},
+								pos:  position{line: 5318, col: 95, offset: 162099},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5293, col: 108, offset: 161427},
+							pos:  position{line: 5318, col: 108, offset: 162112},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5293, col: 114, offset: 161433},
+							pos:   position{line: 5318, col: 114, offset: 162118},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 121, offset: 161440},
+								pos:  position{line: 5318, col: 121, offset: 162125},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5293, col: 134, offset: 161453},
+							pos:  position{line: 5318, col: 134, offset: 162138},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5293, col: 140, offset: 161459},
+							pos:   position{line: 5318, col: 140, offset: 162144},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 153, offset: 161472},
+								pos:  position{line: 5318, col: 153, offset: 162157},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5293, col: 166, offset: 161485},
+							pos:  position{line: 5318, col: 166, offset: 162170},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5293, col: 172, offset: 161491},
+							pos:   position{line: 5318, col: 172, offset: 162176},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5293, col: 179, offset: 161498},
+								pos:  position{line: 5318, col: 179, offset: 162183},
 								name: "QuotedString",
 							},
 						},
@@ -13068,28 +13076,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5311, col: 1, offset: 162074},
+			pos:  position{line: 5336, col: 1, offset: 162759},
 			expr: &actionExpr{
-				pos: position{line: 5311, col: 20, offset: 162093},
+				pos: position{line: 5336, col: 20, offset: 162778},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5311, col: 20, offset: 162093},
+					pos: position{line: 5336, col: 20, offset: 162778},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5311, col: 20, offset: 162093},
+							pos:  position{line: 5336, col: 20, offset: 162778},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5311, col: 25, offset: 162098},
+							pos:  position{line: 5336, col: 25, offset: 162783},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5311, col: 40, offset: 162113},
+							pos:   position{line: 5336, col: 40, offset: 162798},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5311, col: 55, offset: 162128},
+								pos: position{line: 5336, col: 55, offset: 162813},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5311, col: 55, offset: 162128},
+									pos:  position{line: 5336, col: 55, offset: 162813},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13100,42 +13108,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5318, col: 1, offset: 162281},
+			pos:  position{line: 5343, col: 1, offset: 162966},
 			expr: &actionExpr{
-				pos: position{line: 5318, col: 28, offset: 162308},
+				pos: position{line: 5343, col: 28, offset: 162993},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5318, col: 28, offset: 162308},
+					pos: position{line: 5343, col: 28, offset: 162993},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 28, offset: 162308},
+							pos:  position{line: 5343, col: 28, offset: 162993},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 34, offset: 162314},
+							pos:   position{line: 5343, col: 34, offset: 162999},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5318, col: 40, offset: 162320},
+								pos: position{line: 5343, col: 40, offset: 163005},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5318, col: 40, offset: 162320},
+									pos:  position{line: 5343, col: 40, offset: 163005},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 60, offset: 162340},
+							pos:   position{line: 5343, col: 60, offset: 163025},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5318, col: 65, offset: 162345},
+								pos: position{line: 5343, col: 65, offset: 163030},
 								expr: &seqExpr{
-									pos: position{line: 5318, col: 66, offset: 162346},
+									pos: position{line: 5343, col: 66, offset: 163031},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5318, col: 66, offset: 162346},
+											pos:  position{line: 5343, col: 66, offset: 163031},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5318, col: 72, offset: 162352},
+											pos:  position{line: 5343, col: 72, offset: 163037},
 											name: "EventCountArgument",
 										},
 									},
@@ -13148,30 +13156,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5374, col: 1, offset: 164229},
+			pos:  position{line: 5399, col: 1, offset: 164914},
 			expr: &actionExpr{
-				pos: position{line: 5374, col: 23, offset: 164251},
+				pos: position{line: 5399, col: 23, offset: 164936},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5374, col: 23, offset: 164251},
+					pos:   position{line: 5399, col: 23, offset: 164936},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5374, col: 28, offset: 164256},
+						pos: position{line: 5399, col: 28, offset: 164941},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5374, col: 28, offset: 164256},
+								pos:  position{line: 5399, col: 28, offset: 164941},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5374, col: 41, offset: 164269},
+								pos:  position{line: 5399, col: 41, offset: 164954},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5374, col: 58, offset: 164286},
+								pos:  position{line: 5399, col: 58, offset: 164971},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5374, col: 76, offset: 164304},
+								pos:  position{line: 5399, col: 76, offset: 164989},
 								name: "ListVixField",
 							},
 						},
@@ -13181,28 +13189,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5378, col: 1, offset: 164343},
+			pos:  position{line: 5403, col: 1, offset: 165028},
 			expr: &actionExpr{
-				pos: position{line: 5378, col: 15, offset: 164357},
+				pos: position{line: 5403, col: 15, offset: 165042},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5378, col: 15, offset: 164357},
+					pos: position{line: 5403, col: 15, offset: 165042},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5378, col: 15, offset: 164357},
+							pos:        position{line: 5403, col: 15, offset: 165042},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5378, col: 23, offset: 164365},
+							pos:  position{line: 5403, col: 23, offset: 165050},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5378, col: 29, offset: 164371},
+							pos:   position{line: 5403, col: 29, offset: 165056},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5378, col: 35, offset: 164377},
+								pos:  position{line: 5403, col: 35, offset: 165062},
 								name: "IndexName",
 							},
 						},
@@ -13212,28 +13220,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5381, col: 1, offset: 164433},
+			pos:  position{line: 5406, col: 1, offset: 165118},
 			expr: &actionExpr{
-				pos: position{line: 5381, col: 19, offset: 164451},
+				pos: position{line: 5406, col: 19, offset: 165136},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5381, col: 19, offset: 164451},
+					pos: position{line: 5406, col: 19, offset: 165136},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5381, col: 19, offset: 164451},
+							pos:        position{line: 5406, col: 19, offset: 165136},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5381, col: 31, offset: 164463},
+							pos:  position{line: 5406, col: 31, offset: 165148},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5381, col: 37, offset: 164469},
+							pos:   position{line: 5406, col: 37, offset: 165154},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5381, col: 43, offset: 164475},
+								pos:  position{line: 5406, col: 43, offset: 165160},
 								name: "Boolean",
 							},
 						},
@@ -13243,28 +13251,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5384, col: 1, offset: 164551},
+			pos:  position{line: 5409, col: 1, offset: 165236},
 			expr: &actionExpr{
-				pos: position{line: 5384, col: 20, offset: 164570},
+				pos: position{line: 5409, col: 20, offset: 165255},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5384, col: 20, offset: 164570},
+					pos: position{line: 5409, col: 20, offset: 165255},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5384, col: 20, offset: 164570},
+							pos:        position{line: 5409, col: 20, offset: 165255},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5384, col: 34, offset: 164584},
+							pos:  position{line: 5409, col: 34, offset: 165269},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5384, col: 40, offset: 164590},
+							pos:   position{line: 5409, col: 40, offset: 165275},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5384, col: 46, offset: 164596},
+								pos:  position{line: 5409, col: 46, offset: 165281},
 								name: "Boolean",
 							},
 						},
@@ -13274,28 +13282,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5387, col: 1, offset: 164674},
+			pos:  position{line: 5412, col: 1, offset: 165359},
 			expr: &actionExpr{
-				pos: position{line: 5387, col: 17, offset: 164690},
+				pos: position{line: 5412, col: 17, offset: 165375},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5387, col: 17, offset: 164690},
+					pos: position{line: 5412, col: 17, offset: 165375},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5387, col: 17, offset: 164690},
+							pos:        position{line: 5412, col: 17, offset: 165375},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5387, col: 28, offset: 164701},
+							pos:  position{line: 5412, col: 28, offset: 165386},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5387, col: 34, offset: 164707},
+							pos:   position{line: 5412, col: 34, offset: 165392},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5387, col: 40, offset: 164713},
+								pos:  position{line: 5412, col: 40, offset: 165398},
 								name: "Boolean",
 							},
 						},
@@ -13305,24 +13313,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5391, col: 1, offset: 164789},
+			pos:  position{line: 5416, col: 1, offset: 165474},
 			expr: &actionExpr{
-				pos: position{line: 5391, col: 14, offset: 164802},
+				pos: position{line: 5416, col: 14, offset: 165487},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5391, col: 14, offset: 164802},
+					pos: position{line: 5416, col: 14, offset: 165487},
 					expr: &seqExpr{
-						pos: position{line: 5391, col: 15, offset: 164803},
+						pos: position{line: 5416, col: 15, offset: 165488},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5391, col: 15, offset: 164803},
+								pos: position{line: 5416, col: 15, offset: 165488},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5391, col: 16, offset: 164804},
+									pos:  position{line: 5416, col: 16, offset: 165489},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5391, col: 22, offset: 164810,
+								line: 5416, col: 22, offset: 165495,
 							},
 						},
 					},
@@ -13331,39 +13339,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5396, col: 1, offset: 164883},
+			pos:  position{line: 5421, col: 1, offset: 165568},
 			expr: &actionExpr{
-				pos: position{line: 5396, col: 18, offset: 164900},
+				pos: position{line: 5421, col: 18, offset: 165585},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5396, col: 18, offset: 164900},
+					pos: position{line: 5421, col: 18, offset: 165585},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5396, col: 18, offset: 164900},
+							pos:  position{line: 5421, col: 18, offset: 165585},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5396, col: 23, offset: 164905},
+							pos:  position{line: 5421, col: 23, offset: 165590},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5396, col: 36, offset: 164918},
+							pos:   position{line: 5421, col: 36, offset: 165603},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5396, col: 49, offset: 164931},
+								pos: position{line: 5421, col: 49, offset: 165616},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5396, col: 49, offset: 164931},
+									pos:  position{line: 5421, col: 49, offset: 165616},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5396, col: 70, offset: 164952},
+							pos:   position{line: 5421, col: 70, offset: 165637},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5396, col: 77, offset: 164959},
+								pos: position{line: 5421, col: 77, offset: 165644},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5396, col: 77, offset: 164959},
+									pos:  position{line: 5421, col: 77, offset: 165644},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13374,32 +13382,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5426, col: 1, offset: 165722},
+			pos:  position{line: 5451, col: 1, offset: 166407},
 			expr: &actionExpr{
-				pos: position{line: 5426, col: 24, offset: 165745},
+				pos: position{line: 5451, col: 24, offset: 166430},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5426, col: 24, offset: 165745},
+					pos: position{line: 5451, col: 24, offset: 166430},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5426, col: 24, offset: 165745},
+							pos:  position{line: 5451, col: 24, offset: 166430},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5426, col: 30, offset: 165751},
+							pos:        position{line: 5451, col: 30, offset: 166436},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5426, col: 38, offset: 165759},
+							pos:  position{line: 5451, col: 38, offset: 166444},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5426, col: 44, offset: 165765},
+							pos:   position{line: 5451, col: 44, offset: 166450},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5426, col: 48, offset: 165769},
+								pos:  position{line: 5451, col: 48, offset: 166454},
 								name: "String",
 							},
 						},
@@ -13409,22 +13417,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5430, col: 1, offset: 165815},
+			pos:  position{line: 5455, col: 1, offset: 166500},
 			expr: &actionExpr{
-				pos: position{line: 5430, col: 22, offset: 165836},
+				pos: position{line: 5455, col: 22, offset: 166521},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5430, col: 22, offset: 165836},
+					pos: position{line: 5455, col: 22, offset: 166521},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5430, col: 22, offset: 165836},
+							pos:  position{line: 5455, col: 22, offset: 166521},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5430, col: 28, offset: 165842},
+							pos:   position{line: 5455, col: 28, offset: 166527},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5430, col: 38, offset: 165852},
+								pos:  position{line: 5455, col: 38, offset: 166537},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13434,36 +13442,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5434, col: 1, offset: 165911},
+			pos:  position{line: 5459, col: 1, offset: 166596},
 			expr: &actionExpr{
-				pos: position{line: 5434, col: 18, offset: 165928},
+				pos: position{line: 5459, col: 18, offset: 166613},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5434, col: 18, offset: 165928},
+					pos: position{line: 5459, col: 18, offset: 166613},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5434, col: 18, offset: 165928},
+							pos:  position{line: 5459, col: 18, offset: 166613},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5434, col: 23, offset: 165933},
+							pos:  position{line: 5459, col: 23, offset: 166618},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5434, col: 36, offset: 165946},
+							pos:   position{line: 5459, col: 36, offset: 166631},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5434, col: 42, offset: 165952},
+								pos:  position{line: 5459, col: 42, offset: 166637},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5434, col: 56, offset: 165966},
+							pos:   position{line: 5459, col: 56, offset: 166651},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5434, col: 65, offset: 165975},
+								pos: position{line: 5459, col: 65, offset: 166660},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5434, col: 65, offset: 165975},
+									pos:  position{line: 5459, col: 65, offset: 166660},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13474,22 +13482,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5463, col: 1, offset: 166751},
+			pos:  position{line: 5488, col: 1, offset: 167436},
 			expr: &actionExpr{
-				pos: position{line: 5463, col: 18, offset: 166768},
+				pos: position{line: 5488, col: 18, offset: 167453},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5463, col: 18, offset: 166768},
+					pos: position{line: 5488, col: 18, offset: 167453},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5463, col: 18, offset: 166768},
+							pos:  position{line: 5488, col: 18, offset: 167453},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5463, col: 24, offset: 166774},
+							pos:   position{line: 5488, col: 24, offset: 167459},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5463, col: 34, offset: 166784},
+								pos:  position{line: 5488, col: 34, offset: 167469},
 								name: "FieldName",
 							},
 						},
@@ -13499,32 +13507,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5467, col: 1, offset: 166825},
+			pos:  position{line: 5492, col: 1, offset: 167510},
 			expr: &actionExpr{
-				pos: position{line: 5467, col: 18, offset: 166842},
+				pos: position{line: 5492, col: 18, offset: 167527},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5467, col: 18, offset: 166842},
+					pos: position{line: 5492, col: 18, offset: 167527},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5467, col: 18, offset: 166842},
+							pos:  position{line: 5492, col: 18, offset: 167527},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5467, col: 24, offset: 166848},
+							pos:        position{line: 5492, col: 24, offset: 167533},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5467, col: 32, offset: 166856},
+							pos:  position{line: 5492, col: 32, offset: 167541},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5467, col: 38, offset: 166862},
+							pos:   position{line: 5492, col: 38, offset: 167547},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5467, col: 47, offset: 166871},
+								pos:  position{line: 5492, col: 47, offset: 167556},
 								name: "IntegerAsString",
 							},
 						},
@@ -13534,26 +13542,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5471, col: 1, offset: 166917},
+			pos:  position{line: 5496, col: 1, offset: 167602},
 			expr: &actionExpr{
-				pos: position{line: 5471, col: 16, offset: 166932},
+				pos: position{line: 5496, col: 16, offset: 167617},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5471, col: 16, offset: 166932},
+					pos: position{line: 5496, col: 16, offset: 167617},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5471, col: 16, offset: 166932},
+							pos:  position{line: 5496, col: 16, offset: 167617},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5471, col: 22, offset: 166938},
+							pos:  position{line: 5496, col: 22, offset: 167623},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5471, col: 32, offset: 166948},
+							pos:   position{line: 5496, col: 32, offset: 167633},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5471, col: 42, offset: 166958},
+								pos:  position{line: 5496, col: 42, offset: 167643},
 								name: "BoolExpr",
 							},
 						},
@@ -13563,28 +13571,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5475, col: 1, offset: 167018},
+			pos:  position{line: 5500, col: 1, offset: 167703},
 			expr: &actionExpr{
-				pos: position{line: 5475, col: 28, offset: 167045},
+				pos: position{line: 5500, col: 28, offset: 167730},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5475, col: 28, offset: 167045},
+					pos: position{line: 5500, col: 28, offset: 167730},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5475, col: 28, offset: 167045},
+							pos:        position{line: 5500, col: 28, offset: 167730},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5475, col: 37, offset: 167054},
+							pos:  position{line: 5500, col: 37, offset: 167739},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5475, col: 43, offset: 167060},
+							pos:   position{line: 5500, col: 43, offset: 167745},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5475, col: 51, offset: 167068},
+								pos:  position{line: 5500, col: 51, offset: 167753},
 								name: "Boolean",
 							},
 						},
@@ -13594,28 +13602,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5484, col: 1, offset: 167252},
+			pos:  position{line: 5509, col: 1, offset: 167937},
 			expr: &actionExpr{
-				pos: position{line: 5484, col: 28, offset: 167279},
+				pos: position{line: 5509, col: 28, offset: 167964},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5484, col: 28, offset: 167279},
+					pos: position{line: 5509, col: 28, offset: 167964},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5484, col: 28, offset: 167279},
+							pos:        position{line: 5509, col: 28, offset: 167964},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5484, col: 37, offset: 167288},
+							pos:  position{line: 5509, col: 37, offset: 167973},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5484, col: 43, offset: 167294},
+							pos:   position{line: 5509, col: 43, offset: 167979},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5484, col: 51, offset: 167302},
+								pos:  position{line: 5509, col: 51, offset: 167987},
 								name: "Boolean",
 							},
 						},
@@ -13625,28 +13633,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5493, col: 1, offset: 167486},
+			pos:  position{line: 5518, col: 1, offset: 168171},
 			expr: &actionExpr{
-				pos: position{line: 5493, col: 27, offset: 167512},
+				pos: position{line: 5518, col: 27, offset: 168197},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5493, col: 27, offset: 167512},
+					pos: position{line: 5518, col: 27, offset: 168197},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5493, col: 27, offset: 167512},
+							pos:        position{line: 5518, col: 27, offset: 168197},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5493, col: 35, offset: 167520},
+							pos:  position{line: 5518, col: 35, offset: 168205},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5493, col: 41, offset: 167526},
+							pos:   position{line: 5518, col: 41, offset: 168211},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5493, col: 48, offset: 167533},
+								pos:  position{line: 5518, col: 48, offset: 168218},
 								name: "PositiveInteger",
 							},
 						},
@@ -13656,28 +13664,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5502, col: 1, offset: 167724},
+			pos:  position{line: 5527, col: 1, offset: 168409},
 			expr: &actionExpr{
-				pos: position{line: 5502, col: 25, offset: 167748},
+				pos: position{line: 5527, col: 25, offset: 168433},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5502, col: 25, offset: 167748},
+					pos: position{line: 5527, col: 25, offset: 168433},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5502, col: 25, offset: 167748},
+							pos:        position{line: 5527, col: 25, offset: 168433},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5502, col: 31, offset: 167754},
+							pos:  position{line: 5527, col: 31, offset: 168439},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5502, col: 37, offset: 167760},
+							pos:   position{line: 5527, col: 37, offset: 168445},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5502, col: 44, offset: 167767},
+								pos:  position{line: 5527, col: 44, offset: 168452},
 								name: "PositiveInteger",
 							},
 						},
@@ -13687,30 +13695,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5511, col: 1, offset: 167954},
+			pos:  position{line: 5536, col: 1, offset: 168639},
 			expr: &actionExpr{
-				pos: position{line: 5511, col: 22, offset: 167975},
+				pos: position{line: 5536, col: 22, offset: 168660},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5511, col: 22, offset: 167975},
+					pos:   position{line: 5536, col: 22, offset: 168660},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5511, col: 41, offset: 167994},
+						pos: position{line: 5536, col: 41, offset: 168679},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5511, col: 41, offset: 167994},
+								pos:  position{line: 5536, col: 41, offset: 168679},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5511, col: 67, offset: 168020},
+								pos:  position{line: 5536, col: 67, offset: 168705},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5511, col: 93, offset: 168046},
+								pos:  position{line: 5536, col: 93, offset: 168731},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5511, col: 118, offset: 168071},
+								pos:  position{line: 5536, col: 118, offset: 168756},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13720,35 +13728,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5515, col: 1, offset: 168132},
+			pos:  position{line: 5540, col: 1, offset: 168817},
 			expr: &actionExpr{
-				pos: position{line: 5515, col: 26, offset: 168157},
+				pos: position{line: 5540, col: 26, offset: 168842},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5515, col: 26, offset: 168157},
+					pos: position{line: 5540, col: 26, offset: 168842},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5515, col: 26, offset: 168157},
+							pos:   position{line: 5540, col: 26, offset: 168842},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5515, col: 34, offset: 168165},
+								pos:  position{line: 5540, col: 34, offset: 168850},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5515, col: 53, offset: 168184},
+							pos:   position{line: 5540, col: 53, offset: 168869},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5515, col: 58, offset: 168189},
+								pos: position{line: 5540, col: 58, offset: 168874},
 								expr: &seqExpr{
-									pos: position{line: 5515, col: 59, offset: 168190},
+									pos: position{line: 5540, col: 59, offset: 168875},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5515, col: 59, offset: 168190},
+											pos:  position{line: 5540, col: 59, offset: 168875},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5515, col: 65, offset: 168196},
+											pos:  position{line: 5540, col: 65, offset: 168881},
 											name: "InputLookupOption",
 										},
 									},
@@ -13761,35 +13769,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5557, col: 1, offset: 169642},
+			pos:  position{line: 5582, col: 1, offset: 170327},
 			expr: &actionExpr{
-				pos: position{line: 5557, col: 21, offset: 169662},
+				pos: position{line: 5582, col: 21, offset: 170347},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5557, col: 21, offset: 169662},
+					pos: position{line: 5582, col: 21, offset: 170347},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5557, col: 21, offset: 169662},
+							pos:  position{line: 5582, col: 21, offset: 170347},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5557, col: 26, offset: 169667},
+							pos:  position{line: 5582, col: 26, offset: 170352},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5557, col: 42, offset: 169683},
+							pos:   position{line: 5582, col: 42, offset: 170368},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5557, col: 60, offset: 169701},
+								pos: position{line: 5582, col: 60, offset: 170386},
 								expr: &seqExpr{
-									pos: position{line: 5557, col: 61, offset: 169702},
+									pos: position{line: 5582, col: 61, offset: 170387},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5557, col: 61, offset: 169702},
+											pos:  position{line: 5582, col: 61, offset: 170387},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5557, col: 83, offset: 169724},
+											pos:  position{line: 5582, col: 83, offset: 170409},
 											name: "SPACE",
 										},
 									},
@@ -13797,20 +13805,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5557, col: 91, offset: 169732},
+							pos:   position{line: 5582, col: 91, offset: 170417},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5557, col: 101, offset: 169742},
+								pos:  position{line: 5582, col: 101, offset: 170427},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5557, col: 109, offset: 169750},
+							pos:   position{line: 5582, col: 109, offset: 170435},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5557, col: 121, offset: 169762},
+								pos: position{line: 5582, col: 121, offset: 170447},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5557, col: 122, offset: 169763},
+									pos:  position{line: 5582, col: 122, offset: 170448},
 									name: "WhereClause",
 								},
 							},
@@ -13821,15 +13829,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5580, col: 1, offset: 170451},
+			pos:  position{line: 5605, col: 1, offset: 171136},
 			expr: &actionExpr{
-				pos: position{line: 5580, col: 24, offset: 170474},
+				pos: position{line: 5605, col: 24, offset: 171159},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5580, col: 24, offset: 170474},
+					pos:   position{line: 5605, col: 24, offset: 171159},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5580, col: 41, offset: 170491},
+						pos:  position{line: 5605, col: 41, offset: 171176},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13837,26 +13845,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5591, col: 1, offset: 170890},
+			pos:  position{line: 5616, col: 1, offset: 171575},
 			expr: &actionExpr{
-				pos: position{line: 5591, col: 20, offset: 170909},
+				pos: position{line: 5616, col: 20, offset: 171594},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5591, col: 20, offset: 170909},
+					pos:   position{line: 5616, col: 20, offset: 171594},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5591, col: 28, offset: 170917},
+						pos: position{line: 5616, col: 28, offset: 171602},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5591, col: 28, offset: 170917},
+								pos:  position{line: 5616, col: 28, offset: 171602},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5591, col: 52, offset: 170941},
+								pos:  position{line: 5616, col: 52, offset: 171626},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5591, col: 68, offset: 170957},
+								pos:  position{line: 5616, col: 68, offset: 171642},
 								name: "MaxOutOption",
 							},
 						},
@@ -13866,28 +13874,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5596, col: 1, offset: 171055},
+			pos:  position{line: 5621, col: 1, offset: 171740},
 			expr: &actionExpr{
-				pos: position{line: 5596, col: 26, offset: 171080},
+				pos: position{line: 5621, col: 26, offset: 171765},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5596, col: 26, offset: 171080},
+					pos: position{line: 5621, col: 26, offset: 171765},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5596, col: 26, offset: 171080},
+							pos:        position{line: 5621, col: 26, offset: 171765},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5596, col: 44, offset: 171098},
+							pos:  position{line: 5621, col: 44, offset: 171783},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5596, col: 50, offset: 171104},
+							pos:   position{line: 5621, col: 50, offset: 171789},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5596, col: 58, offset: 171112},
+								pos:  position{line: 5621, col: 58, offset: 171797},
 								name: "Boolean",
 							},
 						},
@@ -13897,28 +13905,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5603, col: 1, offset: 171251},
+			pos:  position{line: 5628, col: 1, offset: 171936},
 			expr: &actionExpr{
-				pos: position{line: 5603, col: 18, offset: 171268},
+				pos: position{line: 5628, col: 18, offset: 171953},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5603, col: 18, offset: 171268},
+					pos: position{line: 5628, col: 18, offset: 171953},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5603, col: 18, offset: 171268},
+							pos:        position{line: 5628, col: 18, offset: 171953},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5603, col: 28, offset: 171278},
+							pos:  position{line: 5628, col: 28, offset: 171963},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5603, col: 34, offset: 171284},
+							pos:   position{line: 5628, col: 34, offset: 171969},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5603, col: 39, offset: 171289},
+								pos:  position{line: 5628, col: 39, offset: 171974},
 								name: "IntegerAsString",
 							},
 						},
@@ -13928,28 +13936,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5614, col: 1, offset: 171590},
+			pos:  position{line: 5639, col: 1, offset: 172275},
 			expr: &actionExpr{
-				pos: position{line: 5614, col: 17, offset: 171606},
+				pos: position{line: 5639, col: 17, offset: 172291},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5614, col: 17, offset: 171606},
+					pos: position{line: 5639, col: 17, offset: 172291},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5614, col: 17, offset: 171606},
+							pos:        position{line: 5639, col: 17, offset: 172291},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5614, col: 26, offset: 171615},
+							pos:  position{line: 5639, col: 26, offset: 172300},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5614, col: 32, offset: 171621},
+							pos:   position{line: 5639, col: 32, offset: 172306},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5614, col: 36, offset: 171625},
+								pos:  position{line: 5639, col: 36, offset: 172310},
 								name: "IntegerAsString",
 							},
 						},
@@ -13959,43 +13967,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5626, col: 1, offset: 171980},
+			pos:  position{line: 5651, col: 1, offset: 172665},
 			expr: &actionExpr{
-				pos: position{line: 5626, col: 14, offset: 171993},
+				pos: position{line: 5651, col: 14, offset: 172678},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5626, col: 14, offset: 171993},
+					pos: position{line: 5651, col: 14, offset: 172678},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5626, col: 14, offset: 171993},
+							pos:        position{line: 5651, col: 14, offset: 172678},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5626, col: 18, offset: 171997},
+							pos: position{line: 5651, col: 18, offset: 172682},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5626, col: 18, offset: 171997},
+								pos:  position{line: 5651, col: 18, offset: 172682},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5626, col: 25, offset: 172004},
+							pos:   position{line: 5651, col: 25, offset: 172689},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5626, col: 32, offset: 172011},
+								pos:  position{line: 5651, col: 32, offset: 172696},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5626, col: 44, offset: 172023},
+							pos: position{line: 5651, col: 44, offset: 172708},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5626, col: 44, offset: 172023},
+								pos:  position{line: 5651, col: 44, offset: 172708},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5626, col: 51, offset: 172030},
+							pos:        position{line: 5651, col: 51, offset: 172715},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14006,35 +14014,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5631, col: 1, offset: 172119},
+			pos:  position{line: 5656, col: 1, offset: 172804},
 			expr: &actionExpr{
-				pos: position{line: 5631, col: 25, offset: 172143},
+				pos: position{line: 5656, col: 25, offset: 172828},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5631, col: 25, offset: 172143},
+					pos: position{line: 5656, col: 25, offset: 172828},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5631, col: 25, offset: 172143},
+							pos:   position{line: 5656, col: 25, offset: 172828},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5631, col: 31, offset: 172149},
+								pos:  position{line: 5656, col: 31, offset: 172834},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5631, col: 47, offset: 172165},
+							pos:   position{line: 5656, col: 47, offset: 172850},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5631, col: 52, offset: 172170},
+								pos: position{line: 5656, col: 52, offset: 172855},
 								expr: &seqExpr{
-									pos: position{line: 5631, col: 53, offset: 172171},
+									pos: position{line: 5656, col: 53, offset: 172856},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5631, col: 53, offset: 172171},
+											pos:  position{line: 5656, col: 53, offset: 172856},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5631, col: 59, offset: 172177},
+											pos:  position{line: 5656, col: 59, offset: 172862},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14047,37 +14055,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5658, col: 1, offset: 172987},
+			pos:  position{line: 5683, col: 1, offset: 173672},
 			expr: &actionExpr{
-				pos: position{line: 5658, col: 16, offset: 173002},
+				pos: position{line: 5683, col: 16, offset: 173687},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5658, col: 16, offset: 173002},
+					pos: position{line: 5683, col: 16, offset: 173687},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5658, col: 16, offset: 173002},
+							pos:  position{line: 5683, col: 16, offset: 173687},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5658, col: 21, offset: 173007},
+							pos:  position{line: 5683, col: 21, offset: 173692},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5658, col: 32, offset: 173018},
+							pos:   position{line: 5683, col: 32, offset: 173703},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5658, col: 40, offset: 173026},
+								pos: position{line: 5683, col: 40, offset: 173711},
 								expr: &seqExpr{
-									pos: position{line: 5658, col: 41, offset: 173027},
+									pos: position{line: 5683, col: 41, offset: 173712},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5658, col: 41, offset: 173027},
+											pos:  position{line: 5683, col: 41, offset: 173712},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5658, col: 57, offset: 173043},
+											pos: position{line: 5683, col: 57, offset: 173728},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5658, col: 57, offset: 173043},
+												pos:  position{line: 5683, col: 57, offset: 173728},
 												name: "SPACE",
 											},
 										},
@@ -14086,10 +14094,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5658, col: 66, offset: 173052},
+							pos:   position{line: 5683, col: 66, offset: 173737},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5658, col: 76, offset: 173062},
+								pos:  position{line: 5683, col: 76, offset: 173747},
 								name: "Subsearch",
 							},
 						},
@@ -14099,45 +14107,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5700, col: 1, offset: 174599},
+			pos:  position{line: 5725, col: 1, offset: 175284},
 			expr: &actionExpr{
-				pos: position{line: 5700, col: 17, offset: 174615},
+				pos: position{line: 5725, col: 17, offset: 175300},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5700, col: 17, offset: 174615},
+					pos: position{line: 5725, col: 17, offset: 175300},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5700, col: 17, offset: 174615},
+							pos:  position{line: 5725, col: 17, offset: 175300},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5700, col: 23, offset: 174621},
+							pos:   position{line: 5725, col: 23, offset: 175306},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5700, col: 31, offset: 174629},
+								pos: position{line: 5725, col: 31, offset: 175314},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 31, offset: 174629},
+										pos:  position{line: 5725, col: 31, offset: 175314},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 54, offset: 174652},
+										pos:  position{line: 5725, col: 54, offset: 175337},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 74, offset: 174672},
+										pos:  position{line: 5725, col: 74, offset: 175357},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 91, offset: 174689},
+										pos:  position{line: 5725, col: 91, offset: 175374},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 115, offset: 174713},
+										pos:  position{line: 5725, col: 115, offset: 175398},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5700, col: 135, offset: 174733},
+										pos:  position{line: 5725, col: 135, offset: 175418},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14149,51 +14157,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5704, col: 1, offset: 174788},
+			pos:  position{line: 5729, col: 1, offset: 175473},
 			expr: &actionExpr{
-				pos: position{line: 5704, col: 25, offset: 174812},
+				pos: position{line: 5729, col: 25, offset: 175497},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5704, col: 26, offset: 174813},
+					pos: position{line: 5729, col: 26, offset: 175498},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5704, col: 26, offset: 174813},
+							pos:   position{line: 5729, col: 26, offset: 175498},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5704, col: 33, offset: 174820},
+								pos: position{line: 5729, col: 33, offset: 175505},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5704, col: 33, offset: 174820},
+										pos:        position{line: 5729, col: 33, offset: 175505},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5704, col: 42, offset: 174829},
+										pos:        position{line: 5729, col: 42, offset: 175514},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5704, col: 51, offset: 174838},
+										pos:        position{line: 5729, col: 51, offset: 175523},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5704, col: 60, offset: 174847},
+										pos:        position{line: 5729, col: 60, offset: 175532},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5704, col: 68, offset: 174855},
+										pos:        position{line: 5729, col: 68, offset: 175540},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5704, col: 76, offset: 174863},
+										pos:        position{line: 5729, col: 76, offset: 175548},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14202,19 +14210,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5704, col: 84, offset: 174871},
+							pos:  position{line: 5729, col: 84, offset: 175556},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5704, col: 92, offset: 174879},
+							pos:   position{line: 5729, col: 92, offset: 175564},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5704, col: 105, offset: 174892},
+								pos:  position{line: 5729, col: 105, offset: 175577},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5704, col: 116, offset: 174903},
+							pos:  position{line: 5729, col: 116, offset: 175588},
 							name: "R_PAREN",
 						},
 					},
@@ -14223,15 +14231,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5730, col: 1, offset: 175661},
+			pos:  position{line: 5755, col: 1, offset: 176346},
 			expr: &actionExpr{
-				pos: position{line: 5730, col: 30, offset: 175690},
+				pos: position{line: 5755, col: 30, offset: 176375},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5730, col: 30, offset: 175690},
+					pos:   position{line: 5755, col: 30, offset: 176375},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5730, col: 43, offset: 175703},
+						pos:  position{line: 5755, col: 43, offset: 176388},
 						name: "StringExpr",
 					},
 				},
@@ -14239,61 +14247,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5755, col: 1, offset: 176411},
+			pos:  position{line: 5780, col: 1, offset: 177096},
 			expr: &actionExpr{
-				pos: position{line: 5755, col: 22, offset: 176432},
+				pos: position{line: 5780, col: 22, offset: 177117},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5755, col: 22, offset: 176432},
+					pos: position{line: 5780, col: 22, offset: 177117},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5755, col: 22, offset: 176432},
+							pos:        position{line: 5780, col: 22, offset: 177117},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5755, col: 37, offset: 176447},
+							pos:  position{line: 5780, col: 37, offset: 177132},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5755, col: 43, offset: 176453},
+							pos:   position{line: 5780, col: 43, offset: 177138},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5755, col: 50, offset: 176460},
+								pos: position{line: 5780, col: 50, offset: 177145},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5755, col: 50, offset: 176460},
+										pos:        position{line: 5780, col: 50, offset: 177145},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5755, col: 59, offset: 176469},
+										pos:        position{line: 5780, col: 59, offset: 177154},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5755, col: 68, offset: 176478},
+										pos:        position{line: 5780, col: 68, offset: 177163},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5755, col: 77, offset: 176487},
+										pos:        position{line: 5780, col: 77, offset: 177172},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5755, col: 85, offset: 176495},
+										pos:        position{line: 5780, col: 85, offset: 177180},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5755, col: 93, offset: 176503},
+										pos:        position{line: 5780, col: 93, offset: 177188},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14307,28 +14315,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5768, col: 1, offset: 176832},
+			pos:  position{line: 5793, col: 1, offset: 177517},
 			expr: &actionExpr{
-				pos: position{line: 5768, col: 19, offset: 176850},
+				pos: position{line: 5793, col: 19, offset: 177535},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5768, col: 19, offset: 176850},
+					pos: position{line: 5793, col: 19, offset: 177535},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5768, col: 19, offset: 176850},
+							pos:        position{line: 5793, col: 19, offset: 177535},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5768, col: 31, offset: 176862},
+							pos:  position{line: 5793, col: 31, offset: 177547},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5768, col: 37, offset: 176868},
+							pos:   position{line: 5793, col: 37, offset: 177553},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5768, col: 45, offset: 176876},
+								pos:  position{line: 5793, col: 45, offset: 177561},
 								name: "Boolean",
 							},
 						},
@@ -14338,28 +14346,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5775, col: 1, offset: 176999},
+			pos:  position{line: 5800, col: 1, offset: 177684},
 			expr: &actionExpr{
-				pos: position{line: 5775, col: 26, offset: 177024},
+				pos: position{line: 5800, col: 26, offset: 177709},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5775, col: 26, offset: 177024},
+					pos: position{line: 5800, col: 26, offset: 177709},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5775, col: 26, offset: 177024},
+							pos:        position{line: 5800, col: 26, offset: 177709},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5775, col: 45, offset: 177043},
+							pos:  position{line: 5800, col: 45, offset: 177728},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5775, col: 51, offset: 177049},
+							pos:   position{line: 5800, col: 51, offset: 177734},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5775, col: 59, offset: 177057},
+								pos:  position{line: 5800, col: 59, offset: 177742},
 								name: "Boolean",
 							},
 						},
@@ -14369,28 +14377,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5782, col: 1, offset: 177187},
+			pos:  position{line: 5807, col: 1, offset: 177872},
 			expr: &actionExpr{
-				pos: position{line: 5782, col: 22, offset: 177208},
+				pos: position{line: 5807, col: 22, offset: 177893},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5782, col: 22, offset: 177208},
+					pos: position{line: 5807, col: 22, offset: 177893},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5782, col: 22, offset: 177208},
+							pos:        position{line: 5807, col: 22, offset: 177893},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5782, col: 37, offset: 177223},
+							pos:  position{line: 5807, col: 37, offset: 177908},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5782, col: 43, offset: 177229},
+							pos:   position{line: 5807, col: 43, offset: 177914},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5782, col: 50, offset: 177236},
+								pos:  position{line: 5807, col: 50, offset: 177921},
 								name: "String",
 							},
 						},
@@ -14400,28 +14408,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5789, col: 1, offset: 177362},
+			pos:  position{line: 5814, col: 1, offset: 178047},
 			expr: &actionExpr{
-				pos: position{line: 5789, col: 16, offset: 177377},
+				pos: position{line: 5814, col: 16, offset: 178062},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5789, col: 16, offset: 177377},
+					pos: position{line: 5814, col: 16, offset: 178062},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5789, col: 16, offset: 177377},
+							pos:  position{line: 5814, col: 16, offset: 178062},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5789, col: 21, offset: 177382},
+							pos:  position{line: 5814, col: 21, offset: 178067},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5789, col: 32, offset: 177393},
+							pos:   position{line: 5814, col: 32, offset: 178078},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5789, col: 40, offset: 177401},
+								pos: position{line: 5814, col: 40, offset: 178086},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5789, col: 41, offset: 177402},
+									pos:  position{line: 5814, col: 41, offset: 178087},
 									name: "ToJsonOption",
 								},
 							},
@@ -14432,132 +14440,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5842, col: 1, offset: 179484},
+			pos:  position{line: 5867, col: 1, offset: 180169},
 			expr: &choiceExpr{
-				pos: position{line: 5842, col: 12, offset: 179495},
+				pos: position{line: 5867, col: 12, offset: 180180},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 12, offset: 179495},
+						pos:  position{line: 5867, col: 12, offset: 180180},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 24, offset: 179507},
+						pos:  position{line: 5867, col: 24, offset: 180192},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 36, offset: 179519},
+						pos:  position{line: 5867, col: 36, offset: 180204},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 49, offset: 179532},
+						pos:  position{line: 5867, col: 49, offset: 180217},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 61, offset: 179544},
+						pos:  position{line: 5867, col: 61, offset: 180229},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 81, offset: 179564},
+						pos:  position{line: 5867, col: 81, offset: 180249},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 92, offset: 179575},
+						pos:  position{line: 5867, col: 92, offset: 180260},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 112, offset: 179595},
+						pos:  position{line: 5867, col: 112, offset: 180280},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 123, offset: 179606},
+						pos:  position{line: 5867, col: 123, offset: 180291},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 134, offset: 179617},
+						pos:  position{line: 5867, col: 134, offset: 180302},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 144, offset: 179627},
+						pos:  position{line: 5867, col: 144, offset: 180312},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 154, offset: 179637},
+						pos:  position{line: 5867, col: 154, offset: 180322},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 165, offset: 179648},
+						pos:  position{line: 5867, col: 165, offset: 180333},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 178, offset: 179661},
+						pos:  position{line: 5867, col: 178, offset: 180346},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 194, offset: 179677},
+						pos:  position{line: 5867, col: 194, offset: 180362},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 212, offset: 179695},
+						pos:  position{line: 5867, col: 212, offset: 180380},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 224, offset: 179707},
+						pos:  position{line: 5867, col: 224, offset: 180392},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 235, offset: 179718},
+						pos:  position{line: 5867, col: 235, offset: 180403},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 248, offset: 179731},
+						pos:  position{line: 5867, col: 248, offset: 180416},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 260, offset: 179743},
+						pos:  position{line: 5867, col: 260, offset: 180428},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 273, offset: 179756},
+						pos:  position{line: 5867, col: 273, offset: 180441},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 288, offset: 179771},
+						pos:  position{line: 5867, col: 288, offset: 180456},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 301, offset: 179784},
+						pos:  position{line: 5867, col: 301, offset: 180469},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 318, offset: 179801},
+						pos:  position{line: 5867, col: 318, offset: 180486},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 328, offset: 179811},
+						pos:  position{line: 5867, col: 328, offset: 180496},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 346, offset: 179829},
+						pos:  position{line: 5867, col: 346, offset: 180514},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 361, offset: 179844},
+						pos:  position{line: 5867, col: 361, offset: 180529},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 376, offset: 179859},
+						pos:  position{line: 5867, col: 376, offset: 180544},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 391, offset: 179874},
+						pos:  position{line: 5867, col: 391, offset: 180559},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 409, offset: 179892},
+						pos:  position{line: 5867, col: 409, offset: 180577},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 422, offset: 179905},
+						pos:  position{line: 5867, col: 422, offset: 180590},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14565,18 +14573,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5843, col: 1, offset: 179917},
+			pos:  position{line: 5868, col: 1, offset: 180602},
 			expr: &seqExpr{
-				pos: position{line: 5843, col: 15, offset: 179931},
+				pos: position{line: 5868, col: 15, offset: 180616},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5843, col: 15, offset: 179931},
+						pos:        position{line: 5868, col: 15, offset: 180616},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5843, col: 24, offset: 179940},
+						pos:  position{line: 5868, col: 24, offset: 180625},
 						name: "SPACE",
 					},
 				},
@@ -14584,18 +14592,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5844, col: 1, offset: 179946},
+			pos:  position{line: 5869, col: 1, offset: 180631},
 			expr: &seqExpr{
-				pos: position{line: 5844, col: 14, offset: 179959},
+				pos: position{line: 5869, col: 14, offset: 180644},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5844, col: 14, offset: 179959},
+						pos:        position{line: 5869, col: 14, offset: 180644},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5844, col: 22, offset: 179967},
+						pos:  position{line: 5869, col: 22, offset: 180652},
 						name: "SPACE",
 					},
 				},
@@ -14603,18 +14611,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5845, col: 1, offset: 179973},
+			pos:  position{line: 5870, col: 1, offset: 180658},
 			expr: &seqExpr{
-				pos: position{line: 5845, col: 14, offset: 179986},
+				pos: position{line: 5870, col: 14, offset: 180671},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5845, col: 14, offset: 179986},
+						pos:        position{line: 5870, col: 14, offset: 180671},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5845, col: 22, offset: 179994},
+						pos:  position{line: 5870, col: 22, offset: 180679},
 						name: "SPACE",
 					},
 				},
@@ -14622,18 +14630,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5846, col: 1, offset: 180000},
+			pos:  position{line: 5871, col: 1, offset: 180685},
 			expr: &seqExpr{
-				pos: position{line: 5846, col: 20, offset: 180019},
+				pos: position{line: 5871, col: 20, offset: 180704},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5846, col: 20, offset: 180019},
+						pos:        position{line: 5871, col: 20, offset: 180704},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5846, col: 34, offset: 180033},
+						pos:  position{line: 5871, col: 34, offset: 180718},
 						name: "SPACE",
 					},
 				},
@@ -14641,18 +14649,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5847, col: 1, offset: 180039},
+			pos:  position{line: 5872, col: 1, offset: 180724},
 			expr: &seqExpr{
-				pos: position{line: 5847, col: 15, offset: 180053},
+				pos: position{line: 5872, col: 15, offset: 180738},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5847, col: 15, offset: 180053},
+						pos:        position{line: 5872, col: 15, offset: 180738},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5847, col: 24, offset: 180062},
+						pos:  position{line: 5872, col: 24, offset: 180747},
 						name: "SPACE",
 					},
 				},
@@ -14660,18 +14668,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5848, col: 1, offset: 180068},
+			pos:  position{line: 5873, col: 1, offset: 180753},
 			expr: &seqExpr{
-				pos: position{line: 5848, col: 14, offset: 180081},
+				pos: position{line: 5873, col: 14, offset: 180766},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5848, col: 14, offset: 180081},
+						pos:        position{line: 5873, col: 14, offset: 180766},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5848, col: 22, offset: 180089},
+						pos:  position{line: 5873, col: 22, offset: 180774},
 						name: "SPACE",
 					},
 				},
@@ -14679,9 +14687,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5849, col: 1, offset: 180095},
+			pos:  position{line: 5874, col: 1, offset: 180780},
 			expr: &litMatcher{
-				pos:        position{line: 5849, col: 22, offset: 180116},
+				pos:        position{line: 5874, col: 22, offset: 180801},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14689,16 +14697,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5850, col: 1, offset: 180123},
+			pos:  position{line: 5875, col: 1, offset: 180808},
 			expr: &seqExpr{
-				pos: position{line: 5850, col: 13, offset: 180135},
+				pos: position{line: 5875, col: 13, offset: 180820},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5850, col: 13, offset: 180135},
+						pos:  position{line: 5875, col: 13, offset: 180820},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5850, col: 31, offset: 180153},
+						pos:  position{line: 5875, col: 31, offset: 180838},
 						name: "SPACE",
 					},
 				},
@@ -14706,9 +14714,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5851, col: 1, offset: 180159},
+			pos:  position{line: 5876, col: 1, offset: 180844},
 			expr: &litMatcher{
-				pos:        position{line: 5851, col: 22, offset: 180180},
+				pos:        position{line: 5876, col: 22, offset: 180865},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14716,16 +14724,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5852, col: 1, offset: 180187},
+			pos:  position{line: 5877, col: 1, offset: 180872},
 			expr: &seqExpr{
-				pos: position{line: 5852, col: 13, offset: 180199},
+				pos: position{line: 5877, col: 13, offset: 180884},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5852, col: 13, offset: 180199},
+						pos:  position{line: 5877, col: 13, offset: 180884},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5852, col: 31, offset: 180217},
+						pos:  position{line: 5877, col: 31, offset: 180902},
 						name: "SPACE",
 					},
 				},
@@ -14733,18 +14741,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5853, col: 1, offset: 180223},
+			pos:  position{line: 5878, col: 1, offset: 180908},
 			expr: &seqExpr{
-				pos: position{line: 5853, col: 13, offset: 180235},
+				pos: position{line: 5878, col: 13, offset: 180920},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5853, col: 13, offset: 180235},
+						pos:        position{line: 5878, col: 13, offset: 180920},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5853, col: 20, offset: 180242},
+						pos:  position{line: 5878, col: 20, offset: 180927},
 						name: "SPACE",
 					},
 				},
@@ -14752,18 +14760,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5854, col: 1, offset: 180248},
+			pos:  position{line: 5879, col: 1, offset: 180933},
 			expr: &seqExpr{
-				pos: position{line: 5854, col: 12, offset: 180259},
+				pos: position{line: 5879, col: 12, offset: 180944},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5854, col: 12, offset: 180259},
+						pos:        position{line: 5879, col: 12, offset: 180944},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5854, col: 18, offset: 180265},
+						pos:  position{line: 5879, col: 18, offset: 180950},
 						name: "SPACE",
 					},
 				},
@@ -14771,18 +14779,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5855, col: 1, offset: 180271},
+			pos:  position{line: 5880, col: 1, offset: 180956},
 			expr: &seqExpr{
-				pos: position{line: 5855, col: 13, offset: 180283},
+				pos: position{line: 5880, col: 13, offset: 180968},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5855, col: 13, offset: 180283},
+						pos:        position{line: 5880, col: 13, offset: 180968},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5855, col: 20, offset: 180290},
+						pos:  position{line: 5880, col: 20, offset: 180975},
 						name: "SPACE",
 					},
 				},
@@ -14790,9 +14798,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5856, col: 1, offset: 180296},
+			pos:  position{line: 5881, col: 1, offset: 180981},
 			expr: &litMatcher{
-				pos:        position{line: 5856, col: 12, offset: 180307},
+				pos:        position{line: 5881, col: 12, offset: 180992},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -14800,9 +14808,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5857, col: 1, offset: 180313},
+			pos:  position{line: 5882, col: 1, offset: 180998},
 			expr: &litMatcher{
-				pos:        position{line: 5857, col: 13, offset: 180325},
+				pos:        position{line: 5882, col: 13, offset: 181010},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -14810,18 +14818,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5858, col: 1, offset: 180332},
+			pos:  position{line: 5883, col: 1, offset: 181017},
 			expr: &seqExpr{
-				pos: position{line: 5858, col: 15, offset: 180346},
+				pos: position{line: 5883, col: 15, offset: 181031},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5858, col: 15, offset: 180346},
+						pos:        position{line: 5883, col: 15, offset: 181031},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5858, col: 24, offset: 180355},
+						pos:  position{line: 5883, col: 24, offset: 181040},
 						name: "SPACE",
 					},
 				},
@@ -14829,18 +14837,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5859, col: 1, offset: 180361},
+			pos:  position{line: 5884, col: 1, offset: 181046},
 			expr: &seqExpr{
-				pos: position{line: 5859, col: 18, offset: 180378},
+				pos: position{line: 5884, col: 18, offset: 181063},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5859, col: 18, offset: 180378},
+						pos:        position{line: 5884, col: 18, offset: 181063},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5859, col: 30, offset: 180390},
+						pos:  position{line: 5884, col: 30, offset: 181075},
 						name: "SPACE",
 					},
 				},
@@ -14848,18 +14856,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5860, col: 1, offset: 180396},
+			pos:  position{line: 5885, col: 1, offset: 181081},
 			expr: &seqExpr{
-				pos: position{line: 5860, col: 12, offset: 180407},
+				pos: position{line: 5885, col: 12, offset: 181092},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5860, col: 12, offset: 180407},
+						pos:        position{line: 5885, col: 12, offset: 181092},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5860, col: 18, offset: 180413},
+						pos:  position{line: 5885, col: 18, offset: 181098},
 						name: "SPACE",
 					},
 				},
@@ -14867,9 +14875,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5861, col: 1, offset: 180419},
+			pos:  position{line: 5886, col: 1, offset: 181104},
 			expr: &litMatcher{
-				pos:        position{line: 5861, col: 13, offset: 180431},
+				pos:        position{line: 5886, col: 13, offset: 181116},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -14877,18 +14885,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5862, col: 1, offset: 180438},
+			pos:  position{line: 5887, col: 1, offset: 181123},
 			expr: &seqExpr{
-				pos: position{line: 5862, col: 20, offset: 180457},
+				pos: position{line: 5887, col: 20, offset: 181142},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5862, col: 20, offset: 180457},
+						pos:        position{line: 5887, col: 20, offset: 181142},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5862, col: 34, offset: 180471},
+						pos:  position{line: 5887, col: 34, offset: 181156},
 						name: "SPACE",
 					},
 				},
@@ -14896,9 +14904,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5863, col: 1, offset: 180477},
+			pos:  position{line: 5888, col: 1, offset: 181162},
 			expr: &litMatcher{
-				pos:        position{line: 5863, col: 14, offset: 180490},
+				pos:        position{line: 5888, col: 14, offset: 181175},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -14906,22 +14914,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5864, col: 1, offset: 180498},
+			pos:  position{line: 5889, col: 1, offset: 181183},
 			expr: &seqExpr{
-				pos: position{line: 5864, col: 21, offset: 180518},
+				pos: position{line: 5889, col: 21, offset: 181203},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5864, col: 21, offset: 180518},
+						pos:  position{line: 5889, col: 21, offset: 181203},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5864, col: 27, offset: 180524},
+						pos:        position{line: 5889, col: 27, offset: 181209},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5864, col: 36, offset: 180533},
+						pos:  position{line: 5889, col: 36, offset: 181218},
 						name: "SPACE",
 					},
 				},
@@ -14929,9 +14937,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5865, col: 1, offset: 180539},
+			pos:  position{line: 5890, col: 1, offset: 181224},
 			expr: &litMatcher{
-				pos:        position{line: 5865, col: 15, offset: 180553},
+				pos:        position{line: 5890, col: 15, offset: 181238},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14939,9 +14947,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5866, col: 1, offset: 180562},
+			pos:  position{line: 5891, col: 1, offset: 181247},
 			expr: &litMatcher{
-				pos:        position{line: 5866, col: 14, offset: 180575},
+				pos:        position{line: 5891, col: 14, offset: 181260},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14949,9 +14957,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5867, col: 1, offset: 180583},
+			pos:  position{line: 5892, col: 1, offset: 181268},
 			expr: &litMatcher{
-				pos:        position{line: 5867, col: 15, offset: 180597},
+				pos:        position{line: 5892, col: 15, offset: 181282},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14959,9 +14967,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5868, col: 1, offset: 180606},
+			pos:  position{line: 5893, col: 1, offset: 181291},
 			expr: &litMatcher{
-				pos:        position{line: 5868, col: 17, offset: 180622},
+				pos:        position{line: 5893, col: 17, offset: 181307},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14969,9 +14977,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5869, col: 1, offset: 180633},
+			pos:  position{line: 5894, col: 1, offset: 181318},
 			expr: &litMatcher{
-				pos:        position{line: 5869, col: 15, offset: 180647},
+				pos:        position{line: 5894, col: 15, offset: 181332},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14979,9 +14987,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5870, col: 1, offset: 180656},
+			pos:  position{line: 5895, col: 1, offset: 181341},
 			expr: &litMatcher{
-				pos:        position{line: 5870, col: 19, offset: 180674},
+				pos:        position{line: 5895, col: 19, offset: 181359},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14989,9 +14997,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5871, col: 1, offset: 180687},
+			pos:  position{line: 5896, col: 1, offset: 181372},
 			expr: &litMatcher{
-				pos:        position{line: 5871, col: 17, offset: 180703},
+				pos:        position{line: 5896, col: 17, offset: 181388},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14999,9 +15007,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5872, col: 1, offset: 180714},
+			pos:  position{line: 5897, col: 1, offset: 181399},
 			expr: &litMatcher{
-				pos:        position{line: 5872, col: 17, offset: 180730},
+				pos:        position{line: 5897, col: 17, offset: 181415},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15009,18 +15017,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5873, col: 1, offset: 180741},
+			pos:  position{line: 5898, col: 1, offset: 181426},
 			expr: &seqExpr{
-				pos: position{line: 5873, col: 20, offset: 180760},
+				pos: position{line: 5898, col: 20, offset: 181445},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5873, col: 20, offset: 180760},
+						pos:        position{line: 5898, col: 20, offset: 181445},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5873, col: 34, offset: 180774},
+						pos:  position{line: 5898, col: 34, offset: 181459},
 						name: "SPACE",
 					},
 				},
@@ -15028,28 +15036,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5874, col: 1, offset: 180780},
+			pos:  position{line: 5899, col: 1, offset: 181465},
 			expr: &seqExpr{
-				pos: position{line: 5874, col: 16, offset: 180795},
+				pos: position{line: 5899, col: 16, offset: 181480},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5874, col: 16, offset: 180795},
+						pos: position{line: 5899, col: 16, offset: 181480},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5874, col: 16, offset: 180795},
+							pos:  position{line: 5899, col: 16, offset: 181480},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5874, col: 24, offset: 180803},
+						pos: position{line: 5899, col: 24, offset: 181488},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5874, col: 24, offset: 180803},
+								pos:        position{line: 5899, col: 24, offset: 181488},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5874, col: 30, offset: 180809},
+								pos:        position{line: 5899, col: 30, offset: 181494},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15057,9 +15065,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5874, col: 35, offset: 180814},
+						pos: position{line: 5899, col: 35, offset: 181499},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5874, col: 35, offset: 180814},
+							pos:  position{line: 5899, col: 35, offset: 181499},
 							name: "SPACE",
 						},
 					},
@@ -15068,9 +15076,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5875, col: 1, offset: 180821},
+			pos:  position{line: 5900, col: 1, offset: 181506},
 			expr: &litMatcher{
-				pos:        position{line: 5875, col: 17, offset: 180837},
+				pos:        position{line: 5900, col: 17, offset: 181522},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15078,18 +15086,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5876, col: 1, offset: 180848},
+			pos:  position{line: 5901, col: 1, offset: 181533},
 			expr: &seqExpr{
-				pos: position{line: 5876, col: 15, offset: 180862},
+				pos: position{line: 5901, col: 15, offset: 181547},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5876, col: 15, offset: 180862},
+						pos:        position{line: 5901, col: 15, offset: 181547},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5876, col: 24, offset: 180871},
+						pos:  position{line: 5901, col: 24, offset: 181556},
 						name: "SPACE",
 					},
 				},
@@ -15097,9 +15105,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5877, col: 1, offset: 180877},
+			pos:  position{line: 5902, col: 1, offset: 181562},
 			expr: &litMatcher{
-				pos:        position{line: 5877, col: 15, offset: 180891},
+				pos:        position{line: 5902, col: 15, offset: 181576},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15107,115 +15115,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5880, col: 1, offset: 181004},
+			pos:  position{line: 5905, col: 1, offset: 181689},
 			expr: &choiceExpr{
-				pos: position{line: 5880, col: 16, offset: 181019},
+				pos: position{line: 5905, col: 16, offset: 181704},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5880, col: 16, offset: 181019},
+						pos:        position{line: 5905, col: 16, offset: 181704},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 47, offset: 181050},
+						pos:        position{line: 5905, col: 47, offset: 181735},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 55, offset: 181058},
+						pos:        position{line: 5905, col: 55, offset: 181743},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 16, offset: 181081},
+						pos:        position{line: 5906, col: 16, offset: 181766},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 26, offset: 181091},
+						pos:        position{line: 5906, col: 26, offset: 181776},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 34, offset: 181099},
+						pos:        position{line: 5906, col: 34, offset: 181784},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 42, offset: 181107},
+						pos:        position{line: 5906, col: 42, offset: 181792},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 50, offset: 181115},
+						pos:        position{line: 5906, col: 50, offset: 181800},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 58, offset: 181123},
+						pos:        position{line: 5906, col: 58, offset: 181808},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 66, offset: 181131},
+						pos:        position{line: 5906, col: 66, offset: 181816},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 16, offset: 181153},
+						pos:        position{line: 5907, col: 16, offset: 181838},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 26, offset: 181163},
+						pos:        position{line: 5907, col: 26, offset: 181848},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 34, offset: 181171},
+						pos:        position{line: 5907, col: 34, offset: 181856},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 42, offset: 181179},
+						pos:        position{line: 5907, col: 42, offset: 181864},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 50, offset: 181187},
+						pos:        position{line: 5907, col: 50, offset: 181872},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 58, offset: 181195},
+						pos:        position{line: 5907, col: 58, offset: 181880},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 66, offset: 181203},
+						pos:        position{line: 5907, col: 66, offset: 181888},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5882, col: 74, offset: 181211},
+						pos:        position{line: 5907, col: 74, offset: 181896},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15225,25 +15233,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5883, col: 1, offset: 181217},
+			pos:  position{line: 5908, col: 1, offset: 181902},
 			expr: &choiceExpr{
-				pos: position{line: 5883, col: 16, offset: 181232},
+				pos: position{line: 5908, col: 16, offset: 181917},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5883, col: 16, offset: 181232},
+						pos:        position{line: 5908, col: 16, offset: 181917},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5883, col: 30, offset: 181246},
+						pos:        position{line: 5908, col: 30, offset: 181931},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5883, col: 36, offset: 181252},
+						pos:        position{line: 5908, col: 36, offset: 181937},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15253,18 +15261,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5887, col: 1, offset: 181408},
+			pos:  position{line: 5912, col: 1, offset: 182093},
 			expr: &seqExpr{
-				pos: position{line: 5887, col: 8, offset: 181415},
+				pos: position{line: 5912, col: 8, offset: 182100},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5887, col: 8, offset: 181415},
+						pos:        position{line: 5912, col: 8, offset: 182100},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5887, col: 14, offset: 181421},
+						pos:  position{line: 5912, col: 14, offset: 182106},
 						name: "SPACE",
 					},
 				},
@@ -15272,22 +15280,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5888, col: 1, offset: 181427},
+			pos:  position{line: 5913, col: 1, offset: 182112},
 			expr: &seqExpr{
-				pos: position{line: 5888, col: 7, offset: 181433},
+				pos: position{line: 5913, col: 7, offset: 182118},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5888, col: 7, offset: 181433},
+						pos:  position{line: 5913, col: 7, offset: 182118},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5888, col: 13, offset: 181439},
+						pos:        position{line: 5913, col: 13, offset: 182124},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5888, col: 18, offset: 181444},
+						pos:  position{line: 5913, col: 18, offset: 182129},
 						name: "SPACE",
 					},
 				},
@@ -15295,22 +15303,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5889, col: 1, offset: 181450},
+			pos:  position{line: 5914, col: 1, offset: 182135},
 			expr: &seqExpr{
-				pos: position{line: 5889, col: 8, offset: 181457},
+				pos: position{line: 5914, col: 8, offset: 182142},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 8, offset: 181457},
+						pos:  position{line: 5914, col: 8, offset: 182142},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5889, col: 14, offset: 181463},
+						pos:        position{line: 5914, col: 14, offset: 182148},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 20, offset: 181469},
+						pos:  position{line: 5914, col: 20, offset: 182154},
 						name: "SPACE",
 					},
 				},
@@ -15318,22 +15326,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5890, col: 1, offset: 181475},
+			pos:  position{line: 5915, col: 1, offset: 182160},
 			expr: &seqExpr{
-				pos: position{line: 5890, col: 9, offset: 181483},
+				pos: position{line: 5915, col: 9, offset: 182168},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5890, col: 9, offset: 181483},
+						pos:  position{line: 5915, col: 9, offset: 182168},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5890, col: 24, offset: 181498},
+						pos:        position{line: 5915, col: 24, offset: 182183},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5890, col: 28, offset: 181502},
+						pos:  position{line: 5915, col: 28, offset: 182187},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15341,22 +15349,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5891, col: 1, offset: 181517},
+			pos:  position{line: 5916, col: 1, offset: 182202},
 			expr: &seqExpr{
-				pos: position{line: 5891, col: 7, offset: 181523},
+				pos: position{line: 5916, col: 7, offset: 182208},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5891, col: 7, offset: 181523},
+						pos:  position{line: 5916, col: 7, offset: 182208},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5891, col: 13, offset: 181529},
+						pos:        position{line: 5916, col: 13, offset: 182214},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5891, col: 19, offset: 181535},
+						pos:  position{line: 5916, col: 19, offset: 182220},
 						name: "SPACE",
 					},
 				},
@@ -15364,22 +15372,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5892, col: 1, offset: 181561},
+			pos:  position{line: 5917, col: 1, offset: 182246},
 			expr: &seqExpr{
-				pos: position{line: 5892, col: 7, offset: 181567},
+				pos: position{line: 5917, col: 7, offset: 182252},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5892, col: 7, offset: 181567},
+						pos:  position{line: 5917, col: 7, offset: 182252},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5892, col: 13, offset: 181573},
+						pos:        position{line: 5917, col: 13, offset: 182258},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5892, col: 19, offset: 181579},
+						pos:  position{line: 5917, col: 19, offset: 182264},
 						name: "SPACE",
 					},
 				},
@@ -15387,22 +15395,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5894, col: 1, offset: 181606},
+			pos:  position{line: 5919, col: 1, offset: 182291},
 			expr: &seqExpr{
-				pos: position{line: 5894, col: 10, offset: 181615},
+				pos: position{line: 5919, col: 10, offset: 182300},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5894, col: 10, offset: 181615},
+						pos:  position{line: 5919, col: 10, offset: 182300},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5894, col: 25, offset: 181630},
+						pos:        position{line: 5919, col: 25, offset: 182315},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5894, col: 29, offset: 181634},
+						pos:  position{line: 5919, col: 29, offset: 182319},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15410,22 +15418,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5895, col: 1, offset: 181649},
+			pos:  position{line: 5920, col: 1, offset: 182334},
 			expr: &seqExpr{
-				pos: position{line: 5895, col: 10, offset: 181658},
+				pos: position{line: 5920, col: 10, offset: 182343},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5895, col: 10, offset: 181658},
+						pos:  position{line: 5920, col: 10, offset: 182343},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5895, col: 25, offset: 181673},
+						pos:        position{line: 5920, col: 25, offset: 182358},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5895, col: 29, offset: 181677},
+						pos:  position{line: 5920, col: 29, offset: 182362},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15433,9 +15441,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5896, col: 1, offset: 181692},
+			pos:  position{line: 5921, col: 1, offset: 182377},
 			expr: &litMatcher{
-				pos:        position{line: 5896, col: 10, offset: 181701},
+				pos:        position{line: 5921, col: 10, offset: 182386},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15443,18 +15451,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5897, col: 1, offset: 181705},
+			pos:  position{line: 5922, col: 1, offset: 182390},
 			expr: &seqExpr{
-				pos: position{line: 5897, col: 12, offset: 181716},
+				pos: position{line: 5922, col: 12, offset: 182401},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5897, col: 12, offset: 181716},
+						pos:        position{line: 5922, col: 12, offset: 182401},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5897, col: 16, offset: 181720},
+						pos:  position{line: 5922, col: 16, offset: 182405},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15462,16 +15470,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5898, col: 1, offset: 181735},
+			pos:  position{line: 5923, col: 1, offset: 182420},
 			expr: &seqExpr{
-				pos: position{line: 5898, col: 12, offset: 181746},
+				pos: position{line: 5923, col: 12, offset: 182431},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5898, col: 12, offset: 181746},
+						pos:  position{line: 5923, col: 12, offset: 182431},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5898, col: 27, offset: 181761},
+						pos:        position{line: 5923, col: 27, offset: 182446},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15481,40 +15489,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5900, col: 1, offset: 181766},
+			pos:  position{line: 5925, col: 1, offset: 182451},
 			expr: &notExpr{
-				pos: position{line: 5900, col: 8, offset: 181773},
+				pos: position{line: 5925, col: 8, offset: 182458},
 				expr: &anyMatcher{
-					line: 5900, col: 9, offset: 181774,
+					line: 5925, col: 9, offset: 182459,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5901, col: 1, offset: 181776},
+			pos:  position{line: 5926, col: 1, offset: 182461},
 			expr: &choiceExpr{
-				pos: position{line: 5901, col: 15, offset: 181790},
+				pos: position{line: 5926, col: 15, offset: 182475},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5901, col: 15, offset: 181790},
+						pos:        position{line: 5926, col: 15, offset: 182475},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5901, col: 21, offset: 181796},
+						pos:        position{line: 5926, col: 21, offset: 182481},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5901, col: 28, offset: 181803},
+						pos:        position{line: 5926, col: 28, offset: 182488},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5901, col: 35, offset: 181810},
+						pos:        position{line: 5926, col: 35, offset: 182495},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15524,37 +15532,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5902, col: 1, offset: 181815},
+			pos:  position{line: 5927, col: 1, offset: 182500},
 			expr: &choiceExpr{
-				pos: position{line: 5902, col: 10, offset: 181824},
+				pos: position{line: 5927, col: 10, offset: 182509},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5902, col: 11, offset: 181825},
+						pos: position{line: 5927, col: 11, offset: 182510},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5902, col: 11, offset: 181825},
+								pos: position{line: 5927, col: 11, offset: 182510},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5902, col: 11, offset: 181825},
+									pos:  position{line: 5927, col: 11, offset: 182510},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5902, col: 23, offset: 181837},
+								pos:  position{line: 5927, col: 23, offset: 182522},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5902, col: 31, offset: 181845},
+								pos: position{line: 5927, col: 31, offset: 182530},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5902, col: 31, offset: 181845},
+									pos:  position{line: 5927, col: 31, offset: 182530},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5902, col: 46, offset: 181860},
+						pos: position{line: 5927, col: 46, offset: 182545},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5902, col: 46, offset: 181860},
+							pos:  position{line: 5927, col: 46, offset: 182545},
 							name: "WHITESPACE",
 						},
 					},
@@ -15563,38 +15571,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5903, col: 1, offset: 181872},
+			pos:  position{line: 5928, col: 1, offset: 182557},
 			expr: &seqExpr{
-				pos: position{line: 5903, col: 12, offset: 181883},
+				pos: position{line: 5928, col: 12, offset: 182568},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5903, col: 12, offset: 181883},
+						pos:        position{line: 5928, col: 12, offset: 182568},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5903, col: 18, offset: 181889},
+						pos: position{line: 5928, col: 18, offset: 182574},
 						expr: &seqExpr{
-							pos: position{line: 5903, col: 19, offset: 181890},
+							pos: position{line: 5928, col: 19, offset: 182575},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5903, col: 19, offset: 181890},
+									pos: position{line: 5928, col: 19, offset: 182575},
 									expr: &litMatcher{
-										pos:        position{line: 5903, col: 21, offset: 181892},
+										pos:        position{line: 5928, col: 21, offset: 182577},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5903, col: 28, offset: 181899,
+									line: 5928, col: 28, offset: 182584,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5903, col: 32, offset: 181903},
+						pos:        position{line: 5928, col: 32, offset: 182588},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15604,16 +15612,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5904, col: 1, offset: 181909},
+			pos:  position{line: 5929, col: 1, offset: 182594},
 			expr: &choiceExpr{
-				pos: position{line: 5904, col: 20, offset: 181928},
+				pos: position{line: 5929, col: 20, offset: 182613},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5904, col: 20, offset: 181928},
+						pos:  position{line: 5929, col: 20, offset: 182613},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5904, col: 28, offset: 181936},
+						pos:        position{line: 5929, col: 28, offset: 182621},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15623,16 +15631,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5905, col: 1, offset: 181939},
+			pos:  position{line: 5930, col: 1, offset: 182624},
 			expr: &choiceExpr{
-				pos: position{line: 5905, col: 19, offset: 181957},
+				pos: position{line: 5930, col: 19, offset: 182642},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5905, col: 19, offset: 181957},
+						pos:  position{line: 5930, col: 19, offset: 182642},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5905, col: 27, offset: 181965},
+						pos:  position{line: 5930, col: 27, offset: 182650},
 						name: "SPACE",
 					},
 				},
@@ -20158,6 +20166,7 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 	}
 
 	astDs := make([]*structs.JsonExpr, 1, 5)
+	keyToIdxMap := make(map[string]int)
 
 	key, ok := firstKey.(*structs.JsonExpr)
 	if !ok {
@@ -20175,15 +20184,20 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 		return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
 	}
 
+	rawKey := getRawValJsonObjectKey(key)
+
+	keyToIdxMap[rawKey] = 0
+
 	astDs[0] = &structs.JsonExpr{
 		JsonExprMode: structs.JEMKeyVal,
-		IsTerminal:   true,
+		IsTerminal:   value.JsonExprMode != structs.JEMExpr,
 		Key:          key,
 		Value:        value,
 	}
 
 	var restKey *structs.JsonExpr
 	var restValue *structs.JsonExpr
+
 	if rest != nil {
 		for idx, arg := range rest.([]any) {
 			// Each item in rest is [",", Key, ",", Value]
@@ -20201,12 +20215,23 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 			if !ok {
 				return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
 			}
-			astDs = append(astDs, &structs.JsonExpr{
+
+			rawKey = getRawValJsonObjectKey(restKey)
+
+			keyValueStruct := &structs.JsonExpr{
 				JsonExprMode: structs.JEMKeyVal,
-				IsTerminal:   true,
+				IsTerminal:   restValue.JsonExprMode != structs.JEMExpr,
 				Key:          restKey,
 				Value:        restValue,
-			})
+			}
+
+			var v int
+			if v, ok = keyToIdxMap[rawKey]; ok {
+				astDs[v] = keyValueStruct
+			} else {
+				keyToIdxMap[rawKey] = len(astDs)
+				astDs = append(astDs, keyValueStruct)
+			}
 		}
 	}
 

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"regexp"
@@ -88,6 +87,11 @@ const (
 	TJ_CMD_INCLUDE_INTERNAL
 	TJ_CMD_OUTPUT_FIELD
 )
+
+type JsonExprAstStruct struct {
+	Key   *structs.JsonExpr
+	Value *structs.JsonExpr
+}
 
 func CalculateRelativeTime(timeModifier ast.TimeModifier, currTime time.Time) (int64, error) {
 	var epoch int64 = 0
@@ -291,6 +295,16 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
 		Left:            leftNumericExpr,
 		Right:           rightNumericExpr,
 		NumericExprMode: numericExprMode,
+	}, nil
+}
+
+func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+	return &structs.JsonExpr{
+		IsTerminal:   false,
+		Op:           op,
+		Left:         leftExpr,
+		Right:        rightExpr,
+		JsonExprMode: mode,
 	}, nil
 }
 
@@ -540,177 +554,177 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 527, col: 1, offset: 14904},
+			pos:  position{line: 542, col: 1, offset: 15307},
 			expr: &choiceExpr{
-				pos: position{line: 527, col: 10, offset: 14913},
-				alternatives: []interface{}{
+				pos: position{line: 542, col: 10, offset: 15316},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 527, col: 10, offset: 14913},
+						pos: position{line: 542, col: 10, offset: 15316},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 527, col: 10, offset: 14913},
-							exprs: []interface{}{
+							pos: position{line: 542, col: 10, offset: 15316},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 527, col: 10, offset: 14913},
+									pos:   position{line: 542, col: 10, offset: 15316},
 									label: "indexBlock",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 527, col: 21, offset: 14924},
+										pos: position{line: 542, col: 21, offset: 15327},
 										expr: &ruleRefExpr{
-											pos:  position{line: 527, col: 22, offset: 14925},
+											pos:  position{line: 542, col: 22, offset: 15328},
 											name: "IndexBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 527, col: 35, offset: 14938},
+									pos: position{line: 542, col: 35, offset: 15341},
 									expr: &ruleRefExpr{
-										pos:  position{line: 527, col: 35, offset: 14938},
+										pos:  position{line: 542, col: 35, offset: 15341},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 527, col: 42, offset: 14945},
+									pos:   position{line: 542, col: 42, offset: 15348},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 527, col: 57, offset: 14960},
+										pos:  position{line: 542, col: 57, offset: 15363},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 527, col: 77, offset: 14980},
+									pos:   position{line: 542, col: 77, offset: 15383},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 527, col: 90, offset: 14993},
+										pos: position{line: 542, col: 90, offset: 15396},
 										expr: &ruleRefExpr{
-											pos:  position{line: 527, col: 91, offset: 14994},
+											pos:  position{line: 542, col: 91, offset: 15397},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 527, col: 105, offset: 15008},
+									pos:   position{line: 542, col: 105, offset: 15411},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 527, col: 120, offset: 15023},
+										pos: position{line: 542, col: 120, offset: 15426},
 										expr: &ruleRefExpr{
-											pos:  position{line: 527, col: 121, offset: 15024},
+											pos:  position{line: 542, col: 121, offset: 15427},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 527, col: 144, offset: 15047},
+									pos: position{line: 542, col: 144, offset: 15450},
 									expr: &ruleRefExpr{
-										pos:  position{line: 527, col: 144, offset: 15047},
+										pos:  position{line: 542, col: 144, offset: 15450},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 527, col: 151, offset: 15054},
+									pos:  position{line: 542, col: 151, offset: 15457},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 593, col: 3, offset: 16977},
+						pos: position{line: 608, col: 3, offset: 17380},
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
-							pos: position{line: 593, col: 3, offset: 16977},
-							exprs: []interface{}{
+							pos: position{line: 608, col: 3, offset: 17380},
+							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 593, col: 3, offset: 16977},
+									pos: position{line: 608, col: 3, offset: 17380},
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 3, offset: 16977},
+										pos:  position{line: 608, col: 3, offset: 17380},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 10, offset: 16984},
+									pos:  position{line: 608, col: 10, offset: 17387},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 15, offset: 16989},
+									pos:  position{line: 608, col: 15, offset: 17392},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 28, offset: 17002},
+									pos:  position{line: 608, col: 28, offset: 17405},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 34, offset: 17008},
+									pos:   position{line: 608, col: 34, offset: 17411},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 50, offset: 17024},
+										pos:  position{line: 608, col: 50, offset: 17427},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 593, col: 70, offset: 17044},
+									pos:   position{line: 608, col: 70, offset: 17447},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 593, col: 85, offset: 17059},
+										pos: position{line: 608, col: 85, offset: 17462},
 										expr: &ruleRefExpr{
-											pos:  position{line: 593, col: 86, offset: 17060},
+											pos:  position{line: 608, col: 86, offset: 17463},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 593, col: 109, offset: 17083},
+									pos: position{line: 608, col: 109, offset: 17486},
 									expr: &ruleRefExpr{
-										pos:  position{line: 593, col: 109, offset: 17083},
+										pos:  position{line: 608, col: 109, offset: 17486},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 593, col: 116, offset: 17090},
+									pos:  position{line: 608, col: 116, offset: 17493},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 612, col: 3, offset: 17603},
+						pos: position{line: 627, col: 3, offset: 18006},
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
-							pos: position{line: 612, col: 3, offset: 17603},
-							exprs: []interface{}{
+							pos: position{line: 627, col: 3, offset: 18006},
+							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 612, col: 3, offset: 17603},
+									pos: position{line: 627, col: 3, offset: 18006},
 									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 3, offset: 17603},
+										pos:  position{line: 627, col: 3, offset: 18006},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 612, col: 10, offset: 17610},
+									pos:   position{line: 627, col: 10, offset: 18013},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 22, offset: 17622},
+										pos:  position{line: 627, col: 22, offset: 18025},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 612, col: 39, offset: 17639},
+									pos:   position{line: 627, col: 39, offset: 18042},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 612, col: 54, offset: 17654},
+										pos: position{line: 627, col: 54, offset: 18057},
 										expr: &ruleRefExpr{
-											pos:  position{line: 612, col: 55, offset: 17655},
+											pos:  position{line: 627, col: 55, offset: 18058},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 612, col: 78, offset: 17678},
+									pos: position{line: 627, col: 78, offset: 18081},
 									expr: &ruleRefExpr{
-										pos:  position{line: 612, col: 78, offset: 17678},
+										pos:  position{line: 627, col: 78, offset: 18081},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 612, col: 85, offset: 17685},
+									pos:  position{line: 627, col: 85, offset: 18088},
 									name: "EOF",
 								},
 							},
@@ -721,32 +735,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexAssign",
-			pos:  position{line: 628, col: 1, offset: 18067},
+			pos:  position{line: 643, col: 1, offset: 18470},
 			expr: &actionExpr{
-				pos: position{line: 628, col: 16, offset: 18082},
+				pos: position{line: 643, col: 16, offset: 18485},
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
-					pos: position{line: 628, col: 16, offset: 18082},
-					exprs: []interface{}{
+					pos: position{line: 643, col: 16, offset: 18485},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 628, col: 16, offset: 18082},
+							pos:   position{line: 643, col: 16, offset: 18485},
 							label: "index",
 							expr: &litMatcher{
-								pos:        position{line: 628, col: 23, offset: 18089},
+								pos:        position{line: 643, col: 23, offset: 18492},
 								val:        "_index",
 								ignoreCase: false,
 								want:       "\"_index\"",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 628, col: 33, offset: 18099},
+							pos:  position{line: 643, col: 33, offset: 18502},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 628, col: 39, offset: 18105},
+							pos:   position{line: 643, col: 39, offset: 18508},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 628, col: 49, offset: 18115},
+								pos:  position{line: 643, col: 49, offset: 18518},
 								name: "String",
 							},
 						},
@@ -756,35 +770,35 @@ var g = &grammar{
 		},
 		{
 			name: "IndexExpression",
-			pos:  position{line: 633, col: 1, offset: 18304},
+			pos:  position{line: 648, col: 1, offset: 18707},
 			expr: &actionExpr{
-				pos: position{line: 633, col: 20, offset: 18323},
+				pos: position{line: 648, col: 20, offset: 18726},
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
-					pos: position{line: 633, col: 20, offset: 18323},
-					exprs: []interface{}{
+					pos: position{line: 648, col: 20, offset: 18726},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 633, col: 20, offset: 18323},
+							pos:   position{line: 648, col: 20, offset: 18726},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 633, col: 27, offset: 18330},
+								pos:  position{line: 648, col: 27, offset: 18733},
 								name: "IndexAssign",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 633, col: 40, offset: 18343},
+							pos:   position{line: 648, col: 40, offset: 18746},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 633, col: 45, offset: 18348},
+								pos: position{line: 648, col: 45, offset: 18751},
 								expr: &seqExpr{
-									pos: position{line: 633, col: 46, offset: 18349},
-									exprs: []interface{}{
+									pos: position{line: 648, col: 46, offset: 18752},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 633, col: 46, offset: 18349},
+											pos:  position{line: 648, col: 46, offset: 18752},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 633, col: 49, offset: 18352},
+											pos:  position{line: 648, col: 49, offset: 18755},
 											name: "IndexAssign",
 										},
 									},
@@ -797,32 +811,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexBlock",
-			pos:  position{line: 658, col: 1, offset: 18933},
+			pos:  position{line: 673, col: 1, offset: 19336},
 			expr: &actionExpr{
-				pos: position{line: 658, col: 15, offset: 18947},
+				pos: position{line: 673, col: 15, offset: 19350},
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 658, col: 15, offset: 18947},
-					exprs: []interface{}{
+					pos: position{line: 673, col: 15, offset: 19350},
+					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 658, col: 15, offset: 18947},
+							pos: position{line: 673, col: 15, offset: 19350},
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 15, offset: 18947},
+								pos:  position{line: 673, col: 15, offset: 19350},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 658, col: 22, offset: 18954},
+							pos:   position{line: 673, col: 22, offset: 19357},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 33, offset: 18965},
+								pos:  position{line: 673, col: 33, offset: 19368},
 								name: "IndexExpression",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 658, col: 50, offset: 18982},
+							pos: position{line: 673, col: 50, offset: 19385},
 							expr: &ruleRefExpr{
-								pos:  position{line: 658, col: 50, offset: 18982},
+								pos:  position{line: 673, col: 50, offset: 19385},
 								name: "PIPE",
 							},
 						},
@@ -832,76 +846,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 662, col: 1, offset: 19019},
+			pos:  position{line: 677, col: 1, offset: 19422},
 			expr: &actionExpr{
-				pos: position{line: 662, col: 21, offset: 19039},
+				pos: position{line: 677, col: 21, offset: 19442},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 662, col: 21, offset: 19039},
-					exprs: []interface{}{
+					pos: position{line: 677, col: 21, offset: 19442},
+					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 662, col: 21, offset: 19039},
+							pos:        position{line: 677, col: 21, offset: 19442},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 662, col: 26, offset: 19044},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 662, col: 32, offset: 19050},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 662, col: 36, offset: 19054},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 662, col: 41, offset: 19059},
+							pos:        position{line: 677, col: 26, offset: 19447},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 662, col: 47, offset: 19065},
+							pos:        position{line: 677, col: 32, offset: 19453},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 662, col: 51, offset: 19069},
+							pos:        position{line: 677, col: 36, offset: 19457},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 662, col: 56, offset: 19074},
+							pos:        position{line: 677, col: 41, offset: 19462},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 677, col: 47, offset: 19468},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 677, col: 51, offset: 19472},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 662, col: 61, offset: 19079},
+							pos:        position{line: 677, col: 56, offset: 19477},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 662, col: 66, offset: 19084},
+							pos:        position{line: 677, col: 61, offset: 19482},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 677, col: 66, offset: 19487},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -913,15 +927,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 669, col: 1, offset: 19225},
+			pos:  position{line: 684, col: 1, offset: 19628},
 			expr: &actionExpr{
-				pos: position{line: 669, col: 31, offset: 19255},
+				pos: position{line: 684, col: 31, offset: 19658},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 669, col: 31, offset: 19255},
+					pos:   position{line: 684, col: 31, offset: 19658},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 669, col: 38, offset: 19262},
+						pos:  position{line: 684, col: 38, offset: 19665},
 						name: "IntegerAsString",
 					},
 				},
@@ -929,22 +943,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 687, col: 1, offset: 19905},
+			pos:  position{line: 702, col: 1, offset: 20308},
 			expr: &actionExpr{
-				pos: position{line: 687, col: 26, offset: 19930},
+				pos: position{line: 702, col: 26, offset: 20333},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 687, col: 26, offset: 19930},
+					pos:   position{line: 702, col: 26, offset: 20333},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 687, col: 37, offset: 19941},
-						alternatives: []interface{}{
+						pos: position{line: 702, col: 37, offset: 20344},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 687, col: 37, offset: 19941},
+								pos:  position{line: 702, col: 37, offset: 20344},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 687, col: 53, offset: 19957},
+								pos:  position{line: 702, col: 53, offset: 20360},
 								name: "PartialTimestamp",
 							},
 						},
@@ -954,22 +968,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 696, col: 1, offset: 20215},
+			pos:  position{line: 711, col: 1, offset: 20618},
 			expr: &actionExpr{
-				pos: position{line: 696, col: 17, offset: 20231},
+				pos: position{line: 711, col: 17, offset: 20634},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 696, col: 17, offset: 20231},
+					pos:   position{line: 711, col: 17, offset: 20634},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 696, col: 31, offset: 20245},
-						alternatives: []interface{}{
+						pos: position{line: 711, col: 31, offset: 20648},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 696, col: 31, offset: 20245},
+								pos:  position{line: 711, col: 31, offset: 20648},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 696, col: 55, offset: 20269},
+								pos:  position{line: 711, col: 55, offset: 20672},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -979,28 +993,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 700, col: 1, offset: 20331},
+			pos:  position{line: 715, col: 1, offset: 20734},
 			expr: &actionExpr{
-				pos: position{line: 700, col: 22, offset: 20352},
+				pos: position{line: 715, col: 22, offset: 20755},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 700, col: 22, offset: 20352},
-					exprs: []interface{}{
+					pos: position{line: 715, col: 22, offset: 20755},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 700, col: 22, offset: 20352},
+							pos:        position{line: 715, col: 22, offset: 20755},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 700, col: 28, offset: 20358},
+							pos:  position{line: 715, col: 28, offset: 20761},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 700, col: 34, offset: 20364},
+							pos:   position{line: 715, col: 34, offset: 20767},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 700, col: 45, offset: 20375},
+								pos:  position{line: 715, col: 45, offset: 20778},
 								name: "GenTimestamp",
 							},
 						},
@@ -1010,28 +1024,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 709, col: 1, offset: 20565},
+			pos:  position{line: 724, col: 1, offset: 20968},
 			expr: &actionExpr{
-				pos: position{line: 709, col: 24, offset: 20588},
+				pos: position{line: 724, col: 24, offset: 20991},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 709, col: 24, offset: 20588},
-					exprs: []interface{}{
+					pos: position{line: 724, col: 24, offset: 20991},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 709, col: 24, offset: 20588},
+							pos:        position{line: 724, col: 24, offset: 20991},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 709, col: 32, offset: 20596},
+							pos:  position{line: 724, col: 32, offset: 20999},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 709, col: 38, offset: 20602},
+							pos:   position{line: 724, col: 38, offset: 21005},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 709, col: 49, offset: 20613},
+								pos:  position{line: 724, col: 49, offset: 21016},
 								name: "GenTimestamp",
 							},
 						},
@@ -1041,59 +1055,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 718, col: 1, offset: 20807},
+			pos:  position{line: 733, col: 1, offset: 21210},
 			expr: &actionExpr{
-				pos: position{line: 718, col: 28, offset: 20834},
+				pos: position{line: 733, col: 28, offset: 21237},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 718, col: 28, offset: 20834},
-					exprs: []interface{}{
+					pos: position{line: 733, col: 28, offset: 21237},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 718, col: 28, offset: 20834},
+							pos:        position{line: 733, col: 28, offset: 21237},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 718, col: 40, offset: 20846},
+							pos:  position{line: 733, col: 40, offset: 21249},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 718, col: 46, offset: 20852},
+							pos:   position{line: 733, col: 46, offset: 21255},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 718, col: 53, offset: 20859},
+								pos:  position{line: 733, col: 53, offset: 21262},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 718, col: 69, offset: 20875},
+							pos:   position{line: 733, col: 69, offset: 21278},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 718, col: 77, offset: 20883},
+								pos: position{line: 733, col: 77, offset: 21286},
 								expr: &choiceExpr{
-									pos: position{line: 718, col: 78, offset: 20884},
-									alternatives: []interface{}{
+									pos: position{line: 733, col: 78, offset: 21287},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 718, col: 78, offset: 20884},
+											pos:        position{line: 733, col: 78, offset: 21287},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 718, col: 84, offset: 20890},
+											pos:        position{line: 733, col: 84, offset: 21293},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 718, col: 90, offset: 20896},
+											pos:        position{line: 733, col: 90, offset: 21299},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 718, col: 96, offset: 20902},
+											pos:        position{line: 733, col: 96, offset: 21305},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -1108,26 +1122,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 759, col: 1, offset: 22054},
+			pos:  position{line: 774, col: 1, offset: 22457},
 			expr: &actionExpr{
-				pos: position{line: 759, col: 19, offset: 22072},
+				pos: position{line: 774, col: 19, offset: 22475},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 759, col: 19, offset: 22072},
+					pos:   position{line: 774, col: 19, offset: 22475},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 759, col: 35, offset: 22088},
-						alternatives: []interface{}{
+						pos: position{line: 774, col: 35, offset: 22491},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 759, col: 35, offset: 22088},
+								pos:  position{line: 774, col: 35, offset: 22491},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 759, col: 55, offset: 22108},
+								pos:  position{line: 774, col: 55, offset: 22511},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 759, col: 77, offset: 22130},
+								pos:  position{line: 774, col: 77, offset: 22533},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -1137,35 +1151,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 763, col: 1, offset: 22191},
+			pos:  position{line: 778, col: 1, offset: 22594},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 23, offset: 22213},
+				pos: position{line: 778, col: 23, offset: 22616},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 23, offset: 22213},
-					exprs: []interface{}{
+					pos: position{line: 778, col: 23, offset: 22616},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 763, col: 23, offset: 22213},
+							pos:   position{line: 778, col: 23, offset: 22616},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 29, offset: 22219},
+								pos:  position{line: 778, col: 29, offset: 22622},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 763, col: 44, offset: 22234},
+							pos:   position{line: 778, col: 44, offset: 22637},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 763, col: 49, offset: 22239},
+								pos: position{line: 778, col: 49, offset: 22642},
 								expr: &seqExpr{
-									pos: position{line: 763, col: 50, offset: 22240},
-									exprs: []interface{}{
+									pos: position{line: 778, col: 50, offset: 22643},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 763, col: 50, offset: 22240},
+											pos:  position{line: 778, col: 50, offset: 22643},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 763, col: 56, offset: 22246},
+											pos:  position{line: 778, col: 56, offset: 22649},
 											name: "GenTimesOption",
 										},
 									},
@@ -1178,25 +1192,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 815, col: 1, offset: 23999},
+			pos:  position{line: 830, col: 1, offset: 24402},
 			expr: &actionExpr{
-				pos: position{line: 815, col: 23, offset: 24021},
+				pos: position{line: 830, col: 23, offset: 24424},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 815, col: 23, offset: 24021},
-					exprs: []interface{}{
+					pos: position{line: 830, col: 23, offset: 24424},
+					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 815, col: 23, offset: 24021},
+							pos: position{line: 830, col: 23, offset: 24424},
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 23, offset: 24021},
+								pos:  position{line: 830, col: 23, offset: 24424},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 815, col: 35, offset: 24033},
+							pos:   position{line: 830, col: 35, offset: 24436},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 815, col: 42, offset: 24040},
+								pos:  position{line: 830, col: 42, offset: 24443},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1206,32 +1220,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 819, col: 1, offset: 24081},
+			pos:  position{line: 834, col: 1, offset: 24484},
 			expr: &actionExpr{
-				pos: position{line: 819, col: 16, offset: 24096},
+				pos: position{line: 834, col: 16, offset: 24499},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 819, col: 16, offset: 24096},
-					exprs: []interface{}{
+					pos: position{line: 834, col: 16, offset: 24499},
+					exprs: []any{
 						&notExpr{
-							pos: position{line: 819, col: 16, offset: 24096},
+							pos: position{line: 834, col: 16, offset: 24499},
 							expr: &ruleRefExpr{
-								pos:  position{line: 819, col: 18, offset: 24098},
+								pos:  position{line: 834, col: 18, offset: 24501},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 819, col: 26, offset: 24106},
+							pos: position{line: 834, col: 26, offset: 24509},
 							expr: &ruleRefExpr{
-								pos:  position{line: 819, col: 26, offset: 24106},
+								pos:  position{line: 834, col: 26, offset: 24509},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 819, col: 38, offset: 24118},
+							pos:   position{line: 834, col: 38, offset: 24521},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 819, col: 45, offset: 24125},
+								pos:  position{line: 834, col: 45, offset: 24528},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1241,33 +1255,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 823, col: 1, offset: 24166},
+			pos:  position{line: 838, col: 1, offset: 24569},
 			expr: &actionExpr{
-				pos: position{line: 823, col: 16, offset: 24181},
+				pos: position{line: 838, col: 16, offset: 24584},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 823, col: 16, offset: 24181},
-					exprs: []interface{}{
+					pos: position{line: 838, col: 16, offset: 24584},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 823, col: 16, offset: 24181},
+							pos:  position{line: 838, col: 16, offset: 24584},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 823, col: 21, offset: 24186},
+							pos:   position{line: 838, col: 21, offset: 24589},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 823, col: 28, offset: 24193},
-								alternatives: []interface{}{
+								pos: position{line: 838, col: 28, offset: 24596},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 823, col: 28, offset: 24193},
+										pos:  position{line: 838, col: 28, offset: 24596},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 823, col: 42, offset: 24207},
+										pos:  position{line: 838, col: 42, offset: 24610},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 823, col: 55, offset: 24220},
+										pos:  position{line: 838, col: 55, offset: 24623},
 										name: "TimeModifiers",
 									},
 								},
@@ -1279,114 +1293,114 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 828, col: 1, offset: 24299},
+			pos:  position{line: 843, col: 1, offset: 24702},
 			expr: &actionExpr{
-				pos: position{line: 828, col: 25, offset: 24323},
+				pos: position{line: 843, col: 25, offset: 24726},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 828, col: 25, offset: 24323},
+					pos:   position{line: 843, col: 25, offset: 24726},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 828, col: 32, offset: 24330},
-						alternatives: []interface{}{
+						pos: position{line: 843, col: 32, offset: 24733},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 32, offset: 24330},
+								pos:  position{line: 843, col: 32, offset: 24733},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 51, offset: 24349},
+								pos:  position{line: 843, col: 51, offset: 24752},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 69, offset: 24367},
+								pos:  position{line: 843, col: 69, offset: 24770},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 81, offset: 24379},
+								pos:  position{line: 843, col: 81, offset: 24782},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 94, offset: 24392},
+								pos:  position{line: 843, col: 94, offset: 24795},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 106, offset: 24404},
+								pos:  position{line: 843, col: 106, offset: 24807},
 								name: "RegexAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 122, offset: 24420},
+								pos:  position{line: 843, col: 122, offset: 24823},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 133, offset: 24431},
+								pos:  position{line: 843, col: 133, offset: 24834},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 150, offset: 24448},
+								pos:  position{line: 843, col: 150, offset: 24851},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 164, offset: 24462},
+								pos:  position{line: 843, col: 164, offset: 24865},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 181, offset: 24479},
+								pos:  position{line: 843, col: 181, offset: 24882},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 200, offset: 24498},
+								pos:  position{line: 843, col: 200, offset: 24901},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 213, offset: 24511},
+								pos:  position{line: 843, col: 213, offset: 24914},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 225, offset: 24523},
+								pos:  position{line: 843, col: 225, offset: 24926},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 243, offset: 24541},
+								pos:  position{line: 843, col: 243, offset: 24944},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 256, offset: 24554},
+								pos:  position{line: 843, col: 256, offset: 24957},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 270, offset: 24568},
+								pos:  position{line: 843, col: 270, offset: 24971},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 288, offset: 24586},
+								pos:  position{line: 843, col: 288, offset: 24989},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 300, offset: 24598},
+								pos:  position{line: 843, col: 300, offset: 25001},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 311, offset: 24609},
+								pos:  position{line: 843, col: 311, offset: 25012},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 330, offset: 24628},
+								pos:  position{line: 843, col: 330, offset: 25031},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 346, offset: 24644},
+								pos:  position{line: 843, col: 346, offset: 25047},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 362, offset: 24660},
+								pos:  position{line: 843, col: 362, offset: 25063},
 								name: "InputLookupAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 384, offset: 24682},
+								pos:  position{line: 843, col: 384, offset: 25085},
 								name: "AppendBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 828, col: 398, offset: 24696},
+								pos:  position{line: 843, col: 398, offset: 25099},
 								name: "ToJsonBlock",
 							},
 						},
@@ -1396,37 +1410,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 833, col: 1, offset: 24789},
+			pos:  position{line: 848, col: 1, offset: 25192},
 			expr: &actionExpr{
-				pos: position{line: 833, col: 21, offset: 24809},
+				pos: position{line: 848, col: 21, offset: 25212},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 833, col: 21, offset: 24809},
-					exprs: []interface{}{
+					pos: position{line: 848, col: 21, offset: 25212},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 833, col: 21, offset: 24809},
+							pos:  position{line: 848, col: 21, offset: 25212},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 833, col: 26, offset: 24814},
+							pos:  position{line: 848, col: 26, offset: 25217},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 833, col: 37, offset: 24825},
+							pos:   position{line: 848, col: 37, offset: 25228},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 833, col: 40, offset: 24828},
+								pos: position{line: 848, col: 40, offset: 25231},
 								expr: &choiceExpr{
-									pos: position{line: 833, col: 41, offset: 24829},
-									alternatives: []interface{}{
+									pos: position{line: 848, col: 41, offset: 25232},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 833, col: 41, offset: 24829},
+											pos:        position{line: 848, col: 41, offset: 25232},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 833, col: 47, offset: 24835},
+											pos:        position{line: 848, col: 47, offset: 25238},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1436,14 +1450,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 833, col: 53, offset: 24841},
+							pos:  position{line: 848, col: 53, offset: 25244},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 833, col: 68, offset: 24856},
+							pos:   position{line: 848, col: 68, offset: 25259},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 833, col: 75, offset: 24863},
+								pos:  position{line: 848, col: 75, offset: 25266},
 								name: "FieldNameList",
 							},
 						},
@@ -1453,28 +1467,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 852, col: 1, offset: 25403},
+			pos:  position{line: 867, col: 1, offset: 25806},
 			expr: &actionExpr{
-				pos: position{line: 852, col: 26, offset: 25428},
+				pos: position{line: 867, col: 26, offset: 25831},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 852, col: 26, offset: 25428},
-					exprs: []interface{}{
+					pos: position{line: 867, col: 26, offset: 25831},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 852, col: 26, offset: 25428},
+							pos:   position{line: 867, col: 26, offset: 25831},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 852, col: 31, offset: 25433},
+								pos:  position{line: 867, col: 31, offset: 25836},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 852, col: 47, offset: 25449},
+							pos:   position{line: 867, col: 47, offset: 25852},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 852, col: 56, offset: 25458},
+								pos: position{line: 867, col: 56, offset: 25861},
 								expr: &ruleRefExpr{
-									pos:  position{line: 852, col: 57, offset: 25459},
+									pos:  position{line: 867, col: 57, offset: 25862},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1485,36 +1499,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 916, col: 1, offset: 27752},
+			pos:  position{line: 931, col: 1, offset: 28155},
 			expr: &actionExpr{
-				pos: position{line: 916, col: 20, offset: 27771},
+				pos: position{line: 931, col: 20, offset: 28174},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 916, col: 20, offset: 27771},
-					exprs: []interface{}{
+					pos: position{line: 931, col: 20, offset: 28174},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 916, col: 20, offset: 27771},
+							pos:  position{line: 931, col: 20, offset: 28174},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 916, col: 25, offset: 27776},
+							pos:  position{line: 931, col: 25, offset: 28179},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 35, offset: 27786},
+							pos:   position{line: 931, col: 35, offset: 28189},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 916, col: 41, offset: 27792},
+								pos:  position{line: 931, col: 41, offset: 28195},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 916, col: 64, offset: 27815},
+							pos:   position{line: 931, col: 64, offset: 28218},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 916, col: 72, offset: 27823},
+								pos: position{line: 931, col: 72, offset: 28226},
 								expr: &ruleRefExpr{
-									pos:  position{line: 916, col: 73, offset: 27824},
+									pos:  position{line: 931, col: 73, offset: 28227},
 									name: "StatsOptions",
 								},
 							},
@@ -1525,17 +1539,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 930, col: 1, offset: 28157},
+			pos:  position{line: 945, col: 1, offset: 28560},
 			expr: &actionExpr{
-				pos: position{line: 930, col: 17, offset: 28173},
+				pos: position{line: 945, col: 17, offset: 28576},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 930, col: 17, offset: 28173},
+					pos:   position{line: 945, col: 17, offset: 28576},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 930, col: 24, offset: 28180},
+						pos: position{line: 945, col: 24, offset: 28583},
 						expr: &ruleRefExpr{
-							pos:  position{line: 930, col: 25, offset: 28181},
+							pos:  position{line: 945, col: 25, offset: 28584},
 							name: "StatsOption",
 						},
 					},
@@ -1544,45 +1558,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 968, col: 1, offset: 29622},
+			pos:  position{line: 983, col: 1, offset: 30025},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 16, offset: 29637},
+				pos: position{line: 983, col: 16, offset: 30040},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 968, col: 16, offset: 29637},
-					exprs: []interface{}{
+					pos: position{line: 983, col: 16, offset: 30040},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 16, offset: 29637},
+							pos:  position{line: 983, col: 16, offset: 30040},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 22, offset: 29643},
+							pos:   position{line: 983, col: 22, offset: 30046},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 968, col: 32, offset: 29653},
+								pos:  position{line: 983, col: 32, offset: 30056},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 47, offset: 29668},
+							pos:  position{line: 983, col: 47, offset: 30071},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 53, offset: 29674},
+							pos:   position{line: 983, col: 53, offset: 30077},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 968, col: 58, offset: 29679},
-								alternatives: []interface{}{
+								pos: position{line: 983, col: 58, offset: 30082},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 968, col: 58, offset: 29679},
+										pos:  position{line: 983, col: 58, offset: 30082},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 968, col: 76, offset: 29697},
+										pos:  position{line: 983, col: 76, offset: 30100},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 968, col: 94, offset: 29715},
+										pos:  position{line: 983, col: 94, offset: 30118},
 										name: "QuotedString",
 									},
 								},
@@ -1594,36 +1608,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 973, col: 1, offset: 29820},
+			pos:  position{line: 988, col: 1, offset: 30223},
 			expr: &actionExpr{
-				pos: position{line: 973, col: 19, offset: 29838},
+				pos: position{line: 988, col: 19, offset: 30241},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 973, col: 19, offset: 29838},
+					pos:   position{line: 988, col: 19, offset: 30241},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 973, col: 27, offset: 29846},
-						alternatives: []interface{}{
+						pos: position{line: 988, col: 27, offset: 30249},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 973, col: 27, offset: 29846},
+								pos:        position{line: 988, col: 27, offset: 30249},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 973, col: 38, offset: 29857},
+								pos:        position{line: 988, col: 38, offset: 30260},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 973, col: 58, offset: 29877},
+								pos:        position{line: 988, col: 58, offset: 30280},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 973, col: 68, offset: 29887},
+								pos:        position{line: 988, col: 68, offset: 30290},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1635,22 +1649,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 981, col: 1, offset: 30077},
+			pos:  position{line: 996, col: 1, offset: 30480},
 			expr: &actionExpr{
-				pos: position{line: 981, col: 17, offset: 30093},
+				pos: position{line: 996, col: 17, offset: 30496},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 981, col: 17, offset: 30093},
-					exprs: []interface{}{
+					pos: position{line: 996, col: 17, offset: 30496},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 981, col: 17, offset: 30093},
+							pos:  position{line: 996, col: 17, offset: 30496},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 981, col: 20, offset: 30096},
+							pos:   position{line: 996, col: 20, offset: 30499},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 981, col: 27, offset: 30103},
+								pos:  position{line: 996, col: 27, offset: 30506},
 								name: "FieldNameList",
 							},
 						},
@@ -1660,28 +1674,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 993, col: 1, offset: 30453},
+			pos:  position{line: 1008, col: 1, offset: 30856},
 			expr: &actionExpr{
-				pos: position{line: 993, col: 35, offset: 30487},
+				pos: position{line: 1008, col: 35, offset: 30890},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 993, col: 35, offset: 30487},
-					exprs: []interface{}{
+					pos: position{line: 1008, col: 35, offset: 30890},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 993, col: 35, offset: 30487},
+							pos:        position{line: 1008, col: 35, offset: 30890},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 993, col: 53, offset: 30505},
+							pos:  position{line: 1008, col: 53, offset: 30908},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 993, col: 59, offset: 30511},
+							pos:   position{line: 1008, col: 59, offset: 30914},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 993, col: 67, offset: 30519},
+								pos:  position{line: 1008, col: 67, offset: 30922},
 								name: "Boolean",
 							},
 						},
@@ -1691,28 +1705,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 1005, col: 1, offset: 30780},
+			pos:  position{line: 1020, col: 1, offset: 31183},
 			expr: &actionExpr{
-				pos: position{line: 1005, col: 29, offset: 30808},
+				pos: position{line: 1020, col: 29, offset: 31211},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 1005, col: 29, offset: 30808},
-					exprs: []interface{}{
+					pos: position{line: 1020, col: 29, offset: 31211},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1005, col: 29, offset: 30808},
+							pos:        position{line: 1020, col: 29, offset: 31211},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1005, col: 39, offset: 30818},
+							pos:  position{line: 1020, col: 39, offset: 31221},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1005, col: 45, offset: 30824},
+							pos:   position{line: 1020, col: 45, offset: 31227},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1005, col: 53, offset: 30832},
+								pos:  position{line: 1020, col: 53, offset: 31235},
 								name: "Boolean",
 							},
 						},
@@ -1722,28 +1736,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 1017, col: 1, offset: 31079},
+			pos:  position{line: 1032, col: 1, offset: 31482},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 28, offset: 31106},
+				pos: position{line: 1032, col: 28, offset: 31509},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 1017, col: 28, offset: 31106},
-					exprs: []interface{}{
+					pos: position{line: 1032, col: 28, offset: 31509},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1017, col: 28, offset: 31106},
+							pos:        position{line: 1032, col: 28, offset: 31509},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1017, col: 37, offset: 31115},
+							pos:  position{line: 1032, col: 37, offset: 31518},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1017, col: 43, offset: 31121},
+							pos:   position{line: 1032, col: 43, offset: 31524},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1017, col: 51, offset: 31129},
+								pos:  position{line: 1032, col: 51, offset: 31532},
 								name: "Boolean",
 							},
 						},
@@ -1753,28 +1767,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 1030, col: 1, offset: 31463},
+			pos:  position{line: 1045, col: 1, offset: 31866},
 			expr: &actionExpr{
-				pos: position{line: 1030, col: 28, offset: 31490},
+				pos: position{line: 1045, col: 28, offset: 31893},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 1030, col: 28, offset: 31490},
-					exprs: []interface{}{
+					pos: position{line: 1045, col: 28, offset: 31893},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1030, col: 28, offset: 31490},
+							pos:        position{line: 1045, col: 28, offset: 31893},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1030, col: 37, offset: 31499},
+							pos:  position{line: 1045, col: 37, offset: 31902},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1030, col: 43, offset: 31505},
+							pos:   position{line: 1045, col: 43, offset: 31908},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1030, col: 51, offset: 31513},
+								pos:  position{line: 1045, col: 51, offset: 31916},
 								name: "Boolean",
 							},
 						},
@@ -1784,28 +1798,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 1043, col: 1, offset: 31847},
+			pos:  position{line: 1058, col: 1, offset: 32250},
 			expr: &actionExpr{
-				pos: position{line: 1043, col: 28, offset: 31874},
+				pos: position{line: 1058, col: 28, offset: 32277},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1043, col: 28, offset: 31874},
-					exprs: []interface{}{
+					pos: position{line: 1058, col: 28, offset: 32277},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1043, col: 28, offset: 31874},
+							pos:        position{line: 1058, col: 28, offset: 32277},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1043, col: 37, offset: 31883},
+							pos:  position{line: 1058, col: 37, offset: 32286},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1043, col: 43, offset: 31889},
+							pos:   position{line: 1058, col: 43, offset: 32292},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1043, col: 54, offset: 31900},
+								pos:  position{line: 1058, col: 54, offset: 32303},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1815,37 +1829,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1063, col: 1, offset: 32504},
+			pos:  position{line: 1078, col: 1, offset: 32907},
 			expr: &actionExpr{
-				pos: position{line: 1063, col: 33, offset: 32536},
+				pos: position{line: 1078, col: 33, offset: 32939},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1063, col: 33, offset: 32536},
-					exprs: []interface{}{
+					pos: position{line: 1078, col: 33, offset: 32939},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1063, col: 33, offset: 32536},
+							pos:        position{line: 1078, col: 33, offset: 32939},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1063, col: 48, offset: 32551},
+							pos:  position{line: 1078, col: 48, offset: 32954},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1063, col: 54, offset: 32557},
+							pos:  position{line: 1078, col: 54, offset: 32960},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1063, col: 62, offset: 32565},
+							pos:   position{line: 1078, col: 62, offset: 32968},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1063, col: 71, offset: 32574},
+								pos:  position{line: 1078, col: 71, offset: 32977},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1063, col: 80, offset: 32583},
+							pos:  position{line: 1078, col: 80, offset: 32986},
 							name: "R_PAREN",
 						},
 					},
@@ -1854,37 +1868,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1075, col: 1, offset: 32853},
+			pos:  position{line: 1090, col: 1, offset: 33256},
 			expr: &actionExpr{
-				pos: position{line: 1075, col: 32, offset: 32884},
+				pos: position{line: 1090, col: 32, offset: 33287},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1075, col: 32, offset: 32884},
-					exprs: []interface{}{
+					pos: position{line: 1090, col: 32, offset: 33287},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1075, col: 32, offset: 32884},
+							pos:        position{line: 1090, col: 32, offset: 33287},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 46, offset: 32898},
+							pos:  position{line: 1090, col: 46, offset: 33301},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 52, offset: 32904},
+							pos:  position{line: 1090, col: 52, offset: 33307},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1075, col: 60, offset: 32912},
+							pos:   position{line: 1090, col: 60, offset: 33315},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1075, col: 69, offset: 32921},
+								pos:  position{line: 1090, col: 69, offset: 33324},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1075, col: 78, offset: 32930},
+							pos:  position{line: 1090, col: 78, offset: 33333},
 							name: "R_PAREN",
 						},
 					},
@@ -1893,28 +1907,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1087, col: 1, offset: 33198},
+			pos:  position{line: 1102, col: 1, offset: 33601},
 			expr: &actionExpr{
-				pos: position{line: 1087, col: 32, offset: 33229},
+				pos: position{line: 1102, col: 32, offset: 33632},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1087, col: 32, offset: 33229},
-					exprs: []interface{}{
+					pos: position{line: 1102, col: 32, offset: 33632},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1087, col: 32, offset: 33229},
+							pos:        position{line: 1102, col: 32, offset: 33632},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1087, col: 46, offset: 33243},
+							pos:  position{line: 1102, col: 46, offset: 33646},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1087, col: 52, offset: 33249},
+							pos:   position{line: 1102, col: 52, offset: 33652},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1087, col: 63, offset: 33260},
+								pos:  position{line: 1102, col: 63, offset: 33663},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1924,46 +1938,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1103, col: 1, offset: 33723},
+			pos:  position{line: 1118, col: 1, offset: 34126},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 22, offset: 33744},
+				pos: position{line: 1118, col: 22, offset: 34147},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1103, col: 22, offset: 33744},
+					pos:   position{line: 1118, col: 22, offset: 34147},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1103, col: 32, offset: 33754},
-						alternatives: []interface{}{
+						pos: position{line: 1118, col: 32, offset: 34157},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 32, offset: 33754},
+								pos:  position{line: 1118, col: 32, offset: 34157},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 65, offset: 33787},
+								pos:  position{line: 1118, col: 65, offset: 34190},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 92, offset: 33814},
+								pos:  position{line: 1118, col: 92, offset: 34217},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 118, offset: 33840},
+								pos:  position{line: 1118, col: 118, offset: 34243},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 144, offset: 33866},
+								pos:  position{line: 1118, col: 144, offset: 34269},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 170, offset: 33892},
+								pos:  position{line: 1118, col: 170, offset: 34295},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 201, offset: 33923},
+								pos:  position{line: 1118, col: 201, offset: 34326},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1103, col: 231, offset: 33953},
+								pos:  position{line: 1118, col: 231, offset: 34356},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1973,35 +1987,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1107, col: 1, offset: 34012},
+			pos:  position{line: 1122, col: 1, offset: 34415},
 			expr: &actionExpr{
-				pos: position{line: 1107, col: 26, offset: 34037},
+				pos: position{line: 1122, col: 26, offset: 34440},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1107, col: 26, offset: 34037},
-					exprs: []interface{}{
+					pos: position{line: 1122, col: 26, offset: 34440},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1107, col: 26, offset: 34037},
+							pos:   position{line: 1122, col: 26, offset: 34440},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1107, col: 32, offset: 34043},
+								pos:  position{line: 1122, col: 32, offset: 34446},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1107, col: 50, offset: 34061},
+							pos:   position{line: 1122, col: 50, offset: 34464},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1107, col: 55, offset: 34066},
+								pos: position{line: 1122, col: 55, offset: 34469},
 								expr: &seqExpr{
-									pos: position{line: 1107, col: 56, offset: 34067},
-									exprs: []interface{}{
+									pos: position{line: 1122, col: 56, offset: 34470},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1107, col: 56, offset: 34067},
+											pos:  position{line: 1122, col: 56, offset: 34470},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1107, col: 62, offset: 34073},
+											pos:  position{line: 1122, col: 62, offset: 34476},
 											name: "StreamStatsOption",
 										},
 									},
@@ -2014,41 +2028,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1166, col: 1, offset: 36262},
+			pos:  position{line: 1181, col: 1, offset: 36665},
 			expr: &choiceExpr{
-				pos: position{line: 1166, col: 21, offset: 36282},
-				alternatives: []interface{}{
+				pos: position{line: 1181, col: 21, offset: 36685},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1166, col: 21, offset: 36282},
+						pos: position{line: 1181, col: 21, offset: 36685},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1166, col: 21, offset: 36282},
-							exprs: []interface{}{
+							pos: position{line: 1181, col: 21, offset: 36685},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1166, col: 21, offset: 36282},
+									pos:  position{line: 1181, col: 21, offset: 36685},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1166, col: 26, offset: 36287},
+									pos:  position{line: 1181, col: 26, offset: 36690},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1166, col: 42, offset: 36303},
+									pos:   position{line: 1181, col: 42, offset: 36706},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1166, col: 56, offset: 36317},
+										pos:  position{line: 1181, col: 56, offset: 36720},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1166, col: 79, offset: 36340},
+									pos:  position{line: 1181, col: 79, offset: 36743},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1166, col: 85, offset: 36346},
+									pos:   position{line: 1181, col: 85, offset: 36749},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1166, col: 91, offset: 36352},
+										pos:  position{line: 1181, col: 91, offset: 36755},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2056,24 +2070,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1177, col: 3, offset: 36737},
+						pos: position{line: 1192, col: 3, offset: 37140},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1177, col: 3, offset: 36737},
-							exprs: []interface{}{
+							pos: position{line: 1192, col: 3, offset: 37140},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1177, col: 3, offset: 36737},
+									pos:  position{line: 1192, col: 3, offset: 37140},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1177, col: 8, offset: 36742},
+									pos:  position{line: 1192, col: 8, offset: 37145},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1177, col: 24, offset: 36758},
+									pos:   position{line: 1192, col: 24, offset: 37161},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1177, col: 30, offset: 36764},
+										pos:  position{line: 1192, col: 30, offset: 37167},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2085,31 +2099,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1189, col: 1, offset: 37136},
+			pos:  position{line: 1204, col: 1, offset: 37539},
 			expr: &actionExpr{
-				pos: position{line: 1189, col: 15, offset: 37150},
+				pos: position{line: 1204, col: 15, offset: 37553},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1189, col: 15, offset: 37150},
-					exprs: []interface{}{
+					pos: position{line: 1204, col: 15, offset: 37553},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1189, col: 15, offset: 37150},
+							pos:  position{line: 1204, col: 15, offset: 37553},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1189, col: 25, offset: 37160},
+							pos:   position{line: 1204, col: 25, offset: 37563},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1189, col: 34, offset: 37169},
+								pos: position{line: 1204, col: 34, offset: 37572},
 								expr: &seqExpr{
-									pos: position{line: 1189, col: 35, offset: 37170},
-									exprs: []interface{}{
+									pos: position{line: 1204, col: 35, offset: 37573},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1189, col: 35, offset: 37170},
+											pos:  position{line: 1204, col: 35, offset: 37573},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1189, col: 45, offset: 37180},
+											pos:  position{line: 1204, col: 45, offset: 37583},
 											name: "EqualityOperator",
 										},
 									},
@@ -2117,10 +2131,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1189, col: 64, offset: 37199},
+							pos:   position{line: 1204, col: 64, offset: 37602},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1189, col: 68, offset: 37203},
+								pos:  position{line: 1204, col: 68, offset: 37606},
 								name: "QuotedString",
 							},
 						},
@@ -2130,22 +2144,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1217, col: 1, offset: 37782},
+			pos:  position{line: 1232, col: 1, offset: 38185},
 			expr: &actionExpr{
-				pos: position{line: 1217, col: 18, offset: 37799},
+				pos: position{line: 1232, col: 18, offset: 38202},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1217, col: 18, offset: 37799},
-					exprs: []interface{}{
+					pos: position{line: 1232, col: 18, offset: 38202},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1217, col: 18, offset: 37799},
+							pos:  position{line: 1232, col: 18, offset: 38202},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1217, col: 23, offset: 37804},
+							pos:   position{line: 1232, col: 23, offset: 38207},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1217, col: 28, offset: 37809},
+								pos:  position{line: 1232, col: 28, offset: 38212},
 								name: "RegexBlock",
 							},
 						},
@@ -2155,44 +2169,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1245, col: 1, offset: 38591},
+			pos:  position{line: 1260, col: 1, offset: 38994},
 			expr: &actionExpr{
-				pos: position{line: 1245, col: 17, offset: 38607},
+				pos: position{line: 1260, col: 17, offset: 39010},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1245, col: 17, offset: 38607},
-					exprs: []interface{}{
+					pos: position{line: 1260, col: 17, offset: 39010},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1245, col: 17, offset: 38607},
+							pos:   position{line: 1260, col: 17, offset: 39010},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1245, col: 23, offset: 38613},
+								pos:  position{line: 1260, col: 23, offset: 39016},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1245, col: 36, offset: 38626},
+							pos:   position{line: 1260, col: 36, offset: 39029},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1245, col: 41, offset: 38631},
+								pos: position{line: 1260, col: 41, offset: 39034},
 								expr: &seqExpr{
-									pos: position{line: 1245, col: 42, offset: 38632},
-									exprs: []interface{}{
+									pos: position{line: 1260, col: 42, offset: 39035},
+									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1245, col: 43, offset: 38633},
-											alternatives: []interface{}{
+											pos: position{line: 1260, col: 43, offset: 39036},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1245, col: 43, offset: 38633},
+													pos:  position{line: 1260, col: 43, offset: 39036},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1245, col: 49, offset: 38639},
+													pos:  position{line: 1260, col: 49, offset: 39042},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1245, col: 56, offset: 38646},
+											pos:  position{line: 1260, col: 56, offset: 39049},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2205,35 +2219,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1263, col: 1, offset: 39023},
+			pos:  position{line: 1278, col: 1, offset: 39426},
 			expr: &actionExpr{
-				pos: position{line: 1263, col: 17, offset: 39039},
+				pos: position{line: 1278, col: 17, offset: 39442},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1263, col: 17, offset: 39039},
-					exprs: []interface{}{
+					pos: position{line: 1278, col: 17, offset: 39442},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1263, col: 17, offset: 39039},
+							pos:   position{line: 1278, col: 17, offset: 39442},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1263, col: 23, offset: 39045},
+								pos:  position{line: 1278, col: 23, offset: 39448},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1263, col: 36, offset: 39058},
+							pos:   position{line: 1278, col: 36, offset: 39461},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1263, col: 41, offset: 39063},
+								pos: position{line: 1278, col: 41, offset: 39466},
 								expr: &seqExpr{
-									pos: position{line: 1263, col: 42, offset: 39064},
-									exprs: []interface{}{
+									pos: position{line: 1278, col: 42, offset: 39467},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1263, col: 42, offset: 39064},
+											pos:  position{line: 1278, col: 42, offset: 39467},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1263, col: 45, offset: 39067},
+											pos:  position{line: 1278, col: 45, offset: 39470},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2246,32 +2260,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1281, col: 1, offset: 39432},
+			pos:  position{line: 1296, col: 1, offset: 39835},
 			expr: &choiceExpr{
-				pos: position{line: 1281, col: 17, offset: 39448},
-				alternatives: []interface{}{
+				pos: position{line: 1296, col: 17, offset: 39851},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1281, col: 17, offset: 39448},
+						pos: position{line: 1296, col: 17, offset: 39851},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1281, col: 17, offset: 39448},
-							exprs: []interface{}{
+							pos: position{line: 1296, col: 17, offset: 39851},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1281, col: 17, offset: 39448},
+									pos:   position{line: 1296, col: 17, offset: 39851},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1281, col: 25, offset: 39456},
+										pos: position{line: 1296, col: 25, offset: 39859},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1281, col: 25, offset: 39456},
+											pos:  position{line: 1296, col: 25, offset: 39859},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1281, col: 30, offset: 39461},
+									pos:   position{line: 1296, col: 30, offset: 39864},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1281, col: 36, offset: 39467},
+										pos:  position{line: 1296, col: 36, offset: 39870},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2279,13 +2293,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1292, col: 5, offset: 39763},
+						pos: position{line: 1307, col: 5, offset: 40166},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1292, col: 5, offset: 39763},
+							pos:   position{line: 1307, col: 5, offset: 40166},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1292, col: 12, offset: 39770},
+								pos:  position{line: 1307, col: 12, offset: 40173},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2295,43 +2309,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1296, col: 1, offset: 39811},
+			pos:  position{line: 1311, col: 1, offset: 40214},
 			expr: &choiceExpr{
-				pos: position{line: 1296, col: 17, offset: 39827},
-				alternatives: []interface{}{
+				pos: position{line: 1311, col: 17, offset: 40230},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1296, col: 17, offset: 39827},
+						pos: position{line: 1311, col: 17, offset: 40230},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1296, col: 17, offset: 39827},
-							exprs: []interface{}{
+							pos: position{line: 1311, col: 17, offset: 40230},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1296, col: 17, offset: 39827},
+									pos:  position{line: 1311, col: 17, offset: 40230},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1296, col: 25, offset: 39835},
+									pos:   position{line: 1311, col: 25, offset: 40238},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1296, col: 32, offset: 39842},
+										pos:  position{line: 1311, col: 32, offset: 40245},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1296, col: 45, offset: 39855},
+									pos:  position{line: 1311, col: 45, offset: 40258},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1298, col: 5, offset: 39892},
+						pos: position{line: 1313, col: 5, offset: 40295},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1298, col: 5, offset: 39892},
+							pos:   position{line: 1313, col: 5, offset: 40295},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1298, col: 10, offset: 39897},
+								pos:  position{line: 1313, col: 10, offset: 40300},
 								name: "SearchTerm",
 							},
 						},
@@ -2341,26 +2355,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1304, col: 1, offset: 40055},
+			pos:  position{line: 1319, col: 1, offset: 40458},
 			expr: &actionExpr{
-				pos: position{line: 1304, col: 15, offset: 40069},
+				pos: position{line: 1319, col: 15, offset: 40472},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1304, col: 15, offset: 40069},
+					pos:   position{line: 1319, col: 15, offset: 40472},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1304, col: 21, offset: 40075},
-						alternatives: []interface{}{
+						pos: position{line: 1319, col: 21, offset: 40478},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1304, col: 21, offset: 40075},
+								pos:  position{line: 1319, col: 21, offset: 40478},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1304, col: 44, offset: 40098},
+								pos:  position{line: 1319, col: 44, offset: 40501},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1304, col: 68, offset: 40122},
+								pos:  position{line: 1319, col: 68, offset: 40525},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2370,36 +2384,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1309, col: 1, offset: 40263},
+			pos:  position{line: 1324, col: 1, offset: 40666},
 			expr: &actionExpr{
-				pos: position{line: 1309, col: 19, offset: 40281},
+				pos: position{line: 1324, col: 19, offset: 40684},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1309, col: 19, offset: 40281},
-					exprs: []interface{}{
+					pos: position{line: 1324, col: 19, offset: 40684},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1309, col: 19, offset: 40281},
+							pos:  position{line: 1324, col: 19, offset: 40684},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1309, col: 24, offset: 40286},
+							pos:  position{line: 1324, col: 24, offset: 40689},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1309, col: 38, offset: 40300},
+							pos:   position{line: 1324, col: 38, offset: 40703},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1309, col: 45, offset: 40307},
+								pos:  position{line: 1324, col: 45, offset: 40710},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1309, col: 68, offset: 40330},
+							pos:   position{line: 1324, col: 68, offset: 40733},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1309, col: 78, offset: 40340},
+								pos: position{line: 1324, col: 78, offset: 40743},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1309, col: 79, offset: 40341},
+									pos:  position{line: 1324, col: 79, offset: 40744},
 									name: "LimitExpr",
 								},
 							},
@@ -2410,35 +2424,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1402, col: 1, offset: 43312},
+			pos:  position{line: 1417, col: 1, offset: 43715},
 			expr: &actionExpr{
-				pos: position{line: 1402, col: 27, offset: 43338},
+				pos: position{line: 1417, col: 27, offset: 43741},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1402, col: 27, offset: 43338},
-					exprs: []interface{}{
+					pos: position{line: 1417, col: 27, offset: 43741},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1402, col: 27, offset: 43338},
+							pos:   position{line: 1417, col: 27, offset: 43741},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1402, col: 33, offset: 43344},
+								pos:  position{line: 1417, col: 33, offset: 43747},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1402, col: 51, offset: 43362},
+							pos:   position{line: 1417, col: 51, offset: 43765},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1402, col: 56, offset: 43367},
+								pos: position{line: 1417, col: 56, offset: 43770},
 								expr: &seqExpr{
-									pos: position{line: 1402, col: 57, offset: 43368},
-									exprs: []interface{}{
+									pos: position{line: 1417, col: 57, offset: 43771},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1402, col: 57, offset: 43368},
+											pos:  position{line: 1417, col: 57, offset: 43771},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1402, col: 63, offset: 43374},
+											pos:  position{line: 1417, col: 63, offset: 43777},
 											name: "TimechartArgument",
 										},
 									},
@@ -2451,22 +2465,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1431, col: 1, offset: 44108},
+			pos:  position{line: 1446, col: 1, offset: 44511},
 			expr: &actionExpr{
-				pos: position{line: 1431, col: 22, offset: 44129},
+				pos: position{line: 1446, col: 22, offset: 44532},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1431, col: 22, offset: 44129},
+					pos:   position{line: 1446, col: 22, offset: 44532},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1431, col: 29, offset: 44136},
-						alternatives: []interface{}{
+						pos: position{line: 1446, col: 29, offset: 44539},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1431, col: 29, offset: 44136},
+								pos:  position{line: 1446, col: 29, offset: 44539},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1431, col: 45, offset: 44152},
+								pos:  position{line: 1446, col: 45, offset: 44555},
 								name: "TcOptions",
 							},
 						},
@@ -2476,28 +2490,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1435, col: 1, offset: 44190},
+			pos:  position{line: 1450, col: 1, offset: 44593},
 			expr: &actionExpr{
-				pos: position{line: 1435, col: 18, offset: 44207},
+				pos: position{line: 1450, col: 18, offset: 44610},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1435, col: 18, offset: 44207},
-					exprs: []interface{}{
+					pos: position{line: 1450, col: 18, offset: 44610},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1435, col: 18, offset: 44207},
+							pos:   position{line: 1450, col: 18, offset: 44610},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1435, col: 23, offset: 44212},
+								pos:  position{line: 1450, col: 23, offset: 44615},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1435, col: 39, offset: 44228},
+							pos:   position{line: 1450, col: 39, offset: 44631},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1435, col: 53, offset: 44242},
+								pos: position{line: 1450, col: 53, offset: 44645},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1435, col: 53, offset: 44242},
+									pos:  position{line: 1450, col: 53, offset: 44645},
 									name: "SplitByClause",
 								},
 							},
@@ -2508,22 +2522,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1449, col: 1, offset: 44581},
+			pos:  position{line: 1464, col: 1, offset: 44984},
 			expr: &actionExpr{
-				pos: position{line: 1449, col: 18, offset: 44598},
+				pos: position{line: 1464, col: 18, offset: 45001},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1449, col: 18, offset: 44598},
-					exprs: []interface{}{
+					pos: position{line: 1464, col: 18, offset: 45001},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1449, col: 18, offset: 44598},
+							pos:  position{line: 1464, col: 18, offset: 45001},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1449, col: 21, offset: 44601},
+							pos:   position{line: 1464, col: 21, offset: 45004},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1449, col: 27, offset: 44607},
+								pos:  position{line: 1464, col: 27, offset: 45010},
 								name: "FieldName",
 							},
 						},
@@ -2533,24 +2547,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1457, col: 1, offset: 44736},
+			pos:  position{line: 1472, col: 1, offset: 45139},
 			expr: &actionExpr{
-				pos: position{line: 1457, col: 14, offset: 44749},
+				pos: position{line: 1472, col: 14, offset: 45152},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1457, col: 14, offset: 44749},
+					pos:   position{line: 1472, col: 14, offset: 45152},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1457, col: 22, offset: 44757},
-						alternatives: []interface{}{
+						pos: position{line: 1472, col: 22, offset: 45160},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1457, col: 22, offset: 44757},
+								pos:  position{line: 1472, col: 22, offset: 45160},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1457, col: 35, offset: 44770},
+								pos: position{line: 1472, col: 35, offset: 45173},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1457, col: 36, offset: 44771},
+									pos:  position{line: 1472, col: 36, offset: 45174},
 									name: "TcOption",
 								},
 							},
@@ -2561,34 +2575,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1499, col: 1, offset: 46291},
+			pos:  position{line: 1514, col: 1, offset: 46694},
 			expr: &actionExpr{
-				pos: position{line: 1499, col: 13, offset: 46303},
+				pos: position{line: 1514, col: 13, offset: 46706},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1499, col: 13, offset: 46303},
-					exprs: []interface{}{
+					pos: position{line: 1514, col: 13, offset: 46706},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1499, col: 13, offset: 46303},
+							pos:  position{line: 1514, col: 13, offset: 46706},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1499, col: 19, offset: 46309},
+							pos:   position{line: 1514, col: 19, offset: 46712},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 31, offset: 46321},
+								pos:  position{line: 1514, col: 31, offset: 46724},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1499, col: 43, offset: 46333},
+							pos:  position{line: 1514, col: 43, offset: 46736},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1499, col: 49, offset: 46339},
+							pos:   position{line: 1514, col: 49, offset: 46742},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1499, col: 53, offset: 46343},
+								pos:  position{line: 1514, col: 53, offset: 46746},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2598,36 +2612,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1504, col: 1, offset: 46456},
+			pos:  position{line: 1519, col: 1, offset: 46859},
 			expr: &actionExpr{
-				pos: position{line: 1504, col: 16, offset: 46471},
+				pos: position{line: 1519, col: 16, offset: 46874},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1504, col: 16, offset: 46471},
+					pos:   position{line: 1519, col: 16, offset: 46874},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1504, col: 24, offset: 46479},
-						alternatives: []interface{}{
+						pos: position{line: 1519, col: 24, offset: 46882},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1504, col: 24, offset: 46479},
+								pos:        position{line: 1519, col: 24, offset: 46882},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1504, col: 36, offset: 46491},
+								pos:        position{line: 1519, col: 36, offset: 46894},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1504, col: 49, offset: 46504},
+								pos:        position{line: 1519, col: 49, offset: 46907},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1504, col: 61, offset: 46516},
+								pos:        position{line: 1519, col: 61, offset: 46919},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2639,50 +2653,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1512, col: 1, offset: 46712},
+			pos:  position{line: 1527, col: 1, offset: 47115},
 			expr: &actionExpr{
-				pos: position{line: 1512, col: 17, offset: 46728},
+				pos: position{line: 1527, col: 17, offset: 47131},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1512, col: 17, offset: 46728},
+					pos:   position{line: 1527, col: 17, offset: 47131},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1512, col: 27, offset: 46738},
-						alternatives: []interface{}{
+						pos: position{line: 1527, col: 27, offset: 47141},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 27, offset: 46738},
+								pos:  position{line: 1527, col: 27, offset: 47141},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 36, offset: 46747},
+								pos:  position{line: 1527, col: 36, offset: 47150},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 44, offset: 46755},
+								pos:  position{line: 1527, col: 44, offset: 47158},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 57, offset: 46768},
+								pos:  position{line: 1527, col: 57, offset: 47171},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 66, offset: 46777},
+								pos:  position{line: 1527, col: 66, offset: 47180},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 73, offset: 46784},
+								pos:  position{line: 1527, col: 73, offset: 47187},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 79, offset: 46790},
+								pos:  position{line: 1527, col: 79, offset: 47193},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 86, offset: 46797},
+								pos:  position{line: 1527, col: 86, offset: 47200},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1512, col: 96, offset: 46807},
+								pos:  position{line: 1527, col: 96, offset: 47210},
 								name: "Year",
 							},
 						},
@@ -2692,37 +2706,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1516, col: 1, offset: 46843},
+			pos:  position{line: 1531, col: 1, offset: 47246},
 			expr: &actionExpr{
-				pos: position{line: 1516, col: 21, offset: 46863},
+				pos: position{line: 1531, col: 21, offset: 47266},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1516, col: 21, offset: 46863},
-					exprs: []interface{}{
+					pos: position{line: 1531, col: 21, offset: 47266},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1516, col: 21, offset: 46863},
+							pos:   position{line: 1531, col: 21, offset: 47266},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1516, col: 29, offset: 46871},
-								alternatives: []interface{}{
+								pos: position{line: 1531, col: 29, offset: 47274},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1516, col: 29, offset: 46871},
+										pos:  position{line: 1531, col: 29, offset: 47274},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1516, col: 45, offset: 46887},
+										pos:  position{line: 1531, col: 45, offset: 47290},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1516, col: 62, offset: 46904},
+							pos:   position{line: 1531, col: 62, offset: 47307},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1516, col: 72, offset: 46914},
+								pos: position{line: 1531, col: 72, offset: 47317},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1516, col: 73, offset: 46915},
+									pos:  position{line: 1531, col: 73, offset: 47318},
 									name: "AllTimeScale",
 								},
 							},
@@ -2733,28 +2747,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1575, col: 1, offset: 49606},
+			pos:  position{line: 1590, col: 1, offset: 50009},
 			expr: &actionExpr{
-				pos: position{line: 1575, col: 21, offset: 49626},
+				pos: position{line: 1590, col: 21, offset: 50029},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1575, col: 21, offset: 49626},
-					exprs: []interface{}{
+					pos: position{line: 1590, col: 21, offset: 50029},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1575, col: 21, offset: 49626},
+							pos:        position{line: 1590, col: 21, offset: 50029},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1575, col: 31, offset: 49636},
+							pos:  position{line: 1590, col: 31, offset: 50039},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1575, col: 37, offset: 49642},
+							pos:   position{line: 1590, col: 37, offset: 50045},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1575, col: 48, offset: 49653},
+								pos:  position{line: 1590, col: 48, offset: 50056},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2764,28 +2778,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1586, col: 1, offset: 49894},
+			pos:  position{line: 1601, col: 1, offset: 50297},
 			expr: &actionExpr{
-				pos: position{line: 1586, col: 21, offset: 49914},
+				pos: position{line: 1601, col: 21, offset: 50317},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1586, col: 21, offset: 49914},
-					exprs: []interface{}{
+					pos: position{line: 1601, col: 21, offset: 50317},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1586, col: 21, offset: 49914},
+							pos:        position{line: 1601, col: 21, offset: 50317},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1586, col: 28, offset: 49921},
+							pos:  position{line: 1601, col: 28, offset: 50324},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1586, col: 34, offset: 49927},
+							pos:   position{line: 1601, col: 34, offset: 50330},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1586, col: 43, offset: 49936},
+								pos:  position{line: 1601, col: 43, offset: 50339},
 								name: "IntegerAsString",
 							},
 						},
@@ -2795,31 +2809,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1607, col: 1, offset: 50515},
+			pos:  position{line: 1622, col: 1, offset: 50918},
 			expr: &choiceExpr{
-				pos: position{line: 1607, col: 23, offset: 50537},
-				alternatives: []interface{}{
+				pos: position{line: 1622, col: 23, offset: 50940},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1607, col: 23, offset: 50537},
+						pos: position{line: 1622, col: 23, offset: 50940},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1607, col: 23, offset: 50537},
-							exprs: []interface{}{
+							pos: position{line: 1622, col: 23, offset: 50940},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1607, col: 23, offset: 50537},
+									pos:        position{line: 1622, col: 23, offset: 50940},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1607, col: 35, offset: 50549},
+									pos:  position{line: 1622, col: 35, offset: 50952},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1607, col: 41, offset: 50555},
+									pos:   position{line: 1622, col: 41, offset: 50958},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1607, col: 51, offset: 50565},
+										pos:  position{line: 1622, col: 51, offset: 50968},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2827,33 +2841,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1621, col: 3, offset: 50984},
+						pos: position{line: 1636, col: 3, offset: 51387},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1621, col: 3, offset: 50984},
-							exprs: []interface{}{
+							pos: position{line: 1636, col: 3, offset: 51387},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1621, col: 3, offset: 50984},
+									pos:        position{line: 1636, col: 3, offset: 51387},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1621, col: 15, offset: 50996},
+									pos:  position{line: 1636, col: 15, offset: 51399},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1621, col: 21, offset: 51002},
+									pos:   position{line: 1636, col: 21, offset: 51405},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1621, col: 32, offset: 51013},
-										alternatives: []interface{}{
+										pos: position{line: 1636, col: 32, offset: 51416},
+										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1621, col: 32, offset: 51013},
+												pos:  position{line: 1636, col: 32, offset: 51416},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1621, col: 52, offset: 51033},
+												pos:  position{line: 1636, col: 52, offset: 51436},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2867,35 +2881,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1641, col: 1, offset: 51502},
+			pos:  position{line: 1656, col: 1, offset: 51905},
 			expr: &actionExpr{
-				pos: position{line: 1641, col: 19, offset: 51520},
+				pos: position{line: 1656, col: 19, offset: 51923},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1641, col: 19, offset: 51520},
-					exprs: []interface{}{
+					pos: position{line: 1656, col: 19, offset: 51923},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1641, col: 19, offset: 51520},
+							pos:        position{line: 1656, col: 19, offset: 51923},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1641, col: 27, offset: 51528},
+							pos:  position{line: 1656, col: 27, offset: 51931},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1641, col: 33, offset: 51534},
+							pos:   position{line: 1656, col: 33, offset: 51937},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1641, col: 41, offset: 51542},
-								alternatives: []interface{}{
+								pos: position{line: 1656, col: 41, offset: 51945},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1641, col: 41, offset: 51542},
+										pos:  position{line: 1656, col: 41, offset: 51945},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1641, col: 57, offset: 51558},
+										pos:  position{line: 1656, col: 57, offset: 51961},
 										name: "IntegerAsString",
 									},
 								},
@@ -2907,35 +2921,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1656, col: 1, offset: 51937},
+			pos:  position{line: 1671, col: 1, offset: 52340},
 			expr: &actionExpr{
-				pos: position{line: 1656, col: 17, offset: 51953},
+				pos: position{line: 1671, col: 17, offset: 52356},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1656, col: 17, offset: 51953},
-					exprs: []interface{}{
+					pos: position{line: 1671, col: 17, offset: 52356},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1656, col: 17, offset: 51953},
+							pos:        position{line: 1671, col: 17, offset: 52356},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1656, col: 23, offset: 51959},
+							pos:  position{line: 1671, col: 23, offset: 52362},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1656, col: 29, offset: 51965},
+							pos:   position{line: 1671, col: 29, offset: 52368},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1656, col: 37, offset: 51973},
-								alternatives: []interface{}{
+								pos: position{line: 1671, col: 37, offset: 52376},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1656, col: 37, offset: 51973},
+										pos:  position{line: 1671, col: 37, offset: 52376},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1656, col: 53, offset: 51989},
+										pos:  position{line: 1671, col: 53, offset: 52392},
 										name: "IntegerAsString",
 									},
 								},
@@ -2947,40 +2961,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1671, col: 1, offset: 52360},
+			pos:  position{line: 1686, col: 1, offset: 52763},
 			expr: &choiceExpr{
-				pos: position{line: 1671, col: 18, offset: 52377},
-				alternatives: []interface{}{
+				pos: position{line: 1686, col: 18, offset: 52780},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1671, col: 18, offset: 52377},
+						pos: position{line: 1686, col: 18, offset: 52780},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1671, col: 18, offset: 52377},
-							exprs: []interface{}{
+							pos: position{line: 1686, col: 18, offset: 52780},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1671, col: 18, offset: 52377},
+									pos:        position{line: 1686, col: 18, offset: 52780},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1671, col: 25, offset: 52384},
+									pos:  position{line: 1686, col: 25, offset: 52787},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1671, col: 31, offset: 52390},
+									pos:   position{line: 1686, col: 31, offset: 52793},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1671, col: 36, offset: 52395},
+										pos: position{line: 1686, col: 36, offset: 52798},
 										expr: &choiceExpr{
-											pos: position{line: 1671, col: 37, offset: 52396},
-											alternatives: []interface{}{
+											pos: position{line: 1686, col: 37, offset: 52799},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1671, col: 37, offset: 52396},
+													pos:  position{line: 1686, col: 37, offset: 52799},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1671, col: 53, offset: 52412},
+													pos:  position{line: 1686, col: 53, offset: 52815},
 													name: "IntegerAsString",
 												},
 											},
@@ -2988,25 +3002,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1671, col: 71, offset: 52430},
+									pos:        position{line: 1686, col: 71, offset: 52833},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1671, col: 77, offset: 52436},
+									pos:   position{line: 1686, col: 77, offset: 52839},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1671, col: 82, offset: 52441},
+										pos: position{line: 1686, col: 82, offset: 52844},
 										expr: &choiceExpr{
-											pos: position{line: 1671, col: 83, offset: 52442},
-											alternatives: []interface{}{
+											pos: position{line: 1686, col: 83, offset: 52845},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1671, col: 83, offset: 52442},
+													pos:  position{line: 1686, col: 83, offset: 52845},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1671, col: 99, offset: 52458},
+													pos:  position{line: 1686, col: 99, offset: 52861},
 													name: "IntegerAsString",
 												},
 											},
@@ -3017,26 +3031,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1714, col: 3, offset: 53894},
+						pos: position{line: 1729, col: 3, offset: 54297},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1714, col: 3, offset: 53894},
-							exprs: []interface{}{
+							pos: position{line: 1729, col: 3, offset: 54297},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1714, col: 3, offset: 53894},
+									pos:        position{line: 1729, col: 3, offset: 54297},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1714, col: 10, offset: 53901},
+									pos:  position{line: 1729, col: 10, offset: 54304},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1714, col: 16, offset: 53907},
+									pos:   position{line: 1729, col: 16, offset: 54310},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1714, col: 24, offset: 53915},
+										pos:  position{line: 1729, col: 24, offset: 54318},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3048,38 +3062,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1729, col: 1, offset: 54246},
+			pos:  position{line: 1744, col: 1, offset: 54649},
 			expr: &actionExpr{
-				pos: position{line: 1729, col: 17, offset: 54262},
+				pos: position{line: 1744, col: 17, offset: 54665},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1729, col: 17, offset: 54262},
+					pos:   position{line: 1744, col: 17, offset: 54665},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1729, col: 25, offset: 54270},
-						alternatives: []interface{}{
+						pos: position{line: 1744, col: 25, offset: 54673},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 25, offset: 54270},
+								pos:  position{line: 1744, col: 25, offset: 54673},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 46, offset: 54291},
+								pos:  position{line: 1744, col: 46, offset: 54694},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 65, offset: 54310},
+								pos:  position{line: 1744, col: 65, offset: 54713},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 84, offset: 54329},
+								pos:  position{line: 1744, col: 84, offset: 54732},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 101, offset: 54346},
+								pos:  position{line: 1744, col: 101, offset: 54749},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1729, col: 116, offset: 54361},
+								pos:  position{line: 1744, col: 116, offset: 54764},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3089,35 +3103,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1733, col: 1, offset: 54404},
+			pos:  position{line: 1748, col: 1, offset: 54807},
 			expr: &actionExpr{
-				pos: position{line: 1733, col: 22, offset: 54425},
+				pos: position{line: 1748, col: 22, offset: 54828},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1733, col: 22, offset: 54425},
-					exprs: []interface{}{
+					pos: position{line: 1748, col: 22, offset: 54828},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1733, col: 22, offset: 54425},
+							pos:   position{line: 1748, col: 22, offset: 54828},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1733, col: 29, offset: 54432},
+								pos:  position{line: 1748, col: 29, offset: 54835},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1733, col: 42, offset: 54445},
+							pos:   position{line: 1748, col: 42, offset: 54848},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1733, col: 48, offset: 54451},
+								pos: position{line: 1748, col: 48, offset: 54854},
 								expr: &seqExpr{
-									pos: position{line: 1733, col: 49, offset: 54452},
-									exprs: []interface{}{
+									pos: position{line: 1748, col: 49, offset: 54855},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1733, col: 49, offset: 54452},
+											pos:  position{line: 1748, col: 49, offset: 54855},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1733, col: 55, offset: 54458},
+											pos:  position{line: 1748, col: 55, offset: 54861},
 											name: "BinCmdOption",
 										},
 									},
@@ -3130,51 +3144,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1779, col: 1, offset: 55942},
+			pos:  position{line: 1794, col: 1, offset: 56345},
 			expr: &choiceExpr{
-				pos: position{line: 1779, col: 13, offset: 55954},
-				alternatives: []interface{}{
+				pos: position{line: 1794, col: 13, offset: 56357},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1779, col: 13, offset: 55954},
+						pos: position{line: 1794, col: 13, offset: 56357},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1779, col: 13, offset: 55954},
-							exprs: []interface{}{
+							pos: position{line: 1794, col: 13, offset: 56357},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1779, col: 13, offset: 55954},
+									pos:  position{line: 1794, col: 13, offset: 56357},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1779, col: 18, offset: 55959},
+									pos:  position{line: 1794, col: 18, offset: 56362},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1779, col: 26, offset: 55967},
+									pos:   position{line: 1794, col: 26, offset: 56370},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1779, col: 40, offset: 55981},
+										pos:  position{line: 1794, col: 40, offset: 56384},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1779, col: 59, offset: 56000},
+									pos:  position{line: 1794, col: 59, offset: 56403},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1779, col: 65, offset: 56006},
+									pos:   position{line: 1794, col: 65, offset: 56409},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1779, col: 71, offset: 56012},
+										pos:  position{line: 1794, col: 71, offset: 56415},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1779, col: 81, offset: 56022},
+									pos:   position{line: 1794, col: 81, offset: 56425},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1779, col: 94, offset: 56035},
+										pos: position{line: 1794, col: 94, offset: 56438},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1779, col: 95, offset: 56036},
+											pos:  position{line: 1794, col: 95, offset: 56439},
 											name: "AsField",
 										},
 									},
@@ -3183,34 +3197,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1806, col: 3, offset: 56862},
+						pos: position{line: 1821, col: 3, offset: 57265},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1806, col: 3, offset: 56862},
-							exprs: []interface{}{
+							pos: position{line: 1821, col: 3, offset: 57265},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 3, offset: 56862},
+									pos:  position{line: 1821, col: 3, offset: 57265},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 8, offset: 56867},
+									pos:  position{line: 1821, col: 8, offset: 57270},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1806, col: 16, offset: 56875},
+									pos:   position{line: 1821, col: 16, offset: 57278},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1806, col: 22, offset: 56881},
+										pos:  position{line: 1821, col: 22, offset: 57284},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1806, col: 32, offset: 56891},
+									pos:   position{line: 1821, col: 32, offset: 57294},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1806, col: 45, offset: 56904},
+										pos: position{line: 1821, col: 45, offset: 57307},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1806, col: 46, offset: 56905},
+											pos:  position{line: 1821, col: 46, offset: 57308},
 											name: "AsField",
 										},
 									},
@@ -3223,15 +3237,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1837, col: 1, offset: 57762},
+			pos:  position{line: 1852, col: 1, offset: 58165},
 			expr: &actionExpr{
-				pos: position{line: 1837, col: 15, offset: 57776},
+				pos: position{line: 1852, col: 15, offset: 58179},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1837, col: 15, offset: 57776},
+					pos:   position{line: 1852, col: 15, offset: 58179},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1837, col: 27, offset: 57788},
+						pos:  position{line: 1852, col: 27, offset: 58191},
 						name: "SpanOptions",
 					},
 				},
@@ -3239,26 +3253,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1845, col: 1, offset: 58013},
+			pos:  position{line: 1860, col: 1, offset: 58416},
 			expr: &actionExpr{
-				pos: position{line: 1845, col: 16, offset: 58028},
+				pos: position{line: 1860, col: 16, offset: 58431},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1845, col: 16, offset: 58028},
-					exprs: []interface{}{
+					pos: position{line: 1860, col: 16, offset: 58431},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1845, col: 16, offset: 58028},
+							pos:  position{line: 1860, col: 16, offset: 58431},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1845, col: 25, offset: 58037},
+							pos:  position{line: 1860, col: 25, offset: 58440},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1845, col: 31, offset: 58043},
+							pos:   position{line: 1860, col: 31, offset: 58446},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1845, col: 42, offset: 58054},
+								pos:  position{line: 1860, col: 42, offset: 58457},
 								name: "SpanLength",
 							},
 						},
@@ -3268,26 +3282,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1852, col: 1, offset: 58200},
+			pos:  position{line: 1867, col: 1, offset: 58603},
 			expr: &actionExpr{
-				pos: position{line: 1852, col: 15, offset: 58214},
+				pos: position{line: 1867, col: 15, offset: 58617},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1852, col: 15, offset: 58214},
-					exprs: []interface{}{
+					pos: position{line: 1867, col: 15, offset: 58617},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1852, col: 15, offset: 58214},
+							pos:   position{line: 1867, col: 15, offset: 58617},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1852, col: 24, offset: 58223},
+								pos:  position{line: 1867, col: 24, offset: 58626},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1852, col: 40, offset: 58239},
+							pos:   position{line: 1867, col: 40, offset: 58642},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1852, col: 50, offset: 58249},
+								pos:  position{line: 1867, col: 50, offset: 58652},
 								name: "AllTimeScale",
 							},
 						},
@@ -3297,43 +3311,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1869, col: 1, offset: 58798},
+			pos:  position{line: 1884, col: 1, offset: 59201},
 			expr: &actionExpr{
-				pos: position{line: 1869, col: 14, offset: 58811},
+				pos: position{line: 1884, col: 14, offset: 59214},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1869, col: 14, offset: 58811},
-					exprs: []interface{}{
+					pos: position{line: 1884, col: 14, offset: 59214},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1869, col: 14, offset: 58811},
+							pos:  position{line: 1884, col: 14, offset: 59214},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1869, col: 20, offset: 58817},
+							pos:        position{line: 1884, col: 20, offset: 59220},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1869, col: 28, offset: 58825},
+							pos:  position{line: 1884, col: 28, offset: 59228},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1869, col: 34, offset: 58831},
+							pos:   position{line: 1884, col: 34, offset: 59234},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1869, col: 41, offset: 58838},
+								pos: position{line: 1884, col: 41, offset: 59241},
 								expr: &choiceExpr{
-									pos: position{line: 1869, col: 42, offset: 58839},
-									alternatives: []interface{}{
+									pos: position{line: 1884, col: 42, offset: 59242},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1869, col: 42, offset: 58839},
+											pos:        position{line: 1884, col: 42, offset: 59242},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1869, col: 50, offset: 58847},
+											pos:        position{line: 1884, col: 50, offset: 59250},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3343,14 +3357,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1869, col: 61, offset: 58858},
+							pos:  position{line: 1884, col: 61, offset: 59261},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1869, col: 76, offset: 58873},
+							pos:   position{line: 1884, col: 76, offset: 59276},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1869, col: 86, offset: 58883},
+								pos:  position{line: 1884, col: 86, offset: 59286},
 								name: "IntegerAsString",
 							},
 						},
@@ -3360,22 +3374,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1893, col: 1, offset: 59464},
+			pos:  position{line: 1908, col: 1, offset: 59867},
 			expr: &actionExpr{
-				pos: position{line: 1893, col: 19, offset: 59482},
+				pos: position{line: 1908, col: 19, offset: 59885},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1893, col: 19, offset: 59482},
-					exprs: []interface{}{
+					pos: position{line: 1908, col: 19, offset: 59885},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1893, col: 19, offset: 59482},
+							pos:  position{line: 1908, col: 19, offset: 59885},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1893, col: 24, offset: 59487},
+							pos:   position{line: 1908, col: 24, offset: 59890},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1893, col: 38, offset: 59501},
+								pos:  position{line: 1908, col: 38, offset: 59904},
 								name: "StatisticExpr",
 							},
 						},
@@ -3385,76 +3399,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1930, col: 1, offset: 60639},
+			pos:  position{line: 1945, col: 1, offset: 61042},
 			expr: &actionExpr{
-				pos: position{line: 1930, col: 18, offset: 60656},
+				pos: position{line: 1945, col: 18, offset: 61059},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1930, col: 18, offset: 60656},
-					exprs: []interface{}{
+					pos: position{line: 1945, col: 18, offset: 61059},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1930, col: 18, offset: 60656},
+							pos:   position{line: 1945, col: 18, offset: 61059},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1930, col: 23, offset: 60661},
-								alternatives: []interface{}{
+								pos: position{line: 1945, col: 23, offset: 61064},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1930, col: 23, offset: 60661},
+										pos:  position{line: 1945, col: 23, offset: 61064},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1930, col: 33, offset: 60671},
+										pos:  position{line: 1945, col: 33, offset: 61074},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1930, col: 43, offset: 60681},
+							pos:   position{line: 1945, col: 43, offset: 61084},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1930, col: 49, offset: 60687},
+								pos: position{line: 1945, col: 49, offset: 61090},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1930, col: 50, offset: 60688},
+									pos:  position{line: 1945, col: 50, offset: 61091},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1930, col: 67, offset: 60705},
+							pos:   position{line: 1945, col: 67, offset: 61108},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1930, col: 78, offset: 60716},
-								exprs: []interface{}{
+								pos: position{line: 1945, col: 78, offset: 61119},
+								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1930, col: 78, offset: 60716},
+										pos:  position{line: 1945, col: 78, offset: 61119},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1930, col: 84, offset: 60722},
+										pos:  position{line: 1945, col: 84, offset: 61125},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1930, col: 99, offset: 60737},
+							pos:   position{line: 1945, col: 99, offset: 61140},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1930, col: 108, offset: 60746},
+								pos: position{line: 1945, col: 108, offset: 61149},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1930, col: 109, offset: 60747},
+									pos:  position{line: 1945, col: 109, offset: 61150},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1930, col: 120, offset: 60758},
+							pos:   position{line: 1945, col: 120, offset: 61161},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1930, col: 128, offset: 60766},
+								pos: position{line: 1945, col: 128, offset: 61169},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1930, col: 129, offset: 60767},
+									pos:  position{line: 1945, col: 129, offset: 61170},
 									name: "StatisticOptions",
 								},
 							},
@@ -3465,25 +3479,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1972, col: 1, offset: 61852},
+			pos:  position{line: 1987, col: 1, offset: 62255},
 			expr: &choiceExpr{
-				pos: position{line: 1972, col: 19, offset: 61870},
-				alternatives: []interface{}{
+				pos: position{line: 1987, col: 19, offset: 62273},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1972, col: 19, offset: 61870},
+						pos: position{line: 1987, col: 19, offset: 62273},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1972, col: 19, offset: 61870},
-							exprs: []interface{}{
+							pos: position{line: 1987, col: 19, offset: 62273},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1972, col: 19, offset: 61870},
+									pos:  position{line: 1987, col: 19, offset: 62273},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1972, col: 25, offset: 61876},
+									pos:   position{line: 1987, col: 25, offset: 62279},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1972, col: 32, offset: 61883},
+										pos:  position{line: 1987, col: 32, offset: 62286},
 										name: "IntegerAsString",
 									},
 								},
@@ -3491,30 +3505,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1975, col: 3, offset: 61937},
+						pos: position{line: 1990, col: 3, offset: 62340},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1975, col: 3, offset: 61937},
-							exprs: []interface{}{
+							pos: position{line: 1990, col: 3, offset: 62340},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1975, col: 3, offset: 61937},
+									pos:  position{line: 1990, col: 3, offset: 62340},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1975, col: 9, offset: 61943},
+									pos:        position{line: 1990, col: 9, offset: 62346},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1975, col: 17, offset: 61951},
+									pos:  position{line: 1990, col: 17, offset: 62354},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1975, col: 23, offset: 61957},
+									pos:   position{line: 1990, col: 23, offset: 62360},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1975, col: 30, offset: 61964},
+										pos:  position{line: 1990, col: 30, offset: 62367},
 										name: "IntegerAsString",
 									},
 								},
@@ -3526,17 +3540,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 1980, col: 1, offset: 62062},
+			pos:  position{line: 1995, col: 1, offset: 62465},
 			expr: &actionExpr{
-				pos: position{line: 1980, col: 21, offset: 62082},
+				pos: position{line: 1995, col: 21, offset: 62485},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1980, col: 21, offset: 62082},
+					pos:   position{line: 1995, col: 21, offset: 62485},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1980, col: 28, offset: 62089},
+						pos: position{line: 1995, col: 28, offset: 62492},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1980, col: 29, offset: 62090},
+							pos:  position{line: 1995, col: 29, offset: 62493},
 							name: "StatisticOption",
 						},
 					},
@@ -3545,34 +3559,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 2029, col: 1, offset: 63652},
+			pos:  position{line: 2044, col: 1, offset: 64055},
 			expr: &actionExpr{
-				pos: position{line: 2029, col: 20, offset: 63671},
+				pos: position{line: 2044, col: 20, offset: 64074},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 2029, col: 20, offset: 63671},
-					exprs: []interface{}{
+					pos: position{line: 2044, col: 20, offset: 64074},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 20, offset: 63671},
+							pos:  position{line: 2044, col: 20, offset: 64074},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 26, offset: 63677},
+							pos:   position{line: 2044, col: 26, offset: 64080},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2029, col: 36, offset: 63687},
+								pos:  position{line: 2044, col: 36, offset: 64090},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2029, col: 55, offset: 63706},
+							pos:  position{line: 2044, col: 55, offset: 64109},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2029, col: 61, offset: 63712},
+							pos:   position{line: 2044, col: 61, offset: 64115},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2029, col: 67, offset: 63718},
+								pos:  position{line: 2044, col: 67, offset: 64121},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3582,48 +3596,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 2034, col: 1, offset: 63827},
+			pos:  position{line: 2049, col: 1, offset: 64230},
 			expr: &actionExpr{
-				pos: position{line: 2034, col: 23, offset: 63849},
+				pos: position{line: 2049, col: 23, offset: 64252},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2034, col: 23, offset: 63849},
+					pos:   position{line: 2049, col: 23, offset: 64252},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2034, col: 31, offset: 63857},
-						alternatives: []interface{}{
+						pos: position{line: 2049, col: 31, offset: 64260},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2034, col: 31, offset: 63857},
+								pos:        position{line: 2049, col: 31, offset: 64260},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2034, col: 46, offset: 63872},
+								pos:        position{line: 2049, col: 46, offset: 64275},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2034, col: 60, offset: 63886},
+								pos:        position{line: 2049, col: 60, offset: 64289},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2034, col: 73, offset: 63899},
+								pos:        position{line: 2049, col: 73, offset: 64302},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2034, col: 85, offset: 63911},
+								pos:        position{line: 2049, col: 85, offset: 64314},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2034, col: 102, offset: 63928},
+								pos:        position{line: 2049, col: 102, offset: 64331},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3635,25 +3649,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2042, col: 1, offset: 64115},
+			pos:  position{line: 2057, col: 1, offset: 64518},
 			expr: &choiceExpr{
-				pos: position{line: 2042, col: 13, offset: 64127},
-				alternatives: []interface{}{
+				pos: position{line: 2057, col: 13, offset: 64530},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2042, col: 13, offset: 64127},
+						pos: position{line: 2057, col: 13, offset: 64530},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2042, col: 13, offset: 64127},
-							exprs: []interface{}{
+							pos: position{line: 2057, col: 13, offset: 64530},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2042, col: 13, offset: 64127},
+									pos:  position{line: 2057, col: 13, offset: 64530},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2042, col: 16, offset: 64130},
+									pos:   position{line: 2057, col: 16, offset: 64533},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2042, col: 26, offset: 64140},
+										pos:  position{line: 2057, col: 26, offset: 64543},
 										name: "FieldNameList",
 									},
 								},
@@ -3661,13 +3675,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2045, col: 3, offset: 64197},
+						pos: position{line: 2060, col: 3, offset: 64600},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2045, col: 3, offset: 64197},
+							pos:   position{line: 2060, col: 3, offset: 64600},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2045, col: 16, offset: 64210},
+								pos:  position{line: 2060, col: 16, offset: 64613},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3677,26 +3691,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2049, col: 1, offset: 64268},
+			pos:  position{line: 2064, col: 1, offset: 64671},
 			expr: &actionExpr{
-				pos: position{line: 2049, col: 15, offset: 64282},
+				pos: position{line: 2064, col: 15, offset: 64685},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2049, col: 15, offset: 64282},
-					exprs: []interface{}{
+					pos: position{line: 2064, col: 15, offset: 64685},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2049, col: 15, offset: 64282},
+							pos:  position{line: 2064, col: 15, offset: 64685},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2049, col: 20, offset: 64287},
+							pos:  position{line: 2064, col: 20, offset: 64690},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2049, col: 30, offset: 64297},
+							pos:   position{line: 2064, col: 30, offset: 64700},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2049, col: 40, offset: 64307},
+								pos:  position{line: 2064, col: 40, offset: 64710},
 								name: "DedupExpr",
 							},
 						},
@@ -3706,27 +3720,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2095, col: 1, offset: 65636},
+			pos:  position{line: 2110, col: 1, offset: 66039},
 			expr: &actionExpr{
-				pos: position{line: 2095, col: 14, offset: 65649},
+				pos: position{line: 2110, col: 14, offset: 66052},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2095, col: 14, offset: 65649},
-					exprs: []interface{}{
+					pos: position{line: 2110, col: 14, offset: 66052},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2095, col: 14, offset: 65649},
+							pos:   position{line: 2110, col: 14, offset: 66052},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2095, col: 23, offset: 65658},
+								pos: position{line: 2110, col: 23, offset: 66061},
 								expr: &seqExpr{
-									pos: position{line: 2095, col: 24, offset: 65659},
-									exprs: []interface{}{
+									pos: position{line: 2110, col: 24, offset: 66062},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2095, col: 24, offset: 65659},
+											pos:  position{line: 2110, col: 24, offset: 66062},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2095, col: 30, offset: 65665},
+											pos:  position{line: 2110, col: 30, offset: 66068},
 											name: "IntegerAsString",
 										},
 									},
@@ -3734,45 +3748,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 48, offset: 65683},
+							pos:   position{line: 2110, col: 48, offset: 66086},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2095, col: 57, offset: 65692},
+								pos: position{line: 2110, col: 57, offset: 66095},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2095, col: 58, offset: 65693},
+									pos:  position{line: 2110, col: 58, offset: 66096},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 73, offset: 65708},
+							pos:   position{line: 2110, col: 73, offset: 66111},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2095, col: 83, offset: 65718},
+								pos: position{line: 2110, col: 83, offset: 66121},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2095, col: 84, offset: 65719},
+									pos:  position{line: 2110, col: 84, offset: 66122},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 101, offset: 65736},
+							pos:   position{line: 2110, col: 101, offset: 66139},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2095, col: 110, offset: 65745},
+								pos: position{line: 2110, col: 110, offset: 66148},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2095, col: 111, offset: 65746},
+									pos:  position{line: 2110, col: 111, offset: 66149},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2095, col: 126, offset: 65761},
+							pos:   position{line: 2110, col: 126, offset: 66164},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2095, col: 139, offset: 65774},
+								pos: position{line: 2110, col: 139, offset: 66177},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2095, col: 140, offset: 65775},
+									pos:  position{line: 2110, col: 140, offset: 66178},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3783,27 +3797,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2152, col: 1, offset: 67513},
+			pos:  position{line: 2167, col: 1, offset: 67916},
 			expr: &actionExpr{
-				pos: position{line: 2152, col: 19, offset: 67531},
+				pos: position{line: 2167, col: 19, offset: 67934},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2152, col: 19, offset: 67531},
-					exprs: []interface{}{
+					pos: position{line: 2167, col: 19, offset: 67934},
+					exprs: []any{
 						&notExpr{
-							pos: position{line: 2152, col: 19, offset: 67531},
+							pos: position{line: 2167, col: 19, offset: 67934},
 							expr: &litMatcher{
-								pos:        position{line: 2152, col: 21, offset: 67533},
+								pos:        position{line: 2167, col: 21, offset: 67936},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2152, col: 31, offset: 67543},
+							pos:   position{line: 2167, col: 31, offset: 67946},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2152, col: 37, offset: 67549},
+								pos:  position{line: 2167, col: 37, offset: 67952},
 								name: "FieldName",
 							},
 						},
@@ -3813,48 +3827,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2158, col: 1, offset: 67688},
+			pos:  position{line: 2173, col: 1, offset: 68091},
 			expr: &actionExpr{
-				pos: position{line: 2158, col: 32, offset: 67719},
+				pos: position{line: 2173, col: 32, offset: 68122},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2158, col: 32, offset: 67719},
-					exprs: []interface{}{
+					pos: position{line: 2173, col: 32, offset: 68122},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2158, col: 32, offset: 67719},
+							pos:   position{line: 2173, col: 32, offset: 68122},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 38, offset: 67725},
+								pos:  position{line: 2173, col: 38, offset: 68128},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2158, col: 48, offset: 67735},
+							pos: position{line: 2173, col: 48, offset: 68138},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2158, col: 50, offset: 67737},
+								pos:  position{line: 2173, col: 50, offset: 68140},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2158, col: 57, offset: 67744},
+							pos:   position{line: 2173, col: 57, offset: 68147},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2158, col: 62, offset: 67749},
+								pos: position{line: 2173, col: 62, offset: 68152},
 								expr: &seqExpr{
-									pos: position{line: 2158, col: 63, offset: 67750},
-									exprs: []interface{}{
+									pos: position{line: 2173, col: 63, offset: 68153},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2158, col: 63, offset: 67750},
+											pos:  position{line: 2173, col: 63, offset: 68153},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2158, col: 69, offset: 67756},
+											pos:  position{line: 2173, col: 69, offset: 68159},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2158, col: 79, offset: 67766},
+											pos: position{line: 2173, col: 79, offset: 68169},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2158, col: 81, offset: 67768},
+												pos:  position{line: 2173, col: 81, offset: 68171},
 												name: "EQUAL",
 											},
 										},
@@ -3868,45 +3882,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2169, col: 1, offset: 68043},
+			pos:  position{line: 2184, col: 1, offset: 68446},
 			expr: &actionExpr{
-				pos: position{line: 2169, col: 19, offset: 68061},
+				pos: position{line: 2184, col: 19, offset: 68464},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2169, col: 19, offset: 68061},
-					exprs: []interface{}{
+					pos: position{line: 2184, col: 19, offset: 68464},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2169, col: 19, offset: 68061},
+							pos:  position{line: 2184, col: 19, offset: 68464},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2169, col: 25, offset: 68067},
+							pos:   position{line: 2184, col: 25, offset: 68470},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2169, col: 31, offset: 68073},
+								pos:  position{line: 2184, col: 31, offset: 68476},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2169, col: 46, offset: 68088},
+							pos:   position{line: 2184, col: 46, offset: 68491},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2169, col: 51, offset: 68093},
+								pos: position{line: 2184, col: 51, offset: 68496},
 								expr: &seqExpr{
-									pos: position{line: 2169, col: 52, offset: 68094},
-									exprs: []interface{}{
+									pos: position{line: 2184, col: 52, offset: 68497},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2169, col: 52, offset: 68094},
+											pos:  position{line: 2184, col: 52, offset: 68497},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2169, col: 58, offset: 68100},
+											pos:  position{line: 2184, col: 58, offset: 68503},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2169, col: 73, offset: 68115},
+											pos: position{line: 2184, col: 73, offset: 68518},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2169, col: 74, offset: 68116},
+												pos:  position{line: 2184, col: 74, offset: 68519},
 												name: "EQUAL",
 											},
 										},
@@ -3920,17 +3934,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2187, col: 1, offset: 68644},
+			pos:  position{line: 2202, col: 1, offset: 69047},
 			expr: &actionExpr{
-				pos: position{line: 2187, col: 17, offset: 68660},
+				pos: position{line: 2202, col: 17, offset: 69063},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2187, col: 17, offset: 68660},
+					pos:   position{line: 2202, col: 17, offset: 69063},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2187, col: 24, offset: 68667},
+						pos: position{line: 2202, col: 24, offset: 69070},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2187, col: 25, offset: 68668},
+							pos:  position{line: 2202, col: 25, offset: 69071},
 							name: "DedupOption",
 						},
 					},
@@ -3939,36 +3953,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2227, col: 1, offset: 69934},
+			pos:  position{line: 2242, col: 1, offset: 70337},
 			expr: &actionExpr{
-				pos: position{line: 2227, col: 16, offset: 69949},
+				pos: position{line: 2242, col: 16, offset: 70352},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2227, col: 16, offset: 69949},
-					exprs: []interface{}{
+					pos: position{line: 2242, col: 16, offset: 70352},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2227, col: 16, offset: 69949},
+							pos:  position{line: 2242, col: 16, offset: 70352},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2227, col: 22, offset: 69955},
+							pos:   position{line: 2242, col: 22, offset: 70358},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2227, col: 32, offset: 69965},
+								pos:  position{line: 2242, col: 32, offset: 70368},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2227, col: 47, offset: 69980},
+							pos:        position{line: 2242, col: 47, offset: 70383},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2227, col: 51, offset: 69984},
+							pos:   position{line: 2242, col: 51, offset: 70387},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2227, col: 57, offset: 69990},
+								pos:  position{line: 2242, col: 57, offset: 70393},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3978,30 +3992,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2232, col: 1, offset: 70099},
+			pos:  position{line: 2247, col: 1, offset: 70502},
 			expr: &actionExpr{
-				pos: position{line: 2232, col: 19, offset: 70117},
+				pos: position{line: 2247, col: 19, offset: 70520},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2232, col: 19, offset: 70117},
+					pos:   position{line: 2247, col: 19, offset: 70520},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2232, col: 27, offset: 70125},
-						alternatives: []interface{}{
+						pos: position{line: 2247, col: 27, offset: 70528},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2232, col: 27, offset: 70125},
+								pos:        position{line: 2247, col: 27, offset: 70528},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2232, col: 43, offset: 70141},
+								pos:        position{line: 2247, col: 43, offset: 70544},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2232, col: 57, offset: 70155},
+								pos:        position{line: 2247, col: 57, offset: 70558},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -4013,22 +4027,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2240, col: 1, offset: 70340},
+			pos:  position{line: 2255, col: 1, offset: 70743},
 			expr: &actionExpr{
-				pos: position{line: 2240, col: 22, offset: 70361},
+				pos: position{line: 2255, col: 22, offset: 70764},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2240, col: 22, offset: 70361},
-					exprs: []interface{}{
+					pos: position{line: 2255, col: 22, offset: 70764},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2240, col: 22, offset: 70361},
+							pos:  position{line: 2255, col: 22, offset: 70764},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2240, col: 39, offset: 70378},
+							pos:   position{line: 2255, col: 39, offset: 70781},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2240, col: 53, offset: 70392},
+								pos:  position{line: 2255, col: 53, offset: 70795},
 								name: "SortElements",
 							},
 						},
@@ -4038,35 +4052,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2245, col: 1, offset: 70500},
+			pos:  position{line: 2260, col: 1, offset: 70903},
 			expr: &actionExpr{
-				pos: position{line: 2245, col: 17, offset: 70516},
+				pos: position{line: 2260, col: 17, offset: 70919},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2245, col: 17, offset: 70516},
-					exprs: []interface{}{
+					pos: position{line: 2260, col: 17, offset: 70919},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2245, col: 17, offset: 70516},
+							pos:   position{line: 2260, col: 17, offset: 70919},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2245, col: 23, offset: 70522},
+								pos:  position{line: 2260, col: 23, offset: 70925},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2245, col: 41, offset: 70540},
+							pos:   position{line: 2260, col: 41, offset: 70943},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2245, col: 46, offset: 70545},
+								pos: position{line: 2260, col: 46, offset: 70948},
 								expr: &seqExpr{
-									pos: position{line: 2245, col: 47, offset: 70546},
-									exprs: []interface{}{
+									pos: position{line: 2260, col: 47, offset: 70949},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2245, col: 47, offset: 70546},
+											pos:  position{line: 2260, col: 47, offset: 70949},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2245, col: 62, offset: 70561},
+											pos:  position{line: 2260, col: 62, offset: 70964},
 											name: "SingleSortElement",
 										},
 									},
@@ -4079,22 +4093,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2260, col: 1, offset: 70919},
+			pos:  position{line: 2275, col: 1, offset: 71322},
 			expr: &actionExpr{
-				pos: position{line: 2260, col: 22, offset: 70940},
+				pos: position{line: 2275, col: 22, offset: 71343},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2260, col: 22, offset: 70940},
+					pos:   position{line: 2275, col: 22, offset: 71343},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2260, col: 31, offset: 70949},
-						alternatives: []interface{}{
+						pos: position{line: 2275, col: 31, offset: 71352},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2260, col: 31, offset: 70949},
+								pos:  position{line: 2275, col: 31, offset: 71352},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2260, col: 59, offset: 70977},
+								pos:  position{line: 2275, col: 59, offset: 71380},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4104,33 +4118,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2264, col: 1, offset: 71036},
+			pos:  position{line: 2279, col: 1, offset: 71439},
 			expr: &actionExpr{
-				pos: position{line: 2264, col: 33, offset: 71068},
+				pos: position{line: 2279, col: 33, offset: 71471},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2264, col: 33, offset: 71068},
-					exprs: []interface{}{
+					pos: position{line: 2279, col: 33, offset: 71471},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2264, col: 33, offset: 71068},
+							pos:   position{line: 2279, col: 33, offset: 71471},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2264, col: 47, offset: 71082},
-								alternatives: []interface{}{
+								pos: position{line: 2279, col: 47, offset: 71485},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2264, col: 47, offset: 71082},
+										pos:        position{line: 2279, col: 47, offset: 71485},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2264, col: 53, offset: 71088},
+										pos:        position{line: 2279, col: 53, offset: 71491},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2264, col: 59, offset: 71094},
+										pos:        position{line: 2279, col: 59, offset: 71497},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4139,10 +4153,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2264, col: 63, offset: 71098},
+							pos:   position{line: 2279, col: 63, offset: 71501},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2264, col: 69, offset: 71104},
+								pos:  position{line: 2279, col: 69, offset: 71507},
 								name: "FieldName",
 							},
 						},
@@ -4152,33 +4166,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2279, col: 1, offset: 71379},
+			pos:  position{line: 2294, col: 1, offset: 71782},
 			expr: &actionExpr{
-				pos: position{line: 2279, col: 30, offset: 71408},
+				pos: position{line: 2294, col: 30, offset: 71811},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2279, col: 30, offset: 71408},
-					exprs: []interface{}{
+					pos: position{line: 2294, col: 30, offset: 71811},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2279, col: 30, offset: 71408},
+							pos:   position{line: 2294, col: 30, offset: 71811},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2279, col: 44, offset: 71422},
-								alternatives: []interface{}{
+								pos: position{line: 2294, col: 44, offset: 71825},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2279, col: 44, offset: 71422},
+										pos:        position{line: 2294, col: 44, offset: 71825},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 50, offset: 71428},
+										pos:        position{line: 2294, col: 50, offset: 71831},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 56, offset: 71434},
+										pos:        position{line: 2294, col: 56, offset: 71837},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4187,31 +4201,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2279, col: 60, offset: 71438},
+							pos:   position{line: 2294, col: 60, offset: 71841},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2279, col: 64, offset: 71442},
-								alternatives: []interface{}{
+								pos: position{line: 2294, col: 64, offset: 71845},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2279, col: 64, offset: 71442},
+										pos:        position{line: 2294, col: 64, offset: 71845},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 73, offset: 71451},
+										pos:        position{line: 2294, col: 73, offset: 71854},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 81, offset: 71459},
+										pos:        position{line: 2294, col: 81, offset: 71862},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2279, col: 88, offset: 71466},
+										pos:        position{line: 2294, col: 88, offset: 71869},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4220,19 +4234,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2279, col: 95, offset: 71473},
+							pos:  position{line: 2294, col: 95, offset: 71876},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2279, col: 103, offset: 71481},
+							pos:   position{line: 2294, col: 103, offset: 71884},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2279, col: 109, offset: 71487},
+								pos:  position{line: 2294, col: 109, offset: 71890},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2279, col: 119, offset: 71497},
+							pos:  position{line: 2294, col: 119, offset: 71900},
 							name: "R_PAREN",
 						},
 					},
@@ -4241,26 +4255,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2299, col: 1, offset: 71922},
+			pos:  position{line: 2314, col: 1, offset: 72325},
 			expr: &actionExpr{
-				pos: position{line: 2299, col: 16, offset: 71937},
+				pos: position{line: 2314, col: 16, offset: 72340},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2299, col: 16, offset: 71937},
-					exprs: []interface{}{
+					pos: position{line: 2314, col: 16, offset: 72340},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 16, offset: 71937},
+							pos:  position{line: 2314, col: 16, offset: 72340},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2299, col: 21, offset: 71942},
+							pos:  position{line: 2314, col: 21, offset: 72345},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2299, col: 32, offset: 71953},
+							pos:   position{line: 2314, col: 32, offset: 72356},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2299, col: 43, offset: 71964},
+								pos:  position{line: 2314, col: 43, offset: 72367},
 								name: "RenameExpr",
 							},
 						},
@@ -4270,33 +4284,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2322, col: 1, offset: 72628},
+			pos:  position{line: 2337, col: 1, offset: 73031},
 			expr: &choiceExpr{
-				pos: position{line: 2322, col: 15, offset: 72642},
-				alternatives: []interface{}{
+				pos: position{line: 2337, col: 15, offset: 73045},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2322, col: 15, offset: 72642},
+						pos: position{line: 2337, col: 15, offset: 73045},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2322, col: 15, offset: 72642},
-							exprs: []interface{}{
+							pos: position{line: 2337, col: 15, offset: 73045},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2322, col: 15, offset: 72642},
+									pos:   position{line: 2337, col: 15, offset: 73045},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2322, col: 31, offset: 72658},
+										pos:  position{line: 2337, col: 31, offset: 73061},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2322, col: 41, offset: 72668},
+									pos:  position{line: 2337, col: 41, offset: 73071},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2322, col: 44, offset: 72671},
+									pos:   position{line: 2337, col: 44, offset: 73074},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2322, col: 55, offset: 72682},
+										pos:  position{line: 2337, col: 55, offset: 73085},
 										name: "QuotedString",
 									},
 								},
@@ -4304,28 +4318,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2333, col: 3, offset: 73001},
+						pos: position{line: 2348, col: 3, offset: 73404},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2333, col: 3, offset: 73001},
-							exprs: []interface{}{
+							pos: position{line: 2348, col: 3, offset: 73404},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2333, col: 3, offset: 73001},
+									pos:   position{line: 2348, col: 3, offset: 73404},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2333, col: 19, offset: 73017},
+										pos:  position{line: 2348, col: 19, offset: 73420},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2333, col: 29, offset: 73027},
+									pos:  position{line: 2348, col: 29, offset: 73430},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2333, col: 32, offset: 73030},
+									pos:   position{line: 2348, col: 32, offset: 73433},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2333, col: 43, offset: 73041},
+										pos:  position{line: 2348, col: 43, offset: 73444},
 										name: "RenamePattern",
 									},
 								},
@@ -4337,48 +4351,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2355, col: 1, offset: 73607},
+			pos:  position{line: 2370, col: 1, offset: 74010},
 			expr: &actionExpr{
-				pos: position{line: 2355, col: 13, offset: 73619},
+				pos: position{line: 2370, col: 13, offset: 74022},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2355, col: 13, offset: 73619},
-					exprs: []interface{}{
+					pos: position{line: 2370, col: 13, offset: 74022},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2355, col: 13, offset: 73619},
+							pos:  position{line: 2370, col: 13, offset: 74022},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2355, col: 18, offset: 73624},
+							pos:  position{line: 2370, col: 18, offset: 74027},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2355, col: 26, offset: 73632},
+							pos:        position{line: 2370, col: 26, offset: 74035},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2355, col: 34, offset: 73640},
+							pos:  position{line: 2370, col: 34, offset: 74043},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2355, col: 40, offset: 73646},
+							pos:   position{line: 2370, col: 40, offset: 74049},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2355, col: 46, offset: 73652},
+								pos:  position{line: 2370, col: 46, offset: 74055},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2355, col: 62, offset: 73668},
+							pos:  position{line: 2370, col: 62, offset: 74071},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2355, col: 68, offset: 73674},
+							pos:   position{line: 2370, col: 68, offset: 74077},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2355, col: 72, offset: 73678},
+								pos:  position{line: 2370, col: 72, offset: 74081},
 								name: "QuotedString",
 							},
 						},
@@ -4388,37 +4402,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2384, col: 1, offset: 74407},
+			pos:  position{line: 2399, col: 1, offset: 74810},
 			expr: &actionExpr{
-				pos: position{line: 2384, col: 14, offset: 74420},
+				pos: position{line: 2399, col: 14, offset: 74823},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2384, col: 14, offset: 74420},
-					exprs: []interface{}{
+					pos: position{line: 2399, col: 14, offset: 74823},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2384, col: 14, offset: 74420},
+							pos:  position{line: 2399, col: 14, offset: 74823},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2384, col: 19, offset: 74425},
+							pos:  position{line: 2399, col: 19, offset: 74828},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2384, col: 28, offset: 74434},
+							pos:   position{line: 2399, col: 28, offset: 74837},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2384, col: 34, offset: 74440},
+								pos: position{line: 2399, col: 34, offset: 74843},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2384, col: 35, offset: 74441},
+									pos:  position{line: 2399, col: 35, offset: 74844},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2384, col: 47, offset: 74453},
+							pos:   position{line: 2399, col: 47, offset: 74856},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2384, col: 58, offset: 74464},
+								pos:  position{line: 2399, col: 58, offset: 74867},
 								name: "SortElements",
 							},
 						},
@@ -4428,41 +4442,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2422, col: 1, offset: 75343},
+			pos:  position{line: 2437, col: 1, offset: 75746},
 			expr: &actionExpr{
-				pos: position{line: 2422, col: 14, offset: 75356},
+				pos: position{line: 2437, col: 14, offset: 75759},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2422, col: 14, offset: 75356},
-					exprs: []interface{}{
+					pos: position{line: 2437, col: 14, offset: 75759},
+					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2422, col: 14, offset: 75356},
+							pos: position{line: 2437, col: 14, offset: 75759},
 							expr: &seqExpr{
-								pos: position{line: 2422, col: 15, offset: 75357},
-								exprs: []interface{}{
+								pos: position{line: 2437, col: 15, offset: 75760},
+								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2422, col: 15, offset: 75357},
+										pos:        position{line: 2437, col: 15, offset: 75760},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2422, col: 23, offset: 75365},
+										pos:  position{line: 2437, col: 23, offset: 75768},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2422, col: 31, offset: 75373},
+							pos:   position{line: 2437, col: 31, offset: 75776},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2422, col: 40, offset: 75382},
+								pos:  position{line: 2437, col: 40, offset: 75785},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2422, col: 56, offset: 75398},
+							pos:  position{line: 2437, col: 56, offset: 75801},
 							name: "SPACE",
 						},
 					},
@@ -4471,43 +4485,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2436, col: 1, offset: 75697},
+			pos:  position{line: 2451, col: 1, offset: 76100},
 			expr: &actionExpr{
-				pos: position{line: 2436, col: 14, offset: 75710},
+				pos: position{line: 2451, col: 14, offset: 76113},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2436, col: 14, offset: 75710},
-					exprs: []interface{}{
+					pos: position{line: 2451, col: 14, offset: 76113},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2436, col: 14, offset: 75710},
+							pos:  position{line: 2451, col: 14, offset: 76113},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2436, col: 19, offset: 75715},
+							pos:  position{line: 2451, col: 19, offset: 76118},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2436, col: 28, offset: 75724},
+							pos:   position{line: 2451, col: 28, offset: 76127},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2436, col: 34, offset: 75730},
+								pos:  position{line: 2451, col: 34, offset: 76133},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2436, col: 45, offset: 75741},
+							pos:   position{line: 2451, col: 45, offset: 76144},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2436, col: 50, offset: 75746},
+								pos: position{line: 2451, col: 50, offset: 76149},
 								expr: &seqExpr{
-									pos: position{line: 2436, col: 51, offset: 75747},
-									exprs: []interface{}{
+									pos: position{line: 2451, col: 51, offset: 76150},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2436, col: 51, offset: 75747},
+											pos:  position{line: 2451, col: 51, offset: 76150},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2436, col: 57, offset: 75753},
+											pos:  position{line: 2451, col: 57, offset: 76156},
 											name: "SingleEval",
 										},
 									},
@@ -4520,30 +4534,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2471, col: 1, offset: 76986},
+			pos:  position{line: 2486, col: 1, offset: 77389},
 			expr: &actionExpr{
-				pos: position{line: 2471, col: 15, offset: 77000},
+				pos: position{line: 2486, col: 15, offset: 77403},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2471, col: 15, offset: 77000},
-					exprs: []interface{}{
+					pos: position{line: 2486, col: 15, offset: 77403},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2471, col: 15, offset: 77000},
+							pos:   position{line: 2486, col: 15, offset: 77403},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2471, col: 21, offset: 77006},
+								pos:  position{line: 2486, col: 21, offset: 77409},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2471, col: 31, offset: 77016},
+							pos:  position{line: 2486, col: 31, offset: 77419},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2471, col: 37, offset: 77022},
+							pos:   position{line: 2486, col: 37, offset: 77425},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2471, col: 42, offset: 77027},
+								pos:  position{line: 2486, col: 42, offset: 77430},
 								name: "EvalExpression",
 							},
 						},
@@ -4553,15 +4567,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2484, col: 1, offset: 77428},
+			pos:  position{line: 2499, col: 1, offset: 77831},
 			expr: &actionExpr{
-				pos: position{line: 2484, col: 19, offset: 77446},
+				pos: position{line: 2499, col: 19, offset: 77849},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2484, col: 19, offset: 77446},
+					pos:   position{line: 2499, col: 19, offset: 77849},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2484, col: 25, offset: 77452},
+						pos:  position{line: 2499, col: 25, offset: 77855},
 						name: "ValueExpr",
 					},
 				},
@@ -4569,85 +4583,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2496, col: 1, offset: 77840},
+			pos:  position{line: 2511, col: 1, offset: 78243},
 			expr: &choiceExpr{
-				pos: position{line: 2496, col: 18, offset: 77857},
-				alternatives: []interface{}{
+				pos: position{line: 2511, col: 18, offset: 78260},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2496, col: 18, offset: 77857},
+						pos: position{line: 2511, col: 18, offset: 78260},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2496, col: 18, offset: 77857},
-							exprs: []interface{}{
+							pos: position{line: 2511, col: 18, offset: 78260},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2496, col: 18, offset: 77857},
+									pos:        position{line: 2511, col: 18, offset: 78260},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2496, col: 23, offset: 77862},
+									pos:  position{line: 2511, col: 23, offset: 78265},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2496, col: 31, offset: 77870},
+									pos:   position{line: 2511, col: 31, offset: 78273},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2496, col: 41, offset: 77880},
+										pos:  position{line: 2511, col: 41, offset: 78283},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2496, col: 50, offset: 77889},
+									pos:  position{line: 2511, col: 50, offset: 78292},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2496, col: 56, offset: 77895},
+									pos:   position{line: 2511, col: 56, offset: 78298},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2496, col: 66, offset: 77905},
+										pos:  position{line: 2511, col: 66, offset: 78308},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2496, col: 76, offset: 77915},
+									pos:  position{line: 2511, col: 76, offset: 78318},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2496, col: 82, offset: 77921},
+									pos:   position{line: 2511, col: 82, offset: 78324},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2496, col: 93, offset: 77932},
+										pos:  position{line: 2511, col: 93, offset: 78335},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2496, col: 103, offset: 77942},
+									pos:  position{line: 2511, col: 103, offset: 78345},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2507, col: 3, offset: 78193},
+						pos: position{line: 2522, col: 3, offset: 78596},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2507, col: 3, offset: 78193},
-							exprs: []interface{}{
+							pos: position{line: 2522, col: 3, offset: 78596},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2507, col: 3, offset: 78193},
+									pos:   position{line: 2522, col: 3, offset: 78596},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2507, col: 11, offset: 78201},
-										alternatives: []interface{}{
+										pos: position{line: 2522, col: 11, offset: 78604},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2507, col: 11, offset: 78201},
+												pos:        position{line: 2522, col: 11, offset: 78604},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2507, col: 20, offset: 78210},
+												pos:        position{line: 2522, col: 20, offset: 78613},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4656,31 +4670,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2507, col: 32, offset: 78222},
+									pos:  position{line: 2522, col: 32, offset: 78625},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2507, col: 40, offset: 78230},
+									pos:   position{line: 2522, col: 40, offset: 78633},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2507, col: 45, offset: 78235},
+										pos:  position{line: 2522, col: 45, offset: 78638},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2507, col: 64, offset: 78254},
+									pos:   position{line: 2522, col: 64, offset: 78657},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2507, col: 69, offset: 78259},
+										pos: position{line: 2522, col: 69, offset: 78662},
 										expr: &seqExpr{
-											pos: position{line: 2507, col: 70, offset: 78260},
-											exprs: []interface{}{
+											pos: position{line: 2522, col: 70, offset: 78663},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2507, col: 70, offset: 78260},
+													pos:  position{line: 2522, col: 70, offset: 78663},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2507, col: 76, offset: 78266},
+													pos:  position{line: 2522, col: 76, offset: 78669},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4688,50 +4702,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2507, col: 97, offset: 78287},
+									pos:  position{line: 2522, col: 97, offset: 78690},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2530, col: 3, offset: 78891},
+						pos: position{line: 2545, col: 3, offset: 79294},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2530, col: 3, offset: 78891},
-							exprs: []interface{}{
+							pos: position{line: 2545, col: 3, offset: 79294},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2530, col: 3, offset: 78891},
+									pos:        position{line: 2545, col: 3, offset: 79294},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2530, col: 14, offset: 78902},
+									pos:  position{line: 2545, col: 14, offset: 79305},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2530, col: 22, offset: 78910},
+									pos:   position{line: 2545, col: 22, offset: 79313},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2530, col: 32, offset: 78920},
+										pos:  position{line: 2545, col: 32, offset: 79323},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2530, col: 42, offset: 78930},
+									pos:   position{line: 2545, col: 42, offset: 79333},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2530, col: 47, offset: 78935},
+										pos: position{line: 2545, col: 47, offset: 79338},
 										expr: &seqExpr{
-											pos: position{line: 2530, col: 48, offset: 78936},
-											exprs: []interface{}{
+											pos: position{line: 2545, col: 48, offset: 79339},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2530, col: 48, offset: 78936},
+													pos:  position{line: 2545, col: 48, offset: 79339},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2530, col: 54, offset: 78942},
+													pos:  position{line: 2545, col: 54, offset: 79345},
 													name: "ValueExpr",
 												},
 											},
@@ -4739,73 +4753,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2530, col: 66, offset: 78954},
+									pos:  position{line: 2545, col: 66, offset: 79357},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2547, col: 3, offset: 79373},
+						pos: position{line: 2562, col: 3, offset: 79776},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2547, col: 3, offset: 79373},
-							exprs: []interface{}{
+							pos: position{line: 2562, col: 3, offset: 79776},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2547, col: 3, offset: 79373},
+									pos:        position{line: 2562, col: 3, offset: 79776},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2547, col: 12, offset: 79382},
+									pos:  position{line: 2562, col: 12, offset: 79785},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2547, col: 20, offset: 79390},
+									pos:   position{line: 2562, col: 20, offset: 79793},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2547, col: 30, offset: 79400},
+										pos:  position{line: 2562, col: 30, offset: 79803},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2547, col: 40, offset: 79410},
+									pos:  position{line: 2562, col: 40, offset: 79813},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2547, col: 46, offset: 79416},
+									pos:   position{line: 2562, col: 46, offset: 79819},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2547, col: 57, offset: 79427},
+										pos:  position{line: 2562, col: 57, offset: 79830},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2547, col: 67, offset: 79437},
+									pos:  position{line: 2562, col: 67, offset: 79840},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2559, col: 3, offset: 79717},
+						pos: position{line: 2574, col: 3, offset: 80120},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2559, col: 3, offset: 79717},
-							exprs: []interface{}{
+							pos: position{line: 2574, col: 3, offset: 80120},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2559, col: 3, offset: 79717},
+									pos:        position{line: 2574, col: 3, offset: 80120},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2559, col: 10, offset: 79724},
+									pos:  position{line: 2574, col: 10, offset: 80127},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2559, col: 18, offset: 79732},
+									pos:  position{line: 2574, col: 18, offset: 80135},
 									name: "R_PAREN",
 								},
 							},
@@ -4816,30 +4830,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2566, col: 1, offset: 79829},
+			pos:  position{line: 2581, col: 1, offset: 80232},
 			expr: &actionExpr{
-				pos: position{line: 2566, col: 23, offset: 79851},
+				pos: position{line: 2581, col: 23, offset: 80254},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2566, col: 23, offset: 79851},
-					exprs: []interface{}{
+					pos: position{line: 2581, col: 23, offset: 80254},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2566, col: 23, offset: 79851},
+							pos:   position{line: 2581, col: 23, offset: 80254},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2566, col: 33, offset: 79861},
+								pos:  position{line: 2581, col: 33, offset: 80264},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2566, col: 42, offset: 79870},
+							pos:  position{line: 2581, col: 42, offset: 80273},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2566, col: 48, offset: 79876},
+							pos:   position{line: 2581, col: 48, offset: 80279},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2566, col: 54, offset: 79882},
+								pos:  position{line: 2581, col: 54, offset: 80285},
 								name: "ValueExpr",
 							},
 						},
@@ -4849,15 +4863,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2574, col: 1, offset: 80087},
+			pos:  position{line: 2589, col: 1, offset: 80490},
 			expr: &actionExpr{
-				pos: position{line: 2574, col: 26, offset: 80112},
+				pos: position{line: 2589, col: 26, offset: 80515},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2574, col: 26, offset: 80112},
+					pos:   position{line: 2589, col: 26, offset: 80515},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2574, col: 37, offset: 80123},
+						pos:  position{line: 2589, col: 37, offset: 80526},
 						name: "StringExpr",
 					},
 				},
@@ -4865,15 +4879,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2584, col: 1, offset: 80332},
+			pos:  position{line: 2599, col: 1, offset: 80735},
 			expr: &actionExpr{
-				pos: position{line: 2584, col: 30, offset: 80361},
+				pos: position{line: 2599, col: 30, offset: 80764},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2584, col: 30, offset: 80361},
+					pos:   position{line: 2599, col: 30, offset: 80764},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2584, col: 45, offset: 80376},
+						pos:  position{line: 2599, col: 45, offset: 80779},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4881,22 +4895,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2593, col: 1, offset: 80582},
+			pos:  position{line: 2608, col: 1, offset: 80985},
 			expr: &actionExpr{
-				pos: position{line: 2593, col: 27, offset: 80608},
+				pos: position{line: 2608, col: 27, offset: 81011},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2593, col: 27, offset: 80608},
+					pos:   position{line: 2608, col: 27, offset: 81011},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2593, col: 40, offset: 80621},
-						alternatives: []interface{}{
+						pos: position{line: 2608, col: 40, offset: 81024},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2593, col: 40, offset: 80621},
+								pos:  position{line: 2608, col: 40, offset: 81024},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2593, col: 68, offset: 80649},
+								pos:  position{line: 2608, col: 68, offset: 81052},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4906,182 +4920,182 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2597, col: 1, offset: 80726},
+			pos:  position{line: 2612, col: 1, offset: 81129},
 			expr: &choiceExpr{
-				pos: position{line: 2597, col: 19, offset: 80744},
-				alternatives: []interface{}{
+				pos: position{line: 2612, col: 19, offset: 81147},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2597, col: 19, offset: 80744},
+						pos: position{line: 2612, col: 19, offset: 81147},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2597, col: 20, offset: 80745},
-							exprs: []interface{}{
+							pos: position{line: 2612, col: 20, offset: 81148},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2597, col: 20, offset: 80745},
+									pos:   position{line: 2612, col: 20, offset: 81148},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2597, col: 28, offset: 80753},
+										pos:        position{line: 2612, col: 28, offset: 81156},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2597, col: 37, offset: 80762},
+									pos:  position{line: 2612, col: 37, offset: 81165},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2597, col: 45, offset: 80770},
+									pos:   position{line: 2612, col: 45, offset: 81173},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2597, col: 56, offset: 80781},
+										pos:  position{line: 2612, col: 56, offset: 81184},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2597, col: 67, offset: 80792},
+									pos:  position{line: 2612, col: 67, offset: 81195},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2597, col: 73, offset: 80798},
+									pos:   position{line: 2612, col: 73, offset: 81201},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2597, col: 79, offset: 80804},
+										pos:  position{line: 2612, col: 79, offset: 81207},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2597, col: 90, offset: 80815},
+									pos:  position{line: 2612, col: 90, offset: 81218},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2609, col: 3, offset: 81176},
+						pos: position{line: 2624, col: 3, offset: 81579},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2609, col: 4, offset: 81177},
-							exprs: []interface{}{
+							pos: position{line: 2624, col: 4, offset: 81580},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2609, col: 4, offset: 81177},
+									pos:   position{line: 2624, col: 4, offset: 81580},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2609, col: 12, offset: 81185},
+										pos:        position{line: 2624, col: 12, offset: 81588},
 										val:        "spath",
 										ignoreCase: false,
 										want:       "\"spath\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2609, col: 21, offset: 81194},
+									pos:  position{line: 2624, col: 21, offset: 81597},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2609, col: 29, offset: 81202},
+									pos:   position{line: 2624, col: 29, offset: 81605},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2609, col: 35, offset: 81208},
+										pos:  position{line: 2624, col: 35, offset: 81611},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2609, col: 46, offset: 81219},
+									pos:  position{line: 2624, col: 46, offset: 81622},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2609, col: 52, offset: 81225},
+									pos:   position{line: 2624, col: 52, offset: 81628},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2609, col: 57, offset: 81230},
+										pos:  position{line: 2624, col: 57, offset: 81633},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2609, col: 68, offset: 81241},
+									pos:  position{line: 2624, col: 68, offset: 81644},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2621, col: 3, offset: 81596},
+						pos: position{line: 2636, col: 3, offset: 81999},
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
-							pos: position{line: 2621, col: 4, offset: 81597},
-							exprs: []interface{}{
+							pos: position{line: 2636, col: 4, offset: 82000},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2621, col: 4, offset: 81597},
+									pos:   position{line: 2636, col: 4, offset: 82000},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2621, col: 12, offset: 81605},
+										pos:        position{line: 2636, col: 12, offset: 82008},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2621, col: 23, offset: 81616},
+									pos:  position{line: 2636, col: 23, offset: 82019},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2621, col: 31, offset: 81624},
+									pos:   position{line: 2636, col: 31, offset: 82027},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2621, col: 46, offset: 81639},
+										pos:  position{line: 2636, col: 46, offset: 82042},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2621, col: 61, offset: 81654},
+									pos:  position{line: 2636, col: 61, offset: 82057},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2621, col: 67, offset: 81660},
+									pos:   position{line: 2636, col: 67, offset: 82063},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2621, col: 78, offset: 81671},
+										pos:  position{line: 2636, col: 78, offset: 82074},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2621, col: 90, offset: 81683},
+									pos:   position{line: 2636, col: 90, offset: 82086},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2621, col: 99, offset: 81692},
+										pos: position{line: 2636, col: 99, offset: 82095},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2621, col: 100, offset: 81693},
+											pos:  position{line: 2636, col: 100, offset: 82096},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2621, col: 119, offset: 81712},
+									pos:  position{line: 2636, col: 119, offset: 82115},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2637, col: 3, offset: 82274},
+						pos: position{line: 2652, col: 3, offset: 82677},
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
-							pos: position{line: 2637, col: 4, offset: 82275},
-							exprs: []interface{}{
+							pos: position{line: 2652, col: 4, offset: 82678},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2637, col: 4, offset: 82275},
+									pos:   position{line: 2652, col: 4, offset: 82678},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2637, col: 12, offset: 82283},
-										alternatives: []interface{}{
+										pos: position{line: 2652, col: 12, offset: 82686},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2637, col: 12, offset: 82283},
+												pos:        position{line: 2652, col: 12, offset: 82686},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2637, col: 24, offset: 82295},
+												pos:        position{line: 2652, col: 24, offset: 82698},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -5090,222 +5104,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2637, col: 34, offset: 82305},
+									pos:  position{line: 2652, col: 34, offset: 82708},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2637, col: 42, offset: 82313},
+									pos:   position{line: 2652, col: 42, offset: 82716},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2637, col: 57, offset: 82328},
+										pos:  position{line: 2652, col: 57, offset: 82731},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2637, col: 72, offset: 82343},
+									pos:  position{line: 2652, col: 72, offset: 82746},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2649, col: 3, offset: 82691},
+						pos: position{line: 2664, col: 3, offset: 83094},
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
-							pos: position{line: 2649, col: 4, offset: 82692},
-							exprs: []interface{}{
+							pos: position{line: 2664, col: 4, offset: 83095},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2649, col: 4, offset: 82692},
+									pos:   position{line: 2664, col: 4, offset: 83095},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2649, col: 12, offset: 82700},
+										pos:        position{line: 2664, col: 12, offset: 83103},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 24, offset: 82712},
+									pos:  position{line: 2664, col: 24, offset: 83115},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2649, col: 32, offset: 82720},
+									pos:   position{line: 2664, col: 32, offset: 83123},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2649, col: 42, offset: 82730},
+										pos:  position{line: 2664, col: 42, offset: 83133},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2649, col: 51, offset: 82739},
+									pos:  position{line: 2664, col: 51, offset: 83142},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2662, col: 3, offset: 83086},
+						pos: position{line: 2677, col: 3, offset: 83489},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2662, col: 4, offset: 83087},
-							exprs: []interface{}{
+							pos: position{line: 2677, col: 4, offset: 83490},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2662, col: 4, offset: 83087},
+									pos:   position{line: 2677, col: 4, offset: 83490},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2662, col: 12, offset: 83095},
+										pos:        position{line: 2677, col: 12, offset: 83498},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 21, offset: 83104},
+									pos:  position{line: 2677, col: 21, offset: 83507},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 29, offset: 83112},
+									pos:   position{line: 2677, col: 29, offset: 83515},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2662, col: 44, offset: 83127},
+										pos:  position{line: 2677, col: 44, offset: 83530},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 59, offset: 83142},
+									pos:  position{line: 2677, col: 59, offset: 83545},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2662, col: 65, offset: 83148},
+									pos:   position{line: 2677, col: 65, offset: 83551},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2662, col: 70, offset: 83153},
+										pos:  position{line: 2677, col: 70, offset: 83556},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2662, col: 80, offset: 83163},
+									pos:  position{line: 2677, col: 80, offset: 83566},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2675, col: 3, offset: 83585},
+						pos: position{line: 2690, col: 3, offset: 83988},
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
-							pos: position{line: 2675, col: 4, offset: 83586},
-							exprs: []interface{}{
+							pos: position{line: 2690, col: 4, offset: 83989},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2675, col: 4, offset: 83586},
+									pos:   position{line: 2690, col: 4, offset: 83989},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2675, col: 12, offset: 83594},
+										pos:        position{line: 2690, col: 12, offset: 83997},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2675, col: 23, offset: 83605},
+									pos:  position{line: 2690, col: 23, offset: 84008},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2675, col: 31, offset: 83613},
+									pos:   position{line: 2690, col: 31, offset: 84016},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2675, col: 42, offset: 83624},
+										pos:  position{line: 2690, col: 42, offset: 84027},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2675, col: 54, offset: 83636},
+									pos:  position{line: 2690, col: 54, offset: 84039},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2675, col: 60, offset: 83642},
+									pos:   position{line: 2690, col: 60, offset: 84045},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2675, col: 69, offset: 83651},
+										pos:  position{line: 2690, col: 69, offset: 84054},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2675, col: 81, offset: 83663},
+									pos:  position{line: 2690, col: 81, offset: 84066},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2675, col: 87, offset: 83669},
+									pos:   position{line: 2690, col: 87, offset: 84072},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2675, col: 98, offset: 83680},
+										pos: position{line: 2690, col: 98, offset: 84083},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2675, col: 99, offset: 83681},
+											pos:  position{line: 2690, col: 99, offset: 84084},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2675, col: 112, offset: 83694},
+									pos:  position{line: 2690, col: 112, offset: 84097},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2688, col: 3, offset: 84145},
+						pos: position{line: 2703, col: 3, offset: 84548},
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
-							pos: position{line: 2688, col: 4, offset: 84146},
-							exprs: []interface{}{
+							pos: position{line: 2703, col: 4, offset: 84549},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2688, col: 4, offset: 84146},
+									pos:   position{line: 2703, col: 4, offset: 84549},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2688, col: 12, offset: 84154},
+										pos:        position{line: 2703, col: 12, offset: 84557},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2688, col: 21, offset: 84163},
+									pos:  position{line: 2703, col: 21, offset: 84566},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2688, col: 29, offset: 84171},
+									pos:   position{line: 2703, col: 29, offset: 84574},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2688, col: 36, offset: 84178},
+										pos:  position{line: 2703, col: 36, offset: 84581},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2688, col: 51, offset: 84193},
+									pos:  position{line: 2703, col: 51, offset: 84596},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2688, col: 57, offset: 84199},
+									pos:   position{line: 2703, col: 57, offset: 84602},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2688, col: 65, offset: 84207},
+										pos:  position{line: 2703, col: 65, offset: 84610},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2688, col: 80, offset: 84222},
+									pos:   position{line: 2703, col: 80, offset: 84625},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2688, col: 85, offset: 84227},
+										pos: position{line: 2703, col: 85, offset: 84630},
 										expr: &seqExpr{
-											pos: position{line: 2688, col: 86, offset: 84228},
-											exprs: []interface{}{
+											pos: position{line: 2703, col: 86, offset: 84631},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2688, col: 86, offset: 84228},
+													pos:  position{line: 2703, col: 86, offset: 84631},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2688, col: 92, offset: 84234},
+													pos:  position{line: 2703, col: 92, offset: 84637},
 													name: "StringExpr",
 												},
 											},
@@ -5313,63 +5327,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2688, col: 105, offset: 84247},
+									pos:  position{line: 2703, col: 105, offset: 84650},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2705, col: 3, offset: 84775},
+						pos: position{line: 2720, col: 3, offset: 85178},
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
-							pos: position{line: 2705, col: 4, offset: 84776},
-							exprs: []interface{}{
+							pos: position{line: 2720, col: 4, offset: 85179},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2705, col: 4, offset: 84776},
+									pos:   position{line: 2720, col: 4, offset: 85179},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2705, col: 12, offset: 84784},
+										pos:        position{line: 2720, col: 12, offset: 85187},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2705, col: 32, offset: 84804},
+									pos:  position{line: 2720, col: 32, offset: 85207},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2705, col: 40, offset: 84812},
+									pos:   position{line: 2720, col: 40, offset: 85215},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2705, col: 55, offset: 84827},
+										pos:  position{line: 2720, col: 55, offset: 85230},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2705, col: 70, offset: 84842},
+									pos:   position{line: 2720, col: 70, offset: 85245},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2705, col: 75, offset: 84847},
+										pos: position{line: 2720, col: 75, offset: 85250},
 										expr: &seqExpr{
-											pos: position{line: 2705, col: 76, offset: 84848},
-											exprs: []interface{}{
+											pos: position{line: 2720, col: 76, offset: 85251},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2705, col: 76, offset: 84848},
+													pos:  position{line: 2720, col: 76, offset: 85251},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2705, col: 83, offset: 84855},
-													alternatives: []interface{}{
+													pos: position{line: 2720, col: 83, offset: 85258},
+													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2705, col: 83, offset: 84855},
+															pos:        position{line: 2720, col: 83, offset: 85258},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2705, col: 92, offset: 84864},
+															pos:        position{line: 2720, col: 92, offset: 85267},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5377,7 +5391,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2705, col: 101, offset: 84873},
+													pos:        position{line: 2720, col: 101, offset: 85276},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5387,54 +5401,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2705, col: 108, offset: 84880},
+									pos:  position{line: 2720, col: 108, offset: 85283},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2730, col: 3, offset: 85583},
+						pos: position{line: 2745, col: 3, offset: 85986},
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
-							pos: position{line: 2730, col: 4, offset: 85584},
-							exprs: []interface{}{
+							pos: position{line: 2745, col: 4, offset: 85987},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2730, col: 4, offset: 85584},
+									pos:   position{line: 2745, col: 4, offset: 85987},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2730, col: 12, offset: 85592},
+										pos:        position{line: 2745, col: 12, offset: 85995},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2730, col: 24, offset: 85604},
+									pos:  position{line: 2745, col: 24, offset: 86007},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2730, col: 32, offset: 85612},
+									pos:   position{line: 2745, col: 32, offset: 86015},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2730, col: 41, offset: 85621},
+										pos:  position{line: 2745, col: 41, offset: 86024},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2730, col: 64, offset: 85644},
+									pos:   position{line: 2745, col: 64, offset: 86047},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2730, col: 69, offset: 85649},
+										pos: position{line: 2745, col: 69, offset: 86052},
 										expr: &seqExpr{
-											pos: position{line: 2730, col: 70, offset: 85650},
-											exprs: []interface{}{
+											pos: position{line: 2745, col: 70, offset: 86053},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2730, col: 70, offset: 85650},
+													pos:  position{line: 2745, col: 70, offset: 86053},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2730, col: 76, offset: 85656},
+													pos:  position{line: 2745, col: 76, offset: 86059},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5442,57 +5456,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2730, col: 101, offset: 85681},
+									pos:  position{line: 2745, col: 101, offset: 86084},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2750, col: 3, offset: 86269},
+						pos: position{line: 2765, col: 3, offset: 86672},
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
-							pos: position{line: 2750, col: 3, offset: 86269},
-							exprs: []interface{}{
+							pos: position{line: 2765, col: 3, offset: 86672},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2750, col: 3, offset: 86269},
+									pos:   position{line: 2765, col: 3, offset: 86672},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2750, col: 9, offset: 86275},
+										pos:  position{line: 2765, col: 9, offset: 86678},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2750, col: 25, offset: 86291},
+									pos: position{line: 2765, col: 25, offset: 86694},
 									expr: &choiceExpr{
-										pos: position{line: 2750, col: 27, offset: 86293},
-										alternatives: []interface{}{
+										pos: position{line: 2765, col: 27, offset: 86696},
+										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 27, offset: 86293},
+												pos:  position{line: 2765, col: 27, offset: 86696},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 36, offset: 86302},
+												pos:  position{line: 2765, col: 36, offset: 86705},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 46, offset: 86312},
+												pos:  position{line: 2765, col: 46, offset: 86715},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 54, offset: 86320},
+												pos:  position{line: 2765, col: 54, offset: 86723},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 62, offset: 86328},
+												pos:  position{line: 2765, col: 62, offset: 86731},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2750, col: 70, offset: 86336},
+												pos:  position{line: 2765, col: 70, offset: 86739},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2750, col: 84, offset: 86350},
+												pos:        position{line: 2765, col: 84, offset: 86753},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5508,36 +5522,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2762, col: 1, offset: 86745},
+			pos:  position{line: 2777, col: 1, offset: 87148},
 			expr: &choiceExpr{
-				pos: position{line: 2762, col: 13, offset: 86757},
-				alternatives: []interface{}{
+				pos: position{line: 2777, col: 13, offset: 87160},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2762, col: 13, offset: 86757},
+						pos: position{line: 2777, col: 13, offset: 87160},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2762, col: 14, offset: 86758},
-							exprs: []interface{}{
+							pos: position{line: 2777, col: 14, offset: 87161},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2762, col: 14, offset: 86758},
+									pos:   position{line: 2777, col: 14, offset: 87161},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2762, col: 22, offset: 86766},
-										alternatives: []interface{}{
+										pos: position{line: 2777, col: 22, offset: 87169},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2762, col: 22, offset: 86766},
+												pos:        position{line: 2777, col: 22, offset: 87169},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2762, col: 32, offset: 86776},
+												pos:        position{line: 2777, col: 32, offset: 87179},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2762, col: 42, offset: 86786},
+												pos:        position{line: 2777, col: 42, offset: 87189},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5546,44 +5560,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2762, col: 55, offset: 86799},
+									pos:  position{line: 2777, col: 55, offset: 87202},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2762, col: 63, offset: 86807},
+									pos:   position{line: 2777, col: 63, offset: 87210},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2762, col: 74, offset: 86818},
+										pos:  position{line: 2777, col: 74, offset: 87221},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2762, col: 85, offset: 86829},
+									pos:  position{line: 2777, col: 85, offset: 87232},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2774, col: 3, offset: 87143},
+						pos: position{line: 2789, col: 3, offset: 87546},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2774, col: 4, offset: 87144},
-							exprs: []interface{}{
+							pos: position{line: 2789, col: 4, offset: 87547},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2774, col: 4, offset: 87144},
+									pos:   position{line: 2789, col: 4, offset: 87547},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2774, col: 12, offset: 87152},
-										alternatives: []interface{}{
+										pos: position{line: 2789, col: 12, offset: 87555},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2774, col: 12, offset: 87152},
+												pos:        position{line: 2789, col: 12, offset: 87555},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2774, col: 20, offset: 87160},
+												pos:        position{line: 2789, col: 20, offset: 87563},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5592,31 +5606,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2774, col: 27, offset: 87167},
+									pos:  position{line: 2789, col: 27, offset: 87570},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2774, col: 35, offset: 87175},
+									pos:   position{line: 2789, col: 35, offset: 87578},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2774, col: 44, offset: 87184},
+										pos:  position{line: 2789, col: 44, offset: 87587},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2774, col: 55, offset: 87195},
+									pos:   position{line: 2789, col: 55, offset: 87598},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2774, col: 60, offset: 87200},
+										pos: position{line: 2789, col: 60, offset: 87603},
 										expr: &seqExpr{
-											pos: position{line: 2774, col: 61, offset: 87201},
-											exprs: []interface{}{
+											pos: position{line: 2789, col: 61, offset: 87604},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2774, col: 61, offset: 87201},
+													pos:  position{line: 2789, col: 61, offset: 87604},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2774, col: 67, offset: 87207},
+													pos:  position{line: 2789, col: 67, offset: 87610},
 													name: "StringExpr",
 												},
 											},
@@ -5624,195 +5638,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2774, col: 80, offset: 87220},
+									pos:  position{line: 2789, col: 80, offset: 87623},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2796, col: 3, offset: 87820},
+						pos: position{line: 2811, col: 3, offset: 88223},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2796, col: 4, offset: 87821},
-							exprs: []interface{}{
+							pos: position{line: 2811, col: 4, offset: 88224},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2796, col: 4, offset: 87821},
+									pos:   position{line: 2811, col: 4, offset: 88224},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2796, col: 12, offset: 87829},
+										pos:        position{line: 2811, col: 12, offset: 88232},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2796, col: 23, offset: 87840},
+									pos:  position{line: 2811, col: 23, offset: 88243},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2796, col: 31, offset: 87848},
+									pos:   position{line: 2811, col: 31, offset: 88251},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2796, col: 46, offset: 87863},
+										pos:  position{line: 2811, col: 46, offset: 88266},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2796, col: 61, offset: 87878},
+									pos:  position{line: 2811, col: 61, offset: 88281},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2807, col: 3, offset: 88180},
+						pos: position{line: 2822, col: 3, offset: 88583},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2807, col: 4, offset: 88181},
-							exprs: []interface{}{
+							pos: position{line: 2822, col: 4, offset: 88584},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2807, col: 4, offset: 88181},
+									pos:   position{line: 2822, col: 4, offset: 88584},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2807, col: 12, offset: 88189},
+										pos:        position{line: 2822, col: 12, offset: 88592},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 22, offset: 88199},
+									pos:  position{line: 2822, col: 22, offset: 88602},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 30, offset: 88207},
+									pos:   position{line: 2822, col: 30, offset: 88610},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 45, offset: 88222},
+										pos:  position{line: 2822, col: 45, offset: 88625},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 60, offset: 88237},
+									pos:  position{line: 2822, col: 60, offset: 88640},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2807, col: 66, offset: 88243},
+									pos:   position{line: 2822, col: 66, offset: 88646},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2807, col: 72, offset: 88249},
+										pos:  position{line: 2822, col: 72, offset: 88652},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2807, col: 83, offset: 88260},
+									pos:  position{line: 2822, col: 83, offset: 88663},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2819, col: 3, offset: 88610},
+						pos: position{line: 2834, col: 3, offset: 89013},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2819, col: 4, offset: 88611},
-							exprs: []interface{}{
+							pos: position{line: 2834, col: 4, offset: 89014},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2819, col: 4, offset: 88611},
+									pos:   position{line: 2834, col: 4, offset: 89014},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2819, col: 12, offset: 88619},
+										pos:        position{line: 2834, col: 12, offset: 89022},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2819, col: 22, offset: 88629},
+									pos:  position{line: 2834, col: 22, offset: 89032},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2819, col: 30, offset: 88637},
+									pos:   position{line: 2834, col: 30, offset: 89040},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2819, col: 45, offset: 88652},
+										pos:  position{line: 2834, col: 45, offset: 89055},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2819, col: 60, offset: 88667},
+									pos:  position{line: 2834, col: 60, offset: 89070},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2819, col: 66, offset: 88673},
+									pos:   position{line: 2834, col: 66, offset: 89076},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2819, col: 79, offset: 88686},
+										pos:  position{line: 2834, col: 79, offset: 89089},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2819, col: 90, offset: 88697},
+									pos:  position{line: 2834, col: 90, offset: 89100},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2843, col: 3, offset: 89363},
+						pos: position{line: 2858, col: 3, offset: 89766},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2843, col: 4, offset: 89364},
-							exprs: []interface{}{
+							pos: position{line: 2858, col: 4, offset: 89767},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2843, col: 4, offset: 89364},
+									pos:   position{line: 2858, col: 4, offset: 89767},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2843, col: 12, offset: 89372},
+										pos:        position{line: 2858, col: 12, offset: 89775},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2843, col: 22, offset: 89382},
+									pos:  position{line: 2858, col: 22, offset: 89785},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2843, col: 30, offset: 89390},
+									pos:   position{line: 2858, col: 30, offset: 89793},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2843, col: 41, offset: 89401},
+										pos:  position{line: 2858, col: 41, offset: 89804},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2843, col: 52, offset: 89412},
+									pos:  position{line: 2858, col: 52, offset: 89815},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2843, col: 58, offset: 89418},
+									pos:   position{line: 2858, col: 58, offset: 89821},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2843, col: 69, offset: 89429},
+										pos:  position{line: 2858, col: 69, offset: 89832},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2843, col: 81, offset: 89441},
+									pos:   position{line: 2858, col: 81, offset: 89844},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2843, col: 93, offset: 89453},
+										pos: position{line: 2858, col: 93, offset: 89856},
 										expr: &seqExpr{
-											pos: position{line: 2843, col: 94, offset: 89454},
-											exprs: []interface{}{
+											pos: position{line: 2858, col: 94, offset: 89857},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2843, col: 94, offset: 89454},
+													pos:  position{line: 2858, col: 94, offset: 89857},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2843, col: 100, offset: 89460},
+													pos:  position{line: 2858, col: 100, offset: 89863},
 													name: "NumericExpr",
 												},
 											},
@@ -5820,50 +5834,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2843, col: 114, offset: 89474},
+									pos:  position{line: 2858, col: 114, offset: 89877},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2868, col: 3, offset: 90304},
+						pos: position{line: 2883, col: 3, offset: 90707},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2868, col: 3, offset: 90304},
-							exprs: []interface{}{
+							pos: position{line: 2883, col: 3, offset: 90707},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2868, col: 3, offset: 90304},
+									pos:        position{line: 2883, col: 3, offset: 90707},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2868, col: 14, offset: 90315},
+									pos:  position{line: 2883, col: 14, offset: 90718},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2868, col: 22, offset: 90323},
+									pos:   position{line: 2883, col: 22, offset: 90726},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2868, col: 28, offset: 90329},
+										pos:  position{line: 2883, col: 28, offset: 90732},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2868, col: 38, offset: 90339},
+									pos:   position{line: 2883, col: 38, offset: 90742},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2868, col: 45, offset: 90346},
+										pos: position{line: 2883, col: 45, offset: 90749},
 										expr: &seqExpr{
-											pos: position{line: 2868, col: 46, offset: 90347},
-											exprs: []interface{}{
+											pos: position{line: 2883, col: 46, offset: 90750},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2868, col: 46, offset: 90347},
+													pos:  position{line: 2883, col: 46, offset: 90750},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2868, col: 52, offset: 90353},
+													pos:  position{line: 2883, col: 52, offset: 90756},
 													name: "StringExpr",
 												},
 											},
@@ -5871,38 +5885,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2868, col: 65, offset: 90366},
+									pos:  position{line: 2883, col: 65, offset: 90769},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2881, col: 3, offset: 90734},
+						pos: position{line: 2896, col: 3, offset: 91137},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2881, col: 4, offset: 90735},
-							exprs: []interface{}{
+							pos: position{line: 2896, col: 4, offset: 91138},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2881, col: 4, offset: 90735},
+									pos:   position{line: 2896, col: 4, offset: 91138},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2881, col: 12, offset: 90743},
-										alternatives: []interface{}{
+										pos: position{line: 2896, col: 12, offset: 91146},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2881, col: 12, offset: 90743},
+												pos:        position{line: 2896, col: 12, offset: 91146},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2881, col: 22, offset: 90753},
+												pos:        position{line: 2896, col: 22, offset: 91156},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2881, col: 32, offset: 90763},
+												pos:        position{line: 2896, col: 32, offset: 91166},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5911,171 +5925,171 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2881, col: 40, offset: 90771},
+									pos:  position{line: 2896, col: 40, offset: 91174},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2881, col: 48, offset: 90779},
+									pos:   position{line: 2896, col: 48, offset: 91182},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2881, col: 54, offset: 90785},
+										pos:  position{line: 2896, col: 54, offset: 91188},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2881, col: 66, offset: 90797},
+									pos:   position{line: 2896, col: 66, offset: 91200},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2881, col: 82, offset: 90813},
+										pos: position{line: 2896, col: 82, offset: 91216},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2881, col: 83, offset: 90814},
+											pos:  position{line: 2896, col: 83, offset: 91217},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2881, col: 101, offset: 90832},
+									pos:  position{line: 2896, col: 101, offset: 91235},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2900, col: 3, offset: 91272},
+						pos: position{line: 2915, col: 3, offset: 91675},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2900, col: 3, offset: 91272},
-							exprs: []interface{}{
+							pos: position{line: 2915, col: 3, offset: 91675},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2900, col: 3, offset: 91272},
+									pos:        position{line: 2915, col: 3, offset: 91675},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2900, col: 12, offset: 91281},
+									pos:  position{line: 2915, col: 12, offset: 91684},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2900, col: 20, offset: 91289},
+									pos:   position{line: 2915, col: 20, offset: 91692},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2900, col: 25, offset: 91294},
+										pos:  position{line: 2915, col: 25, offset: 91697},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2900, col: 36, offset: 91305},
+									pos:  position{line: 2915, col: 36, offset: 91708},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2900, col: 42, offset: 91311},
+									pos:   position{line: 2915, col: 42, offset: 91714},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2900, col: 45, offset: 91314},
+										pos:  position{line: 2915, col: 45, offset: 91717},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2900, col: 55, offset: 91324},
+									pos:  position{line: 2915, col: 55, offset: 91727},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2907, col: 3, offset: 91482},
+						pos: position{line: 2922, col: 3, offset: 91885},
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
-							pos: position{line: 2907, col: 3, offset: 91482},
-							exprs: []interface{}{
+							pos: position{line: 2922, col: 3, offset: 91885},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2907, col: 3, offset: 91482},
+									pos:        position{line: 2922, col: 3, offset: 91885},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2907, col: 21, offset: 91500},
+									pos:  position{line: 2922, col: 21, offset: 91903},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2907, col: 29, offset: 91508},
+									pos:   position{line: 2922, col: 29, offset: 91911},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2907, col: 33, offset: 91512},
+										pos:  position{line: 2922, col: 33, offset: 91915},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2907, col: 43, offset: 91522},
+									pos:  position{line: 2922, col: 43, offset: 91925},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2907, col: 49, offset: 91528},
+									pos:   position{line: 2922, col: 49, offset: 91931},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2907, col: 53, offset: 91532},
+										pos:  position{line: 2922, col: 53, offset: 91935},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2907, col: 66, offset: 91545},
+									pos:  position{line: 2922, col: 66, offset: 91948},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2907, col: 72, offset: 91551},
+									pos:   position{line: 2922, col: 72, offset: 91954},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2907, col: 78, offset: 91557},
+										pos:  position{line: 2922, col: 78, offset: 91960},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2907, col: 91, offset: 91570},
+									pos:  position{line: 2922, col: 91, offset: 91973},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2918, col: 3, offset: 91878},
+						pos: position{line: 2933, col: 3, offset: 92281},
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
-							pos: position{line: 2918, col: 3, offset: 91878},
-							exprs: []interface{}{
+							pos: position{line: 2933, col: 3, offset: 92281},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2918, col: 3, offset: 91878},
+									pos:        position{line: 2933, col: 3, offset: 92281},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2918, col: 12, offset: 91887},
+									pos:  position{line: 2933, col: 12, offset: 92290},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2918, col: 20, offset: 91895},
+									pos:   position{line: 2933, col: 20, offset: 92298},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2918, col: 27, offset: 91902},
+										pos:  position{line: 2933, col: 27, offset: 92305},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2918, col: 38, offset: 91913},
+									pos:   position{line: 2933, col: 38, offset: 92316},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2918, col: 43, offset: 91918},
+										pos: position{line: 2933, col: 43, offset: 92321},
 										expr: &seqExpr{
-											pos: position{line: 2918, col: 44, offset: 91919},
-											exprs: []interface{}{
+											pos: position{line: 2933, col: 44, offset: 92322},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2918, col: 44, offset: 91919},
+													pos:  position{line: 2933, col: 44, offset: 92322},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2918, col: 50, offset: 91925},
+													pos:  position{line: 2933, col: 50, offset: 92328},
 													name: "StringExpr",
 												},
 											},
@@ -6083,47 +6097,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2918, col: 63, offset: 91938},
+									pos:  position{line: 2933, col: 63, offset: 92341},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2936, col: 3, offset: 92405},
+						pos: position{line: 2951, col: 3, offset: 92808},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2936, col: 3, offset: 92405},
-							exprs: []interface{}{
+							pos: position{line: 2951, col: 3, offset: 92808},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2936, col: 3, offset: 92405},
+									pos:        position{line: 2951, col: 3, offset: 92808},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2936, col: 12, offset: 92414},
+									pos:  position{line: 2951, col: 12, offset: 92817},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2936, col: 20, offset: 92422},
+									pos:   position{line: 2951, col: 20, offset: 92825},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2936, col: 42, offset: 92444},
+										pos: position{line: 2951, col: 42, offset: 92847},
 										expr: &seqExpr{
-											pos: position{line: 2936, col: 43, offset: 92445},
-											exprs: []interface{}{
+											pos: position{line: 2951, col: 43, offset: 92848},
+											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2936, col: 44, offset: 92446},
-													alternatives: []interface{}{
+													pos: position{line: 2951, col: 44, offset: 92849},
+													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2936, col: 44, offset: 92446},
+															pos:        position{line: 2951, col: 44, offset: 92849},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2936, col: 53, offset: 92455},
+															pos:        position{line: 2951, col: 53, offset: 92858},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6131,7 +6145,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2936, col: 62, offset: 92464},
+													pos:        position{line: 2951, col: 62, offset: 92867},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6141,56 +6155,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2936, col: 69, offset: 92471},
+									pos:  position{line: 2951, col: 69, offset: 92874},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2958, col: 3, offset: 93068},
+						pos: position{line: 2973, col: 3, offset: 93471},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2958, col: 3, offset: 93068},
-							exprs: []interface{}{
+							pos: position{line: 2973, col: 3, offset: 93471},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2958, col: 3, offset: 93068},
+									pos:        position{line: 2973, col: 3, offset: 93471},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2958, col: 13, offset: 93078},
+									pos:  position{line: 2973, col: 13, offset: 93481},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2958, col: 21, offset: 93086},
+									pos:   position{line: 2973, col: 21, offset: 93489},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2958, col: 27, offset: 93092},
+										pos:  position{line: 2973, col: 27, offset: 93495},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2958, col: 43, offset: 93108},
+									pos:   position{line: 2973, col: 43, offset: 93511},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2958, col: 53, offset: 93118},
+										pos: position{line: 2973, col: 53, offset: 93521},
 										expr: &seqExpr{
-											pos: position{line: 2958, col: 54, offset: 93119},
-											exprs: []interface{}{
+											pos: position{line: 2973, col: 54, offset: 93522},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2958, col: 54, offset: 93119},
+													pos:  position{line: 2973, col: 54, offset: 93522},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2958, col: 60, offset: 93125},
+													pos:        position{line: 2973, col: 60, offset: 93528},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2958, col: 73, offset: 93138},
+													pos:  position{line: 2973, col: 73, offset: 93541},
 													name: "FloatAsString",
 												},
 											},
@@ -6198,40 +6212,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2958, col: 89, offset: 93154},
+									pos:   position{line: 2973, col: 89, offset: 93557},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2958, col: 95, offset: 93160},
+										pos: position{line: 2973, col: 95, offset: 93563},
 										expr: &seqExpr{
-											pos: position{line: 2958, col: 96, offset: 93161},
-											exprs: []interface{}{
+											pos: position{line: 2973, col: 96, offset: 93564},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2958, col: 96, offset: 93161},
+													pos:  position{line: 2973, col: 96, offset: 93564},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2958, col: 102, offset: 93167},
+													pos:        position{line: 2973, col: 102, offset: 93570},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2958, col: 112, offset: 93177},
-													alternatives: []interface{}{
+													pos: position{line: 2973, col: 112, offset: 93580},
+													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2958, col: 112, offset: 93177},
+															pos:        position{line: 2973, col: 112, offset: 93580},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2958, col: 125, offset: 93190},
+															pos:        position{line: 2973, col: 125, offset: 93593},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2958, col: 137, offset: 93202},
+															pos:        position{line: 2973, col: 137, offset: 93605},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6243,25 +6257,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2958, col: 151, offset: 93216},
+									pos:   position{line: 2973, col: 151, offset: 93619},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2958, col: 158, offset: 93223},
+										pos: position{line: 2973, col: 158, offset: 93626},
 										expr: &seqExpr{
-											pos: position{line: 2958, col: 159, offset: 93224},
-											exprs: []interface{}{
+											pos: position{line: 2973, col: 159, offset: 93627},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2958, col: 159, offset: 93224},
+													pos:  position{line: 2973, col: 159, offset: 93627},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2958, col: 165, offset: 93230},
+													pos:        position{line: 2973, col: 165, offset: 93633},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2958, col: 175, offset: 93240},
+													pos:  position{line: 2973, col: 175, offset: 93643},
 													name: "QuotedString",
 												},
 											},
@@ -6269,213 +6283,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2958, col: 190, offset: 93255},
+									pos:  position{line: 2973, col: 190, offset: 93658},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2998, col: 3, offset: 94250},
+						pos: position{line: 3013, col: 3, offset: 94653},
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
-							pos: position{line: 2998, col: 3, offset: 94250},
-							exprs: []interface{}{
+							pos: position{line: 3013, col: 3, offset: 94653},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2998, col: 3, offset: 94250},
+									pos:        position{line: 3013, col: 3, offset: 94653},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2998, col: 15, offset: 94262},
+									pos:  position{line: 3013, col: 15, offset: 94665},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2998, col: 23, offset: 94270},
+									pos:   position{line: 3013, col: 23, offset: 94673},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2998, col: 30, offset: 94277},
+										pos: position{line: 3013, col: 30, offset: 94680},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2998, col: 31, offset: 94278},
+											pos:  position{line: 3013, col: 31, offset: 94681},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2998, col: 44, offset: 94291},
+									pos:  position{line: 3013, col: 44, offset: 94694},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3009, col: 3, offset: 94482},
+						pos: position{line: 3024, col: 3, offset: 94885},
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
-							pos: position{line: 3009, col: 3, offset: 94482},
-							exprs: []interface{}{
+							pos: position{line: 3024, col: 3, offset: 94885},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3009, col: 3, offset: 94482},
+									pos:        position{line: 3024, col: 3, offset: 94885},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3009, col: 12, offset: 94491},
+									pos:  position{line: 3024, col: 12, offset: 94894},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3009, col: 20, offset: 94499},
+									pos:   position{line: 3024, col: 20, offset: 94902},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3009, col: 30, offset: 94509},
+										pos:  position{line: 3024, col: 30, offset: 94912},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3009, col: 40, offset: 94519},
+									pos:  position{line: 3024, col: 40, offset: 94922},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3015, col: 3, offset: 94642},
+						pos: position{line: 3030, col: 3, offset: 95045},
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
-							pos: position{line: 3015, col: 3, offset: 94642},
-							exprs: []interface{}{
+							pos: position{line: 3030, col: 3, offset: 95045},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3015, col: 3, offset: 94642},
+									pos:        position{line: 3030, col: 3, offset: 95045},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3015, col: 13, offset: 94652},
+									pos:  position{line: 3030, col: 13, offset: 95055},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3015, col: 21, offset: 94660},
+									pos:   position{line: 3030, col: 21, offset: 95063},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3015, col: 25, offset: 94664},
+										pos:  position{line: 3030, col: 25, offset: 95067},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3015, col: 35, offset: 94674},
+									pos:  position{line: 3030, col: 35, offset: 95077},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3015, col: 41, offset: 94680},
+									pos:   position{line: 3030, col: 41, offset: 95083},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3015, col: 47, offset: 94686},
+										pos:  position{line: 3030, col: 47, offset: 95089},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3015, col: 58, offset: 94697},
+									pos:  position{line: 3030, col: 58, offset: 95100},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3015, col: 64, offset: 94703},
+									pos:   position{line: 3030, col: 64, offset: 95106},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3015, col: 76, offset: 94715},
+										pos:  position{line: 3030, col: 76, offset: 95118},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3015, col: 87, offset: 94726},
+									pos:  position{line: 3030, col: 87, offset: 95129},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3022, col: 3, offset: 94950},
+						pos: position{line: 3037, col: 3, offset: 95353},
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
-							pos: position{line: 3022, col: 3, offset: 94950},
-							exprs: []interface{}{
+							pos: position{line: 3037, col: 3, offset: 95353},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3022, col: 3, offset: 94950},
+									pos:        position{line: 3037, col: 3, offset: 95353},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3022, col: 14, offset: 94961},
+									pos:  position{line: 3037, col: 14, offset: 95364},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3022, col: 22, offset: 94969},
+									pos:   position{line: 3037, col: 22, offset: 95372},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3022, col: 26, offset: 94973},
+										pos:  position{line: 3037, col: 26, offset: 95376},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3022, col: 36, offset: 94983},
+									pos:  position{line: 3037, col: 36, offset: 95386},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3022, col: 42, offset: 94989},
+									pos:   position{line: 3037, col: 42, offset: 95392},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3022, col: 49, offset: 94996},
+										pos:  position{line: 3037, col: 49, offset: 95399},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3022, col: 60, offset: 95007},
+									pos:  position{line: 3037, col: 60, offset: 95410},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3030, col: 3, offset: 95171},
+						pos: position{line: 3045, col: 3, offset: 95574},
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
-							pos: position{line: 3030, col: 3, offset: 95171},
-							exprs: []interface{}{
+							pos: position{line: 3045, col: 3, offset: 95574},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3030, col: 3, offset: 95171},
+									pos:        position{line: 3045, col: 3, offset: 95574},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 14, offset: 95182},
+									pos:  position{line: 3045, col: 14, offset: 95585},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 22, offset: 95190},
+									pos:   position{line: 3045, col: 22, offset: 95593},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 26, offset: 95194},
+										pos:  position{line: 3045, col: 26, offset: 95597},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 36, offset: 95204},
+									pos:  position{line: 3045, col: 36, offset: 95607},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3030, col: 42, offset: 95210},
+									pos:   position{line: 3045, col: 42, offset: 95613},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3030, col: 49, offset: 95217},
+										pos:  position{line: 3045, col: 49, offset: 95620},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3030, col: 60, offset: 95228},
+									pos:  position{line: 3045, col: 60, offset: 95631},
 									name: "R_PAREN",
 								},
 							},
@@ -6486,15 +6500,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 3038, col: 1, offset: 95390},
+			pos:  position{line: 3053, col: 1, offset: 95793},
 			expr: &actionExpr{
-				pos: position{line: 3038, col: 21, offset: 95410},
+				pos: position{line: 3053, col: 21, offset: 95813},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3038, col: 21, offset: 95410},
+					pos:   position{line: 3053, col: 21, offset: 95813},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3038, col: 25, offset: 95414},
+						pos:  position{line: 3053, col: 25, offset: 95817},
 						name: "QuotedString",
 					},
 				},
@@ -6502,15 +6516,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3045, col: 1, offset: 95541},
+			pos:  position{line: 3060, col: 1, offset: 95944},
 			expr: &actionExpr{
-				pos: position{line: 3045, col: 22, offset: 95562},
+				pos: position{line: 3060, col: 22, offset: 95965},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3045, col: 22, offset: 95562},
+					pos:   position{line: 3060, col: 22, offset: 95965},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3045, col: 26, offset: 95566},
+						pos:  position{line: 3060, col: 26, offset: 95969},
 						name: "UnquotedString",
 					},
 				},
@@ -6518,22 +6532,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3052, col: 1, offset: 95694},
+			pos:  position{line: 3067, col: 1, offset: 96097},
 			expr: &actionExpr{
-				pos: position{line: 3052, col: 20, offset: 95713},
+				pos: position{line: 3067, col: 20, offset: 96116},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3052, col: 20, offset: 95713},
-					exprs: []interface{}{
+					pos: position{line: 3067, col: 20, offset: 96116},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3052, col: 20, offset: 95713},
+							pos:  position{line: 3067, col: 20, offset: 96116},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3052, col: 26, offset: 95719},
+							pos:   position{line: 3067, col: 26, offset: 96122},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3052, col: 38, offset: 95731},
+								pos:  position{line: 3067, col: 38, offset: 96134},
 								name: "String",
 							},
 						},
@@ -6543,27 +6557,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3058, col: 1, offset: 95916},
+			pos:  position{line: 3073, col: 1, offset: 96319},
 			expr: &choiceExpr{
-				pos: position{line: 3058, col: 20, offset: 95935},
-				alternatives: []interface{}{
+				pos: position{line: 3073, col: 20, offset: 96338},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3058, col: 20, offset: 95935},
+						pos: position{line: 3073, col: 20, offset: 96338},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3058, col: 20, offset: 95935},
-							exprs: []interface{}{
+							pos: position{line: 3073, col: 20, offset: 96338},
+							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3058, col: 20, offset: 95935},
+									pos:        position{line: 3073, col: 20, offset: 96338},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3058, col: 28, offset: 95943},
+									pos: position{line: 3073, col: 28, offset: 96346},
 									expr: &charClassMatcher{
-										pos:        position{line: 3058, col: 28, offset: 95943},
+										pos:        position{line: 3073, col: 28, offset: 96346},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6572,9 +6586,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3058, col: 42, offset: 95957},
+									pos: position{line: 3073, col: 42, offset: 96360},
 									expr: &litMatcher{
-										pos:        position{line: 3058, col: 44, offset: 95959},
+										pos:        position{line: 3073, col: 44, offset: 96362},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6584,27 +6598,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3061, col: 3, offset: 96001},
+						pos: position{line: 3076, col: 3, offset: 96404},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3061, col: 3, offset: 96001},
-							exprs: []interface{}{
+							pos: position{line: 3076, col: 3, offset: 96404},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3061, col: 3, offset: 96001},
+									pos:        position{line: 3076, col: 3, offset: 96404},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3061, col: 7, offset: 96005},
+									pos:   position{line: 3076, col: 7, offset: 96408},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3061, col: 13, offset: 96011},
+										pos:  position{line: 3076, col: 13, offset: 96414},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3061, col: 23, offset: 96021},
+									pos:        position{line: 3076, col: 23, offset: 96424},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6617,26 +6631,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3066, col: 1, offset: 96089},
+			pos:  position{line: 3081, col: 1, offset: 96492},
 			expr: &actionExpr{
-				pos: position{line: 3066, col: 15, offset: 96103},
+				pos: position{line: 3081, col: 15, offset: 96506},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3066, col: 15, offset: 96103},
-					exprs: []interface{}{
+					pos: position{line: 3081, col: 15, offset: 96506},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3066, col: 15, offset: 96103},
+							pos:  position{line: 3081, col: 15, offset: 96506},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3066, col: 20, offset: 96108},
+							pos:  position{line: 3081, col: 20, offset: 96511},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3066, col: 30, offset: 96118},
+							pos:   position{line: 3081, col: 30, offset: 96521},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3066, col: 40, offset: 96128},
+								pos:  position{line: 3081, col: 40, offset: 96531},
 								name: "BoolExpr",
 							},
 						},
@@ -6646,15 +6660,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3079, col: 1, offset: 96471},
+			pos:  position{line: 3094, col: 1, offset: 96874},
 			expr: &actionExpr{
-				pos: position{line: 3079, col: 13, offset: 96483},
+				pos: position{line: 3094, col: 13, offset: 96886},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3079, col: 13, offset: 96483},
+					pos:   position{line: 3094, col: 13, offset: 96886},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3079, col: 18, offset: 96488},
+						pos:  position{line: 3094, col: 18, offset: 96891},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6662,35 +6676,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3084, col: 1, offset: 96558},
+			pos:  position{line: 3099, col: 1, offset: 96961},
 			expr: &actionExpr{
-				pos: position{line: 3084, col: 19, offset: 96576},
+				pos: position{line: 3099, col: 19, offset: 96979},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3084, col: 19, offset: 96576},
-					exprs: []interface{}{
+					pos: position{line: 3099, col: 19, offset: 96979},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3084, col: 19, offset: 96576},
+							pos:   position{line: 3099, col: 19, offset: 96979},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3084, col: 25, offset: 96582},
+								pos:  position{line: 3099, col: 25, offset: 96985},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3084, col: 40, offset: 96597},
+							pos:   position{line: 3099, col: 40, offset: 97000},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3084, col: 45, offset: 96602},
+								pos: position{line: 3099, col: 45, offset: 97005},
 								expr: &seqExpr{
-									pos: position{line: 3084, col: 46, offset: 96603},
-									exprs: []interface{}{
+									pos: position{line: 3099, col: 46, offset: 97006},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3084, col: 46, offset: 96603},
+											pos:  position{line: 3099, col: 46, offset: 97006},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3084, col: 49, offset: 96606},
+											pos:  position{line: 3099, col: 49, offset: 97009},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6703,35 +6717,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3104, col: 1, offset: 97044},
+			pos:  position{line: 3119, col: 1, offset: 97447},
 			expr: &actionExpr{
-				pos: position{line: 3104, col: 19, offset: 97062},
+				pos: position{line: 3119, col: 19, offset: 97465},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3104, col: 19, offset: 97062},
-					exprs: []interface{}{
+					pos: position{line: 3119, col: 19, offset: 97465},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3104, col: 19, offset: 97062},
+							pos:   position{line: 3119, col: 19, offset: 97465},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3104, col: 25, offset: 97068},
+								pos:  position{line: 3119, col: 25, offset: 97471},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3104, col: 40, offset: 97083},
+							pos:   position{line: 3119, col: 40, offset: 97486},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3104, col: 45, offset: 97088},
+								pos: position{line: 3119, col: 45, offset: 97491},
 								expr: &seqExpr{
-									pos: position{line: 3104, col: 46, offset: 97089},
-									exprs: []interface{}{
+									pos: position{line: 3119, col: 46, offset: 97492},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3104, col: 46, offset: 97089},
+											pos:  position{line: 3119, col: 46, offset: 97492},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3104, col: 50, offset: 97093},
+											pos:  position{line: 3119, col: 50, offset: 97496},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6744,47 +6758,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3124, col: 1, offset: 97532},
+			pos:  position{line: 3139, col: 1, offset: 97935},
 			expr: &choiceExpr{
-				pos: position{line: 3124, col: 19, offset: 97550},
-				alternatives: []interface{}{
+				pos: position{line: 3139, col: 19, offset: 97953},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3124, col: 19, offset: 97550},
+						pos: position{line: 3139, col: 19, offset: 97953},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3124, col: 19, offset: 97550},
-							exprs: []interface{}{
+							pos: position{line: 3139, col: 19, offset: 97953},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3124, col: 19, offset: 97550},
+									pos:  position{line: 3139, col: 19, offset: 97953},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3124, col: 23, offset: 97554},
+									pos:  position{line: 3139, col: 23, offset: 97957},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3124, col: 31, offset: 97562},
+									pos:   position{line: 3139, col: 31, offset: 97965},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3124, col: 37, offset: 97568},
+										pos:  position{line: 3139, col: 37, offset: 97971},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3124, col: 52, offset: 97583},
+									pos:  position{line: 3139, col: 52, offset: 97986},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3134, col: 3, offset: 97786},
+						pos: position{line: 3149, col: 3, offset: 98189},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3134, col: 3, offset: 97786},
+							pos:   position{line: 3149, col: 3, offset: 98189},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3134, col: 9, offset: 97792},
+								pos:  position{line: 3149, col: 9, offset: 98195},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6794,50 +6808,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3139, col: 1, offset: 97863},
+			pos:  position{line: 3154, col: 1, offset: 98266},
 			expr: &choiceExpr{
-				pos: position{line: 3139, col: 19, offset: 97881},
-				alternatives: []interface{}{
+				pos: position{line: 3154, col: 19, offset: 98284},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3139, col: 19, offset: 97881},
+						pos: position{line: 3154, col: 19, offset: 98284},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3139, col: 19, offset: 97881},
-							exprs: []interface{}{
+							pos: position{line: 3154, col: 19, offset: 98284},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3139, col: 19, offset: 97881},
+									pos:  position{line: 3154, col: 19, offset: 98284},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3139, col: 27, offset: 97889},
+									pos:   position{line: 3154, col: 27, offset: 98292},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3139, col: 33, offset: 97895},
+										pos:  position{line: 3154, col: 33, offset: 98298},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3139, col: 48, offset: 97910},
+									pos:  position{line: 3154, col: 48, offset: 98313},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3142, col: 3, offset: 97946},
+						pos: position{line: 3157, col: 3, offset: 98349},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3142, col: 3, offset: 97946},
+							pos:   position{line: 3157, col: 3, offset: 98349},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3142, col: 10, offset: 97953},
-								alternatives: []interface{}{
+								pos: position{line: 3157, col: 10, offset: 98356},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3142, col: 10, offset: 97953},
+										pos:  position{line: 3157, col: 10, offset: 98356},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3142, col: 31, offset: 97974},
+										pos:  position{line: 3157, col: 31, offset: 98377},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6849,72 +6863,72 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3147, col: 1, offset: 98094},
+			pos:  position{line: 3162, col: 1, offset: 98497},
 			expr: &choiceExpr{
-				pos: position{line: 3147, col: 23, offset: 98116},
-				alternatives: []interface{}{
+				pos: position{line: 3162, col: 23, offset: 98519},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3147, col: 23, offset: 98116},
+						pos: position{line: 3162, col: 23, offset: 98519},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3147, col: 24, offset: 98117},
-							exprs: []interface{}{
+							pos: position{line: 3162, col: 24, offset: 98520},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3147, col: 24, offset: 98117},
+									pos:   position{line: 3162, col: 24, offset: 98520},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3147, col: 28, offset: 98121},
-										alternatives: []interface{}{
+										pos: position{line: 3162, col: 28, offset: 98524},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3147, col: 28, offset: 98121},
+												pos:        position{line: 3162, col: 28, offset: 98524},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 39, offset: 98132},
+												pos:        position{line: 3162, col: 39, offset: 98535},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 49, offset: 98142},
+												pos:        position{line: 3162, col: 49, offset: 98545},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 59, offset: 98152},
+												pos:        position{line: 3162, col: 59, offset: 98555},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 70, offset: 98163},
+												pos:        position{line: 3162, col: 70, offset: 98566},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 84, offset: 98177},
+												pos:        position{line: 3162, col: 84, offset: 98580},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 94, offset: 98187},
+												pos:        position{line: 3162, col: 94, offset: 98590},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 110, offset: 98203},
+												pos:        position{line: 3162, col: 110, offset: 98606},
 												val:        "ismv",
 												ignoreCase: false,
 												want:       "\"ismv\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3147, col: 119, offset: 98212},
+												pos:        position{line: 3162, col: 119, offset: 98615},
 												val:        "isobject",
 												ignoreCase: false,
 												want:       "\"isobject\"",
@@ -6923,56 +6937,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 131, offset: 98224},
+									pos:  position{line: 3162, col: 131, offset: 98627},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 139, offset: 98232},
+									pos:   position{line: 3162, col: 139, offset: 98635},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3147, col: 145, offset: 98238},
+										pos:  position{line: 3162, col: 145, offset: 98641},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 155, offset: 98248},
+									pos:  position{line: 3162, col: 155, offset: 98651},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3177, col: 3, offset: 99119},
+						pos: position{line: 3192, col: 3, offset: 99522},
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3177, col: 3, offset: 99119},
-							exprs: []interface{}{
+							pos: position{line: 3192, col: 3, offset: 99522},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3177, col: 3, offset: 99119},
+									pos:   position{line: 3192, col: 3, offset: 99522},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3177, col: 11, offset: 99127},
-										alternatives: []interface{}{
+										pos: position{line: 3192, col: 11, offset: 99530},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3177, col: 11, offset: 99127},
+												pos:        position{line: 3192, col: 11, offset: 99530},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3177, col: 20, offset: 99136},
+												pos:        position{line: 3192, col: 20, offset: 99539},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3177, col: 29, offset: 99145},
+												pos:        position{line: 3192, col: 29, offset: 99548},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3177, col: 39, offset: 99155},
+												pos:        position{line: 3192, col: 39, offset: 99558},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -6981,86 +6995,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3177, col: 52, offset: 99168},
+									pos:  position{line: 3192, col: 52, offset: 99571},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3177, col: 60, offset: 99176},
+									pos:   position{line: 3192, col: 60, offset: 99579},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3177, col: 70, offset: 99186},
+										pos:  position{line: 3192, col: 70, offset: 99589},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3177, col: 80, offset: 99196},
+									pos:  position{line: 3192, col: 80, offset: 99599},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3177, col: 86, offset: 99202},
+									pos:   position{line: 3192, col: 86, offset: 99605},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3177, col: 97, offset: 99213},
+										pos:  position{line: 3192, col: 97, offset: 99616},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3177, col: 107, offset: 99223},
+									pos:  position{line: 3192, col: 107, offset: 99626},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3190, col: 3, offset: 99593},
+						pos: position{line: 3205, col: 3, offset: 99996},
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
-							pos: position{line: 3190, col: 3, offset: 99593},
-							exprs: []interface{}{
+							pos: position{line: 3205, col: 3, offset: 99996},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3190, col: 3, offset: 99593},
+									pos:   position{line: 3205, col: 3, offset: 99996},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3190, col: 8, offset: 99598},
+										pos:  position{line: 3205, col: 8, offset: 100001},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3190, col: 18, offset: 99608},
+									pos:  position{line: 3205, col: 18, offset: 100011},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3190, col: 24, offset: 99614},
+									pos:        position{line: 3205, col: 24, offset: 100017},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3190, col: 29, offset: 99619},
+									pos:  position{line: 3205, col: 29, offset: 100022},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3190, col: 37, offset: 99627},
+									pos:   position{line: 3205, col: 37, offset: 100030},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3190, col: 50, offset: 99640},
+										pos:  position{line: 3205, col: 50, offset: 100043},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3190, col: 60, offset: 99650},
+									pos:   position{line: 3205, col: 60, offset: 100053},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3190, col: 65, offset: 99655},
+										pos: position{line: 3205, col: 65, offset: 100058},
 										expr: &seqExpr{
-											pos: position{line: 3190, col: 66, offset: 99656},
-											exprs: []interface{}{
+											pos: position{line: 3205, col: 66, offset: 100059},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3190, col: 66, offset: 99656},
+													pos:  position{line: 3205, col: 66, offset: 100059},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3190, col: 72, offset: 99662},
+													pos:  position{line: 3205, col: 72, offset: 100065},
 													name: "ValueExpr",
 												},
 											},
@@ -7068,50 +7082,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3190, col: 84, offset: 99674},
+									pos:  position{line: 3205, col: 84, offset: 100077},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3209, col: 3, offset: 100225},
+						pos: position{line: 3224, col: 3, offset: 100628},
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
-							pos: position{line: 3209, col: 3, offset: 100225},
-							exprs: []interface{}{
+							pos: position{line: 3224, col: 3, offset: 100628},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3209, col: 3, offset: 100225},
+									pos:        position{line: 3224, col: 3, offset: 100628},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3209, col: 8, offset: 100230},
+									pos:  position{line: 3224, col: 8, offset: 100633},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3209, col: 16, offset: 100238},
+									pos:   position{line: 3224, col: 16, offset: 100641},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3209, col: 29, offset: 100251},
+										pos:  position{line: 3224, col: 29, offset: 100654},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3209, col: 39, offset: 100261},
+									pos:   position{line: 3224, col: 39, offset: 100664},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3209, col: 44, offset: 100266},
+										pos: position{line: 3224, col: 44, offset: 100669},
 										expr: &seqExpr{
-											pos: position{line: 3209, col: 45, offset: 100267},
-											exprs: []interface{}{
+											pos: position{line: 3224, col: 45, offset: 100670},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3209, col: 45, offset: 100267},
+													pos:  position{line: 3224, col: 45, offset: 100670},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3209, col: 51, offset: 100273},
+													pos:  position{line: 3224, col: 51, offset: 100676},
 													name: "ValueExpr",
 												},
 											},
@@ -7119,7 +7133,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3209, col: 63, offset: 100285},
+									pos:  position{line: 3224, col: 63, offset: 100688},
 									name: "R_PAREN",
 								},
 							},
@@ -7130,34 +7144,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3227, col: 1, offset: 100706},
+			pos:  position{line: 3242, col: 1, offset: 101109},
 			expr: &actionExpr{
-				pos: position{line: 3227, col: 23, offset: 100728},
+				pos: position{line: 3242, col: 23, offset: 101131},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3227, col: 23, offset: 100728},
-					exprs: []interface{}{
+					pos: position{line: 3242, col: 23, offset: 101131},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3227, col: 23, offset: 100728},
+							pos:   position{line: 3242, col: 23, offset: 101131},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3227, col: 28, offset: 100733},
+								pos:  position{line: 3242, col: 28, offset: 101136},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3227, col: 38, offset: 100743},
+							pos:   position{line: 3242, col: 38, offset: 101146},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3227, col: 41, offset: 100746},
+								pos:  position{line: 3242, col: 41, offset: 101149},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3227, col: 62, offset: 100767},
+							pos:   position{line: 3242, col: 62, offset: 101170},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3227, col: 68, offset: 100773},
+								pos:  position{line: 3242, col: 68, offset: 101176},
 								name: "ValueExpr",
 							},
 						},
@@ -7167,130 +7181,142 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3245, col: 1, offset: 101367},
+			pos:  position{line: 3260, col: 1, offset: 101770},
 			expr: &choiceExpr{
-				pos: position{line: 3245, col: 14, offset: 101380},
-				alternatives: []interface{}{
+				pos: position{line: 3260, col: 14, offset: 101783},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3245, col: 14, offset: 101380},
+						pos: position{line: 3260, col: 14, offset: 101783},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3245, col: 14, offset: 101380},
+							pos:   position{line: 3260, col: 14, offset: 101783},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3245, col: 24, offset: 101390},
+								pos:  position{line: 3260, col: 24, offset: 101793},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3254, col: 3, offset: 101580},
+						pos: position{line: 3269, col: 3, offset: 101983},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3254, col: 3, offset: 101580},
-							exprs: []interface{}{
+							pos: position{line: 3269, col: 3, offset: 101983},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3254, col: 3, offset: 101580},
+									pos:  position{line: 3269, col: 3, offset: 101983},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3254, col: 12, offset: 101589},
+									pos:   position{line: 3269, col: 12, offset: 101992},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3254, col: 22, offset: 101599},
+										pos:  position{line: 3269, col: 22, offset: 102002},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3254, col: 37, offset: 101614},
+									pos:  position{line: 3269, col: 37, offset: 102017},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3263, col: 3, offset: 101798},
+						pos: position{line: 3278, col: 3, offset: 102201},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3263, col: 3, offset: 101798},
+							pos:   position{line: 3278, col: 3, offset: 102201},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3263, col: 11, offset: 101806},
+								pos:  position{line: 3278, col: 11, offset: 102209},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3272, col: 3, offset: 101986},
+						pos: position{line: 3287, col: 3, offset: 102389},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3272, col: 3, offset: 101986},
+							pos:   position{line: 3287, col: 3, offset: 102389},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3272, col: 7, offset: 101990},
+								pos:  position{line: 3287, col: 7, offset: 102393},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3281, col: 3, offset: 102162},
+						pos: position{line: 3296, col: 3, offset: 102565},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3281, col: 3, offset: 102162},
-							exprs: []interface{}{
+							pos: position{line: 3296, col: 3, offset: 102565},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3281, col: 3, offset: 102162},
+									pos:  position{line: 3296, col: 3, offset: 102565},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3281, col: 12, offset: 102171},
+									pos:   position{line: 3296, col: 12, offset: 102574},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3281, col: 16, offset: 102175},
+										pos:  position{line: 3296, col: 16, offset: 102578},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3281, col: 28, offset: 102187},
+									pos:  position{line: 3296, col: 28, offset: 102590},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3290, col: 3, offset: 102356},
+						pos: position{line: 3305, col: 3, offset: 102759},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3290, col: 3, offset: 102356},
-							exprs: []interface{}{
+							pos: position{line: 3305, col: 3, offset: 102759},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3290, col: 3, offset: 102356},
+									pos:  position{line: 3305, col: 3, offset: 102759},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3290, col: 11, offset: 102364},
+									pos:   position{line: 3305, col: 11, offset: 102767},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3290, col: 19, offset: 102372},
+										pos:  position{line: 3305, col: 19, offset: 102775},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3290, col: 28, offset: 102381},
+									pos:  position{line: 3305, col: 28, offset: 102784},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3299, col: 3, offset: 102553},
+						pos: position{line: 3314, col: 3, offset: 102956},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3299, col: 3, offset: 102553},
+							pos:   position{line: 3314, col: 3, offset: 102956},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3299, col: 18, offset: 102568},
+								pos:  position{line: 3314, col: 18, offset: 102971},
 								name: "MultiValueExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3323, col: 3, offset: 103169},
+						run: (*parser).callonValueExpr32,
+						expr: &labeledExpr{
+							pos:   position{line: 3323, col: 3, offset: 103169},
+							label: "jsonExpr",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3323, col: 12, offset: 103178},
+								name: "JsonExpr",
 							},
 						},
 					},
@@ -7299,28 +7325,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3309, col: 1, offset: 102765},
+			pos:  position{line: 3332, col: 1, offset: 103345},
 			expr: &choiceExpr{
-				pos: position{line: 3309, col: 15, offset: 102779},
-				alternatives: []interface{}{
+				pos: position{line: 3332, col: 15, offset: 103359},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3309, col: 15, offset: 102779},
+						pos: position{line: 3332, col: 15, offset: 103359},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3309, col: 15, offset: 102779},
-							exprs: []interface{}{
+							pos: position{line: 3332, col: 15, offset: 103359},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3309, col: 15, offset: 102779},
+									pos:   position{line: 3332, col: 15, offset: 103359},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3309, col: 20, offset: 102784},
+										pos:  position{line: 3332, col: 20, offset: 103364},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3309, col: 29, offset: 102793},
+									pos: position{line: 3332, col: 29, offset: 103373},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3309, col: 31, offset: 102795},
+										pos:  position{line: 3332, col: 31, offset: 103375},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7328,23 +7354,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3317, col: 3, offset: 102965},
+						pos: position{line: 3340, col: 3, offset: 103545},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3317, col: 3, offset: 102965},
-							exprs: []interface{}{
+							pos: position{line: 3340, col: 3, offset: 103545},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3317, col: 3, offset: 102965},
+									pos:   position{line: 3340, col: 3, offset: 103545},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3317, col: 7, offset: 102969},
+										pos:  position{line: 3340, col: 7, offset: 103549},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3317, col: 20, offset: 102982},
+									pos: position{line: 3340, col: 20, offset: 103562},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3317, col: 22, offset: 102984},
+										pos:  position{line: 3340, col: 22, offset: 103564},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7352,50 +7378,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3325, col: 3, offset: 103149},
+						pos: position{line: 3348, col: 3, offset: 103729},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3325, col: 3, offset: 103149},
-							exprs: []interface{}{
+							pos: position{line: 3348, col: 3, offset: 103729},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3325, col: 3, offset: 103149},
+									pos:   position{line: 3348, col: 3, offset: 103729},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3325, col: 9, offset: 103155},
+										pos:  position{line: 3348, col: 9, offset: 103735},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3325, col: 25, offset: 103171},
+									pos: position{line: 3348, col: 25, offset: 103751},
 									expr: &choiceExpr{
-										pos: position{line: 3325, col: 27, offset: 103173},
-										alternatives: []interface{}{
+										pos: position{line: 3348, col: 27, offset: 103753},
+										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 27, offset: 103173},
+												pos:  position{line: 3348, col: 27, offset: 103753},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 36, offset: 103182},
+												pos:  position{line: 3348, col: 36, offset: 103762},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 46, offset: 103192},
+												pos:  position{line: 3348, col: 46, offset: 103772},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 54, offset: 103200},
+												pos:  position{line: 3348, col: 54, offset: 103780},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 62, offset: 103208},
+												pos:  position{line: 3348, col: 62, offset: 103788},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3325, col: 70, offset: 103216},
+												pos:  position{line: 3348, col: 70, offset: 103796},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3325, col: 84, offset: 103230},
+												pos:        position{line: 3348, col: 84, offset: 103810},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7407,13 +7433,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3333, col: 3, offset: 103380},
+						pos: position{line: 3356, col: 3, offset: 103960},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3333, col: 3, offset: 103380},
+							pos:   position{line: 3356, col: 3, offset: 103960},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3333, col: 10, offset: 103387},
+								pos:  position{line: 3356, col: 10, offset: 103967},
 								name: "ConcatExpr",
 							},
 						},
@@ -7423,35 +7449,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3343, col: 1, offset: 103593},
+			pos:  position{line: 3366, col: 1, offset: 104173},
 			expr: &actionExpr{
-				pos: position{line: 3343, col: 15, offset: 103607},
+				pos: position{line: 3366, col: 15, offset: 104187},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3343, col: 15, offset: 103607},
-					exprs: []interface{}{
+					pos: position{line: 3366, col: 15, offset: 104187},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3343, col: 15, offset: 103607},
+							pos:   position{line: 3366, col: 15, offset: 104187},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3343, col: 21, offset: 103613},
+								pos:  position{line: 3366, col: 21, offset: 104193},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3343, col: 32, offset: 103624},
+							pos:   position{line: 3366, col: 32, offset: 104204},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3343, col: 37, offset: 103629},
+								pos: position{line: 3366, col: 37, offset: 104209},
 								expr: &seqExpr{
-									pos: position{line: 3343, col: 38, offset: 103630},
-									exprs: []interface{}{
+									pos: position{line: 3366, col: 38, offset: 104210},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3343, col: 38, offset: 103630},
+											pos:  position{line: 3366, col: 38, offset: 104210},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3343, col: 50, offset: 103642},
+											pos:  position{line: 3366, col: 50, offset: 104222},
 											name: "ConcatAtom",
 										},
 									},
@@ -7459,28 +7485,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3343, col: 63, offset: 103655},
+							pos: position{line: 3366, col: 63, offset: 104235},
 							expr: &choiceExpr{
-								pos: position{line: 3343, col: 65, offset: 103657},
-								alternatives: []interface{}{
+								pos: position{line: 3366, col: 65, offset: 104237},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3343, col: 65, offset: 103657},
+										pos:  position{line: 3366, col: 65, offset: 104237},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3343, col: 74, offset: 103666},
+										pos:  position{line: 3366, col: 74, offset: 104246},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3343, col: 84, offset: 103676},
+										pos:  position{line: 3366, col: 84, offset: 104256},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3343, col: 92, offset: 103684},
+										pos:  position{line: 3366, col: 92, offset: 104264},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3343, col: 100, offset: 103692},
+										pos:        position{line: 3366, col: 100, offset: 104272},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7494,54 +7520,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3361, col: 1, offset: 104098},
+			pos:  position{line: 3384, col: 1, offset: 104678},
 			expr: &choiceExpr{
-				pos: position{line: 3361, col: 15, offset: 104112},
-				alternatives: []interface{}{
+				pos: position{line: 3384, col: 15, offset: 104692},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3361, col: 15, offset: 104112},
+						pos: position{line: 3384, col: 15, offset: 104692},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3361, col: 15, offset: 104112},
+							pos:   position{line: 3384, col: 15, offset: 104692},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3361, col: 20, offset: 104117},
+								pos:  position{line: 3384, col: 20, offset: 104697},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3370, col: 3, offset: 104281},
+						pos: position{line: 3393, col: 3, offset: 104861},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3370, col: 3, offset: 104281},
+							pos:   position{line: 3393, col: 3, offset: 104861},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3370, col: 7, offset: 104285},
+								pos:  position{line: 3393, col: 7, offset: 104865},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3378, col: 3, offset: 104424},
+						pos: position{line: 3401, col: 3, offset: 105004},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3378, col: 3, offset: 104424},
+							pos:   position{line: 3401, col: 3, offset: 105004},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3378, col: 10, offset: 104431},
+								pos:  position{line: 3401, col: 10, offset: 105011},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3386, col: 3, offset: 104570},
+						pos: position{line: 3409, col: 3, offset: 105150},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3386, col: 3, offset: 104570},
+							pos:   position{line: 3409, col: 3, offset: 105150},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3386, col: 9, offset: 104576},
+								pos:  position{line: 3409, col: 9, offset: 105156},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7551,32 +7577,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3396, col: 1, offset: 104745},
+			pos:  position{line: 3419, col: 1, offset: 105325},
 			expr: &actionExpr{
-				pos: position{line: 3396, col: 16, offset: 104760},
+				pos: position{line: 3419, col: 16, offset: 105340},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3396, col: 16, offset: 104760},
-					exprs: []interface{}{
+					pos: position{line: 3419, col: 16, offset: 105340},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3396, col: 16, offset: 104760},
+							pos:   position{line: 3419, col: 16, offset: 105340},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3396, col: 21, offset: 104765},
+								pos:  position{line: 3419, col: 21, offset: 105345},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3396, col: 39, offset: 104783},
+							pos: position{line: 3419, col: 39, offset: 105363},
 							expr: &choiceExpr{
-								pos: position{line: 3396, col: 41, offset: 104785},
-								alternatives: []interface{}{
+								pos: position{line: 3419, col: 41, offset: 105365},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3396, col: 41, offset: 104785},
+										pos:  position{line: 3419, col: 41, offset: 105365},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3396, col: 55, offset: 104799},
+										pos:        position{line: 3419, col: 55, offset: 105379},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7590,44 +7616,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3401, col: 1, offset: 104864},
+			pos:  position{line: 3424, col: 1, offset: 105444},
 			expr: &actionExpr{
-				pos: position{line: 3401, col: 22, offset: 104885},
+				pos: position{line: 3424, col: 22, offset: 105465},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3401, col: 22, offset: 104885},
-					exprs: []interface{}{
+					pos: position{line: 3424, col: 22, offset: 105465},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3401, col: 22, offset: 104885},
+							pos:   position{line: 3424, col: 22, offset: 105465},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3401, col: 28, offset: 104891},
+								pos:  position{line: 3424, col: 28, offset: 105471},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3401, col: 46, offset: 104909},
+							pos:   position{line: 3424, col: 46, offset: 105489},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3401, col: 51, offset: 104914},
+								pos: position{line: 3424, col: 51, offset: 105494},
 								expr: &seqExpr{
-									pos: position{line: 3401, col: 52, offset: 104915},
-									exprs: []interface{}{
+									pos: position{line: 3424, col: 52, offset: 105495},
+									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3401, col: 53, offset: 104916},
-											alternatives: []interface{}{
+											pos: position{line: 3424, col: 53, offset: 105496},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3401, col: 53, offset: 104916},
+													pos:  position{line: 3424, col: 53, offset: 105496},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3401, col: 62, offset: 104925},
+													pos:  position{line: 3424, col: 62, offset: 105505},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3401, col: 71, offset: 104934},
+											pos:  position{line: 3424, col: 71, offset: 105514},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7640,48 +7666,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3422, col: 1, offset: 105435},
+			pos:  position{line: 3445, col: 1, offset: 106015},
 			expr: &actionExpr{
-				pos: position{line: 3422, col: 22, offset: 105456},
+				pos: position{line: 3445, col: 22, offset: 106036},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3422, col: 22, offset: 105456},
-					exprs: []interface{}{
+					pos: position{line: 3445, col: 22, offset: 106036},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3422, col: 22, offset: 105456},
+							pos:   position{line: 3445, col: 22, offset: 106036},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3422, col: 28, offset: 105462},
+								pos:  position{line: 3445, col: 28, offset: 106042},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3422, col: 46, offset: 105480},
+							pos:   position{line: 3445, col: 46, offset: 106060},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3422, col: 51, offset: 105485},
+								pos: position{line: 3445, col: 51, offset: 106065},
 								expr: &seqExpr{
-									pos: position{line: 3422, col: 52, offset: 105486},
-									exprs: []interface{}{
+									pos: position{line: 3445, col: 52, offset: 106066},
+									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3422, col: 53, offset: 105487},
-											alternatives: []interface{}{
+											pos: position{line: 3445, col: 53, offset: 106067},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3422, col: 53, offset: 105487},
+													pos:  position{line: 3445, col: 53, offset: 106067},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3422, col: 61, offset: 105495},
+													pos:  position{line: 3445, col: 61, offset: 106075},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3422, col: 69, offset: 105503},
+													pos:  position{line: 3445, col: 69, offset: 106083},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3422, col: 76, offset: 105510},
+											pos:  position{line: 3445, col: 76, offset: 106090},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7694,22 +7720,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3442, col: 1, offset: 105979},
+			pos:  position{line: 3465, col: 1, offset: 106559},
 			expr: &actionExpr{
-				pos: position{line: 3442, col: 21, offset: 105999},
+				pos: position{line: 3465, col: 21, offset: 106579},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3442, col: 21, offset: 105999},
-					exprs: []interface{}{
+					pos: position{line: 3465, col: 21, offset: 106579},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3442, col: 21, offset: 105999},
+							pos:  position{line: 3465, col: 21, offset: 106579},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3442, col: 27, offset: 106005},
+							pos:   position{line: 3465, col: 27, offset: 106585},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3442, col: 32, offset: 106010},
+								pos:  position{line: 3465, col: 32, offset: 106590},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7719,67 +7745,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3452, col: 1, offset: 106254},
+			pos:  position{line: 3475, col: 1, offset: 106834},
 			expr: &choiceExpr{
-				pos: position{line: 3452, col: 22, offset: 106275},
-				alternatives: []interface{}{
+				pos: position{line: 3475, col: 22, offset: 106855},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3452, col: 22, offset: 106275},
+						pos: position{line: 3475, col: 22, offset: 106855},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3452, col: 22, offset: 106275},
-							exprs: []interface{}{
+							pos: position{line: 3475, col: 22, offset: 106855},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3452, col: 22, offset: 106275},
+									pos:  position{line: 3475, col: 22, offset: 106855},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3452, col: 30, offset: 106283},
+									pos:   position{line: 3475, col: 30, offset: 106863},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3452, col: 35, offset: 106288},
+										pos:  position{line: 3475, col: 35, offset: 106868},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3452, col: 53, offset: 106306},
+									pos:  position{line: 3475, col: 53, offset: 106886},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3455, col: 3, offset: 106341},
+						pos: position{line: 3478, col: 3, offset: 106921},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3455, col: 3, offset: 106341},
+							pos:   position{line: 3478, col: 3, offset: 106921},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3455, col: 20, offset: 106358},
+								pos:  position{line: 3478, col: 20, offset: 106938},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3458, col: 3, offset: 106412},
+						pos: position{line: 3481, col: 3, offset: 106992},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3458, col: 3, offset: 106412},
+							pos:   position{line: 3481, col: 3, offset: 106992},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3458, col: 9, offset: 106418},
+								pos:  position{line: 3481, col: 9, offset: 106998},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3468, col: 3, offset: 106637},
+						pos: position{line: 3491, col: 3, offset: 107217},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3468, col: 3, offset: 106637},
+							pos:   position{line: 3491, col: 3, offset: 107217},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3468, col: 10, offset: 106644},
+								pos:  position{line: 3491, col: 10, offset: 107224},
 								name: "NumberAsString",
 							},
 						},
@@ -7789,144 +7815,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3481, col: 1, offset: 107022},
+			pos:  position{line: 3504, col: 1, offset: 107602},
 			expr: &choiceExpr{
-				pos: position{line: 3481, col: 20, offset: 107041},
-				alternatives: []interface{}{
+				pos: position{line: 3504, col: 20, offset: 107621},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3481, col: 20, offset: 107041},
+						pos: position{line: 3504, col: 20, offset: 107621},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3481, col: 21, offset: 107042},
-							exprs: []interface{}{
+							pos: position{line: 3504, col: 21, offset: 107622},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3481, col: 21, offset: 107042},
+									pos:   position{line: 3504, col: 21, offset: 107622},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3481, col: 29, offset: 107050},
-										alternatives: []interface{}{
+										pos: position{line: 3504, col: 29, offset: 107630},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3481, col: 29, offset: 107050},
+												pos:        position{line: 3504, col: 29, offset: 107630},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 37, offset: 107058},
+												pos:        position{line: 3504, col: 37, offset: 107638},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 46, offset: 107067},
+												pos:        position{line: 3504, col: 46, offset: 107647},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 58, offset: 107079},
+												pos:        position{line: 3504, col: 58, offset: 107659},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 67, offset: 107088},
+												pos:        position{line: 3504, col: 67, offset: 107668},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 77, offset: 107098},
+												pos:        position{line: 3504, col: 77, offset: 107678},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 85, offset: 107106},
+												pos:        position{line: 3504, col: 85, offset: 107686},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 95, offset: 107116},
+												pos:        position{line: 3504, col: 95, offset: 107696},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 102, offset: 107123},
+												pos:        position{line: 3504, col: 102, offset: 107703},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 113, offset: 107134},
+												pos:        position{line: 3504, col: 113, offset: 107714},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 123, offset: 107144},
+												pos:        position{line: 3504, col: 123, offset: 107724},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 132, offset: 107153},
+												pos:        position{line: 3504, col: 132, offset: 107733},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 142, offset: 107163},
+												pos:        position{line: 3504, col: 142, offset: 107743},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 151, offset: 107172},
+												pos:        position{line: 3504, col: 151, offset: 107752},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 161, offset: 107182},
+												pos:        position{line: 3504, col: 161, offset: 107762},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 170, offset: 107191},
+												pos:        position{line: 3504, col: 170, offset: 107771},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 179, offset: 107200},
+												pos:        position{line: 3504, col: 179, offset: 107780},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 187, offset: 107208},
+												pos:        position{line: 3504, col: 187, offset: 107788},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 196, offset: 107217},
+												pos:        position{line: 3504, col: 196, offset: 107797},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 204, offset: 107225},
+												pos:        position{line: 3504, col: 204, offset: 107805},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3481, col: 213, offset: 107234},
+												pos:        position{line: 3504, col: 213, offset: 107814},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7935,102 +7961,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3481, col: 220, offset: 107241},
+									pos:  position{line: 3504, col: 220, offset: 107821},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3481, col: 228, offset: 107249},
+									pos:   position{line: 3504, col: 228, offset: 107829},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3481, col: 234, offset: 107255},
+										pos:  position{line: 3504, col: 234, offset: 107835},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3481, col: 253, offset: 107274},
+									pos:  position{line: 3504, col: 253, offset: 107854},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3501, col: 3, offset: 107786},
+						pos: position{line: 3524, col: 3, offset: 108366},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3501, col: 3, offset: 107786},
-							exprs: []interface{}{
+							pos: position{line: 3524, col: 3, offset: 108366},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3501, col: 3, offset: 107786},
+									pos:   position{line: 3524, col: 3, offset: 108366},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3501, col: 13, offset: 107796},
+										pos:        position{line: 3524, col: 13, offset: 108376},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3501, col: 21, offset: 107804},
+									pos:  position{line: 3524, col: 21, offset: 108384},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3501, col: 29, offset: 107812},
+									pos:   position{line: 3524, col: 29, offset: 108392},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3501, col: 35, offset: 107818},
+										pos:  position{line: 3524, col: 35, offset: 108398},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3501, col: 54, offset: 107837},
+									pos:   position{line: 3524, col: 54, offset: 108417},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3501, col: 69, offset: 107852},
+										pos: position{line: 3524, col: 69, offset: 108432},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3501, col: 70, offset: 107853},
+											pos:  position{line: 3524, col: 70, offset: 108433},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3501, col: 89, offset: 107872},
+									pos:  position{line: 3524, col: 89, offset: 108452},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3522, col: 3, offset: 108490},
+						pos: position{line: 3545, col: 3, offset: 109070},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3522, col: 4, offset: 108491},
-							exprs: []interface{}{
+							pos: position{line: 3545, col: 4, offset: 109071},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3522, col: 4, offset: 108491},
+									pos:   position{line: 3545, col: 4, offset: 109071},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3522, col: 12, offset: 108499},
-										alternatives: []interface{}{
+										pos: position{line: 3545, col: 12, offset: 109079},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3522, col: 12, offset: 108499},
+												pos:        position{line: 3545, col: 12, offset: 109079},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3522, col: 20, offset: 108507},
+												pos:        position{line: 3545, col: 20, offset: 109087},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3522, col: 27, offset: 108514},
+												pos:        position{line: 3545, col: 27, offset: 109094},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3522, col: 38, offset: 108525},
+												pos:        position{line: 3545, col: 38, offset: 109105},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -8039,54 +8065,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3522, col: 46, offset: 108533},
+									pos:  position{line: 3545, col: 46, offset: 109113},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3522, col: 54, offset: 108541},
+									pos:  position{line: 3545, col: 54, offset: 109121},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3535, col: 3, offset: 108827},
+						pos: position{line: 3558, col: 3, offset: 109407},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3535, col: 3, offset: 108827},
-							exprs: []interface{}{
+							pos: position{line: 3558, col: 3, offset: 109407},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3535, col: 3, offset: 108827},
+									pos:        position{line: 3558, col: 3, offset: 109407},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3535, col: 14, offset: 108838},
+									pos:  position{line: 3558, col: 14, offset: 109418},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3535, col: 22, offset: 108846},
+									pos:   position{line: 3558, col: 22, offset: 109426},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3535, col: 33, offset: 108857},
+										pos:  position{line: 3558, col: 33, offset: 109437},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3535, col: 44, offset: 108868},
+									pos:   position{line: 3558, col: 44, offset: 109448},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3535, col: 53, offset: 108877},
+										pos: position{line: 3558, col: 53, offset: 109457},
 										expr: &seqExpr{
-											pos: position{line: 3535, col: 54, offset: 108878},
-											exprs: []interface{}{
+											pos: position{line: 3558, col: 54, offset: 109458},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3535, col: 54, offset: 108878},
+													pos:  position{line: 3558, col: 54, offset: 109458},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3535, col: 60, offset: 108884},
+													pos:  position{line: 3558, col: 60, offset: 109464},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8094,38 +8120,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3535, col: 80, offset: 108904},
+									pos:  position{line: 3558, col: 80, offset: 109484},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3563, col: 3, offset: 109747},
+						pos: position{line: 3586, col: 3, offset: 110327},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3563, col: 4, offset: 109748},
-							exprs: []interface{}{
+							pos: position{line: 3586, col: 4, offset: 110328},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3563, col: 4, offset: 109748},
+									pos:   position{line: 3586, col: 4, offset: 110328},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3563, col: 12, offset: 109756},
-										alternatives: []interface{}{
+										pos: position{line: 3586, col: 12, offset: 110336},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3563, col: 12, offset: 109756},
+												pos:        position{line: 3586, col: 12, offset: 110336},
 												val:        "bit_and",
 												ignoreCase: false,
 												want:       "\"bit_and\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3563, col: 24, offset: 109768},
+												pos:        position{line: 3586, col: 24, offset: 110348},
 												val:        "bit_or",
 												ignoreCase: false,
 												want:       "\"bit_or\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3563, col: 35, offset: 109779},
+												pos:        position{line: 3586, col: 35, offset: 110359},
 												val:        "bit_xor",
 												ignoreCase: false,
 												want:       "\"bit_xor\"",
@@ -8134,43 +8160,43 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3563, col: 46, offset: 109790},
+									pos:  position{line: 3586, col: 46, offset: 110370},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3563, col: 54, offset: 109798},
+									pos:   position{line: 3586, col: 54, offset: 110378},
 									label: "firstArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3563, col: 63, offset: 109807},
+										pos:  position{line: 3586, col: 63, offset: 110387},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3563, col: 81, offset: 109825},
+									pos:  position{line: 3586, col: 81, offset: 110405},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3563, col: 87, offset: 109831},
+									pos:   position{line: 3586, col: 87, offset: 110411},
 									label: "secondArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3563, col: 97, offset: 109841},
+										pos:  position{line: 3586, col: 97, offset: 110421},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3563, col: 115, offset: 109859},
+									pos:   position{line: 3586, col: 115, offset: 110439},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3563, col: 120, offset: 109864},
+										pos: position{line: 3586, col: 120, offset: 110444},
 										expr: &seqExpr{
-											pos: position{line: 3563, col: 121, offset: 109865},
-											exprs: []interface{}{
+											pos: position{line: 3586, col: 121, offset: 110445},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3563, col: 121, offset: 109865},
+													pos:  position{line: 3586, col: 121, offset: 110445},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3563, col: 127, offset: 109871},
+													pos:  position{line: 3586, col: 127, offset: 110451},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8178,38 +8204,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3563, col: 147, offset: 109891},
+									pos:  position{line: 3586, col: 147, offset: 110471},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3603, col: 3, offset: 111049},
+						pos: position{line: 3622, col: 3, offset: 111568},
 						run: (*parser).callonNumericEvalExpr83,
 						expr: &seqExpr{
-							pos: position{line: 3603, col: 4, offset: 111050},
-							exprs: []interface{}{
+							pos: position{line: 3622, col: 4, offset: 111569},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3603, col: 4, offset: 111050},
+									pos:   position{line: 3622, col: 4, offset: 111569},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3603, col: 12, offset: 111058},
-										alternatives: []interface{}{
+										pos: position{line: 3622, col: 12, offset: 111577},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3603, col: 12, offset: 111058},
+												pos:        position{line: 3622, col: 12, offset: 111577},
 												val:        "bit_not",
 												ignoreCase: false,
 												want:       "\"bit_not\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3603, col: 24, offset: 111070},
+												pos:        position{line: 3622, col: 24, offset: 111589},
 												val:        "bit_shift_left",
 												ignoreCase: false,
 												want:       "\"bit_shift_left\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3603, col: 43, offset: 111089},
+												pos:        position{line: 3622, col: 43, offset: 111608},
 												val:        "bit_shift_right",
 												ignoreCase: false,
 												want:       "\"bit_shift_right\"",
@@ -8218,31 +8244,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3603, col: 62, offset: 111108},
+									pos:  position{line: 3622, col: 62, offset: 111627},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3603, col: 70, offset: 111116},
+									pos:   position{line: 3622, col: 70, offset: 111635},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3603, col: 75, offset: 111121},
+										pos:  position{line: 3622, col: 75, offset: 111640},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3603, col: 93, offset: 111139},
+									pos:   position{line: 3622, col: 93, offset: 111658},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3603, col: 99, offset: 111145},
+										pos: position{line: 3622, col: 99, offset: 111664},
 										expr: &seqExpr{
-											pos: position{line: 3603, col: 100, offset: 111146},
-											exprs: []interface{}{
+											pos: position{line: 3622, col: 100, offset: 111665},
+											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3603, col: 100, offset: 111146},
+													pos:  position{line: 3622, col: 100, offset: 111665},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3603, col: 106, offset: 111152},
+													pos:  position{line: 3622, col: 106, offset: 111671},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8250,73 +8276,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3603, col: 126, offset: 111172},
+									pos:  position{line: 3622, col: 126, offset: 111691},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3630, col: 3, offset: 112096},
+						pos: position{line: 3649, col: 3, offset: 112615},
 						run: (*parser).callonNumericEvalExpr99,
 						expr: &seqExpr{
-							pos: position{line: 3630, col: 3, offset: 112096},
-							exprs: []interface{}{
+							pos: position{line: 3649, col: 3, offset: 112615},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3630, col: 3, offset: 112096},
+									pos:   position{line: 3649, col: 3, offset: 112615},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3630, col: 12, offset: 112105},
+										pos:        position{line: 3649, col: 12, offset: 112624},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3630, col: 18, offset: 112111},
+									pos:  position{line: 3649, col: 18, offset: 112630},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3630, col: 26, offset: 112119},
+									pos:   position{line: 3649, col: 26, offset: 112638},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3630, col: 31, offset: 112124},
+										pos:  position{line: 3649, col: 31, offset: 112643},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3630, col: 39, offset: 112132},
+									pos:  position{line: 3649, col: 39, offset: 112651},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3633, col: 3, offset: 112167},
+						pos: position{line: 3652, col: 3, offset: 112686},
 						run: (*parser).callonNumericEvalExpr107,
 						expr: &seqExpr{
-							pos: position{line: 3633, col: 4, offset: 112168},
-							exprs: []interface{}{
+							pos: position{line: 3652, col: 4, offset: 112687},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3633, col: 4, offset: 112168},
+									pos:   position{line: 3652, col: 4, offset: 112687},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3633, col: 12, offset: 112176},
-										alternatives: []interface{}{
+										pos: position{line: 3652, col: 12, offset: 112695},
+										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3633, col: 12, offset: 112176},
+												pos:        position{line: 3652, col: 12, offset: 112695},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3633, col: 20, offset: 112184},
+												pos:        position{line: 3652, col: 20, offset: 112703},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3633, col: 30, offset: 112194},
+												pos:        position{line: 3652, col: 30, offset: 112713},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8325,128 +8351,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3633, col: 39, offset: 112203},
+									pos:  position{line: 3652, col: 39, offset: 112722},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3633, col: 47, offset: 112211},
+									pos:   position{line: 3652, col: 47, offset: 112730},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3633, col: 53, offset: 112217},
+										pos:  position{line: 3652, col: 53, offset: 112736},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3633, col: 72, offset: 112236},
+									pos:   position{line: 3652, col: 72, offset: 112755},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3633, col: 79, offset: 112243},
+										pos:  position{line: 3652, col: 79, offset: 112762},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3633, col: 97, offset: 112261},
+									pos:  position{line: 3652, col: 97, offset: 112780},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3663, col: 3, offset: 113100},
+						pos: position{line: 3682, col: 3, offset: 113619},
 						run: (*parser).callonNumericEvalExpr120,
 						expr: &seqExpr{
-							pos: position{line: 3663, col: 4, offset: 113101},
-							exprs: []interface{}{
+							pos: position{line: 3682, col: 4, offset: 113620},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3663, col: 4, offset: 113101},
+									pos:   position{line: 3682, col: 4, offset: 113620},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3663, col: 11, offset: 113108},
+										pos:        position{line: 3682, col: 11, offset: 113627},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3663, col: 17, offset: 113114},
+									pos:  position{line: 3682, col: 17, offset: 113633},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3663, col: 25, offset: 113122},
+									pos:   position{line: 3682, col: 25, offset: 113641},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3663, col: 31, offset: 113128},
+										pos:  position{line: 3682, col: 31, offset: 113647},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3663, col: 50, offset: 113147},
+									pos:   position{line: 3682, col: 50, offset: 113666},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3663, col: 56, offset: 113153},
+										pos: position{line: 3682, col: 56, offset: 113672},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3663, col: 57, offset: 113154},
+											pos:  position{line: 3682, col: 57, offset: 113673},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3663, col: 76, offset: 113173},
+									pos:  position{line: 3682, col: 76, offset: 113692},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3692, col: 3, offset: 113946},
+						pos: position{line: 3711, col: 3, offset: 114465},
 						run: (*parser).callonNumericEvalExpr131,
 						expr: &seqExpr{
-							pos: position{line: 3692, col: 3, offset: 113946},
-							exprs: []interface{}{
+							pos: position{line: 3711, col: 3, offset: 114465},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3692, col: 3, offset: 113946},
+									pos:   position{line: 3711, col: 3, offset: 114465},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3692, col: 11, offset: 113954},
+										pos:        position{line: 3711, col: 11, offset: 114473},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3692, col: 28, offset: 113971},
+									pos:  position{line: 3711, col: 28, offset: 114490},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3692, col: 36, offset: 113979},
+									pos:   position{line: 3711, col: 36, offset: 114498},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3692, col: 42, offset: 113985},
+										pos:  position{line: 3711, col: 42, offset: 114504},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3692, col: 61, offset: 114004},
+									pos:  position{line: 3711, col: 61, offset: 114523},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3692, col: 67, offset: 114010},
+									pos:  position{line: 3711, col: 67, offset: 114529},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3692, col: 73, offset: 114016},
+									pos:   position{line: 3711, col: 73, offset: 114535},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3692, col: 84, offset: 114027},
+										pos:  position{line: 3711, col: 84, offset: 114546},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3692, col: 120, offset: 114063},
+									pos:  position{line: 3711, col: 120, offset: 114582},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3692, col: 126, offset: 114069},
+									pos:  position{line: 3711, col: 126, offset: 114588},
 									name: "R_PAREN",
 								},
 							},
@@ -8456,29 +8482,224 @@ var g = &grammar{
 			},
 		},
 		{
-			name: "LenExpr",
-			pos:  position{line: 3709, col: 1, offset: 114599},
+			name: "JsonExprLevel1",
+			pos:  position{line: 3728, col: 1, offset: 115118},
 			expr: &choiceExpr{
-				pos: position{line: 3709, col: 12, offset: 114610},
-				alternatives: []interface{}{
+				pos: position{line: 3728, col: 19, offset: 115136},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3709, col: 12, offset: 114610},
+						pos: position{line: 3728, col: 19, offset: 115136},
+						run: (*parser).callonJsonExprLevel12,
+						expr: &labeledExpr{
+							pos:   position{line: 3728, col: 19, offset: 115136},
+							label: "jsonExpr",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3728, col: 28, offset: 115145},
+								name: "JsonExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3731, col: 3, offset: 115185},
+						run: (*parser).callonJsonExprLevel15,
+						expr: &labeledExpr{
+							pos:   position{line: 3731, col: 3, offset: 115185},
+							label: "field",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3731, col: 9, offset: 115191},
+								name: "EvalFieldToRead",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3745, col: 3, offset: 115537},
+						run: (*parser).callonJsonExprLevel18,
+						expr: &labeledExpr{
+							pos:   position{line: 3745, col: 3, offset: 115537},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3745, col: 9, offset: 115543},
+								name: "NumericEvalExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3759, col: 3, offset: 115907},
+						run: (*parser).callonJsonExprLevel111,
+						expr: &labeledExpr{
+							pos:   position{line: 3759, col: 3, offset: 115907},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3759, col: 9, offset: 115913},
+								name: "NumericExprLevel3",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3773, col: 3, offset: 116279},
+						run: (*parser).callonJsonExprLevel114,
+						expr: &labeledExpr{
+							pos:   position{line: 3773, col: 3, offset: 116279},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3773, col: 9, offset: 116285},
+								name: "MultiValueExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3787, col: 3, offset: 116662},
+						run: (*parser).callonJsonExprLevel117,
+						expr: &labeledExpr{
+							pos:   position{line: 3787, col: 3, offset: 116662},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3787, col: 9, offset: 116668},
+								name: "BoolExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3801, col: 3, offset: 117023},
+						run: (*parser).callonJsonExprLevel120,
+						expr: &labeledExpr{
+							pos:   position{line: 3801, col: 3, offset: 117023},
+							label: "value",
+							expr: &seqExpr{
+								pos: position{line: 3801, col: 10, offset: 117030},
+								exprs: []any{
+									&litMatcher{
+										pos:        position{line: 3801, col: 10, offset: 117030},
+										val:        "null",
+										ignoreCase: false,
+										want:       "\"null\"",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 3801, col: 17, offset: 117037},
+										name: "L_PAREN",
+									},
+									&ruleRefExpr{
+										pos:  position{line: 3801, col: 25, offset: 117045},
+										name: "R_PAREN",
+									},
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3811, col: 3, offset: 117240},
+						run: (*parser).callonJsonExprLevel126,
+						expr: &labeledExpr{
+							pos:   position{line: 3811, col: 3, offset: 117240},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3811, col: 9, offset: 117246},
+								name: "StringExpr",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "JsonExpr",
+			pos:  position{line: 3826, col: 1, offset: 117609},
+			expr: &actionExpr{
+				pos: position{line: 3826, col: 13, offset: 117621},
+				run: (*parser).callonJsonExpr1,
+				expr: &seqExpr{
+					pos: position{line: 3826, col: 13, offset: 117621},
+					exprs: []any{
+						&litMatcher{
+							pos:        position{line: 3826, col: 13, offset: 117621},
+							val:        "json_object",
+							ignoreCase: false,
+							want:       "\"json_object\"",
+						},
+						&ruleRefExpr{
+							pos:  position{line: 3826, col: 27, offset: 117635},
+							name: "L_PAREN",
+						},
+						&labeledExpr{
+							pos:   position{line: 3826, col: 35, offset: 117643},
+							label: "firstKey",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3826, col: 45, offset: 117653},
+								name: "JsonExprLevel1",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 3826, col: 61, offset: 117669},
+							name: "COMMA",
+						},
+						&labeledExpr{
+							pos:   position{line: 3826, col: 67, offset: 117675},
+							label: "firstValue",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3826, col: 79, offset: 117687},
+								name: "JsonExprLevel1",
+							},
+						},
+						&labeledExpr{
+							pos:   position{line: 3826, col: 95, offset: 117703},
+							label: "rest",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 3826, col: 100, offset: 117708},
+								expr: &seqExpr{
+									pos: position{line: 3826, col: 101, offset: 117709},
+									exprs: []any{
+										&ruleRefExpr{
+											pos:  position{line: 3826, col: 101, offset: 117709},
+											name: "COMMA",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 3826, col: 107, offset: 117715},
+											name: "String",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 3826, col: 114, offset: 117722},
+											name: "COMMA",
+										},
+										&ruleRefExpr{
+											pos:  position{line: 3826, col: 120, offset: 117728},
+											name: "JsonExprLevel1",
+										},
+									},
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 3826, col: 137, offset: 117745},
+							name: "R_PAREN",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "LenExpr",
+			pos:  position{line: 3900, col: 1, offset: 120200},
+			expr: &choiceExpr{
+				pos: position{line: 3900, col: 12, offset: 120211},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 3900, col: 12, offset: 120211},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3709, col: 12, offset: 114610},
-							exprs: []interface{}{
+							pos: position{line: 3900, col: 12, offset: 120211},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3709, col: 12, offset: 114610},
+									pos:   position{line: 3900, col: 12, offset: 120211},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3709, col: 16, offset: 114614},
+										pos:  position{line: 3900, col: 16, offset: 120215},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3709, col: 29, offset: 114627},
+									pos: position{line: 3900, col: 29, offset: 120228},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3709, col: 31, offset: 114629},
+										pos:  position{line: 3900, col: 31, offset: 120230},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8486,50 +8707,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3725, col: 3, offset: 115004},
+						pos: position{line: 3916, col: 3, offset: 120605},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3725, col: 3, offset: 115004},
-							exprs: []interface{}{
+							pos: position{line: 3916, col: 3, offset: 120605},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3725, col: 3, offset: 115004},
+									pos:   position{line: 3916, col: 3, offset: 120605},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3725, col: 9, offset: 115010},
+										pos:  position{line: 3916, col: 9, offset: 120611},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3725, col: 25, offset: 115026},
+									pos: position{line: 3916, col: 25, offset: 120627},
 									expr: &choiceExpr{
-										pos: position{line: 3725, col: 27, offset: 115028},
-										alternatives: []interface{}{
+										pos: position{line: 3916, col: 27, offset: 120629},
+										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 27, offset: 115028},
+												pos:  position{line: 3916, col: 27, offset: 120629},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 36, offset: 115037},
+												pos:  position{line: 3916, col: 36, offset: 120638},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 46, offset: 115047},
+												pos:  position{line: 3916, col: 46, offset: 120648},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 54, offset: 115055},
+												pos:  position{line: 3916, col: 54, offset: 120656},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 62, offset: 115063},
+												pos:  position{line: 3916, col: 62, offset: 120664},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3725, col: 70, offset: 115071},
+												pos:  position{line: 3916, col: 70, offset: 120672},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3725, col: 84, offset: 115085},
+												pos:        position{line: 3916, col: 84, offset: 120686},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8545,28 +8766,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3742, col: 1, offset: 115436},
+			pos:  position{line: 3933, col: 1, offset: 121037},
 			expr: &actionExpr{
-				pos: position{line: 3742, col: 19, offset: 115454},
+				pos: position{line: 3933, col: 19, offset: 121055},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3742, col: 19, offset: 115454},
-					exprs: []interface{}{
+					pos: position{line: 3933, col: 19, offset: 121055},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3742, col: 19, offset: 115454},
+							pos:        position{line: 3933, col: 19, offset: 121055},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3742, col: 26, offset: 115461},
+							pos:  position{line: 3933, col: 26, offset: 121062},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3742, col: 32, offset: 115467},
+							pos:   position{line: 3933, col: 32, offset: 121068},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3742, col: 40, offset: 115475},
+								pos:  position{line: 3933, col: 40, offset: 121076},
 								name: "Boolean",
 							},
 						},
@@ -8576,28 +8797,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3753, col: 1, offset: 115664},
+			pos:  position{line: 3944, col: 1, offset: 121265},
 			expr: &actionExpr{
-				pos: position{line: 3753, col: 23, offset: 115686},
+				pos: position{line: 3944, col: 23, offset: 121287},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3753, col: 23, offset: 115686},
-					exprs: []interface{}{
+					pos: position{line: 3944, col: 23, offset: 121287},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3753, col: 23, offset: 115686},
+							pos:        position{line: 3944, col: 23, offset: 121287},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3753, col: 34, offset: 115697},
+							pos:  position{line: 3944, col: 34, offset: 121298},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3753, col: 40, offset: 115703},
+							pos:   position{line: 3944, col: 40, offset: 121304},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3753, col: 48, offset: 115711},
+								pos:  position{line: 3944, col: 48, offset: 121312},
 								name: "Boolean",
 							},
 						},
@@ -8607,28 +8828,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3764, col: 1, offset: 115908},
+			pos:  position{line: 3955, col: 1, offset: 121509},
 			expr: &actionExpr{
-				pos: position{line: 3764, col: 20, offset: 115927},
+				pos: position{line: 3955, col: 20, offset: 121528},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3764, col: 20, offset: 115927},
-					exprs: []interface{}{
+					pos: position{line: 3955, col: 20, offset: 121528},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3764, col: 20, offset: 115927},
+							pos:        position{line: 3955, col: 20, offset: 121528},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3764, col: 28, offset: 115935},
+							pos:  position{line: 3955, col: 28, offset: 121536},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3764, col: 34, offset: 115941},
+							pos:   position{line: 3955, col: 34, offset: 121542},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3764, col: 43, offset: 115950},
+								pos:  position{line: 3955, col: 43, offset: 121551},
 								name: "IntegerAsString",
 							},
 						},
@@ -8638,15 +8859,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3779, col: 1, offset: 116312},
+			pos:  position{line: 3970, col: 1, offset: 121913},
 			expr: &actionExpr{
-				pos: position{line: 3779, col: 19, offset: 116330},
+				pos: position{line: 3970, col: 19, offset: 121931},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3779, col: 19, offset: 116330},
+					pos:   position{line: 3970, col: 19, offset: 121931},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3779, col: 28, offset: 116339},
+						pos:  position{line: 3970, col: 28, offset: 121940},
 						name: "BoolExpr",
 					},
 				},
@@ -8654,30 +8875,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3790, col: 1, offset: 116551},
+			pos:  position{line: 3981, col: 1, offset: 122152},
 			expr: &actionExpr{
-				pos: position{line: 3790, col: 15, offset: 116565},
+				pos: position{line: 3981, col: 15, offset: 122166},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3790, col: 15, offset: 116565},
+					pos:   position{line: 3981, col: 15, offset: 122166},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3790, col: 23, offset: 116573},
-						alternatives: []interface{}{
+						pos: position{line: 3981, col: 23, offset: 122174},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3790, col: 23, offset: 116573},
+								pos:  position{line: 3981, col: 23, offset: 122174},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3790, col: 44, offset: 116594},
+								pos:  position{line: 3981, col: 44, offset: 122195},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3790, col: 61, offset: 116611},
+								pos:  position{line: 3981, col: 61, offset: 122212},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3790, col: 79, offset: 116629},
+								pos:  position{line: 3981, col: 79, offset: 122230},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8687,35 +8908,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3794, col: 1, offset: 116673},
+			pos:  position{line: 3985, col: 1, offset: 122274},
 			expr: &actionExpr{
-				pos: position{line: 3794, col: 19, offset: 116691},
+				pos: position{line: 3985, col: 19, offset: 122292},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3794, col: 19, offset: 116691},
-					exprs: []interface{}{
+					pos: position{line: 3985, col: 19, offset: 122292},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3794, col: 19, offset: 116691},
+							pos:   position{line: 3985, col: 19, offset: 122292},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3794, col: 26, offset: 116698},
+								pos:  position{line: 3985, col: 26, offset: 122299},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3794, col: 37, offset: 116709},
+							pos:   position{line: 3985, col: 37, offset: 122310},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3794, col: 43, offset: 116715},
+								pos: position{line: 3985, col: 43, offset: 122316},
 								expr: &seqExpr{
-									pos: position{line: 3794, col: 44, offset: 116716},
-									exprs: []interface{}{
+									pos: position{line: 3985, col: 44, offset: 122317},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3794, col: 44, offset: 116716},
+											pos:  position{line: 3985, col: 44, offset: 122317},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3794, col: 50, offset: 116722},
+											pos:  position{line: 3985, col: 50, offset: 122323},
 											name: "HeadOption",
 										},
 									},
@@ -8728,29 +8949,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 3851, col: 1, offset: 118522},
+			pos:  position{line: 4042, col: 1, offset: 124123},
 			expr: &choiceExpr{
-				pos: position{line: 3851, col: 14, offset: 118535},
-				alternatives: []interface{}{
+				pos: position{line: 4042, col: 14, offset: 124136},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3851, col: 14, offset: 118535},
+						pos: position{line: 4042, col: 14, offset: 124136},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3851, col: 14, offset: 118535},
-							exprs: []interface{}{
+							pos: position{line: 4042, col: 14, offset: 124136},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3851, col: 14, offset: 118535},
+									pos:  position{line: 4042, col: 14, offset: 124136},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3851, col: 19, offset: 118540},
+									pos:  position{line: 4042, col: 19, offset: 124141},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3851, col: 28, offset: 118549},
+									pos:   position{line: 4042, col: 28, offset: 124150},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3851, col: 37, offset: 118558},
+										pos:  position{line: 4042, col: 37, offset: 124159},
 										name: "HeadOptionList",
 									},
 								},
@@ -8758,24 +8979,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3862, col: 3, offset: 118877},
+						pos: position{line: 4053, col: 3, offset: 124478},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3862, col: 3, offset: 118877},
-							exprs: []interface{}{
+							pos: position{line: 4053, col: 3, offset: 124478},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3862, col: 3, offset: 118877},
+									pos:  position{line: 4053, col: 3, offset: 124478},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3862, col: 8, offset: 118882},
+									pos:  position{line: 4053, col: 8, offset: 124483},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 3862, col: 17, offset: 118891},
+									pos:   position{line: 4053, col: 17, offset: 124492},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3862, col: 26, offset: 118900},
+										pos:  position{line: 4053, col: 26, offset: 124501},
 										name: "IntegerAsString",
 									},
 								},
@@ -8783,17 +9004,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3882, col: 3, offset: 119417},
+						pos: position{line: 4073, col: 3, offset: 125018},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 3882, col: 3, offset: 119417},
-							exprs: []interface{}{
+							pos: position{line: 4073, col: 3, offset: 125018},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3882, col: 3, offset: 119417},
+									pos:  position{line: 4073, col: 3, offset: 125018},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3882, col: 8, offset: 119422},
+									pos:  position{line: 4073, col: 8, offset: 125023},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -8804,29 +9025,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 3900, col: 1, offset: 119892},
+			pos:  position{line: 4091, col: 1, offset: 125493},
 			expr: &choiceExpr{
-				pos: position{line: 3900, col: 14, offset: 119905},
-				alternatives: []interface{}{
+				pos: position{line: 4091, col: 14, offset: 125506},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3900, col: 14, offset: 119905},
+						pos: position{line: 4091, col: 14, offset: 125506},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 3900, col: 14, offset: 119905},
-							exprs: []interface{}{
+							pos: position{line: 4091, col: 14, offset: 125506},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3900, col: 14, offset: 119905},
+									pos:  position{line: 4091, col: 14, offset: 125506},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3900, col: 19, offset: 119910},
+									pos:  position{line: 4091, col: 19, offset: 125511},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 3900, col: 28, offset: 119919},
+									pos:   position{line: 4091, col: 28, offset: 125520},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3900, col: 37, offset: 119928},
+										pos:  position{line: 4091, col: 37, offset: 125529},
 										name: "IntegerAsString",
 									},
 								},
@@ -8834,17 +9055,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3921, col: 3, offset: 120502},
+						pos: position{line: 4112, col: 3, offset: 126103},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 3921, col: 3, offset: 120502},
-							exprs: []interface{}{
+							pos: position{line: 4112, col: 3, offset: 126103},
+							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3921, col: 3, offset: 120502},
+									pos:  position{line: 4112, col: 3, offset: 126103},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3921, col: 8, offset: 120507},
+									pos:  position{line: 4112, col: 8, offset: 126108},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -8855,44 +9076,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 3942, col: 1, offset: 121125},
+			pos:  position{line: 4133, col: 1, offset: 126726},
 			expr: &actionExpr{
-				pos: position{line: 3942, col: 20, offset: 121144},
+				pos: position{line: 4133, col: 20, offset: 126745},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 3942, col: 20, offset: 121144},
-					exprs: []interface{}{
+					pos: position{line: 4133, col: 20, offset: 126745},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3942, col: 20, offset: 121144},
+							pos:   position{line: 4133, col: 20, offset: 126745},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3942, col: 26, offset: 121150},
+								pos:  position{line: 4133, col: 26, offset: 126751},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3942, col: 37, offset: 121161},
+							pos:   position{line: 4133, col: 37, offset: 126762},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3942, col: 42, offset: 121166},
+								pos: position{line: 4133, col: 42, offset: 126767},
 								expr: &seqExpr{
-									pos: position{line: 3942, col: 43, offset: 121167},
-									exprs: []interface{}{
+									pos: position{line: 4133, col: 43, offset: 126768},
+									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3942, col: 44, offset: 121168},
-											alternatives: []interface{}{
+											pos: position{line: 4133, col: 44, offset: 126769},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3942, col: 44, offset: 121168},
+													pos:  position{line: 4133, col: 44, offset: 126769},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3942, col: 52, offset: 121176},
+													pos:  position{line: 4133, col: 52, offset: 126777},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3942, col: 59, offset: 121183},
+											pos:  position{line: 4133, col: 59, offset: 126784},
 											name: "Aggregator",
 										},
 									},
@@ -8905,28 +9126,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 3959, col: 1, offset: 121686},
+			pos:  position{line: 4150, col: 1, offset: 127287},
 			expr: &actionExpr{
-				pos: position{line: 3959, col: 15, offset: 121700},
+				pos: position{line: 4150, col: 15, offset: 127301},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 3959, col: 15, offset: 121700},
-					exprs: []interface{}{
+					pos: position{line: 4150, col: 15, offset: 127301},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3959, col: 15, offset: 121700},
+							pos:   position{line: 4150, col: 15, offset: 127301},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3959, col: 23, offset: 121708},
+								pos:  position{line: 4150, col: 23, offset: 127309},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3959, col: 35, offset: 121720},
+							pos:   position{line: 4150, col: 35, offset: 127321},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 3959, col: 43, offset: 121728},
+								pos: position{line: 4150, col: 43, offset: 127329},
 								expr: &ruleRefExpr{
-									pos:  position{line: 3959, col: 43, offset: 121728},
+									pos:  position{line: 4150, col: 43, offset: 127329},
 									name: "AsField",
 								},
 							},
@@ -8937,26 +9158,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 3975, col: 1, offset: 122569},
+			pos:  position{line: 4166, col: 1, offset: 128170},
 			expr: &actionExpr{
-				pos: position{line: 3975, col: 16, offset: 122584},
+				pos: position{line: 4166, col: 16, offset: 128185},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 3975, col: 16, offset: 122584},
+					pos:   position{line: 4166, col: 16, offset: 128185},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 3975, col: 21, offset: 122589},
-						alternatives: []interface{}{
+						pos: position{line: 4166, col: 21, offset: 128190},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3975, col: 21, offset: 122589},
+								pos:  position{line: 4166, col: 21, offset: 128190},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3975, col: 32, offset: 122600},
+								pos:  position{line: 4166, col: 32, offset: 128201},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3975, col: 48, offset: 122616},
+								pos:  position{line: 4166, col: 48, offset: 128217},
 								name: "AggCommon",
 							},
 						},
@@ -8966,165 +9187,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 3980, col: 1, offset: 122784},
+			pos:  position{line: 4171, col: 1, offset: 128385},
 			expr: &actionExpr{
-				pos: position{line: 3980, col: 18, offset: 122801},
+				pos: position{line: 4171, col: 18, offset: 128402},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3980, col: 19, offset: 122802},
-					alternatives: []interface{}{
+					pos: position{line: 4171, col: 19, offset: 128403},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3980, col: 19, offset: 122802},
+							pos:        position{line: 4171, col: 19, offset: 128403},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 30, offset: 122813},
+							pos:        position{line: 4171, col: 30, offset: 128414},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 39, offset: 122822},
+							pos:        position{line: 4171, col: 39, offset: 128423},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 47, offset: 122830},
+							pos:        position{line: 4171, col: 47, offset: 128431},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 57, offset: 122840},
+							pos:        position{line: 4171, col: 57, offset: 128441},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 65, offset: 122848},
+							pos:        position{line: 4171, col: 65, offset: 128449},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 76, offset: 122859},
+							pos:        position{line: 4171, col: 76, offset: 128460},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 86, offset: 122869},
+							pos:        position{line: 4171, col: 86, offset: 128470},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 95, offset: 122878},
+							pos:        position{line: 4171, col: 95, offset: 128479},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 105, offset: 122888},
+							pos:        position{line: 4171, col: 105, offset: 128489},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 114, offset: 122897},
+							pos:        position{line: 4171, col: 114, offset: 128498},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 122, offset: 122905},
+							pos:        position{line: 4171, col: 122, offset: 128506},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 133, offset: 122916},
+							pos:        position{line: 4171, col: 133, offset: 128517},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3980, col: 142, offset: 122925},
+							pos:        position{line: 4171, col: 142, offset: 128526},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 1, offset: 122934},
+							pos:        position{line: 4172, col: 1, offset: 128535},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 10, offset: 122943},
+							pos:        position{line: 4172, col: 10, offset: 128544},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 26, offset: 122959},
+							pos:        position{line: 4172, col: 26, offset: 128560},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 37, offset: 122970},
+							pos:        position{line: 4172, col: 37, offset: 128571},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 46, offset: 122979},
+							pos:        position{line: 4172, col: 46, offset: 128580},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 56, offset: 122989},
+							pos:        position{line: 4172, col: 56, offset: 128590},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 72, offset: 123005},
+							pos:        position{line: 4172, col: 72, offset: 128606},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 82, offset: 123015},
+							pos:        position{line: 4172, col: 82, offset: 128616},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 100, offset: 123033},
+							pos:        position{line: 4172, col: 100, offset: 128634},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 113, offset: 123046},
+							pos:        position{line: 4172, col: 113, offset: 128647},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 132, offset: 123065},
+							pos:        position{line: 4172, col: 132, offset: 128666},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3981, col: 139, offset: 123072},
+							pos:        position{line: 4172, col: 139, offset: 128673},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9135,33 +9356,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 3985, col: 1, offset: 123115},
+			pos:  position{line: 4176, col: 1, offset: 128716},
 			expr: &actionExpr{
-				pos: position{line: 3985, col: 22, offset: 123136},
+				pos: position{line: 4176, col: 22, offset: 128737},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 3985, col: 23, offset: 123137},
-					alternatives: []interface{}{
+					pos: position{line: 4176, col: 23, offset: 128738},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 3985, col: 23, offset: 123137},
+							pos:        position{line: 4176, col: 23, offset: 128738},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3985, col: 37, offset: 123151},
+							pos:        position{line: 4176, col: 37, offset: 128752},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3985, col: 51, offset: 123165},
+							pos:        position{line: 4176, col: 51, offset: 128766},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 3985, col: 60, offset: 123174},
+							pos:        position{line: 4176, col: 60, offset: 128775},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9172,29 +9393,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 3989, col: 1, offset: 123215},
+			pos:  position{line: 4180, col: 1, offset: 128816},
 			expr: &actionExpr{
-				pos: position{line: 3989, col: 12, offset: 123226},
+				pos: position{line: 4180, col: 12, offset: 128827},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 3989, col: 12, offset: 123226},
-					exprs: []interface{}{
+					pos: position{line: 4180, col: 12, offset: 128827},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3989, col: 12, offset: 123226},
+							pos:  position{line: 4180, col: 12, offset: 128827},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 3989, col: 15, offset: 123229},
+							pos:   position{line: 4180, col: 15, offset: 128830},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 3989, col: 23, offset: 123237},
-								alternatives: []interface{}{
+								pos: position{line: 4180, col: 23, offset: 128838},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3989, col: 23, offset: 123237},
+										pos:  position{line: 4180, col: 23, offset: 128838},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3989, col: 35, offset: 123249},
+										pos:  position{line: 4180, col: 35, offset: 128850},
 										name: "String",
 									},
 								},
@@ -9206,27 +9427,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4003, col: 1, offset: 123578},
+			pos:  position{line: 4194, col: 1, offset: 129179},
 			expr: &choiceExpr{
-				pos: position{line: 4003, col: 13, offset: 123590},
-				alternatives: []interface{}{
+				pos: position{line: 4194, col: 13, offset: 129191},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4003, col: 13, offset: 123590},
+						pos: position{line: 4194, col: 13, offset: 129191},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4003, col: 13, offset: 123590},
-							exprs: []interface{}{
+							pos: position{line: 4194, col: 13, offset: 129191},
+							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4003, col: 14, offset: 123591},
-									alternatives: []interface{}{
+									pos: position{line: 4194, col: 14, offset: 129192},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4003, col: 14, offset: 123591},
+											pos:        position{line: 4194, col: 14, offset: 129192},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4003, col: 24, offset: 123601},
+											pos:        position{line: 4194, col: 24, offset: 129202},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9234,47 +9455,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4003, col: 29, offset: 123606},
+									pos:  position{line: 4194, col: 29, offset: 129207},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4003, col: 37, offset: 123614},
+									pos:        position{line: 4194, col: 37, offset: 129215},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4003, col: 44, offset: 123621},
+									pos:   position{line: 4194, col: 44, offset: 129222},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4003, col: 54, offset: 123631},
+										pos:  position{line: 4194, col: 54, offset: 129232},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4003, col: 64, offset: 123641},
+									pos:  position{line: 4194, col: 64, offset: 129242},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4013, col: 3, offset: 123870},
+						pos: position{line: 4204, col: 3, offset: 129471},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4013, col: 3, offset: 123870},
-							exprs: []interface{}{
+							pos: position{line: 4204, col: 3, offset: 129471},
+							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4013, col: 4, offset: 123871},
-									alternatives: []interface{}{
+									pos: position{line: 4204, col: 4, offset: 129472},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4013, col: 4, offset: 123871},
+											pos:        position{line: 4204, col: 4, offset: 129472},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4013, col: 14, offset: 123881},
+											pos:        position{line: 4204, col: 14, offset: 129482},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9282,38 +9503,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4013, col: 19, offset: 123886},
+									pos:  position{line: 4204, col: 19, offset: 129487},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4013, col: 27, offset: 123894},
+									pos:   position{line: 4204, col: 27, offset: 129495},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4013, col: 33, offset: 123900},
+										pos:  position{line: 4204, col: 33, offset: 129501},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4013, col: 43, offset: 123910},
+									pos:  position{line: 4204, col: 43, offset: 129511},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4020, col: 5, offset: 124062},
+						pos: position{line: 4211, col: 5, offset: 129663},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4020, col: 6, offset: 124063},
-							alternatives: []interface{}{
+							pos: position{line: 4211, col: 6, offset: 129664},
+							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4020, col: 6, offset: 124063},
+									pos:        position{line: 4211, col: 6, offset: 129664},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4020, col: 16, offset: 124073},
+									pos:        position{line: 4211, col: 16, offset: 129674},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9326,77 +9547,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4029, col: 1, offset: 124210},
+			pos:  position{line: 4220, col: 1, offset: 129811},
 			expr: &choiceExpr{
-				pos: position{line: 4029, col: 14, offset: 124223},
-				alternatives: []interface{}{
+				pos: position{line: 4220, col: 14, offset: 129824},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4029, col: 14, offset: 124223},
+						pos: position{line: 4220, col: 14, offset: 129824},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4029, col: 14, offset: 124223},
-							exprs: []interface{}{
+							pos: position{line: 4220, col: 14, offset: 129824},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4029, col: 14, offset: 124223},
+									pos:   position{line: 4220, col: 14, offset: 129824},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4029, col: 22, offset: 124231},
+										pos:  position{line: 4220, col: 22, offset: 129832},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4029, col: 36, offset: 124245},
+									pos:  position{line: 4220, col: 36, offset: 129846},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4029, col: 44, offset: 124253},
+									pos:        position{line: 4220, col: 44, offset: 129854},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4029, col: 51, offset: 124260},
+									pos:   position{line: 4220, col: 51, offset: 129861},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4029, col: 61, offset: 124270},
+										pos:  position{line: 4220, col: 61, offset: 129871},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4029, col: 71, offset: 124280},
+									pos:  position{line: 4220, col: 71, offset: 129881},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4044, col: 3, offset: 124691},
+						pos: position{line: 4235, col: 3, offset: 130292},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4044, col: 3, offset: 124691},
-							exprs: []interface{}{
+							pos: position{line: 4235, col: 3, offset: 130292},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4044, col: 3, offset: 124691},
+									pos:   position{line: 4235, col: 3, offset: 130292},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4044, col: 11, offset: 124699},
+										pos:  position{line: 4235, col: 11, offset: 130300},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4044, col: 25, offset: 124713},
+									pos:  position{line: 4235, col: 25, offset: 130314},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4044, col: 33, offset: 124721},
+									pos:   position{line: 4235, col: 33, offset: 130322},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4044, col: 39, offset: 124727},
+										pos:  position{line: 4235, col: 39, offset: 130328},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4044, col: 49, offset: 124737},
+									pos:  position{line: 4235, col: 49, offset: 130338},
 									name: "R_PAREN",
 								},
 							},
@@ -9407,22 +9628,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4074, col: 1, offset: 125718},
+			pos:  position{line: 4265, col: 1, offset: 131319},
 			expr: &actionExpr{
-				pos: position{line: 4074, col: 18, offset: 125735},
+				pos: position{line: 4265, col: 18, offset: 131336},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4074, col: 18, offset: 125735},
+					pos:   position{line: 4265, col: 18, offset: 131336},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4074, col: 26, offset: 125743},
-						alternatives: []interface{}{
+						pos: position{line: 4265, col: 26, offset: 131344},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4074, col: 26, offset: 125743},
+								pos:  position{line: 4265, col: 26, offset: 131344},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4074, col: 42, offset: 125759},
+								pos:  position{line: 4265, col: 42, offset: 131360},
 								name: "IntegerAsString",
 							},
 						},
@@ -9432,161 +9653,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4086, col: 1, offset: 126126},
+			pos:  position{line: 4277, col: 1, offset: 131727},
 			expr: &choiceExpr{
-				pos: position{line: 4086, col: 18, offset: 126143},
-				alternatives: []interface{}{
+				pos: position{line: 4277, col: 18, offset: 131744},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4086, col: 18, offset: 126143},
+						pos: position{line: 4277, col: 18, offset: 131744},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4086, col: 18, offset: 126143},
-							exprs: []interface{}{
+							pos: position{line: 4277, col: 18, offset: 131744},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4086, col: 18, offset: 126143},
+									pos:   position{line: 4277, col: 18, offset: 131744},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4086, col: 26, offset: 126151},
+										pos:  position{line: 4277, col: 26, offset: 131752},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4086, col: 44, offset: 126169},
+									pos:   position{line: 4277, col: 44, offset: 131770},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4086, col: 58, offset: 126183},
+										pos:  position{line: 4277, col: 58, offset: 131784},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4086, col: 72, offset: 126197},
+									pos:  position{line: 4277, col: 72, offset: 131798},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4086, col: 80, offset: 126205},
+									pos:        position{line: 4277, col: 80, offset: 131806},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4086, col: 87, offset: 126212},
+									pos:   position{line: 4277, col: 87, offset: 131813},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4086, col: 97, offset: 126222},
+										pos:  position{line: 4277, col: 97, offset: 131823},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4086, col: 107, offset: 126232},
+									pos:  position{line: 4277, col: 107, offset: 131833},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4102, col: 3, offset: 126756},
+						pos: position{line: 4293, col: 3, offset: 132357},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4102, col: 3, offset: 126756},
-							exprs: []interface{}{
+							pos: position{line: 4293, col: 3, offset: 132357},
+							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4102, col: 3, offset: 126756},
+									pos:   position{line: 4293, col: 3, offset: 132357},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4102, col: 11, offset: 126764},
+										pos:  position{line: 4293, col: 11, offset: 132365},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4102, col: 29, offset: 126782},
+									pos:   position{line: 4293, col: 29, offset: 132383},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4102, col: 43, offset: 126796},
+										pos:  position{line: 4293, col: 43, offset: 132397},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4102, col: 57, offset: 126810},
+									pos:  position{line: 4293, col: 57, offset: 132411},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4102, col: 65, offset: 126818},
+									pos:   position{line: 4293, col: 65, offset: 132419},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4102, col: 71, offset: 126824},
+										pos:  position{line: 4293, col: 71, offset: 132425},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4102, col: 81, offset: 126834},
+									pos:  position{line: 4293, col: 81, offset: 132435},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4117, col: 3, offset: 127314},
+						pos: position{line: 4308, col: 3, offset: 132915},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4117, col: 3, offset: 127314},
-							exprs: []interface{}{
+							pos: position{line: 4308, col: 3, offset: 132915},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4117, col: 4, offset: 127315},
+									pos:        position{line: 4308, col: 4, offset: 132916},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4117, col: 14, offset: 127325},
+									pos:  position{line: 4308, col: 14, offset: 132926},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4117, col: 22, offset: 127333},
+									pos:   position{line: 4308, col: 22, offset: 132934},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4117, col: 28, offset: 127339},
+										pos:  position{line: 4308, col: 28, offset: 132940},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4117, col: 38, offset: 127349},
+									pos:  position{line: 4308, col: 38, offset: 132950},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4132, col: 3, offset: 127736},
+						pos: position{line: 4323, col: 3, offset: 133337},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4132, col: 3, offset: 127736},
-							exprs: []interface{}{
+							pos: position{line: 4323, col: 3, offset: 133337},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4132, col: 4, offset: 127737},
+									pos:        position{line: 4323, col: 4, offset: 133338},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4132, col: 14, offset: 127747},
+									pos:  position{line: 4323, col: 14, offset: 133348},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4132, col: 22, offset: 127755},
+									pos:        position{line: 4323, col: 22, offset: 133356},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4132, col: 29, offset: 127762},
+									pos:   position{line: 4323, col: 29, offset: 133363},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4132, col: 39, offset: 127772},
+										pos:  position{line: 4323, col: 39, offset: 133373},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4132, col: 49, offset: 127782},
+									pos:  position{line: 4323, col: 49, offset: 133383},
 									name: "R_PAREN",
 								},
 							},
@@ -9597,22 +9818,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4150, col: 1, offset: 128213},
+			pos:  position{line: 4341, col: 1, offset: 133814},
 			expr: &actionExpr{
-				pos: position{line: 4150, col: 25, offset: 128237},
+				pos: position{line: 4341, col: 25, offset: 133838},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4150, col: 25, offset: 128237},
+					pos:   position{line: 4341, col: 25, offset: 133838},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4150, col: 39, offset: 128251},
-						alternatives: []interface{}{
+						pos: position{line: 4341, col: 39, offset: 133852},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4150, col: 39, offset: 128251},
+								pos:  position{line: 4341, col: 39, offset: 133852},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4150, col: 67, offset: 128279},
+								pos:  position{line: 4341, col: 67, offset: 133880},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9622,43 +9843,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4154, col: 1, offset: 128342},
+			pos:  position{line: 4345, col: 1, offset: 133943},
 			expr: &actionExpr{
-				pos: position{line: 4154, col: 30, offset: 128371},
+				pos: position{line: 4345, col: 30, offset: 133972},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4154, col: 30, offset: 128371},
-					exprs: []interface{}{
+					pos: position{line: 4345, col: 30, offset: 133972},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4154, col: 30, offset: 128371},
+							pos:   position{line: 4345, col: 30, offset: 133972},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4154, col: 34, offset: 128375},
+								pos:  position{line: 4345, col: 34, offset: 133976},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4154, col: 44, offset: 128385},
+							pos:   position{line: 4345, col: 44, offset: 133986},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4154, col: 48, offset: 128389},
-								alternatives: []interface{}{
+								pos: position{line: 4345, col: 48, offset: 133990},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4154, col: 48, offset: 128389},
+										pos:  position{line: 4345, col: 48, offset: 133990},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4154, col: 67, offset: 128408},
+										pos:  position{line: 4345, col: 67, offset: 134009},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4154, col: 87, offset: 128428},
+							pos:   position{line: 4345, col: 87, offset: 134029},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4154, col: 93, offset: 128434},
+								pos:  position{line: 4345, col: 93, offset: 134035},
 								name: "Number",
 							},
 						},
@@ -9668,15 +9889,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4167, col: 1, offset: 128668},
+			pos:  position{line: 4358, col: 1, offset: 134269},
 			expr: &actionExpr{
-				pos: position{line: 4167, col: 32, offset: 128699},
+				pos: position{line: 4358, col: 32, offset: 134300},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4167, col: 32, offset: 128699},
+					pos:   position{line: 4358, col: 32, offset: 134300},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4167, col: 38, offset: 128705},
+						pos:  position{line: 4358, col: 38, offset: 134306},
 						name: "Number",
 					},
 				},
@@ -9684,34 +9905,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4180, col: 1, offset: 128922},
+			pos:  position{line: 4371, col: 1, offset: 134523},
 			expr: &actionExpr{
-				pos: position{line: 4180, col: 26, offset: 128947},
+				pos: position{line: 4371, col: 26, offset: 134548},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4180, col: 26, offset: 128947},
-					exprs: []interface{}{
+					pos: position{line: 4371, col: 26, offset: 134548},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4180, col: 26, offset: 128947},
+							pos:   position{line: 4371, col: 26, offset: 134548},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4180, col: 30, offset: 128951},
+								pos:  position{line: 4371, col: 30, offset: 134552},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4180, col: 40, offset: 128961},
+							pos:   position{line: 4371, col: 40, offset: 134562},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4180, col: 43, offset: 128964},
+								pos:  position{line: 4371, col: 43, offset: 134565},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4180, col: 60, offset: 128981},
+							pos:   position{line: 4371, col: 60, offset: 134582},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4180, col: 66, offset: 128987},
+								pos:  position{line: 4371, col: 66, offset: 134588},
 								name: "Boolean",
 							},
 						},
@@ -9721,22 +9942,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4193, col: 1, offset: 129222},
+			pos:  position{line: 4384, col: 1, offset: 134823},
 			expr: &actionExpr{
-				pos: position{line: 4193, col: 25, offset: 129246},
+				pos: position{line: 4384, col: 25, offset: 134847},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4193, col: 25, offset: 129246},
+					pos:   position{line: 4384, col: 25, offset: 134847},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4193, col: 39, offset: 129260},
-						alternatives: []interface{}{
+						pos: position{line: 4384, col: 39, offset: 134861},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4193, col: 39, offset: 129260},
+								pos:  position{line: 4384, col: 39, offset: 134861},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4193, col: 67, offset: 129288},
+								pos:  position{line: 4384, col: 67, offset: 134889},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9746,41 +9967,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4197, col: 1, offset: 129351},
+			pos:  position{line: 4388, col: 1, offset: 134952},
 			expr: &actionExpr{
-				pos: position{line: 4197, col: 30, offset: 129380},
+				pos: position{line: 4388, col: 30, offset: 134981},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4197, col: 30, offset: 129380},
-					exprs: []interface{}{
+					pos: position{line: 4388, col: 30, offset: 134981},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4197, col: 30, offset: 129380},
+							pos:   position{line: 4388, col: 30, offset: 134981},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4197, col: 34, offset: 129384},
+								pos:  position{line: 4388, col: 34, offset: 134985},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4197, col: 44, offset: 129394},
+							pos:   position{line: 4388, col: 44, offset: 134995},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4197, col: 47, offset: 129397},
+								pos:  position{line: 4388, col: 47, offset: 134998},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4197, col: 64, offset: 129414},
+							pos:   position{line: 4388, col: 64, offset: 135015},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4197, col: 81, offset: 129431},
-								alternatives: []interface{}{
+								pos: position{line: 4388, col: 81, offset: 135032},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4197, col: 81, offset: 129431},
+										pos:  position{line: 4388, col: 81, offset: 135032},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4197, col: 103, offset: 129453},
+										pos:  position{line: 4388, col: 103, offset: 135054},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -9792,22 +10013,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4213, col: 1, offset: 129885},
+			pos:  position{line: 4404, col: 1, offset: 135486},
 			expr: &actionExpr{
-				pos: position{line: 4213, col: 32, offset: 129916},
+				pos: position{line: 4404, col: 32, offset: 135517},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4213, col: 32, offset: 129916},
+					pos:   position{line: 4404, col: 32, offset: 135517},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4213, col: 49, offset: 129933},
-						alternatives: []interface{}{
+						pos: position{line: 4404, col: 49, offset: 135534},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4213, col: 49, offset: 129933},
+								pos:  position{line: 4404, col: 49, offset: 135534},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4213, col: 71, offset: 129955},
+								pos:  position{line: 4404, col: 71, offset: 135556},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -9817,33 +10038,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4230, col: 1, offset: 130466},
+			pos:  position{line: 4421, col: 1, offset: 136067},
 			expr: &actionExpr{
-				pos: position{line: 4230, col: 24, offset: 130489},
+				pos: position{line: 4421, col: 24, offset: 136090},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4230, col: 24, offset: 130489},
-					exprs: []interface{}{
+					pos: position{line: 4421, col: 24, offset: 136090},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4230, col: 24, offset: 130489},
+							pos:        position{line: 4421, col: 24, offset: 136090},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4230, col: 31, offset: 130496},
+							pos:  position{line: 4421, col: 31, offset: 136097},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4230, col: 39, offset: 130504},
+							pos:   position{line: 4421, col: 39, offset: 136105},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4230, col: 45, offset: 130510},
+								pos:  position{line: 4421, col: 45, offset: 136111},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4230, col: 52, offset: 130517},
+							pos:  position{line: 4421, col: 52, offset: 136118},
 							name: "R_PAREN",
 						},
 					},
@@ -9852,49 +10073,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4239, col: 1, offset: 130754},
+			pos:  position{line: 4430, col: 1, offset: 136355},
 			expr: &choiceExpr{
-				pos: position{line: 4239, col: 26, offset: 130779},
-				alternatives: []interface{}{
+				pos: position{line: 4430, col: 26, offset: 136380},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4239, col: 26, offset: 130779},
+						pos: position{line: 4430, col: 26, offset: 136380},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4239, col: 26, offset: 130779},
-							exprs: []interface{}{
+							pos: position{line: 4430, col: 26, offset: 136380},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4239, col: 26, offset: 130779},
+									pos:        position{line: 4430, col: 26, offset: 136380},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4239, col: 33, offset: 130786},
+									pos:  position{line: 4430, col: 33, offset: 136387},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4239, col: 41, offset: 130794},
+									pos:   position{line: 4430, col: 41, offset: 136395},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4239, col: 47, offset: 130800},
+										pos:  position{line: 4430, col: 47, offset: 136401},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4239, col: 54, offset: 130807},
+									pos:  position{line: 4430, col: 54, offset: 136408},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4248, col: 3, offset: 130997},
+						pos: position{line: 4439, col: 3, offset: 136598},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4248, col: 3, offset: 130997},
+							pos:   position{line: 4439, col: 3, offset: 136598},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4248, col: 9, offset: 131003},
+								pos:  position{line: 4439, col: 9, offset: 136604},
 								name: "String",
 							},
 						},
@@ -9904,35 +10125,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4258, col: 1, offset: 131283},
+			pos:  position{line: 4449, col: 1, offset: 136884},
 			expr: &actionExpr{
-				pos: position{line: 4258, col: 18, offset: 131300},
+				pos: position{line: 4449, col: 18, offset: 136901},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4258, col: 18, offset: 131300},
-					exprs: []interface{}{
+					pos: position{line: 4449, col: 18, offset: 136901},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4258, col: 18, offset: 131300},
+							pos:   position{line: 4449, col: 18, offset: 136901},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4258, col: 24, offset: 131306},
+								pos:  position{line: 4449, col: 24, offset: 136907},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4258, col: 34, offset: 131316},
+							pos:   position{line: 4449, col: 34, offset: 136917},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4258, col: 39, offset: 131321},
+								pos: position{line: 4449, col: 39, offset: 136922},
 								expr: &seqExpr{
-									pos: position{line: 4258, col: 40, offset: 131322},
-									exprs: []interface{}{
+									pos: position{line: 4449, col: 40, offset: 136923},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4258, col: 40, offset: 131322},
+											pos:  position{line: 4449, col: 40, offset: 136923},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4258, col: 46, offset: 131328},
+											pos:  position{line: 4449, col: 46, offset: 136929},
 											name: "FieldName",
 										},
 									},
@@ -9945,16 +10166,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4275, col: 1, offset: 131823},
+			pos:  position{line: 4466, col: 1, offset: 137424},
 			expr: &choiceExpr{
-				pos: position{line: 4275, col: 18, offset: 131840},
-				alternatives: []interface{}{
+				pos: position{line: 4466, col: 18, offset: 137441},
+				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4275, col: 18, offset: 131840},
+						pos:  position{line: 4466, col: 18, offset: 137441},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4275, col: 38, offset: 131860},
+						pos:  position{line: 4466, col: 38, offset: 137461},
 						name: "EarliestOnly",
 					},
 				},
@@ -9962,62 +10183,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4277, col: 1, offset: 131874},
+			pos:  position{line: 4468, col: 1, offset: 137475},
 			expr: &actionExpr{
-				pos: position{line: 4277, col: 22, offset: 131895},
+				pos: position{line: 4468, col: 22, offset: 137496},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4277, col: 22, offset: 131895},
-					exprs: []interface{}{
+					pos: position{line: 4468, col: 22, offset: 137496},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 22, offset: 131895},
+							pos:  position{line: 4468, col: 22, offset: 137496},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 35, offset: 131908},
+							pos:  position{line: 4468, col: 35, offset: 137509},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4277, col: 41, offset: 131914},
+							pos:   position{line: 4468, col: 41, offset: 137515},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4277, col: 55, offset: 131928},
-								alternatives: []interface{}{
+								pos: position{line: 4468, col: 55, offset: 137529},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4277, col: 55, offset: 131928},
+										pos:  position{line: 4468, col: 55, offset: 137529},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4277, col: 75, offset: 131948},
+										pos:  position{line: 4468, col: 75, offset: 137549},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 94, offset: 131967},
+							pos:  position{line: 4468, col: 94, offset: 137568},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 100, offset: 131973},
+							pos:  position{line: 4468, col: 100, offset: 137574},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4277, col: 111, offset: 131984},
+							pos:  position{line: 4468, col: 111, offset: 137585},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4277, col: 117, offset: 131990},
+							pos:   position{line: 4468, col: 117, offset: 137591},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4277, col: 129, offset: 132002},
-								alternatives: []interface{}{
+								pos: position{line: 4468, col: 129, offset: 137603},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4277, col: 129, offset: 132002},
+										pos:  position{line: 4468, col: 129, offset: 137603},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4277, col: 149, offset: 132022},
+										pos:  position{line: 4468, col: 149, offset: 137623},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10029,33 +10250,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4318, col: 1, offset: 133161},
+			pos:  position{line: 4509, col: 1, offset: 138762},
 			expr: &actionExpr{
-				pos: position{line: 4318, col: 17, offset: 133177},
+				pos: position{line: 4509, col: 17, offset: 138778},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4318, col: 17, offset: 133177},
-					exprs: []interface{}{
+					pos: position{line: 4509, col: 17, offset: 138778},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4318, col: 17, offset: 133177},
+							pos:  position{line: 4509, col: 17, offset: 138778},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4318, col: 30, offset: 133190},
+							pos:  position{line: 4509, col: 30, offset: 138791},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4318, col: 36, offset: 133196},
+							pos:   position{line: 4509, col: 36, offset: 138797},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4318, col: 50, offset: 133210},
-								alternatives: []interface{}{
+								pos: position{line: 4509, col: 50, offset: 138811},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4318, col: 50, offset: 133210},
+										pos:  position{line: 4509, col: 50, offset: 138811},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4318, col: 70, offset: 133230},
+										pos:  position{line: 4509, col: 70, offset: 138831},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10067,24 +10288,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4346, col: 1, offset: 133938},
+			pos:  position{line: 4537, col: 1, offset: 139539},
 			expr: &actionExpr{
-				pos: position{line: 4346, col: 23, offset: 133960},
+				pos: position{line: 4537, col: 23, offset: 139561},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4346, col: 23, offset: 133960},
-					exprs: []interface{}{
+					pos: position{line: 4537, col: 23, offset: 139561},
+					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4346, col: 23, offset: 133960},
+							pos:        position{line: 4537, col: 23, offset: 139561},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4346, col: 27, offset: 133964},
+							pos: position{line: 4537, col: 27, offset: 139565},
 							expr: &charClassMatcher{
-								pos:        position{line: 4346, col: 27, offset: 133964},
+								pos:        position{line: 4537, col: 27, offset: 139565},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10097,21 +10318,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4350, col: 1, offset: 134007},
+			pos:  position{line: 4541, col: 1, offset: 139608},
 			expr: &actionExpr{
-				pos: position{line: 4350, col: 13, offset: 134019},
+				pos: position{line: 4541, col: 13, offset: 139620},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4350, col: 14, offset: 134020},
-					exprs: []interface{}{
+					pos: position{line: 4541, col: 14, offset: 139621},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4350, col: 14, offset: 134020},
+							pos:        position{line: 4541, col: 14, offset: 139621},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4350, col: 17, offset: 134023},
+							pos:        position{line: 4541, col: 17, offset: 139624},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10123,15 +10344,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4354, col: 1, offset: 134066},
+			pos:  position{line: 4545, col: 1, offset: 139667},
 			expr: &actionExpr{
-				pos: position{line: 4354, col: 16, offset: 134081},
+				pos: position{line: 4545, col: 16, offset: 139682},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4354, col: 16, offset: 134081},
+					pos:   position{line: 4545, col: 16, offset: 139682},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4354, col: 26, offset: 134091},
+						pos:  position{line: 4545, col: 26, offset: 139692},
 						name: "AllTimeScale",
 					},
 				},
@@ -10139,31 +10360,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4361, col: 1, offset: 134318},
+			pos:  position{line: 4552, col: 1, offset: 139919},
 			expr: &actionExpr{
-				pos: position{line: 4361, col: 9, offset: 134326},
+				pos: position{line: 4552, col: 9, offset: 139927},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4361, col: 9, offset: 134326},
-					exprs: []interface{}{
+					pos: position{line: 4552, col: 9, offset: 139927},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4361, col: 9, offset: 134326},
+							pos:        position{line: 4552, col: 9, offset: 139927},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4361, col: 13, offset: 134330},
+							pos:   position{line: 4552, col: 13, offset: 139931},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4361, col: 19, offset: 134336},
-								alternatives: []interface{}{
+								pos: position{line: 4552, col: 19, offset: 139937},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4361, col: 19, offset: 134336},
+										pos:  position{line: 4552, col: 19, offset: 139937},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4361, col: 30, offset: 134347},
+										pos:  position{line: 4552, col: 30, offset: 139948},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10175,26 +10396,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4365, col: 1, offset: 134395},
+			pos:  position{line: 4556, col: 1, offset: 139996},
 			expr: &actionExpr{
-				pos: position{line: 4365, col: 11, offset: 134405},
+				pos: position{line: 4556, col: 11, offset: 140006},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4365, col: 11, offset: 134405},
-					exprs: []interface{}{
+					pos: position{line: 4556, col: 11, offset: 140006},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4365, col: 11, offset: 134405},
+							pos:   position{line: 4556, col: 11, offset: 140006},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4365, col: 16, offset: 134410},
+								pos:  position{line: 4556, col: 16, offset: 140011},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4365, col: 36, offset: 134430},
+							pos:   position{line: 4556, col: 36, offset: 140031},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4365, col: 43, offset: 134437},
+								pos:  position{line: 4556, col: 43, offset: 140038},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10204,44 +10425,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4393, col: 1, offset: 135176},
+			pos:  position{line: 4584, col: 1, offset: 140777},
 			expr: &actionExpr{
-				pos: position{line: 4393, col: 29, offset: 135204},
+				pos: position{line: 4584, col: 29, offset: 140805},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4393, col: 29, offset: 135204},
-					exprs: []interface{}{
+					pos: position{line: 4584, col: 29, offset: 140805},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4393, col: 29, offset: 135204},
+							pos:   position{line: 4584, col: 29, offset: 140805},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4393, col: 36, offset: 135211},
-								alternatives: []interface{}{
+								pos: position{line: 4584, col: 36, offset: 140812},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4393, col: 36, offset: 135211},
+										pos:  position{line: 4584, col: 36, offset: 140812},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4393, col: 45, offset: 135220},
+										pos:  position{line: 4584, col: 45, offset: 140821},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4393, col: 51, offset: 135226},
+							pos:   position{line: 4584, col: 51, offset: 140827},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4393, col: 57, offset: 135232},
+								pos: position{line: 4584, col: 57, offset: 140833},
 								expr: &choiceExpr{
-									pos: position{line: 4393, col: 58, offset: 135233},
-									alternatives: []interface{}{
+									pos: position{line: 4584, col: 58, offset: 140834},
+									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4393, col: 58, offset: 135233},
+											pos:  position{line: 4584, col: 58, offset: 140834},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4393, col: 67, offset: 135242},
+											pos:  position{line: 4584, col: 67, offset: 140843},
 											name: "Snap",
 										},
 									},
@@ -10254,29 +10475,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4440, col: 1, offset: 136674},
+			pos:  position{line: 4631, col: 1, offset: 142275},
 			expr: &actionExpr{
-				pos: position{line: 4440, col: 22, offset: 136695},
+				pos: position{line: 4631, col: 22, offset: 142296},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4440, col: 22, offset: 136695},
-					exprs: []interface{}{
+					pos: position{line: 4631, col: 22, offset: 142296},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4440, col: 22, offset: 136695},
+							pos:   position{line: 4631, col: 22, offset: 142296},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4440, col: 34, offset: 136707},
+								pos: position{line: 4631, col: 34, offset: 142308},
 								expr: &choiceExpr{
-									pos: position{line: 4440, col: 35, offset: 136708},
-									alternatives: []interface{}{
+									pos: position{line: 4631, col: 35, offset: 142309},
+									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4440, col: 35, offset: 136708},
+											pos:        position{line: 4631, col: 35, offset: 142309},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4440, col: 43, offset: 136716},
+											pos:        position{line: 4631, col: 43, offset: 142317},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10286,12 +10507,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4440, col: 49, offset: 136722},
+							pos:   position{line: 4631, col: 49, offset: 142323},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4440, col: 57, offset: 136730},
+								pos: position{line: 4631, col: 57, offset: 142331},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4440, col: 58, offset: 136731},
+									pos:  position{line: 4631, col: 58, offset: 142332},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10302,31 +10523,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4465, col: 1, offset: 137414},
+			pos:  position{line: 4656, col: 1, offset: 143015},
 			expr: &actionExpr{
-				pos: position{line: 4465, col: 39, offset: 137452},
+				pos: position{line: 4656, col: 39, offset: 143053},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4465, col: 39, offset: 137452},
-					exprs: []interface{}{
+					pos: position{line: 4656, col: 39, offset: 143053},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4465, col: 39, offset: 137452},
+							pos:   position{line: 4656, col: 39, offset: 143053},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4465, col: 46, offset: 137459},
+								pos: position{line: 4656, col: 46, offset: 143060},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4465, col: 47, offset: 137460},
+									pos:  position{line: 4656, col: 47, offset: 143061},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4465, col: 56, offset: 137469},
+							pos:   position{line: 4656, col: 56, offset: 143070},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4465, col: 66, offset: 137479},
+								pos: position{line: 4656, col: 66, offset: 143080},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4465, col: 67, offset: 137480},
+									pos:  position{line: 4656, col: 67, offset: 143081},
 									name: "Snap",
 								},
 							},
@@ -10337,136 +10558,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4492, col: 1, offset: 138110},
+			pos:  position{line: 4683, col: 1, offset: 143711},
 			expr: &actionExpr{
-				pos: position{line: 4492, col: 18, offset: 138127},
+				pos: position{line: 4683, col: 18, offset: 143728},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4492, col: 18, offset: 138127},
-					exprs: []interface{}{
+					pos: position{line: 4683, col: 18, offset: 143728},
+					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 18, offset: 138127},
+							pos:        position{line: 4683, col: 18, offset: 143728},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 23, offset: 138132},
+							pos:        position{line: 4683, col: 23, offset: 143733},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4492, col: 29, offset: 138138},
+							pos:        position{line: 4683, col: 29, offset: 143739},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 33, offset: 138142},
+							pos:        position{line: 4683, col: 33, offset: 143743},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 38, offset: 138147},
+							pos:        position{line: 4683, col: 38, offset: 143748},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4492, col: 44, offset: 138153},
+							pos:        position{line: 4683, col: 44, offset: 143754},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 48, offset: 138157},
+							pos:        position{line: 4683, col: 48, offset: 143758},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 53, offset: 138162},
+							pos:        position{line: 4683, col: 53, offset: 143763},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 58, offset: 138167},
+							pos:        position{line: 4683, col: 58, offset: 143768},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 63, offset: 138172},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4492, col: 69, offset: 138178},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4492, col: 73, offset: 138182},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4492, col: 78, offset: 138187},
+							pos:        position{line: 4683, col: 63, offset: 143773},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4492, col: 84, offset: 138193},
+							pos:        position{line: 4683, col: 69, offset: 143779},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 88, offset: 138197},
+							pos:        position{line: 4683, col: 73, offset: 143783},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 93, offset: 138202},
+							pos:        position{line: 4683, col: 78, offset: 143788},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4492, col: 99, offset: 138208},
+							pos:        position{line: 4683, col: 84, offset: 143794},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 103, offset: 138212},
+							pos:        position{line: 4683, col: 88, offset: 143798},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4492, col: 108, offset: 138217},
+							pos:        position{line: 4683, col: 93, offset: 143803},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4683, col: 99, offset: 143809},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4683, col: 103, offset: 143813},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4683, col: 108, offset: 143818},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10478,15 +10699,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4496, col: 1, offset: 138259},
+			pos:  position{line: 4687, col: 1, offset: 143860},
 			expr: &actionExpr{
-				pos: position{line: 4496, col: 22, offset: 138280},
+				pos: position{line: 4687, col: 22, offset: 143881},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4496, col: 22, offset: 138280},
+					pos:   position{line: 4687, col: 22, offset: 143881},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4496, col: 32, offset: 138290},
+						pos:  position{line: 4687, col: 32, offset: 143891},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10494,18 +10715,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4507, col: 1, offset: 138733},
+			pos:  position{line: 4698, col: 1, offset: 144334},
 			expr: &choiceExpr{
-				pos: position{line: 4507, col: 14, offset: 138746},
-				alternatives: []interface{}{
+				pos: position{line: 4698, col: 14, offset: 144347},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4507, col: 14, offset: 138746},
+						pos: position{line: 4698, col: 14, offset: 144347},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4507, col: 14, offset: 138746},
-							exprs: []interface{}{
+							pos: position{line: 4698, col: 14, offset: 144347},
+							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4507, col: 14, offset: 138746},
+									pos:        position{line: 4698, col: 14, offset: 144347},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10513,9 +10734,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4507, col: 29, offset: 138761},
+									pos: position{line: 4698, col: 29, offset: 144362},
 									expr: &charClassMatcher{
-										pos:        position{line: 4507, col: 29, offset: 138761},
+										pos:        position{line: 4698, col: 29, offset: 144362},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10527,10 +10748,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4510, col: 3, offset: 138817},
+						pos: position{line: 4701, col: 3, offset: 144418},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4510, col: 3, offset: 138817},
+							pos:  position{line: 4701, col: 3, offset: 144418},
 							name: "QuotedString",
 						},
 					},
@@ -10539,15 +10760,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4514, col: 1, offset: 138880},
+			pos:  position{line: 4705, col: 1, offset: 144481},
 			expr: &actionExpr{
-				pos: position{line: 4514, col: 24, offset: 138903},
+				pos: position{line: 4705, col: 24, offset: 144504},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4514, col: 24, offset: 138903},
-					exprs: []interface{}{
+					pos: position{line: 4705, col: 24, offset: 144504},
+					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4514, col: 24, offset: 138903},
+							pos:        position{line: 4705, col: 24, offset: 144504},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10555,9 +10776,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4514, col: 39, offset: 138918},
+							pos: position{line: 4705, col: 39, offset: 144519},
 							expr: &charClassMatcher{
-								pos:        position{line: 4514, col: 39, offset: 138918},
+								pos:        position{line: 4705, col: 39, offset: 144519},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10571,22 +10792,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4518, col: 1, offset: 138971},
+			pos:  position{line: 4709, col: 1, offset: 144572},
 			expr: &actionExpr{
-				pos: position{line: 4518, col: 11, offset: 138981},
+				pos: position{line: 4709, col: 11, offset: 144582},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4518, col: 11, offset: 138981},
+					pos:   position{line: 4709, col: 11, offset: 144582},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4518, col: 16, offset: 138986},
-						alternatives: []interface{}{
+						pos: position{line: 4709, col: 16, offset: 144587},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4518, col: 16, offset: 138986},
+								pos:  position{line: 4709, col: 16, offset: 144587},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4518, col: 31, offset: 139001},
+								pos:  position{line: 4709, col: 31, offset: 144602},
 								name: "UnquotedString",
 							},
 						},
@@ -10596,38 +10817,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4522, col: 1, offset: 139042},
+			pos:  position{line: 4713, col: 1, offset: 144643},
 			expr: &actionExpr{
-				pos: position{line: 4522, col: 17, offset: 139058},
+				pos: position{line: 4713, col: 17, offset: 144659},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4522, col: 17, offset: 139058},
-					exprs: []interface{}{
+					pos: position{line: 4713, col: 17, offset: 144659},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4522, col: 17, offset: 139058},
+							pos:        position{line: 4713, col: 17, offset: 144659},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4522, col: 21, offset: 139062},
+							pos: position{line: 4713, col: 21, offset: 144663},
 							expr: &choiceExpr{
-								pos: position{line: 4522, col: 22, offset: 139063},
-								alternatives: []interface{}{
+								pos: position{line: 4713, col: 22, offset: 144664},
+								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4522, col: 22, offset: 139063},
-										exprs: []interface{}{
+										pos: position{line: 4713, col: 22, offset: 144664},
+										exprs: []any{
 											&notExpr{
-												pos: position{line: 4522, col: 22, offset: 139063},
+												pos: position{line: 4713, col: 22, offset: 144664},
 												expr: &litMatcher{
-													pos:        position{line: 4522, col: 23, offset: 139064},
+													pos:        position{line: 4713, col: 23, offset: 144665},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4522, col: 28, offset: 139069},
+												pos:        position{line: 4713, col: 28, offset: 144670},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -10636,16 +10857,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4522, col: 35, offset: 139076},
-										exprs: []interface{}{
+										pos: position{line: 4713, col: 35, offset: 144677},
+										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4522, col: 35, offset: 139076},
+												pos:        position{line: 4713, col: 35, offset: 144677},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4522, col: 40, offset: 139081,
+												line: 4713, col: 40, offset: 144682,
 											},
 										},
 									},
@@ -10653,7 +10874,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4522, col: 44, offset: 139085},
+							pos:        position{line: 4713, col: 44, offset: 144686},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10664,48 +10885,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4527, col: 1, offset: 139196},
+			pos:  position{line: 4718, col: 1, offset: 144797},
 			expr: &actionExpr{
-				pos: position{line: 4527, col: 19, offset: 139214},
+				pos: position{line: 4718, col: 19, offset: 144815},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4527, col: 19, offset: 139214},
+					pos: position{line: 4718, col: 19, offset: 144815},
 					expr: &choiceExpr{
-						pos: position{line: 4527, col: 20, offset: 139215},
-						alternatives: []interface{}{
+						pos: position{line: 4718, col: 20, offset: 144816},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4527, col: 20, offset: 139215},
+								pos:        position{line: 4718, col: 20, offset: 144816},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4527, col: 27, offset: 139222},
-								exprs: []interface{}{
+								pos: position{line: 4718, col: 27, offset: 144823},
+								exprs: []any{
 									&notExpr{
-										pos: position{line: 4527, col: 27, offset: 139222},
+										pos: position{line: 4718, col: 27, offset: 144823},
 										expr: &choiceExpr{
-											pos: position{line: 4527, col: 29, offset: 139224},
-											alternatives: []interface{}{
+											pos: position{line: 4718, col: 29, offset: 144825},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4527, col: 29, offset: 139224},
+													pos:  position{line: 4718, col: 29, offset: 144825},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4527, col: 43, offset: 139238},
+													pos:        position{line: 4718, col: 43, offset: 144839},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4527, col: 49, offset: 139244},
+													pos:  position{line: 4718, col: 49, offset: 144845},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4527, col: 54, offset: 139249,
+										line: 4718, col: 54, offset: 144850,
 									},
 								},
 							},
@@ -10716,12 +10937,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4534, col: 1, offset: 139364},
+			pos:  position{line: 4725, col: 1, offset: 144965},
 			expr: &choiceExpr{
-				pos: position{line: 4534, col: 16, offset: 139379},
-				alternatives: []interface{}{
+				pos: position{line: 4725, col: 16, offset: 144980},
+				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4534, col: 16, offset: 139379},
+						pos:        position{line: 4725, col: 16, offset: 144980},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10729,18 +10950,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4534, col: 37, offset: 139400},
-						exprs: []interface{}{
+						pos: position{line: 4725, col: 37, offset: 145001},
+						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4534, col: 37, offset: 139400},
+								pos:        position{line: 4725, col: 37, offset: 145001},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4534, col: 41, offset: 139404},
+								pos: position{line: 4725, col: 41, offset: 145005},
 								expr: &charClassMatcher{
-									pos:        position{line: 4534, col: 41, offset: 139404},
+									pos:        position{line: 4725, col: 41, offset: 145005},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10748,7 +10969,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4534, col: 48, offset: 139411},
+								pos:        position{line: 4725, col: 48, offset: 145012},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10760,46 +10981,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4536, col: 1, offset: 139417},
+			pos:  position{line: 4727, col: 1, offset: 145018},
 			expr: &actionExpr{
-				pos: position{line: 4536, col: 39, offset: 139455},
+				pos: position{line: 4727, col: 39, offset: 145056},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4536, col: 39, offset: 139455},
+					pos: position{line: 4727, col: 39, offset: 145056},
 					expr: &choiceExpr{
-						pos: position{line: 4536, col: 40, offset: 139456},
-						alternatives: []interface{}{
+						pos: position{line: 4727, col: 40, offset: 145057},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4536, col: 40, offset: 139456},
+								pos:  position{line: 4727, col: 40, offset: 145057},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4536, col: 54, offset: 139470},
-								exprs: []interface{}{
+								pos: position{line: 4727, col: 54, offset: 145071},
+								exprs: []any{
 									&notExpr{
-										pos: position{line: 4536, col: 54, offset: 139470},
+										pos: position{line: 4727, col: 54, offset: 145071},
 										expr: &choiceExpr{
-											pos: position{line: 4536, col: 56, offset: 139472},
-											alternatives: []interface{}{
+											pos: position{line: 4727, col: 56, offset: 145073},
+											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4536, col: 56, offset: 139472},
+													pos:  position{line: 4727, col: 56, offset: 145073},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4536, col: 70, offset: 139486},
+													pos:        position{line: 4727, col: 70, offset: 145087},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4536, col: 76, offset: 139492},
+													pos:  position{line: 4727, col: 76, offset: 145093},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4536, col: 81, offset: 139497,
+										line: 4727, col: 81, offset: 145098,
 									},
 								},
 							},
@@ -10810,21 +11031,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4540, col: 1, offset: 139537},
+			pos:  position{line: 4731, col: 1, offset: 145138},
 			expr: &actionExpr{
-				pos: position{line: 4540, col: 12, offset: 139548},
+				pos: position{line: 4731, col: 12, offset: 145149},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4540, col: 13, offset: 139549},
-					alternatives: []interface{}{
+					pos: position{line: 4731, col: 13, offset: 145150},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4540, col: 13, offset: 139549},
+							pos:        position{line: 4731, col: 13, offset: 145150},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4540, col: 22, offset: 139558},
+							pos:        position{line: 4731, col: 22, offset: 145159},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -10835,14 +11056,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4546, col: 1, offset: 139712},
+			pos:  position{line: 4737, col: 1, offset: 145313},
 			expr: &actionExpr{
-				pos: position{line: 4546, col: 18, offset: 139729},
+				pos: position{line: 4737, col: 18, offset: 145330},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4546, col: 18, offset: 139729},
+					pos: position{line: 4737, col: 18, offset: 145330},
 					expr: &charClassMatcher{
-						pos:        position{line: 4546, col: 18, offset: 139729},
+						pos:        position{line: 4737, col: 18, offset: 145330},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10854,15 +11075,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4550, col: 1, offset: 139780},
+			pos:  position{line: 4741, col: 1, offset: 145381},
 			expr: &actionExpr{
-				pos: position{line: 4550, col: 11, offset: 139790},
+				pos: position{line: 4741, col: 11, offset: 145391},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4550, col: 11, offset: 139790},
+					pos:   position{line: 4741, col: 11, offset: 145391},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4550, col: 18, offset: 139797},
+						pos:  position{line: 4741, col: 18, offset: 145398},
 						name: "NumberAsString",
 					},
 				},
@@ -10870,59 +11091,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4556, col: 1, offset: 139986},
+			pos:  position{line: 4747, col: 1, offset: 145587},
 			expr: &actionExpr{
-				pos: position{line: 4556, col: 19, offset: 140004},
+				pos: position{line: 4747, col: 19, offset: 145605},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4556, col: 19, offset: 140004},
-					exprs: []interface{}{
+					pos: position{line: 4747, col: 19, offset: 145605},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4556, col: 19, offset: 140004},
+							pos:   position{line: 4747, col: 19, offset: 145605},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4556, col: 27, offset: 140012},
-								alternatives: []interface{}{
+								pos: position{line: 4747, col: 27, offset: 145613},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4556, col: 27, offset: 140012},
+										pos:  position{line: 4747, col: 27, offset: 145613},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4556, col: 43, offset: 140028},
+										pos:  position{line: 4747, col: 43, offset: 145629},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4556, col: 60, offset: 140045},
+							pos: position{line: 4747, col: 60, offset: 145646},
 							expr: &choiceExpr{
-								pos: position{line: 4556, col: 62, offset: 140047},
-								alternatives: []interface{}{
+								pos: position{line: 4747, col: 62, offset: 145648},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4556, col: 62, offset: 140047},
+										pos:  position{line: 4747, col: 62, offset: 145648},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4556, col: 70, offset: 140055},
+										pos:        position{line: 4747, col: 70, offset: 145656},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4556, col: 76, offset: 140061},
+										pos:        position{line: 4747, col: 76, offset: 145662},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4556, col: 82, offset: 140067},
+										pos:        position{line: 4747, col: 82, offset: 145668},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4556, col: 88, offset: 140073},
+										pos:  position{line: 4747, col: 88, offset: 145674},
 										name: "EOF",
 									},
 								},
@@ -10934,17 +11155,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4562, col: 1, offset: 140202},
+			pos:  position{line: 4753, col: 1, offset: 145803},
 			expr: &actionExpr{
-				pos: position{line: 4562, col: 18, offset: 140219},
+				pos: position{line: 4753, col: 18, offset: 145820},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4562, col: 18, offset: 140219},
-					exprs: []interface{}{
+					pos: position{line: 4753, col: 18, offset: 145820},
+					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4562, col: 18, offset: 140219},
+							pos: position{line: 4753, col: 18, offset: 145820},
 							expr: &charClassMatcher{
-								pos:        position{line: 4562, col: 18, offset: 140219},
+								pos:        position{line: 4753, col: 18, offset: 145820},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -10952,9 +11173,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4562, col: 24, offset: 140225},
+							pos: position{line: 4753, col: 24, offset: 145826},
 							expr: &charClassMatcher{
-								pos:        position{line: 4562, col: 24, offset: 140225},
+								pos:        position{line: 4753, col: 24, offset: 145826},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10962,15 +11183,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4562, col: 31, offset: 140232},
+							pos:        position{line: 4753, col: 31, offset: 145833},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4562, col: 35, offset: 140236},
+							pos: position{line: 4753, col: 35, offset: 145837},
 							expr: &charClassMatcher{
-								pos:        position{line: 4562, col: 35, offset: 140236},
+								pos:        position{line: 4753, col: 35, offset: 145837},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10983,17 +11204,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4567, col: 1, offset: 140331},
+			pos:  position{line: 4758, col: 1, offset: 145932},
 			expr: &actionExpr{
-				pos: position{line: 4567, col: 20, offset: 140350},
+				pos: position{line: 4758, col: 20, offset: 145951},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4567, col: 20, offset: 140350},
-					exprs: []interface{}{
+					pos: position{line: 4758, col: 20, offset: 145951},
+					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4567, col: 20, offset: 140350},
+							pos: position{line: 4758, col: 20, offset: 145951},
 							expr: &charClassMatcher{
-								pos:        position{line: 4567, col: 20, offset: 140350},
+								pos:        position{line: 4758, col: 20, offset: 145951},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11001,9 +11222,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4567, col: 26, offset: 140356},
+							pos: position{line: 4758, col: 26, offset: 145957},
 							expr: &charClassMatcher{
-								pos:        position{line: 4567, col: 26, offset: 140356},
+								pos:        position{line: 4758, col: 26, offset: 145957},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11016,14 +11237,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4571, col: 1, offset: 140399},
+			pos:  position{line: 4762, col: 1, offset: 146000},
 			expr: &actionExpr{
-				pos: position{line: 4571, col: 28, offset: 140426},
+				pos: position{line: 4762, col: 28, offset: 146027},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4571, col: 28, offset: 140426},
+					pos: position{line: 4762, col: 28, offset: 146027},
 					expr: &charClassMatcher{
-						pos:        position{line: 4571, col: 28, offset: 140426},
+						pos:        position{line: 4762, col: 28, offset: 146027},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11034,15 +11255,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4575, col: 1, offset: 140469},
+			pos:  position{line: 4766, col: 1, offset: 146070},
 			expr: &actionExpr{
-				pos: position{line: 4575, col: 20, offset: 140488},
+				pos: position{line: 4766, col: 20, offset: 146089},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4575, col: 20, offset: 140488},
+					pos:   position{line: 4766, col: 20, offset: 146089},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4575, col: 27, offset: 140495},
+						pos:  position{line: 4766, col: 27, offset: 146096},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11050,37 +11271,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4583, col: 1, offset: 140742},
+			pos:  position{line: 4774, col: 1, offset: 146343},
 			expr: &actionExpr{
-				pos: position{line: 4583, col: 21, offset: 140762},
+				pos: position{line: 4774, col: 21, offset: 146363},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4583, col: 21, offset: 140762},
-					exprs: []interface{}{
+					pos: position{line: 4774, col: 21, offset: 146363},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4583, col: 21, offset: 140762},
+							pos:  position{line: 4774, col: 21, offset: 146363},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4583, col: 36, offset: 140777},
+							pos:   position{line: 4774, col: 36, offset: 146378},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4583, col: 40, offset: 140781},
-								alternatives: []interface{}{
+								pos: position{line: 4774, col: 40, offset: 146382},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4583, col: 40, offset: 140781},
+										pos:        position{line: 4774, col: 40, offset: 146382},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4583, col: 47, offset: 140788},
+										pos:        position{line: 4774, col: 47, offset: 146389},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4583, col: 53, offset: 140794},
+										pos:        position{line: 4774, col: 53, offset: 146395},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11089,7 +11310,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4583, col: 59, offset: 140800},
+							pos:  position{line: 4774, col: 59, offset: 146401},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11098,43 +11319,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4594, col: 1, offset: 141030},
+			pos:  position{line: 4785, col: 1, offset: 146631},
 			expr: &actionExpr{
-				pos: position{line: 4594, col: 23, offset: 141052},
+				pos: position{line: 4785, col: 23, offset: 146653},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4594, col: 23, offset: 141052},
-					exprs: []interface{}{
+					pos: position{line: 4785, col: 23, offset: 146653},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4594, col: 23, offset: 141052},
+							pos:  position{line: 4785, col: 23, offset: 146653},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4594, col: 38, offset: 141067},
+							pos:   position{line: 4785, col: 38, offset: 146668},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4594, col: 42, offset: 141071},
-								alternatives: []interface{}{
+								pos: position{line: 4785, col: 42, offset: 146672},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4594, col: 42, offset: 141071},
+										pos:        position{line: 4785, col: 42, offset: 146672},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4594, col: 49, offset: 141078},
+										pos:        position{line: 4785, col: 49, offset: 146679},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4594, col: 55, offset: 141084},
+										pos:        position{line: 4785, col: 55, offset: 146685},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4594, col: 62, offset: 141091},
+										pos:        position{line: 4785, col: 62, offset: 146692},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11143,7 +11364,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4594, col: 67, offset: 141096},
+							pos:  position{line: 4785, col: 67, offset: 146697},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11152,30 +11373,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4602, col: 1, offset: 141279},
+			pos:  position{line: 4793, col: 1, offset: 146880},
 			expr: &choiceExpr{
-				pos: position{line: 4602, col: 25, offset: 141303},
-				alternatives: []interface{}{
+				pos: position{line: 4793, col: 25, offset: 146904},
+				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4602, col: 25, offset: 141303},
+						pos: position{line: 4793, col: 25, offset: 146904},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4602, col: 25, offset: 141303},
+							pos:   position{line: 4793, col: 25, offset: 146904},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4602, col: 28, offset: 141306},
+								pos:  position{line: 4793, col: 28, offset: 146907},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4605, col: 3, offset: 141348},
+						pos: position{line: 4796, col: 3, offset: 146949},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4605, col: 3, offset: 141348},
+							pos:   position{line: 4796, col: 3, offset: 146949},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4605, col: 6, offset: 141351},
+								pos:  position{line: 4796, col: 6, offset: 146952},
 								name: "InequalityOperator",
 							},
 						},
@@ -11185,25 +11406,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4609, col: 1, offset: 141394},
+			pos:  position{line: 4800, col: 1, offset: 146995},
 			expr: &actionExpr{
-				pos: position{line: 4609, col: 11, offset: 141404},
+				pos: position{line: 4800, col: 11, offset: 147005},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4609, col: 11, offset: 141404},
-					exprs: []interface{}{
+					pos: position{line: 4800, col: 11, offset: 147005},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4609, col: 11, offset: 141404},
+							pos:  position{line: 4800, col: 11, offset: 147005},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4609, col: 26, offset: 141419},
+							pos:        position{line: 4800, col: 26, offset: 147020},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4609, col: 30, offset: 141423},
+							pos:  position{line: 4800, col: 30, offset: 147024},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11212,25 +11433,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4613, col: 1, offset: 141463},
+			pos:  position{line: 4804, col: 1, offset: 147064},
 			expr: &actionExpr{
-				pos: position{line: 4613, col: 12, offset: 141474},
+				pos: position{line: 4804, col: 12, offset: 147075},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4613, col: 12, offset: 141474},
-					exprs: []interface{}{
+					pos: position{line: 4804, col: 12, offset: 147075},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 12, offset: 141474},
+							pos:  position{line: 4804, col: 12, offset: 147075},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4613, col: 27, offset: 141489},
+							pos:        position{line: 4804, col: 27, offset: 147090},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4613, col: 31, offset: 141493},
+							pos:  position{line: 4804, col: 31, offset: 147094},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11239,25 +11460,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4617, col: 1, offset: 141533},
+			pos:  position{line: 4808, col: 1, offset: 147134},
 			expr: &actionExpr{
-				pos: position{line: 4617, col: 10, offset: 141542},
+				pos: position{line: 4808, col: 10, offset: 147143},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4617, col: 10, offset: 141542},
-					exprs: []interface{}{
+					pos: position{line: 4808, col: 10, offset: 147143},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4617, col: 10, offset: 141542},
+							pos:  position{line: 4808, col: 10, offset: 147143},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4617, col: 25, offset: 141557},
+							pos:        position{line: 4808, col: 25, offset: 147158},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4617, col: 29, offset: 141561},
+							pos:  position{line: 4808, col: 29, offset: 147162},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11266,25 +11487,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4621, col: 1, offset: 141601},
+			pos:  position{line: 4812, col: 1, offset: 147202},
 			expr: &actionExpr{
-				pos: position{line: 4621, col: 10, offset: 141610},
+				pos: position{line: 4812, col: 10, offset: 147211},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4621, col: 10, offset: 141610},
-					exprs: []interface{}{
+					pos: position{line: 4812, col: 10, offset: 147211},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4621, col: 10, offset: 141610},
+							pos:  position{line: 4812, col: 10, offset: 147211},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4621, col: 25, offset: 141625},
+							pos:        position{line: 4812, col: 25, offset: 147226},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4621, col: 29, offset: 141629},
+							pos:  position{line: 4812, col: 29, offset: 147230},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11293,25 +11514,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4625, col: 1, offset: 141669},
+			pos:  position{line: 4816, col: 1, offset: 147270},
 			expr: &actionExpr{
-				pos: position{line: 4625, col: 10, offset: 141678},
+				pos: position{line: 4816, col: 10, offset: 147279},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4625, col: 10, offset: 141678},
-					exprs: []interface{}{
+					pos: position{line: 4816, col: 10, offset: 147279},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 10, offset: 141678},
+							pos:  position{line: 4816, col: 10, offset: 147279},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4625, col: 25, offset: 141693},
+							pos:        position{line: 4816, col: 25, offset: 147294},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4625, col: 29, offset: 141697},
+							pos:  position{line: 4816, col: 29, offset: 147298},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11320,39 +11541,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4630, col: 1, offset: 141761},
+			pos:  position{line: 4821, col: 1, offset: 147362},
 			expr: &actionExpr{
-				pos: position{line: 4630, col: 11, offset: 141771},
+				pos: position{line: 4821, col: 11, offset: 147372},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4630, col: 12, offset: 141772},
-					alternatives: []interface{}{
+					pos: position{line: 4821, col: 12, offset: 147373},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4630, col: 12, offset: 141772},
+							pos:        position{line: 4821, col: 12, offset: 147373},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4630, col: 24, offset: 141784},
+							pos:        position{line: 4821, col: 24, offset: 147385},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4630, col: 35, offset: 141795},
+							pos:        position{line: 4821, col: 35, offset: 147396},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4630, col: 44, offset: 141804},
+							pos:        position{line: 4821, col: 44, offset: 147405},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4630, col: 52, offset: 141812},
+							pos:        position{line: 4821, col: 52, offset: 147413},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11363,39 +11584,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4634, col: 1, offset: 141854},
+			pos:  position{line: 4825, col: 1, offset: 147455},
 			expr: &actionExpr{
-				pos: position{line: 4634, col: 11, offset: 141864},
+				pos: position{line: 4825, col: 11, offset: 147465},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4634, col: 12, offset: 141865},
-					alternatives: []interface{}{
+					pos: position{line: 4825, col: 12, offset: 147466},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4634, col: 12, offset: 141865},
+							pos:        position{line: 4825, col: 12, offset: 147466},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4634, col: 24, offset: 141877},
+							pos:        position{line: 4825, col: 24, offset: 147478},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4634, col: 35, offset: 141888},
+							pos:        position{line: 4825, col: 35, offset: 147489},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4634, col: 44, offset: 141897},
+							pos:        position{line: 4825, col: 44, offset: 147498},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4634, col: 52, offset: 141905},
+							pos:        position{line: 4825, col: 52, offset: 147506},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11406,39 +11627,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4638, col: 1, offset: 141947},
+			pos:  position{line: 4829, col: 1, offset: 147548},
 			expr: &actionExpr{
-				pos: position{line: 4638, col: 9, offset: 141955},
+				pos: position{line: 4829, col: 9, offset: 147556},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4638, col: 10, offset: 141956},
-					alternatives: []interface{}{
+					pos: position{line: 4829, col: 10, offset: 147557},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4638, col: 10, offset: 141956},
+							pos:        position{line: 4829, col: 10, offset: 147557},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4638, col: 20, offset: 141966},
+							pos:        position{line: 4829, col: 20, offset: 147567},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4638, col: 29, offset: 141975},
+							pos:        position{line: 4829, col: 29, offset: 147576},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4638, col: 37, offset: 141983},
+							pos:        position{line: 4829, col: 37, offset: 147584},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4638, col: 44, offset: 141990},
+							pos:        position{line: 4829, col: 44, offset: 147591},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11449,27 +11670,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4642, col: 1, offset: 142030},
+			pos:  position{line: 4833, col: 1, offset: 147631},
 			expr: &actionExpr{
-				pos: position{line: 4642, col: 8, offset: 142037},
+				pos: position{line: 4833, col: 8, offset: 147638},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4642, col: 9, offset: 142038},
-					alternatives: []interface{}{
+					pos: position{line: 4833, col: 9, offset: 147639},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4642, col: 9, offset: 142038},
+							pos:        position{line: 4833, col: 9, offset: 147639},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4642, col: 18, offset: 142047},
+							pos:        position{line: 4833, col: 18, offset: 147648},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4642, col: 26, offset: 142055},
+							pos:        position{line: 4833, col: 26, offset: 147656},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11480,27 +11701,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4646, col: 1, offset: 142094},
+			pos:  position{line: 4837, col: 1, offset: 147695},
 			expr: &actionExpr{
-				pos: position{line: 4646, col: 9, offset: 142102},
+				pos: position{line: 4837, col: 9, offset: 147703},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4646, col: 10, offset: 142103},
-					alternatives: []interface{}{
+					pos: position{line: 4837, col: 10, offset: 147704},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4646, col: 10, offset: 142103},
+							pos:        position{line: 4837, col: 10, offset: 147704},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4646, col: 20, offset: 142113},
+							pos:        position{line: 4837, col: 20, offset: 147714},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4646, col: 29, offset: 142122},
+							pos:        position{line: 4837, col: 29, offset: 147723},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11511,27 +11732,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4650, col: 1, offset: 142162},
+			pos:  position{line: 4841, col: 1, offset: 147763},
 			expr: &actionExpr{
-				pos: position{line: 4650, col: 10, offset: 142171},
+				pos: position{line: 4841, col: 10, offset: 147772},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4650, col: 11, offset: 142172},
-					alternatives: []interface{}{
+					pos: position{line: 4841, col: 11, offset: 147773},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4650, col: 11, offset: 142172},
+							pos:        position{line: 4841, col: 11, offset: 147773},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4650, col: 22, offset: 142183},
+							pos:        position{line: 4841, col: 22, offset: 147784},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4650, col: 32, offset: 142193},
+							pos:        position{line: 4841, col: 32, offset: 147794},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11542,39 +11763,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4654, col: 1, offset: 142236},
+			pos:  position{line: 4845, col: 1, offset: 147837},
 			expr: &actionExpr{
-				pos: position{line: 4654, col: 12, offset: 142247},
+				pos: position{line: 4845, col: 12, offset: 147848},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4654, col: 13, offset: 142248},
-					alternatives: []interface{}{
+					pos: position{line: 4845, col: 13, offset: 147849},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4654, col: 13, offset: 142248},
+							pos:        position{line: 4845, col: 13, offset: 147849},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4654, col: 26, offset: 142261},
+							pos:        position{line: 4845, col: 26, offset: 147862},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4654, col: 38, offset: 142273},
+							pos:        position{line: 4845, col: 38, offset: 147874},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4654, col: 47, offset: 142282},
+							pos:        position{line: 4845, col: 47, offset: 147883},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4654, col: 55, offset: 142290},
+							pos:        position{line: 4845, col: 55, offset: 147891},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11585,39 +11806,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4658, col: 1, offset: 142333},
+			pos:  position{line: 4849, col: 1, offset: 147934},
 			expr: &actionExpr{
-				pos: position{line: 4658, col: 9, offset: 142341},
+				pos: position{line: 4849, col: 9, offset: 147942},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4658, col: 10, offset: 142342},
-					alternatives: []interface{}{
+					pos: position{line: 4849, col: 10, offset: 147943},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4658, col: 10, offset: 142342},
+							pos:        position{line: 4849, col: 10, offset: 147943},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4658, col: 20, offset: 142352},
+							pos:        position{line: 4849, col: 20, offset: 147953},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4658, col: 29, offset: 142361},
+							pos:        position{line: 4849, col: 29, offset: 147962},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4658, col: 37, offset: 142369},
+							pos:        position{line: 4849, col: 37, offset: 147970},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4658, col: 44, offset: 142376},
+							pos:        position{line: 4849, col: 44, offset: 147977},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11628,33 +11849,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4663, col: 1, offset: 142508},
+			pos:  position{line: 4854, col: 1, offset: 148109},
 			expr: &actionExpr{
-				pos: position{line: 4663, col: 15, offset: 142522},
+				pos: position{line: 4854, col: 15, offset: 148123},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4663, col: 16, offset: 142523},
-					alternatives: []interface{}{
+					pos: position{line: 4854, col: 16, offset: 148124},
+					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4663, col: 16, offset: 142523},
+							pos:        position{line: 4854, col: 16, offset: 148124},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4663, col: 23, offset: 142530},
+							pos:        position{line: 4854, col: 23, offset: 148131},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4663, col: 30, offset: 142537},
+							pos:        position{line: 4854, col: 30, offset: 148138},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4663, col: 37, offset: 142544},
+							pos:        position{line: 4854, col: 37, offset: 148145},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11665,26 +11886,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4672, col: 1, offset: 142768},
+			pos:  position{line: 4863, col: 1, offset: 148369},
 			expr: &actionExpr{
-				pos: position{line: 4672, col: 21, offset: 142788},
+				pos: position{line: 4863, col: 21, offset: 148389},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4672, col: 21, offset: 142788},
-					exprs: []interface{}{
+					pos: position{line: 4863, col: 21, offset: 148389},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4672, col: 21, offset: 142788},
+							pos:  position{line: 4863, col: 21, offset: 148389},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4672, col: 26, offset: 142793},
+							pos:  position{line: 4863, col: 26, offset: 148394},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4672, col: 42, offset: 142809},
+							pos:   position{line: 4863, col: 42, offset: 148410},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4672, col: 53, offset: 142820},
+								pos:  position{line: 4863, col: 53, offset: 148421},
 								name: "TransactionOptions",
 							},
 						},
@@ -11694,17 +11915,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4682, col: 1, offset: 143195},
+			pos:  position{line: 4873, col: 1, offset: 148796},
 			expr: &actionExpr{
-				pos: position{line: 4682, col: 23, offset: 143217},
+				pos: position{line: 4873, col: 23, offset: 148818},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4682, col: 23, offset: 143217},
+					pos:   position{line: 4873, col: 23, offset: 148818},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4682, col: 34, offset: 143228},
+						pos: position{line: 4873, col: 34, offset: 148829},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4682, col: 34, offset: 143228},
+							pos:  position{line: 4873, col: 34, offset: 148829},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11713,35 +11934,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4697, col: 1, offset: 143619},
+			pos:  position{line: 4888, col: 1, offset: 149220},
 			expr: &actionExpr{
-				pos: position{line: 4697, col: 37, offset: 143655},
+				pos: position{line: 4888, col: 37, offset: 149256},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4697, col: 37, offset: 143655},
-					exprs: []interface{}{
+					pos: position{line: 4888, col: 37, offset: 149256},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4697, col: 37, offset: 143655},
+							pos:   position{line: 4888, col: 37, offset: 149256},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4697, col: 43, offset: 143661},
+								pos:  position{line: 4888, col: 43, offset: 149262},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4697, col: 71, offset: 143689},
+							pos:   position{line: 4888, col: 71, offset: 149290},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4697, col: 76, offset: 143694},
+								pos: position{line: 4888, col: 76, offset: 149295},
 								expr: &seqExpr{
-									pos: position{line: 4697, col: 77, offset: 143695},
-									exprs: []interface{}{
+									pos: position{line: 4888, col: 77, offset: 149296},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4697, col: 77, offset: 143695},
+											pos:  position{line: 4888, col: 77, offset: 149296},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4697, col: 83, offset: 143701},
+											pos:  position{line: 4888, col: 83, offset: 149302},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11754,26 +11975,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4732, col: 1, offset: 144690},
+			pos:  position{line: 4923, col: 1, offset: 150291},
 			expr: &actionExpr{
-				pos: position{line: 4732, col: 32, offset: 144721},
+				pos: position{line: 4923, col: 32, offset: 150322},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4732, col: 32, offset: 144721},
+					pos:   position{line: 4923, col: 32, offset: 150322},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4732, col: 40, offset: 144729},
-						alternatives: []interface{}{
+						pos: position{line: 4923, col: 40, offset: 150330},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4732, col: 40, offset: 144729},
+								pos:  position{line: 4923, col: 40, offset: 150330},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4732, col: 77, offset: 144766},
+								pos:  position{line: 4923, col: 77, offset: 150367},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4732, col: 96, offset: 144785},
+								pos:  position{line: 4923, col: 96, offset: 150386},
 								name: "EndsWithOption",
 							},
 						},
@@ -11783,15 +12004,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4736, col: 1, offset: 144829},
+			pos:  position{line: 4927, col: 1, offset: 150430},
 			expr: &actionExpr{
-				pos: position{line: 4736, col: 39, offset: 144867},
+				pos: position{line: 4927, col: 39, offset: 150468},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4736, col: 39, offset: 144867},
+					pos:   position{line: 4927, col: 39, offset: 150468},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4736, col: 46, offset: 144874},
+						pos:  position{line: 4927, col: 46, offset: 150475},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -11799,28 +12020,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4747, col: 1, offset: 145090},
+			pos:  position{line: 4938, col: 1, offset: 150691},
 			expr: &actionExpr{
-				pos: position{line: 4747, col: 21, offset: 145110},
+				pos: position{line: 4938, col: 21, offset: 150711},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4747, col: 21, offset: 145110},
-					exprs: []interface{}{
+					pos: position{line: 4938, col: 21, offset: 150711},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4747, col: 21, offset: 145110},
+							pos:        position{line: 4938, col: 21, offset: 150711},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4747, col: 34, offset: 145123},
+							pos:  position{line: 4938, col: 34, offset: 150724},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4747, col: 40, offset: 145129},
+							pos:   position{line: 4938, col: 40, offset: 150730},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4747, col: 48, offset: 145137},
+								pos:  position{line: 4938, col: 48, offset: 150738},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11830,28 +12051,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4757, col: 1, offset: 145375},
+			pos:  position{line: 4948, col: 1, offset: 150976},
 			expr: &actionExpr{
-				pos: position{line: 4757, col: 19, offset: 145393},
+				pos: position{line: 4948, col: 19, offset: 150994},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4757, col: 19, offset: 145393},
-					exprs: []interface{}{
+					pos: position{line: 4948, col: 19, offset: 150994},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4757, col: 19, offset: 145393},
+							pos:        position{line: 4948, col: 19, offset: 150994},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4757, col: 30, offset: 145404},
+							pos:  position{line: 4948, col: 30, offset: 151005},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4757, col: 36, offset: 145410},
+							pos:   position{line: 4948, col: 36, offset: 151011},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4757, col: 44, offset: 145418},
+								pos:  position{line: 4948, col: 44, offset: 151019},
 								name: "TransactionFilterString",
 							},
 						},
@@ -11861,26 +12082,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4768, col: 1, offset: 145687},
+			pos:  position{line: 4959, col: 1, offset: 151288},
 			expr: &actionExpr{
-				pos: position{line: 4768, col: 28, offset: 145714},
+				pos: position{line: 4959, col: 28, offset: 151315},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4768, col: 28, offset: 145714},
+					pos:   position{line: 4959, col: 28, offset: 151315},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4768, col: 37, offset: 145723},
-						alternatives: []interface{}{
+						pos: position{line: 4959, col: 37, offset: 151324},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4768, col: 37, offset: 145723},
+								pos:  position{line: 4959, col: 37, offset: 151324},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4768, col: 63, offset: 145749},
+								pos:  position{line: 4959, col: 63, offset: 151350},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4768, col: 81, offset: 145767},
+								pos:  position{line: 4959, col: 81, offset: 151368},
 								name: "TransactionSearch",
 							},
 						},
@@ -11890,22 +12111,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4772, col: 1, offset: 145815},
+			pos:  position{line: 4963, col: 1, offset: 151416},
 			expr: &actionExpr{
-				pos: position{line: 4772, col: 28, offset: 145842},
+				pos: position{line: 4963, col: 28, offset: 151443},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4772, col: 28, offset: 145842},
+					pos:   position{line: 4963, col: 28, offset: 151443},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4772, col: 33, offset: 145847},
-						alternatives: []interface{}{
+						pos: position{line: 4963, col: 33, offset: 151448},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4772, col: 33, offset: 145847},
+								pos:  position{line: 4963, col: 33, offset: 151448},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4772, col: 64, offset: 145878},
+								pos:  position{line: 4963, col: 64, offset: 151479},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -11915,29 +12136,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4776, col: 1, offset: 145938},
+			pos:  position{line: 4967, col: 1, offset: 151539},
 			expr: &actionExpr{
-				pos: position{line: 4776, col: 38, offset: 145975},
+				pos: position{line: 4967, col: 38, offset: 151576},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4776, col: 38, offset: 145975},
-					exprs: []interface{}{
+					pos: position{line: 4967, col: 38, offset: 151576},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4776, col: 38, offset: 145975},
+							pos:        position{line: 4967, col: 38, offset: 151576},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4776, col: 42, offset: 145979},
+							pos:   position{line: 4967, col: 42, offset: 151580},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4776, col: 55, offset: 145992},
+								pos:  position{line: 4967, col: 55, offset: 151593},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4776, col: 68, offset: 146005},
+							pos:        position{line: 4967, col: 68, offset: 151606},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11948,23 +12169,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4784, col: 1, offset: 146144},
+			pos:  position{line: 4975, col: 1, offset: 151745},
 			expr: &actionExpr{
-				pos: position{line: 4784, col: 21, offset: 146164},
+				pos: position{line: 4975, col: 21, offset: 151765},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4784, col: 21, offset: 146164},
-					exprs: []interface{}{
+					pos: position{line: 4975, col: 21, offset: 151765},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4784, col: 21, offset: 146164},
+							pos:        position{line: 4975, col: 21, offset: 151765},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4784, col: 25, offset: 146168},
+							pos: position{line: 4975, col: 25, offset: 151769},
 							expr: &charClassMatcher{
-								pos:        position{line: 4784, col: 25, offset: 146168},
+								pos:        position{line: 4975, col: 25, offset: 151769},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -11972,7 +12193,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4784, col: 44, offset: 146187},
+							pos:        position{line: 4975, col: 44, offset: 151788},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11983,15 +12204,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4789, col: 1, offset: 146298},
+			pos:  position{line: 4980, col: 1, offset: 151899},
 			expr: &actionExpr{
-				pos: position{line: 4789, col: 33, offset: 146330},
+				pos: position{line: 4980, col: 33, offset: 151931},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4789, col: 33, offset: 146330},
+					pos:   position{line: 4980, col: 33, offset: 151931},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4789, col: 37, offset: 146334},
+						pos:  position{line: 4980, col: 37, offset: 151935},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -11999,15 +12220,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4797, col: 1, offset: 146489},
+			pos:  position{line: 4988, col: 1, offset: 152090},
 			expr: &actionExpr{
-				pos: position{line: 4797, col: 22, offset: 146510},
+				pos: position{line: 4988, col: 22, offset: 152111},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4797, col: 22, offset: 146510},
+					pos:   position{line: 4988, col: 22, offset: 152111},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4797, col: 27, offset: 146515},
+						pos:  position{line: 4988, col: 27, offset: 152116},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12015,37 +12236,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4807, col: 1, offset: 146687},
+			pos:  position{line: 4998, col: 1, offset: 152288},
 			expr: &actionExpr{
-				pos: position{line: 4807, col: 20, offset: 146706},
+				pos: position{line: 4998, col: 20, offset: 152307},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4807, col: 20, offset: 146706},
-					exprs: []interface{}{
+					pos: position{line: 4998, col: 20, offset: 152307},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4807, col: 20, offset: 146706},
+							pos:        position{line: 4998, col: 20, offset: 152307},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4807, col: 27, offset: 146713},
+							pos:  position{line: 4998, col: 27, offset: 152314},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4807, col: 42, offset: 146728},
+							pos:  position{line: 4998, col: 42, offset: 152329},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4807, col: 50, offset: 146736},
+							pos:   position{line: 4998, col: 50, offset: 152337},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4807, col: 60, offset: 146746},
+								pos:  position{line: 4998, col: 60, offset: 152347},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4807, col: 69, offset: 146755},
+							pos:  position{line: 4998, col: 69, offset: 152356},
 							name: "R_PAREN",
 						},
 					},
@@ -12054,22 +12275,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 4817, col: 1, offset: 147058},
+			pos:  position{line: 5008, col: 1, offset: 152659},
 			expr: &actionExpr{
-				pos: position{line: 4817, col: 20, offset: 147077},
+				pos: position{line: 5008, col: 20, offset: 152678},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4817, col: 20, offset: 147077},
-					exprs: []interface{}{
+					pos: position{line: 5008, col: 20, offset: 152678},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4817, col: 20, offset: 147077},
+							pos:  position{line: 5008, col: 20, offset: 152678},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4817, col: 25, offset: 147082},
+							pos:   position{line: 5008, col: 25, offset: 152683},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4817, col: 42, offset: 147099},
+								pos:  position{line: 5008, col: 42, offset: 152700},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12079,41 +12300,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 4821, col: 1, offset: 147148},
+			pos:  position{line: 5012, col: 1, offset: 152749},
 			expr: &actionExpr{
-				pos: position{line: 4821, col: 16, offset: 147163},
+				pos: position{line: 5012, col: 16, offset: 152764},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4821, col: 16, offset: 147163},
-					exprs: []interface{}{
+					pos: position{line: 5012, col: 16, offset: 152764},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4821, col: 16, offset: 147163},
+							pos:  position{line: 5012, col: 16, offset: 152764},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4821, col: 27, offset: 147174},
+							pos:  position{line: 5012, col: 27, offset: 152775},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4821, col: 33, offset: 147180},
+							pos:   position{line: 5012, col: 33, offset: 152781},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4821, col: 50, offset: 147197},
+								pos: position{line: 5012, col: 50, offset: 152798},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4821, col: 50, offset: 147197},
+									pos:  position{line: 5012, col: 50, offset: 152798},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4821, col: 70, offset: 147217},
+							pos:  position{line: 5012, col: 70, offset: 152818},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4821, col: 85, offset: 147232},
+							pos:   position{line: 5012, col: 85, offset: 152833},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4821, col: 91, offset: 147238},
+								pos:  position{line: 5012, col: 91, offset: 152839},
 								name: "FieldName",
 							},
 						},
@@ -12123,35 +12344,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 4850, col: 1, offset: 148009},
+			pos:  position{line: 5041, col: 1, offset: 153610},
 			expr: &actionExpr{
-				pos: position{line: 4850, col: 23, offset: 148031},
+				pos: position{line: 5041, col: 23, offset: 153632},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4850, col: 23, offset: 148031},
-					exprs: []interface{}{
+					pos: position{line: 5041, col: 23, offset: 153632},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4850, col: 23, offset: 148031},
+							pos:   position{line: 5041, col: 23, offset: 153632},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4850, col: 31, offset: 148039},
+								pos:  position{line: 5041, col: 31, offset: 153640},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4850, col: 46, offset: 148054},
+							pos:   position{line: 5041, col: 46, offset: 153655},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4850, col: 52, offset: 148060},
+								pos: position{line: 5041, col: 52, offset: 153661},
 								expr: &seqExpr{
-									pos: position{line: 4850, col: 53, offset: 148061},
-									exprs: []interface{}{
+									pos: position{line: 5041, col: 53, offset: 153662},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4850, col: 53, offset: 148061},
+											pos:  position{line: 5041, col: 53, offset: 153662},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4850, col: 59, offset: 148067},
+											pos:  position{line: 5041, col: 59, offset: 153668},
 											name: "MVBlockOption",
 										},
 									},
@@ -12164,26 +12385,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 4884, col: 1, offset: 149123},
+			pos:  position{line: 5075, col: 1, offset: 154724},
 			expr: &actionExpr{
-				pos: position{line: 4884, col: 18, offset: 149140},
+				pos: position{line: 5075, col: 18, offset: 154741},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4884, col: 18, offset: 149140},
+					pos:   position{line: 5075, col: 18, offset: 154741},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4884, col: 27, offset: 149149},
-						alternatives: []interface{}{
+						pos: position{line: 5075, col: 27, offset: 154750},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4884, col: 27, offset: 149149},
+								pos:  position{line: 5075, col: 27, offset: 154750},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4884, col: 41, offset: 149163},
+								pos:  position{line: 5075, col: 41, offset: 154764},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4884, col: 60, offset: 149182},
+								pos:  position{line: 5075, col: 60, offset: 154783},
 								name: "SetSvOption",
 							},
 						},
@@ -12193,22 +12414,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 4888, col: 1, offset: 149223},
+			pos:  position{line: 5079, col: 1, offset: 154824},
 			expr: &actionExpr{
-				pos: position{line: 4888, col: 16, offset: 149238},
+				pos: position{line: 5079, col: 16, offset: 154839},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4888, col: 16, offset: 149238},
+					pos:   position{line: 5079, col: 16, offset: 154839},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4888, col: 28, offset: 149250},
-						alternatives: []interface{}{
+						pos: position{line: 5079, col: 28, offset: 154851},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4888, col: 28, offset: 149250},
+								pos:  position{line: 5079, col: 28, offset: 154851},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4888, col: 46, offset: 149268},
+								pos:  position{line: 5079, col: 46, offset: 154869},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12218,28 +12439,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 4892, col: 1, offset: 149315},
+			pos:  position{line: 5083, col: 1, offset: 154916},
 			expr: &actionExpr{
-				pos: position{line: 4892, col: 20, offset: 149334},
+				pos: position{line: 5083, col: 20, offset: 154935},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4892, col: 20, offset: 149334},
-					exprs: []interface{}{
+					pos: position{line: 5083, col: 20, offset: 154935},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4892, col: 20, offset: 149334},
+							pos:        position{line: 5083, col: 20, offset: 154935},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4892, col: 28, offset: 149342},
+							pos:  position{line: 5083, col: 28, offset: 154943},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4892, col: 34, offset: 149348},
+							pos:   position{line: 5083, col: 34, offset: 154949},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4892, col: 38, offset: 149352},
+								pos:  position{line: 5083, col: 38, offset: 154953},
 								name: "QuotedString",
 							},
 						},
@@ -12249,28 +12470,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 4903, col: 1, offset: 149603},
+			pos:  position{line: 5094, col: 1, offset: 155204},
 			expr: &actionExpr{
-				pos: position{line: 4903, col: 19, offset: 149621},
+				pos: position{line: 5094, col: 19, offset: 155222},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 4903, col: 19, offset: 149621},
-					exprs: []interface{}{
+					pos: position{line: 5094, col: 19, offset: 155222},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4903, col: 19, offset: 149621},
+							pos:        position{line: 5094, col: 19, offset: 155222},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4903, col: 31, offset: 149633},
+							pos:  position{line: 5094, col: 31, offset: 155234},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4903, col: 37, offset: 149639},
+							pos:   position{line: 5094, col: 37, offset: 155240},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4903, col: 41, offset: 149643},
+								pos:  position{line: 5094, col: 41, offset: 155244},
 								name: "QuotedString",
 							},
 						},
@@ -12280,28 +12501,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 4921, col: 1, offset: 150114},
+			pos:  position{line: 5112, col: 1, offset: 155715},
 			expr: &actionExpr{
-				pos: position{line: 4921, col: 21, offset: 150134},
+				pos: position{line: 5112, col: 21, offset: 155735},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 4921, col: 21, offset: 150134},
-					exprs: []interface{}{
+					pos: position{line: 5112, col: 21, offset: 155735},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4921, col: 21, offset: 150134},
+							pos:        position{line: 5112, col: 21, offset: 155735},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4921, col: 34, offset: 150147},
+							pos:  position{line: 5112, col: 34, offset: 155748},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4921, col: 40, offset: 150153},
+							pos:   position{line: 5112, col: 40, offset: 155754},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4921, col: 48, offset: 150161},
+								pos:  position{line: 5112, col: 48, offset: 155762},
 								name: "Boolean",
 							},
 						},
@@ -12311,28 +12532,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 4933, col: 1, offset: 150401},
+			pos:  position{line: 5124, col: 1, offset: 156002},
 			expr: &actionExpr{
-				pos: position{line: 4933, col: 16, offset: 150416},
+				pos: position{line: 5124, col: 16, offset: 156017},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 4933, col: 16, offset: 150416},
-					exprs: []interface{}{
+					pos: position{line: 5124, col: 16, offset: 156017},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4933, col: 16, offset: 150416},
+							pos:        position{line: 5124, col: 16, offset: 156017},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4933, col: 24, offset: 150424},
+							pos:  position{line: 5124, col: 24, offset: 156025},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4933, col: 30, offset: 150430},
+							pos:   position{line: 5124, col: 30, offset: 156031},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4933, col: 38, offset: 150438},
+								pos:  position{line: 5124, col: 38, offset: 156039},
 								name: "Boolean",
 							},
 						},
@@ -12342,28 +12563,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 4945, col: 1, offset: 150703},
+			pos:  position{line: 5136, col: 1, offset: 156304},
 			expr: &actionExpr{
-				pos: position{line: 4945, col: 15, offset: 150717},
+				pos: position{line: 5136, col: 15, offset: 156318},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4945, col: 15, offset: 150717},
-					exprs: []interface{}{
+					pos: position{line: 5136, col: 15, offset: 156318},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4945, col: 15, offset: 150717},
+							pos:  position{line: 5136, col: 15, offset: 156318},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4945, col: 20, offset: 150722},
+							pos:  position{line: 5136, col: 20, offset: 156323},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 4945, col: 30, offset: 150732},
+							pos:   position{line: 5136, col: 30, offset: 156333},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4945, col: 40, offset: 150742},
+								pos: position{line: 5136, col: 40, offset: 156343},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4945, col: 40, offset: 150742},
+									pos:  position{line: 5136, col: 40, offset: 156343},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12374,39 +12595,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 4952, col: 1, offset: 150868},
+			pos:  position{line: 5143, col: 1, offset: 156469},
 			expr: &actionExpr{
-				pos: position{line: 4952, col: 23, offset: 150890},
+				pos: position{line: 5143, col: 23, offset: 156491},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 4952, col: 23, offset: 150890},
-					exprs: []interface{}{
+					pos: position{line: 5143, col: 23, offset: 156491},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4952, col: 23, offset: 150890},
+							pos:  position{line: 5143, col: 23, offset: 156491},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4952, col: 29, offset: 150896},
+							pos:   position{line: 5143, col: 29, offset: 156497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4952, col: 35, offset: 150902},
+								pos:  position{line: 5143, col: 35, offset: 156503},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4952, col: 49, offset: 150916},
+							pos:   position{line: 5143, col: 49, offset: 156517},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4952, col: 54, offset: 150921},
+								pos: position{line: 5143, col: 54, offset: 156522},
 								expr: &seqExpr{
-									pos: position{line: 4952, col: 55, offset: 150922},
-									exprs: []interface{}{
+									pos: position{line: 5143, col: 55, offset: 156523},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4952, col: 55, offset: 150922},
+											pos:  position{line: 5143, col: 55, offset: 156523},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4952, col: 61, offset: 150928},
+											pos:  position{line: 5143, col: 61, offset: 156529},
 											name: "SPathArgument",
 										},
 									},
@@ -12419,26 +12640,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 4984, col: 1, offset: 151821},
+			pos:  position{line: 5175, col: 1, offset: 157422},
 			expr: &actionExpr{
-				pos: position{line: 4984, col: 18, offset: 151838},
+				pos: position{line: 5175, col: 18, offset: 157439},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 4984, col: 18, offset: 151838},
+					pos:   position{line: 5175, col: 18, offset: 157439},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 4984, col: 23, offset: 151843},
-						alternatives: []interface{}{
+						pos: position{line: 5175, col: 23, offset: 157444},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4984, col: 23, offset: 151843},
+								pos:  position{line: 5175, col: 23, offset: 157444},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4984, col: 36, offset: 151856},
+								pos:  position{line: 5175, col: 36, offset: 157457},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4984, col: 50, offset: 151870},
+								pos:  position{line: 5175, col: 50, offset: 157471},
 								name: "PathField",
 							},
 						},
@@ -12448,28 +12669,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 4988, col: 1, offset: 151906},
+			pos:  position{line: 5179, col: 1, offset: 157507},
 			expr: &actionExpr{
-				pos: position{line: 4988, col: 15, offset: 151920},
+				pos: position{line: 5179, col: 15, offset: 157521},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 4988, col: 15, offset: 151920},
-					exprs: []interface{}{
+					pos: position{line: 5179, col: 15, offset: 157521},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4988, col: 15, offset: 151920},
+							pos:        position{line: 5179, col: 15, offset: 157521},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4988, col: 23, offset: 151928},
+							pos:  position{line: 5179, col: 23, offset: 157529},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4988, col: 29, offset: 151934},
+							pos:   position{line: 5179, col: 29, offset: 157535},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4988, col: 35, offset: 151940},
+								pos:  position{line: 5179, col: 35, offset: 157541},
 								name: "FieldName",
 							},
 						},
@@ -12479,28 +12700,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 4991, col: 1, offset: 151996},
+			pos:  position{line: 5182, col: 1, offset: 157597},
 			expr: &actionExpr{
-				pos: position{line: 4991, col: 16, offset: 152011},
+				pos: position{line: 5182, col: 16, offset: 157612},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 4991, col: 16, offset: 152011},
-					exprs: []interface{}{
+					pos: position{line: 5182, col: 16, offset: 157612},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4991, col: 16, offset: 152011},
+							pos:        position{line: 5182, col: 16, offset: 157612},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4991, col: 25, offset: 152020},
+							pos:  position{line: 5182, col: 25, offset: 157621},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4991, col: 31, offset: 152026},
+							pos:   position{line: 5182, col: 31, offset: 157627},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4991, col: 37, offset: 152032},
+								pos:  position{line: 5182, col: 37, offset: 157633},
 								name: "FieldName",
 							},
 						},
@@ -12510,34 +12731,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 4994, col: 1, offset: 152089},
+			pos:  position{line: 5185, col: 1, offset: 157690},
 			expr: &actionExpr{
-				pos: position{line: 4994, col: 14, offset: 152102},
+				pos: position{line: 5185, col: 14, offset: 157703},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 4994, col: 15, offset: 152103},
-					alternatives: []interface{}{
+					pos: position{line: 5185, col: 15, offset: 157704},
+					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 4994, col: 15, offset: 152103},
-							exprs: []interface{}{
+							pos: position{line: 5185, col: 15, offset: 157704},
+							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4994, col: 15, offset: 152103},
+									pos:        position{line: 5185, col: 15, offset: 157704},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4994, col: 22, offset: 152110},
+									pos:  position{line: 5185, col: 22, offset: 157711},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4994, col: 28, offset: 152116},
+									pos:  position{line: 5185, col: 28, offset: 157717},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4994, col: 47, offset: 152135},
+							pos:  position{line: 5185, col: 47, offset: 157736},
 							name: "SPathFieldString",
 						},
 					},
@@ -12546,16 +12767,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5006, col: 1, offset: 152547},
+			pos:  position{line: 5197, col: 1, offset: 158148},
 			expr: &choiceExpr{
-				pos: position{line: 5006, col: 21, offset: 152567},
-				alternatives: []interface{}{
+				pos: position{line: 5197, col: 21, offset: 158168},
+				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5006, col: 21, offset: 152567},
+						pos:  position{line: 5197, col: 21, offset: 158168},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5006, col: 36, offset: 152582},
+						pos:  position{line: 5197, col: 36, offset: 158183},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12563,28 +12784,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5009, col: 1, offset: 152655},
+			pos:  position{line: 5200, col: 1, offset: 158256},
 			expr: &actionExpr{
-				pos: position{line: 5009, col: 16, offset: 152670},
+				pos: position{line: 5200, col: 16, offset: 158271},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5009, col: 16, offset: 152670},
-					exprs: []interface{}{
+					pos: position{line: 5200, col: 16, offset: 158271},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 16, offset: 152670},
+							pos:  position{line: 5200, col: 16, offset: 158271},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5009, col: 21, offset: 152675},
+							pos:  position{line: 5200, col: 21, offset: 158276},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5009, col: 32, offset: 152686},
+							pos:   position{line: 5200, col: 32, offset: 158287},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5009, col: 46, offset: 152700},
+								pos: position{line: 5200, col: 46, offset: 158301},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5009, col: 46, offset: 152700},
+									pos:  position{line: 5200, col: 46, offset: 158301},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12595,39 +12816,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5031, col: 1, offset: 153309},
+			pos:  position{line: 5222, col: 1, offset: 158910},
 			expr: &actionExpr{
-				pos: position{line: 5031, col: 24, offset: 153332},
+				pos: position{line: 5222, col: 24, offset: 158933},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5031, col: 24, offset: 153332},
-					exprs: []interface{}{
+					pos: position{line: 5222, col: 24, offset: 158933},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5031, col: 24, offset: 153332},
+							pos:  position{line: 5222, col: 24, offset: 158933},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5031, col: 30, offset: 153338},
+							pos:   position{line: 5222, col: 30, offset: 158939},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5031, col: 37, offset: 153345},
+								pos:  position{line: 5222, col: 37, offset: 158946},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5031, col: 52, offset: 153360},
+							pos:   position{line: 5222, col: 52, offset: 158961},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5031, col: 57, offset: 153365},
+								pos: position{line: 5222, col: 57, offset: 158966},
 								expr: &seqExpr{
-									pos: position{line: 5031, col: 58, offset: 153366},
-									exprs: []interface{}{
+									pos: position{line: 5222, col: 58, offset: 158967},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5031, col: 58, offset: 153366},
+											pos:  position{line: 5222, col: 58, offset: 158967},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5031, col: 64, offset: 153372},
+											pos:  position{line: 5222, col: 64, offset: 158973},
 											name: "FormatArgument",
 										},
 									},
@@ -12640,30 +12861,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5065, col: 1, offset: 154561},
+			pos:  position{line: 5256, col: 1, offset: 160162},
 			expr: &actionExpr{
-				pos: position{line: 5065, col: 19, offset: 154579},
+				pos: position{line: 5256, col: 19, offset: 160180},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5065, col: 19, offset: 154579},
+					pos:   position{line: 5256, col: 19, offset: 160180},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5065, col: 28, offset: 154588},
-						alternatives: []interface{}{
+						pos: position{line: 5256, col: 28, offset: 160189},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5065, col: 28, offset: 154588},
+								pos:  position{line: 5256, col: 28, offset: 160189},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5065, col: 46, offset: 154606},
+								pos:  position{line: 5256, col: 46, offset: 160207},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5065, col: 65, offset: 154625},
+								pos:  position{line: 5256, col: 65, offset: 160226},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5065, col: 82, offset: 154642},
+								pos:  position{line: 5256, col: 82, offset: 160243},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12673,28 +12894,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5069, col: 1, offset: 154692},
+			pos:  position{line: 5260, col: 1, offset: 160293},
 			expr: &actionExpr{
-				pos: position{line: 5069, col: 20, offset: 154711},
+				pos: position{line: 5260, col: 20, offset: 160312},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5069, col: 20, offset: 154711},
-					exprs: []interface{}{
+					pos: position{line: 5260, col: 20, offset: 160312},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5069, col: 20, offset: 154711},
+							pos:        position{line: 5260, col: 20, offset: 160312},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5069, col: 28, offset: 154719},
+							pos:  position{line: 5260, col: 28, offset: 160320},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5069, col: 34, offset: 154725},
+							pos:   position{line: 5260, col: 34, offset: 160326},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5069, col: 38, offset: 154729},
+								pos:  position{line: 5260, col: 38, offset: 160330},
 								name: "QuotedString",
 							},
 						},
@@ -12704,28 +12925,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5078, col: 1, offset: 154941},
+			pos:  position{line: 5269, col: 1, offset: 160542},
 			expr: &actionExpr{
-				pos: position{line: 5078, col: 21, offset: 154961},
+				pos: position{line: 5269, col: 21, offset: 160562},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5078, col: 21, offset: 154961},
-					exprs: []interface{}{
+					pos: position{line: 5269, col: 21, offset: 160562},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5078, col: 21, offset: 154961},
+							pos:        position{line: 5269, col: 21, offset: 160562},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5078, col: 34, offset: 154974},
+							pos:  position{line: 5269, col: 34, offset: 160575},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5078, col: 40, offset: 154980},
+							pos:   position{line: 5269, col: 40, offset: 160581},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5078, col: 47, offset: 154987},
+								pos:  position{line: 5269, col: 47, offset: 160588},
 								name: "IntegerAsString",
 							},
 						},
@@ -12735,28 +12956,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5091, col: 1, offset: 155393},
+			pos:  position{line: 5282, col: 1, offset: 160994},
 			expr: &actionExpr{
-				pos: position{line: 5091, col: 19, offset: 155411},
+				pos: position{line: 5282, col: 19, offset: 161012},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5091, col: 19, offset: 155411},
-					exprs: []interface{}{
+					pos: position{line: 5282, col: 19, offset: 161012},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5091, col: 19, offset: 155411},
+							pos:        position{line: 5282, col: 19, offset: 161012},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5091, col: 30, offset: 155422},
+							pos:  position{line: 5282, col: 30, offset: 161023},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5091, col: 36, offset: 155428},
+							pos:   position{line: 5282, col: 36, offset: 161029},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5091, col: 40, offset: 155432},
+								pos:  position{line: 5282, col: 40, offset: 161033},
 								name: "QuotedString",
 							},
 						},
@@ -12766,78 +12987,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5100, col: 1, offset: 155647},
+			pos:  position{line: 5291, col: 1, offset: 161248},
 			expr: &actionExpr{
-				pos: position{line: 5100, col: 24, offset: 155670},
+				pos: position{line: 5291, col: 24, offset: 161271},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5100, col: 24, offset: 155670},
-					exprs: []interface{}{
+					pos: position{line: 5291, col: 24, offset: 161271},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5100, col: 24, offset: 155670},
+							pos:   position{line: 5291, col: 24, offset: 161271},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 34, offset: 155680},
+								pos:  position{line: 5291, col: 34, offset: 161281},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 47, offset: 155693},
+							pos:  position{line: 5291, col: 47, offset: 161294},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 53, offset: 155699},
+							pos:   position{line: 5291, col: 53, offset: 161300},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 63, offset: 155709},
+								pos:  position{line: 5291, col: 63, offset: 161310},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 76, offset: 155722},
+							pos:  position{line: 5291, col: 76, offset: 161323},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 82, offset: 155728},
+							pos:   position{line: 5291, col: 82, offset: 161329},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 95, offset: 155741},
+								pos:  position{line: 5291, col: 95, offset: 161342},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 108, offset: 155754},
+							pos:  position{line: 5291, col: 108, offset: 161355},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 114, offset: 155760},
+							pos:   position{line: 5291, col: 114, offset: 161361},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 121, offset: 155767},
+								pos:  position{line: 5291, col: 121, offset: 161368},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 134, offset: 155780},
+							pos:  position{line: 5291, col: 134, offset: 161381},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 140, offset: 155786},
+							pos:   position{line: 5291, col: 140, offset: 161387},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 153, offset: 155799},
+								pos:  position{line: 5291, col: 153, offset: 161400},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5100, col: 166, offset: 155812},
+							pos:  position{line: 5291, col: 166, offset: 161413},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5100, col: 172, offset: 155818},
+							pos:   position{line: 5291, col: 172, offset: 161419},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5100, col: 179, offset: 155825},
+								pos:  position{line: 5291, col: 179, offset: 161426},
 								name: "QuotedString",
 							},
 						},
@@ -12847,28 +13068,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5118, col: 1, offset: 156401},
+			pos:  position{line: 5309, col: 1, offset: 162002},
 			expr: &actionExpr{
-				pos: position{line: 5118, col: 20, offset: 156420},
+				pos: position{line: 5309, col: 20, offset: 162021},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5118, col: 20, offset: 156420},
-					exprs: []interface{}{
+					pos: position{line: 5309, col: 20, offset: 162021},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5118, col: 20, offset: 156420},
+							pos:  position{line: 5309, col: 20, offset: 162021},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5118, col: 25, offset: 156425},
+							pos:  position{line: 5309, col: 25, offset: 162026},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5118, col: 40, offset: 156440},
+							pos:   position{line: 5309, col: 40, offset: 162041},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5118, col: 55, offset: 156455},
+								pos: position{line: 5309, col: 55, offset: 162056},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5118, col: 55, offset: 156455},
+									pos:  position{line: 5309, col: 55, offset: 162056},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -12879,42 +13100,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5125, col: 1, offset: 156608},
+			pos:  position{line: 5316, col: 1, offset: 162209},
 			expr: &actionExpr{
-				pos: position{line: 5125, col: 28, offset: 156635},
+				pos: position{line: 5316, col: 28, offset: 162236},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5125, col: 28, offset: 156635},
-					exprs: []interface{}{
+					pos: position{line: 5316, col: 28, offset: 162236},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5125, col: 28, offset: 156635},
+							pos:  position{line: 5316, col: 28, offset: 162236},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5125, col: 34, offset: 156641},
+							pos:   position{line: 5316, col: 34, offset: 162242},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5125, col: 40, offset: 156647},
+								pos: position{line: 5316, col: 40, offset: 162248},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5125, col: 40, offset: 156647},
+									pos:  position{line: 5316, col: 40, offset: 162248},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5125, col: 60, offset: 156667},
+							pos:   position{line: 5316, col: 60, offset: 162268},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5125, col: 65, offset: 156672},
+								pos: position{line: 5316, col: 65, offset: 162273},
 								expr: &seqExpr{
-									pos: position{line: 5125, col: 66, offset: 156673},
-									exprs: []interface{}{
+									pos: position{line: 5316, col: 66, offset: 162274},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5125, col: 66, offset: 156673},
+											pos:  position{line: 5316, col: 66, offset: 162274},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5125, col: 72, offset: 156679},
+											pos:  position{line: 5316, col: 72, offset: 162280},
 											name: "EventCountArgument",
 										},
 									},
@@ -12927,30 +13148,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5181, col: 1, offset: 158556},
+			pos:  position{line: 5372, col: 1, offset: 164157},
 			expr: &actionExpr{
-				pos: position{line: 5181, col: 23, offset: 158578},
+				pos: position{line: 5372, col: 23, offset: 164179},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5181, col: 23, offset: 158578},
+					pos:   position{line: 5372, col: 23, offset: 164179},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5181, col: 28, offset: 158583},
-						alternatives: []interface{}{
+						pos: position{line: 5372, col: 28, offset: 164184},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5181, col: 28, offset: 158583},
+								pos:  position{line: 5372, col: 28, offset: 164184},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5181, col: 41, offset: 158596},
+								pos:  position{line: 5372, col: 41, offset: 164197},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5181, col: 58, offset: 158613},
+								pos:  position{line: 5372, col: 58, offset: 164214},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5181, col: 76, offset: 158631},
+								pos:  position{line: 5372, col: 76, offset: 164232},
 								name: "ListVixField",
 							},
 						},
@@ -12960,28 +13181,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5185, col: 1, offset: 158670},
+			pos:  position{line: 5376, col: 1, offset: 164271},
 			expr: &actionExpr{
-				pos: position{line: 5185, col: 15, offset: 158684},
+				pos: position{line: 5376, col: 15, offset: 164285},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5185, col: 15, offset: 158684},
-					exprs: []interface{}{
+					pos: position{line: 5376, col: 15, offset: 164285},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5185, col: 15, offset: 158684},
+							pos:        position{line: 5376, col: 15, offset: 164285},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5185, col: 23, offset: 158692},
+							pos:  position{line: 5376, col: 23, offset: 164293},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5185, col: 29, offset: 158698},
+							pos:   position{line: 5376, col: 29, offset: 164299},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5185, col: 35, offset: 158704},
+								pos:  position{line: 5376, col: 35, offset: 164305},
 								name: "IndexName",
 							},
 						},
@@ -12991,28 +13212,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5188, col: 1, offset: 158760},
+			pos:  position{line: 5379, col: 1, offset: 164361},
 			expr: &actionExpr{
-				pos: position{line: 5188, col: 19, offset: 158778},
+				pos: position{line: 5379, col: 19, offset: 164379},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5188, col: 19, offset: 158778},
-					exprs: []interface{}{
+					pos: position{line: 5379, col: 19, offset: 164379},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5188, col: 19, offset: 158778},
+							pos:        position{line: 5379, col: 19, offset: 164379},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5188, col: 31, offset: 158790},
+							pos:  position{line: 5379, col: 31, offset: 164391},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5188, col: 37, offset: 158796},
+							pos:   position{line: 5379, col: 37, offset: 164397},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5188, col: 43, offset: 158802},
+								pos:  position{line: 5379, col: 43, offset: 164403},
 								name: "Boolean",
 							},
 						},
@@ -13022,28 +13243,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5191, col: 1, offset: 158878},
+			pos:  position{line: 5382, col: 1, offset: 164479},
 			expr: &actionExpr{
-				pos: position{line: 5191, col: 20, offset: 158897},
+				pos: position{line: 5382, col: 20, offset: 164498},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5191, col: 20, offset: 158897},
-					exprs: []interface{}{
+					pos: position{line: 5382, col: 20, offset: 164498},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5191, col: 20, offset: 158897},
+							pos:        position{line: 5382, col: 20, offset: 164498},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5191, col: 34, offset: 158911},
+							pos:  position{line: 5382, col: 34, offset: 164512},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5191, col: 40, offset: 158917},
+							pos:   position{line: 5382, col: 40, offset: 164518},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5191, col: 46, offset: 158923},
+								pos:  position{line: 5382, col: 46, offset: 164524},
 								name: "Boolean",
 							},
 						},
@@ -13053,28 +13274,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5194, col: 1, offset: 159001},
+			pos:  position{line: 5385, col: 1, offset: 164602},
 			expr: &actionExpr{
-				pos: position{line: 5194, col: 17, offset: 159017},
+				pos: position{line: 5385, col: 17, offset: 164618},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5194, col: 17, offset: 159017},
-					exprs: []interface{}{
+					pos: position{line: 5385, col: 17, offset: 164618},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5194, col: 17, offset: 159017},
+							pos:        position{line: 5385, col: 17, offset: 164618},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5194, col: 28, offset: 159028},
+							pos:  position{line: 5385, col: 28, offset: 164629},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5194, col: 34, offset: 159034},
+							pos:   position{line: 5385, col: 34, offset: 164635},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5194, col: 40, offset: 159040},
+								pos:  position{line: 5385, col: 40, offset: 164641},
 								name: "Boolean",
 							},
 						},
@@ -13084,24 +13305,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5198, col: 1, offset: 159116},
+			pos:  position{line: 5389, col: 1, offset: 164717},
 			expr: &actionExpr{
-				pos: position{line: 5198, col: 14, offset: 159129},
+				pos: position{line: 5389, col: 14, offset: 164730},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5198, col: 14, offset: 159129},
+					pos: position{line: 5389, col: 14, offset: 164730},
 					expr: &seqExpr{
-						pos: position{line: 5198, col: 15, offset: 159130},
-						exprs: []interface{}{
+						pos: position{line: 5389, col: 15, offset: 164731},
+						exprs: []any{
 							&notExpr{
-								pos: position{line: 5198, col: 15, offset: 159130},
+								pos: position{line: 5389, col: 15, offset: 164731},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5198, col: 16, offset: 159131},
+									pos:  position{line: 5389, col: 16, offset: 164732},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5198, col: 22, offset: 159137,
+								line: 5389, col: 22, offset: 164738,
 							},
 						},
 					},
@@ -13110,39 +13331,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5203, col: 1, offset: 159210},
+			pos:  position{line: 5394, col: 1, offset: 164811},
 			expr: &actionExpr{
-				pos: position{line: 5203, col: 18, offset: 159227},
+				pos: position{line: 5394, col: 18, offset: 164828},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5203, col: 18, offset: 159227},
-					exprs: []interface{}{
+					pos: position{line: 5394, col: 18, offset: 164828},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5203, col: 18, offset: 159227},
+							pos:  position{line: 5394, col: 18, offset: 164828},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5203, col: 23, offset: 159232},
+							pos:  position{line: 5394, col: 23, offset: 164833},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5203, col: 36, offset: 159245},
+							pos:   position{line: 5394, col: 36, offset: 164846},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5203, col: 49, offset: 159258},
+								pos: position{line: 5394, col: 49, offset: 164859},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5203, col: 49, offset: 159258},
+									pos:  position{line: 5394, col: 49, offset: 164859},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5203, col: 70, offset: 159279},
+							pos:   position{line: 5394, col: 70, offset: 164880},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5203, col: 77, offset: 159286},
+								pos: position{line: 5394, col: 77, offset: 164887},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5203, col: 77, offset: 159286},
+									pos:  position{line: 5394, col: 77, offset: 164887},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13153,32 +13374,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5233, col: 1, offset: 160049},
+			pos:  position{line: 5424, col: 1, offset: 165650},
 			expr: &actionExpr{
-				pos: position{line: 5233, col: 24, offset: 160072},
+				pos: position{line: 5424, col: 24, offset: 165673},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5233, col: 24, offset: 160072},
-					exprs: []interface{}{
+					pos: position{line: 5424, col: 24, offset: 165673},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5233, col: 24, offset: 160072},
+							pos:  position{line: 5424, col: 24, offset: 165673},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5233, col: 30, offset: 160078},
+							pos:        position{line: 5424, col: 30, offset: 165679},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5233, col: 38, offset: 160086},
+							pos:  position{line: 5424, col: 38, offset: 165687},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5233, col: 44, offset: 160092},
+							pos:   position{line: 5424, col: 44, offset: 165693},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5233, col: 48, offset: 160096},
+								pos:  position{line: 5424, col: 48, offset: 165697},
 								name: "String",
 							},
 						},
@@ -13188,22 +13409,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5237, col: 1, offset: 160142},
+			pos:  position{line: 5428, col: 1, offset: 165743},
 			expr: &actionExpr{
-				pos: position{line: 5237, col: 22, offset: 160163},
+				pos: position{line: 5428, col: 22, offset: 165764},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5237, col: 22, offset: 160163},
-					exprs: []interface{}{
+					pos: position{line: 5428, col: 22, offset: 165764},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5237, col: 22, offset: 160163},
+							pos:  position{line: 5428, col: 22, offset: 165764},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5237, col: 28, offset: 160169},
+							pos:   position{line: 5428, col: 28, offset: 165770},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5237, col: 38, offset: 160179},
+								pos:  position{line: 5428, col: 38, offset: 165780},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13213,36 +13434,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5241, col: 1, offset: 160238},
+			pos:  position{line: 5432, col: 1, offset: 165839},
 			expr: &actionExpr{
-				pos: position{line: 5241, col: 18, offset: 160255},
+				pos: position{line: 5432, col: 18, offset: 165856},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5241, col: 18, offset: 160255},
-					exprs: []interface{}{
+					pos: position{line: 5432, col: 18, offset: 165856},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5241, col: 18, offset: 160255},
+							pos:  position{line: 5432, col: 18, offset: 165856},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5241, col: 23, offset: 160260},
+							pos:  position{line: 5432, col: 23, offset: 165861},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5241, col: 36, offset: 160273},
+							pos:   position{line: 5432, col: 36, offset: 165874},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5241, col: 42, offset: 160279},
+								pos:  position{line: 5432, col: 42, offset: 165880},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5241, col: 56, offset: 160293},
+							pos:   position{line: 5432, col: 56, offset: 165894},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5241, col: 65, offset: 160302},
+								pos: position{line: 5432, col: 65, offset: 165903},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5241, col: 65, offset: 160302},
+									pos:  position{line: 5432, col: 65, offset: 165903},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13253,22 +13474,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5270, col: 1, offset: 161078},
+			pos:  position{line: 5461, col: 1, offset: 166679},
 			expr: &actionExpr{
-				pos: position{line: 5270, col: 18, offset: 161095},
+				pos: position{line: 5461, col: 18, offset: 166696},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5270, col: 18, offset: 161095},
-					exprs: []interface{}{
+					pos: position{line: 5461, col: 18, offset: 166696},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5270, col: 18, offset: 161095},
+							pos:  position{line: 5461, col: 18, offset: 166696},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5270, col: 24, offset: 161101},
+							pos:   position{line: 5461, col: 24, offset: 166702},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5270, col: 34, offset: 161111},
+								pos:  position{line: 5461, col: 34, offset: 166712},
 								name: "FieldName",
 							},
 						},
@@ -13278,32 +13499,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5274, col: 1, offset: 161152},
+			pos:  position{line: 5465, col: 1, offset: 166753},
 			expr: &actionExpr{
-				pos: position{line: 5274, col: 18, offset: 161169},
+				pos: position{line: 5465, col: 18, offset: 166770},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5274, col: 18, offset: 161169},
-					exprs: []interface{}{
+					pos: position{line: 5465, col: 18, offset: 166770},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5274, col: 18, offset: 161169},
+							pos:  position{line: 5465, col: 18, offset: 166770},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5274, col: 24, offset: 161175},
+							pos:        position{line: 5465, col: 24, offset: 166776},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5274, col: 32, offset: 161183},
+							pos:  position{line: 5465, col: 32, offset: 166784},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5274, col: 38, offset: 161189},
+							pos:   position{line: 5465, col: 38, offset: 166790},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5274, col: 47, offset: 161198},
+								pos:  position{line: 5465, col: 47, offset: 166799},
 								name: "IntegerAsString",
 							},
 						},
@@ -13313,26 +13534,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5278, col: 1, offset: 161244},
+			pos:  position{line: 5469, col: 1, offset: 166845},
 			expr: &actionExpr{
-				pos: position{line: 5278, col: 16, offset: 161259},
+				pos: position{line: 5469, col: 16, offset: 166860},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5278, col: 16, offset: 161259},
-					exprs: []interface{}{
+					pos: position{line: 5469, col: 16, offset: 166860},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5278, col: 16, offset: 161259},
+							pos:  position{line: 5469, col: 16, offset: 166860},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5278, col: 22, offset: 161265},
+							pos:  position{line: 5469, col: 22, offset: 166866},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5278, col: 32, offset: 161275},
+							pos:   position{line: 5469, col: 32, offset: 166876},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5278, col: 42, offset: 161285},
+								pos:  position{line: 5469, col: 42, offset: 166886},
 								name: "BoolExpr",
 							},
 						},
@@ -13342,28 +13563,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5282, col: 1, offset: 161345},
+			pos:  position{line: 5473, col: 1, offset: 166946},
 			expr: &actionExpr{
-				pos: position{line: 5282, col: 28, offset: 161372},
+				pos: position{line: 5473, col: 28, offset: 166973},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5282, col: 28, offset: 161372},
-					exprs: []interface{}{
+					pos: position{line: 5473, col: 28, offset: 166973},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5282, col: 28, offset: 161372},
+							pos:        position{line: 5473, col: 28, offset: 166973},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5282, col: 37, offset: 161381},
+							pos:  position{line: 5473, col: 37, offset: 166982},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5282, col: 43, offset: 161387},
+							pos:   position{line: 5473, col: 43, offset: 166988},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5282, col: 51, offset: 161395},
+								pos:  position{line: 5473, col: 51, offset: 166996},
 								name: "Boolean",
 							},
 						},
@@ -13373,28 +13594,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5291, col: 1, offset: 161579},
+			pos:  position{line: 5482, col: 1, offset: 167180},
 			expr: &actionExpr{
-				pos: position{line: 5291, col: 28, offset: 161606},
+				pos: position{line: 5482, col: 28, offset: 167207},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5291, col: 28, offset: 161606},
-					exprs: []interface{}{
+					pos: position{line: 5482, col: 28, offset: 167207},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5291, col: 28, offset: 161606},
+							pos:        position{line: 5482, col: 28, offset: 167207},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 37, offset: 161615},
+							pos:  position{line: 5482, col: 37, offset: 167216},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 43, offset: 161621},
+							pos:   position{line: 5482, col: 43, offset: 167222},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 51, offset: 161629},
+								pos:  position{line: 5482, col: 51, offset: 167230},
 								name: "Boolean",
 							},
 						},
@@ -13404,28 +13625,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5300, col: 1, offset: 161813},
+			pos:  position{line: 5491, col: 1, offset: 167414},
 			expr: &actionExpr{
-				pos: position{line: 5300, col: 27, offset: 161839},
+				pos: position{line: 5491, col: 27, offset: 167440},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5300, col: 27, offset: 161839},
-					exprs: []interface{}{
+					pos: position{line: 5491, col: 27, offset: 167440},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5300, col: 27, offset: 161839},
+							pos:        position{line: 5491, col: 27, offset: 167440},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5300, col: 35, offset: 161847},
+							pos:  position{line: 5491, col: 35, offset: 167448},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5300, col: 41, offset: 161853},
+							pos:   position{line: 5491, col: 41, offset: 167454},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5300, col: 48, offset: 161860},
+								pos:  position{line: 5491, col: 48, offset: 167461},
 								name: "PositiveInteger",
 							},
 						},
@@ -13435,28 +13656,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5309, col: 1, offset: 162051},
+			pos:  position{line: 5500, col: 1, offset: 167652},
 			expr: &actionExpr{
-				pos: position{line: 5309, col: 25, offset: 162075},
+				pos: position{line: 5500, col: 25, offset: 167676},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5309, col: 25, offset: 162075},
-					exprs: []interface{}{
+					pos: position{line: 5500, col: 25, offset: 167676},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5309, col: 25, offset: 162075},
+							pos:        position{line: 5500, col: 25, offset: 167676},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5309, col: 31, offset: 162081},
+							pos:  position{line: 5500, col: 31, offset: 167682},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5309, col: 37, offset: 162087},
+							pos:   position{line: 5500, col: 37, offset: 167688},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5309, col: 44, offset: 162094},
+								pos:  position{line: 5500, col: 44, offset: 167695},
 								name: "PositiveInteger",
 							},
 						},
@@ -13466,30 +13687,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5318, col: 1, offset: 162281},
+			pos:  position{line: 5509, col: 1, offset: 167882},
 			expr: &actionExpr{
-				pos: position{line: 5318, col: 22, offset: 162302},
+				pos: position{line: 5509, col: 22, offset: 167903},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5318, col: 22, offset: 162302},
+					pos:   position{line: 5509, col: 22, offset: 167903},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5318, col: 41, offset: 162321},
-						alternatives: []interface{}{
+						pos: position{line: 5509, col: 41, offset: 167922},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5318, col: 41, offset: 162321},
+								pos:  position{line: 5509, col: 41, offset: 167922},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5318, col: 67, offset: 162347},
+								pos:  position{line: 5509, col: 67, offset: 167948},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5318, col: 93, offset: 162373},
+								pos:  position{line: 5509, col: 93, offset: 167974},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5318, col: 118, offset: 162398},
+								pos:  position{line: 5509, col: 118, offset: 167999},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13499,35 +13720,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5322, col: 1, offset: 162459},
+			pos:  position{line: 5513, col: 1, offset: 168060},
 			expr: &actionExpr{
-				pos: position{line: 5322, col: 26, offset: 162484},
+				pos: position{line: 5513, col: 26, offset: 168085},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5322, col: 26, offset: 162484},
-					exprs: []interface{}{
+					pos: position{line: 5513, col: 26, offset: 168085},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5322, col: 26, offset: 162484},
+							pos:   position{line: 5513, col: 26, offset: 168085},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5322, col: 34, offset: 162492},
+								pos:  position{line: 5513, col: 34, offset: 168093},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5322, col: 53, offset: 162511},
+							pos:   position{line: 5513, col: 53, offset: 168112},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5322, col: 58, offset: 162516},
+								pos: position{line: 5513, col: 58, offset: 168117},
 								expr: &seqExpr{
-									pos: position{line: 5322, col: 59, offset: 162517},
-									exprs: []interface{}{
+									pos: position{line: 5513, col: 59, offset: 168118},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5322, col: 59, offset: 162517},
+											pos:  position{line: 5513, col: 59, offset: 168118},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5322, col: 65, offset: 162523},
+											pos:  position{line: 5513, col: 65, offset: 168124},
 											name: "InputLookupOption",
 										},
 									},
@@ -13540,35 +13761,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5364, col: 1, offset: 163969},
+			pos:  position{line: 5555, col: 1, offset: 169570},
 			expr: &actionExpr{
-				pos: position{line: 5364, col: 21, offset: 163989},
+				pos: position{line: 5555, col: 21, offset: 169590},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5364, col: 21, offset: 163989},
-					exprs: []interface{}{
+					pos: position{line: 5555, col: 21, offset: 169590},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5364, col: 21, offset: 163989},
+							pos:  position{line: 5555, col: 21, offset: 169590},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5364, col: 26, offset: 163994},
+							pos:  position{line: 5555, col: 26, offset: 169595},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5364, col: 42, offset: 164010},
+							pos:   position{line: 5555, col: 42, offset: 169611},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5364, col: 60, offset: 164028},
+								pos: position{line: 5555, col: 60, offset: 169629},
 								expr: &seqExpr{
-									pos: position{line: 5364, col: 61, offset: 164029},
-									exprs: []interface{}{
+									pos: position{line: 5555, col: 61, offset: 169630},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5364, col: 61, offset: 164029},
+											pos:  position{line: 5555, col: 61, offset: 169630},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5364, col: 83, offset: 164051},
+											pos:  position{line: 5555, col: 83, offset: 169652},
 											name: "SPACE",
 										},
 									},
@@ -13576,20 +13797,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5364, col: 91, offset: 164059},
+							pos:   position{line: 5555, col: 91, offset: 169660},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5364, col: 101, offset: 164069},
+								pos:  position{line: 5555, col: 101, offset: 169670},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5364, col: 109, offset: 164077},
+							pos:   position{line: 5555, col: 109, offset: 169678},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5364, col: 121, offset: 164089},
+								pos: position{line: 5555, col: 121, offset: 169690},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5364, col: 122, offset: 164090},
+									pos:  position{line: 5555, col: 122, offset: 169691},
 									name: "WhereClause",
 								},
 							},
@@ -13600,15 +13821,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5387, col: 1, offset: 164778},
+			pos:  position{line: 5578, col: 1, offset: 170379},
 			expr: &actionExpr{
-				pos: position{line: 5387, col: 24, offset: 164801},
+				pos: position{line: 5578, col: 24, offset: 170402},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5387, col: 24, offset: 164801},
+					pos:   position{line: 5578, col: 24, offset: 170402},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5387, col: 41, offset: 164818},
+						pos:  position{line: 5578, col: 41, offset: 170419},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13616,26 +13837,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5398, col: 1, offset: 165217},
+			pos:  position{line: 5589, col: 1, offset: 170818},
 			expr: &actionExpr{
-				pos: position{line: 5398, col: 20, offset: 165236},
+				pos: position{line: 5589, col: 20, offset: 170837},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5398, col: 20, offset: 165236},
+					pos:   position{line: 5589, col: 20, offset: 170837},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5398, col: 28, offset: 165244},
-						alternatives: []interface{}{
+						pos: position{line: 5589, col: 28, offset: 170845},
+						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5398, col: 28, offset: 165244},
+								pos:  position{line: 5589, col: 28, offset: 170845},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5398, col: 52, offset: 165268},
+								pos:  position{line: 5589, col: 52, offset: 170869},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5398, col: 68, offset: 165284},
+								pos:  position{line: 5589, col: 68, offset: 170885},
 								name: "MaxOutOption",
 							},
 						},
@@ -13645,28 +13866,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5403, col: 1, offset: 165382},
+			pos:  position{line: 5594, col: 1, offset: 170983},
 			expr: &actionExpr{
-				pos: position{line: 5403, col: 26, offset: 165407},
+				pos: position{line: 5594, col: 26, offset: 171008},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5403, col: 26, offset: 165407},
-					exprs: []interface{}{
+					pos: position{line: 5594, col: 26, offset: 171008},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5403, col: 26, offset: 165407},
+							pos:        position{line: 5594, col: 26, offset: 171008},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5403, col: 44, offset: 165425},
+							pos:  position{line: 5594, col: 44, offset: 171026},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5403, col: 50, offset: 165431},
+							pos:   position{line: 5594, col: 50, offset: 171032},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5403, col: 58, offset: 165439},
+								pos:  position{line: 5594, col: 58, offset: 171040},
 								name: "Boolean",
 							},
 						},
@@ -13676,28 +13897,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5410, col: 1, offset: 165578},
+			pos:  position{line: 5601, col: 1, offset: 171179},
 			expr: &actionExpr{
-				pos: position{line: 5410, col: 18, offset: 165595},
+				pos: position{line: 5601, col: 18, offset: 171196},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5410, col: 18, offset: 165595},
-					exprs: []interface{}{
+					pos: position{line: 5601, col: 18, offset: 171196},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5410, col: 18, offset: 165595},
+							pos:        position{line: 5601, col: 18, offset: 171196},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5410, col: 28, offset: 165605},
+							pos:  position{line: 5601, col: 28, offset: 171206},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5410, col: 34, offset: 165611},
+							pos:   position{line: 5601, col: 34, offset: 171212},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5410, col: 39, offset: 165616},
+								pos:  position{line: 5601, col: 39, offset: 171217},
 								name: "IntegerAsString",
 							},
 						},
@@ -13707,28 +13928,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5421, col: 1, offset: 165917},
+			pos:  position{line: 5612, col: 1, offset: 171518},
 			expr: &actionExpr{
-				pos: position{line: 5421, col: 17, offset: 165933},
+				pos: position{line: 5612, col: 17, offset: 171534},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5421, col: 17, offset: 165933},
-					exprs: []interface{}{
+					pos: position{line: 5612, col: 17, offset: 171534},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5421, col: 17, offset: 165933},
+							pos:        position{line: 5612, col: 17, offset: 171534},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5421, col: 26, offset: 165942},
+							pos:  position{line: 5612, col: 26, offset: 171543},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5421, col: 32, offset: 165948},
+							pos:   position{line: 5612, col: 32, offset: 171549},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5421, col: 36, offset: 165952},
+								pos:  position{line: 5612, col: 36, offset: 171553},
 								name: "IntegerAsString",
 							},
 						},
@@ -13738,43 +13959,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5433, col: 1, offset: 166307},
+			pos:  position{line: 5624, col: 1, offset: 171908},
 			expr: &actionExpr{
-				pos: position{line: 5433, col: 14, offset: 166320},
+				pos: position{line: 5624, col: 14, offset: 171921},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5433, col: 14, offset: 166320},
-					exprs: []interface{}{
+					pos: position{line: 5624, col: 14, offset: 171921},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5433, col: 14, offset: 166320},
+							pos:        position{line: 5624, col: 14, offset: 171921},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5433, col: 18, offset: 166324},
+							pos: position{line: 5624, col: 18, offset: 171925},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5433, col: 18, offset: 166324},
+								pos:  position{line: 5624, col: 18, offset: 171925},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5433, col: 25, offset: 166331},
+							pos:   position{line: 5624, col: 25, offset: 171932},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5433, col: 32, offset: 166338},
+								pos:  position{line: 5624, col: 32, offset: 171939},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5433, col: 44, offset: 166350},
+							pos: position{line: 5624, col: 44, offset: 171951},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5433, col: 44, offset: 166350},
+								pos:  position{line: 5624, col: 44, offset: 171951},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5433, col: 51, offset: 166357},
+							pos:        position{line: 5624, col: 51, offset: 171958},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -13785,35 +14006,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5438, col: 1, offset: 166446},
+			pos:  position{line: 5629, col: 1, offset: 172047},
 			expr: &actionExpr{
-				pos: position{line: 5438, col: 25, offset: 166470},
+				pos: position{line: 5629, col: 25, offset: 172071},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5438, col: 25, offset: 166470},
-					exprs: []interface{}{
+					pos: position{line: 5629, col: 25, offset: 172071},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5438, col: 25, offset: 166470},
+							pos:   position{line: 5629, col: 25, offset: 172071},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5438, col: 31, offset: 166476},
+								pos:  position{line: 5629, col: 31, offset: 172077},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5438, col: 47, offset: 166492},
+							pos:   position{line: 5629, col: 47, offset: 172093},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5438, col: 52, offset: 166497},
+								pos: position{line: 5629, col: 52, offset: 172098},
 								expr: &seqExpr{
-									pos: position{line: 5438, col: 53, offset: 166498},
-									exprs: []interface{}{
+									pos: position{line: 5629, col: 53, offset: 172099},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5438, col: 53, offset: 166498},
+											pos:  position{line: 5629, col: 53, offset: 172099},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5438, col: 59, offset: 166504},
+											pos:  position{line: 5629, col: 59, offset: 172105},
 											name: "AppendCmdOption",
 										},
 									},
@@ -13826,37 +14047,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5465, col: 1, offset: 167314},
+			pos:  position{line: 5656, col: 1, offset: 172915},
 			expr: &actionExpr{
-				pos: position{line: 5465, col: 16, offset: 167329},
+				pos: position{line: 5656, col: 16, offset: 172930},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5465, col: 16, offset: 167329},
-					exprs: []interface{}{
+					pos: position{line: 5656, col: 16, offset: 172930},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5465, col: 16, offset: 167329},
+							pos:  position{line: 5656, col: 16, offset: 172930},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5465, col: 21, offset: 167334},
+							pos:  position{line: 5656, col: 21, offset: 172935},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5465, col: 32, offset: 167345},
+							pos:   position{line: 5656, col: 32, offset: 172946},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5465, col: 40, offset: 167353},
+								pos: position{line: 5656, col: 40, offset: 172954},
 								expr: &seqExpr{
-									pos: position{line: 5465, col: 41, offset: 167354},
-									exprs: []interface{}{
+									pos: position{line: 5656, col: 41, offset: 172955},
+									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5465, col: 41, offset: 167354},
+											pos:  position{line: 5656, col: 41, offset: 172955},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5465, col: 57, offset: 167370},
+											pos: position{line: 5656, col: 57, offset: 172971},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5465, col: 57, offset: 167370},
+												pos:  position{line: 5656, col: 57, offset: 172971},
 												name: "SPACE",
 											},
 										},
@@ -13865,10 +14086,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5465, col: 66, offset: 167379},
+							pos:   position{line: 5656, col: 66, offset: 172980},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5465, col: 76, offset: 167389},
+								pos:  position{line: 5656, col: 76, offset: 172990},
 								name: "Subsearch",
 							},
 						},
@@ -13878,45 +14099,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5507, col: 1, offset: 168926},
+			pos:  position{line: 5698, col: 1, offset: 174527},
 			expr: &actionExpr{
-				pos: position{line: 5507, col: 17, offset: 168942},
+				pos: position{line: 5698, col: 17, offset: 174543},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5507, col: 17, offset: 168942},
-					exprs: []interface{}{
+					pos: position{line: 5698, col: 17, offset: 174543},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5507, col: 17, offset: 168942},
+							pos:  position{line: 5698, col: 17, offset: 174543},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5507, col: 23, offset: 168948},
+							pos:   position{line: 5698, col: 23, offset: 174549},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5507, col: 31, offset: 168956},
-								alternatives: []interface{}{
+								pos: position{line: 5698, col: 31, offset: 174557},
+								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 31, offset: 168956},
+										pos:  position{line: 5698, col: 31, offset: 174557},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 54, offset: 168979},
+										pos:  position{line: 5698, col: 54, offset: 174580},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 74, offset: 168999},
+										pos:  position{line: 5698, col: 74, offset: 174600},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 91, offset: 169016},
+										pos:  position{line: 5698, col: 91, offset: 174617},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 115, offset: 169040},
+										pos:  position{line: 5698, col: 115, offset: 174641},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5507, col: 135, offset: 169060},
+										pos:  position{line: 5698, col: 135, offset: 174661},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -13928,51 +14149,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5511, col: 1, offset: 169115},
+			pos:  position{line: 5702, col: 1, offset: 174716},
 			expr: &actionExpr{
-				pos: position{line: 5511, col: 25, offset: 169139},
+				pos: position{line: 5702, col: 25, offset: 174740},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5511, col: 26, offset: 169140},
-					exprs: []interface{}{
+					pos: position{line: 5702, col: 26, offset: 174741},
+					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5511, col: 26, offset: 169140},
+							pos:   position{line: 5702, col: 26, offset: 174741},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5511, col: 33, offset: 169147},
-								alternatives: []interface{}{
+								pos: position{line: 5702, col: 33, offset: 174748},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5511, col: 33, offset: 169147},
+										pos:        position{line: 5702, col: 33, offset: 174748},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5511, col: 42, offset: 169156},
+										pos:        position{line: 5702, col: 42, offset: 174757},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5511, col: 51, offset: 169165},
+										pos:        position{line: 5702, col: 51, offset: 174766},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5511, col: 60, offset: 169174},
+										pos:        position{line: 5702, col: 60, offset: 174775},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5511, col: 68, offset: 169182},
+										pos:        position{line: 5702, col: 68, offset: 174783},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5511, col: 76, offset: 169190},
+										pos:        position{line: 5702, col: 76, offset: 174791},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -13981,19 +14202,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5511, col: 84, offset: 169198},
+							pos:  position{line: 5702, col: 84, offset: 174799},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5511, col: 92, offset: 169206},
+							pos:   position{line: 5702, col: 92, offset: 174807},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5511, col: 105, offset: 169219},
+								pos:  position{line: 5702, col: 105, offset: 174820},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5511, col: 116, offset: 169230},
+							pos:  position{line: 5702, col: 116, offset: 174831},
 							name: "R_PAREN",
 						},
 					},
@@ -14002,15 +14223,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5537, col: 1, offset: 169988},
+			pos:  position{line: 5728, col: 1, offset: 175589},
 			expr: &actionExpr{
-				pos: position{line: 5537, col: 30, offset: 170017},
+				pos: position{line: 5728, col: 30, offset: 175618},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5537, col: 30, offset: 170017},
+					pos:   position{line: 5728, col: 30, offset: 175618},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5537, col: 43, offset: 170030},
+						pos:  position{line: 5728, col: 43, offset: 175631},
 						name: "StringExpr",
 					},
 				},
@@ -14018,61 +14239,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5562, col: 1, offset: 170738},
+			pos:  position{line: 5753, col: 1, offset: 176339},
 			expr: &actionExpr{
-				pos: position{line: 5562, col: 22, offset: 170759},
+				pos: position{line: 5753, col: 22, offset: 176360},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5562, col: 22, offset: 170759},
-					exprs: []interface{}{
+					pos: position{line: 5753, col: 22, offset: 176360},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5562, col: 22, offset: 170759},
+							pos:        position{line: 5753, col: 22, offset: 176360},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5562, col: 37, offset: 170774},
+							pos:  position{line: 5753, col: 37, offset: 176375},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5562, col: 43, offset: 170780},
+							pos:   position{line: 5753, col: 43, offset: 176381},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5562, col: 50, offset: 170787},
-								alternatives: []interface{}{
+								pos: position{line: 5753, col: 50, offset: 176388},
+								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5562, col: 50, offset: 170787},
+										pos:        position{line: 5753, col: 50, offset: 176388},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5562, col: 59, offset: 170796},
+										pos:        position{line: 5753, col: 59, offset: 176397},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5562, col: 68, offset: 170805},
+										pos:        position{line: 5753, col: 68, offset: 176406},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5562, col: 77, offset: 170814},
+										pos:        position{line: 5753, col: 77, offset: 176415},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5562, col: 85, offset: 170822},
+										pos:        position{line: 5753, col: 85, offset: 176423},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5562, col: 93, offset: 170830},
+										pos:        position{line: 5753, col: 93, offset: 176431},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14086,28 +14307,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5575, col: 1, offset: 171159},
+			pos:  position{line: 5766, col: 1, offset: 176760},
 			expr: &actionExpr{
-				pos: position{line: 5575, col: 19, offset: 171177},
+				pos: position{line: 5766, col: 19, offset: 176778},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5575, col: 19, offset: 171177},
-					exprs: []interface{}{
+					pos: position{line: 5766, col: 19, offset: 176778},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5575, col: 19, offset: 171177},
+							pos:        position{line: 5766, col: 19, offset: 176778},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5575, col: 31, offset: 171189},
+							pos:  position{line: 5766, col: 31, offset: 176790},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5575, col: 37, offset: 171195},
+							pos:   position{line: 5766, col: 37, offset: 176796},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5575, col: 45, offset: 171203},
+								pos:  position{line: 5766, col: 45, offset: 176804},
 								name: "Boolean",
 							},
 						},
@@ -14117,28 +14338,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5582, col: 1, offset: 171326},
+			pos:  position{line: 5773, col: 1, offset: 176927},
 			expr: &actionExpr{
-				pos: position{line: 5582, col: 26, offset: 171351},
+				pos: position{line: 5773, col: 26, offset: 176952},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5582, col: 26, offset: 171351},
-					exprs: []interface{}{
+					pos: position{line: 5773, col: 26, offset: 176952},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5582, col: 26, offset: 171351},
+							pos:        position{line: 5773, col: 26, offset: 176952},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5582, col: 45, offset: 171370},
+							pos:  position{line: 5773, col: 45, offset: 176971},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5582, col: 51, offset: 171376},
+							pos:   position{line: 5773, col: 51, offset: 176977},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5582, col: 59, offset: 171384},
+								pos:  position{line: 5773, col: 59, offset: 176985},
 								name: "Boolean",
 							},
 						},
@@ -14148,28 +14369,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5589, col: 1, offset: 171514},
+			pos:  position{line: 5780, col: 1, offset: 177115},
 			expr: &actionExpr{
-				pos: position{line: 5589, col: 22, offset: 171535},
+				pos: position{line: 5780, col: 22, offset: 177136},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5589, col: 22, offset: 171535},
-					exprs: []interface{}{
+					pos: position{line: 5780, col: 22, offset: 177136},
+					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5589, col: 22, offset: 171535},
+							pos:        position{line: 5780, col: 22, offset: 177136},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5589, col: 37, offset: 171550},
+							pos:  position{line: 5780, col: 37, offset: 177151},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5589, col: 43, offset: 171556},
+							pos:   position{line: 5780, col: 43, offset: 177157},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5589, col: 50, offset: 171563},
+								pos:  position{line: 5780, col: 50, offset: 177164},
 								name: "String",
 							},
 						},
@@ -14179,28 +14400,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5596, col: 1, offset: 171689},
+			pos:  position{line: 5787, col: 1, offset: 177290},
 			expr: &actionExpr{
-				pos: position{line: 5596, col: 16, offset: 171704},
+				pos: position{line: 5787, col: 16, offset: 177305},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5596, col: 16, offset: 171704},
-					exprs: []interface{}{
+					pos: position{line: 5787, col: 16, offset: 177305},
+					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5596, col: 16, offset: 171704},
+							pos:  position{line: 5787, col: 16, offset: 177305},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5596, col: 21, offset: 171709},
+							pos:  position{line: 5787, col: 21, offset: 177310},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5596, col: 32, offset: 171720},
+							pos:   position{line: 5787, col: 32, offset: 177321},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5596, col: 40, offset: 171728},
+								pos: position{line: 5787, col: 40, offset: 177329},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5596, col: 41, offset: 171729},
+									pos:  position{line: 5787, col: 41, offset: 177330},
 									name: "ToJsonOption",
 								},
 							},
@@ -14211,132 +14432,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5649, col: 1, offset: 173811},
+			pos:  position{line: 5840, col: 1, offset: 179412},
 			expr: &choiceExpr{
-				pos: position{line: 5649, col: 12, offset: 173822},
-				alternatives: []interface{}{
+				pos: position{line: 5840, col: 12, offset: 179423},
+				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 12, offset: 173822},
+						pos:  position{line: 5840, col: 12, offset: 179423},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 24, offset: 173834},
+						pos:  position{line: 5840, col: 24, offset: 179435},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 36, offset: 173846},
+						pos:  position{line: 5840, col: 36, offset: 179447},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 49, offset: 173859},
+						pos:  position{line: 5840, col: 49, offset: 179460},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 61, offset: 173871},
+						pos:  position{line: 5840, col: 61, offset: 179472},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 81, offset: 173891},
+						pos:  position{line: 5840, col: 81, offset: 179492},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 92, offset: 173902},
+						pos:  position{line: 5840, col: 92, offset: 179503},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 112, offset: 173922},
+						pos:  position{line: 5840, col: 112, offset: 179523},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 123, offset: 173933},
+						pos:  position{line: 5840, col: 123, offset: 179534},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 134, offset: 173944},
+						pos:  position{line: 5840, col: 134, offset: 179545},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 144, offset: 173954},
+						pos:  position{line: 5840, col: 144, offset: 179555},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 154, offset: 173964},
+						pos:  position{line: 5840, col: 154, offset: 179565},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 165, offset: 173975},
+						pos:  position{line: 5840, col: 165, offset: 179576},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 178, offset: 173988},
+						pos:  position{line: 5840, col: 178, offset: 179589},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 194, offset: 174004},
+						pos:  position{line: 5840, col: 194, offset: 179605},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 212, offset: 174022},
+						pos:  position{line: 5840, col: 212, offset: 179623},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 224, offset: 174034},
+						pos:  position{line: 5840, col: 224, offset: 179635},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 235, offset: 174045},
+						pos:  position{line: 5840, col: 235, offset: 179646},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 248, offset: 174058},
+						pos:  position{line: 5840, col: 248, offset: 179659},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 260, offset: 174070},
+						pos:  position{line: 5840, col: 260, offset: 179671},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 273, offset: 174083},
+						pos:  position{line: 5840, col: 273, offset: 179684},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 288, offset: 174098},
+						pos:  position{line: 5840, col: 288, offset: 179699},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 301, offset: 174111},
+						pos:  position{line: 5840, col: 301, offset: 179712},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 318, offset: 174128},
+						pos:  position{line: 5840, col: 318, offset: 179729},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 328, offset: 174138},
+						pos:  position{line: 5840, col: 328, offset: 179739},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 346, offset: 174156},
+						pos:  position{line: 5840, col: 346, offset: 179757},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 361, offset: 174171},
+						pos:  position{line: 5840, col: 361, offset: 179772},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 376, offset: 174186},
+						pos:  position{line: 5840, col: 376, offset: 179787},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 391, offset: 174201},
+						pos:  position{line: 5840, col: 391, offset: 179802},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 409, offset: 174219},
+						pos:  position{line: 5840, col: 409, offset: 179820},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5649, col: 422, offset: 174232},
+						pos:  position{line: 5840, col: 422, offset: 179833},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14344,18 +14565,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5650, col: 1, offset: 174244},
+			pos:  position{line: 5841, col: 1, offset: 179845},
 			expr: &seqExpr{
-				pos: position{line: 5650, col: 15, offset: 174258},
-				exprs: []interface{}{
+				pos: position{line: 5841, col: 15, offset: 179859},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5650, col: 15, offset: 174258},
+						pos:        position{line: 5841, col: 15, offset: 179859},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5650, col: 24, offset: 174267},
+						pos:  position{line: 5841, col: 24, offset: 179868},
 						name: "SPACE",
 					},
 				},
@@ -14363,18 +14584,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5651, col: 1, offset: 174273},
+			pos:  position{line: 5842, col: 1, offset: 179874},
 			expr: &seqExpr{
-				pos: position{line: 5651, col: 14, offset: 174286},
-				exprs: []interface{}{
+				pos: position{line: 5842, col: 14, offset: 179887},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5651, col: 14, offset: 174286},
+						pos:        position{line: 5842, col: 14, offset: 179887},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5651, col: 22, offset: 174294},
+						pos:  position{line: 5842, col: 22, offset: 179895},
 						name: "SPACE",
 					},
 				},
@@ -14382,18 +14603,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5652, col: 1, offset: 174300},
+			pos:  position{line: 5843, col: 1, offset: 179901},
 			expr: &seqExpr{
-				pos: position{line: 5652, col: 14, offset: 174313},
-				exprs: []interface{}{
+				pos: position{line: 5843, col: 14, offset: 179914},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5652, col: 14, offset: 174313},
+						pos:        position{line: 5843, col: 14, offset: 179914},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5652, col: 22, offset: 174321},
+						pos:  position{line: 5843, col: 22, offset: 179922},
 						name: "SPACE",
 					},
 				},
@@ -14401,18 +14622,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5653, col: 1, offset: 174327},
+			pos:  position{line: 5844, col: 1, offset: 179928},
 			expr: &seqExpr{
-				pos: position{line: 5653, col: 20, offset: 174346},
-				exprs: []interface{}{
+				pos: position{line: 5844, col: 20, offset: 179947},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5653, col: 20, offset: 174346},
+						pos:        position{line: 5844, col: 20, offset: 179947},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5653, col: 34, offset: 174360},
+						pos:  position{line: 5844, col: 34, offset: 179961},
 						name: "SPACE",
 					},
 				},
@@ -14420,18 +14641,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5654, col: 1, offset: 174366},
+			pos:  position{line: 5845, col: 1, offset: 179967},
 			expr: &seqExpr{
-				pos: position{line: 5654, col: 15, offset: 174380},
-				exprs: []interface{}{
+				pos: position{line: 5845, col: 15, offset: 179981},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5654, col: 15, offset: 174380},
+						pos:        position{line: 5845, col: 15, offset: 179981},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5654, col: 24, offset: 174389},
+						pos:  position{line: 5845, col: 24, offset: 179990},
 						name: "SPACE",
 					},
 				},
@@ -14439,18 +14660,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5655, col: 1, offset: 174395},
+			pos:  position{line: 5846, col: 1, offset: 179996},
 			expr: &seqExpr{
-				pos: position{line: 5655, col: 14, offset: 174408},
-				exprs: []interface{}{
+				pos: position{line: 5846, col: 14, offset: 180009},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5655, col: 14, offset: 174408},
+						pos:        position{line: 5846, col: 14, offset: 180009},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5655, col: 22, offset: 174416},
+						pos:  position{line: 5846, col: 22, offset: 180017},
 						name: "SPACE",
 					},
 				},
@@ -14458,9 +14679,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5656, col: 1, offset: 174422},
+			pos:  position{line: 5847, col: 1, offset: 180023},
 			expr: &litMatcher{
-				pos:        position{line: 5656, col: 22, offset: 174443},
+				pos:        position{line: 5847, col: 22, offset: 180044},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14468,16 +14689,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5657, col: 1, offset: 174450},
+			pos:  position{line: 5848, col: 1, offset: 180051},
 			expr: &seqExpr{
-				pos: position{line: 5657, col: 13, offset: 174462},
-				exprs: []interface{}{
+				pos: position{line: 5848, col: 13, offset: 180063},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5657, col: 13, offset: 174462},
+						pos:  position{line: 5848, col: 13, offset: 180063},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5657, col: 31, offset: 174480},
+						pos:  position{line: 5848, col: 31, offset: 180081},
 						name: "SPACE",
 					},
 				},
@@ -14485,9 +14706,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5658, col: 1, offset: 174486},
+			pos:  position{line: 5849, col: 1, offset: 180087},
 			expr: &litMatcher{
-				pos:        position{line: 5658, col: 22, offset: 174507},
+				pos:        position{line: 5849, col: 22, offset: 180108},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14495,16 +14716,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5659, col: 1, offset: 174514},
+			pos:  position{line: 5850, col: 1, offset: 180115},
 			expr: &seqExpr{
-				pos: position{line: 5659, col: 13, offset: 174526},
-				exprs: []interface{}{
+				pos: position{line: 5850, col: 13, offset: 180127},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5659, col: 13, offset: 174526},
+						pos:  position{line: 5850, col: 13, offset: 180127},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5659, col: 31, offset: 174544},
+						pos:  position{line: 5850, col: 31, offset: 180145},
 						name: "SPACE",
 					},
 				},
@@ -14512,18 +14733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5660, col: 1, offset: 174550},
+			pos:  position{line: 5851, col: 1, offset: 180151},
 			expr: &seqExpr{
-				pos: position{line: 5660, col: 13, offset: 174562},
-				exprs: []interface{}{
+				pos: position{line: 5851, col: 13, offset: 180163},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5660, col: 13, offset: 174562},
+						pos:        position{line: 5851, col: 13, offset: 180163},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5660, col: 20, offset: 174569},
+						pos:  position{line: 5851, col: 20, offset: 180170},
 						name: "SPACE",
 					},
 				},
@@ -14531,18 +14752,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5661, col: 1, offset: 174575},
+			pos:  position{line: 5852, col: 1, offset: 180176},
 			expr: &seqExpr{
-				pos: position{line: 5661, col: 12, offset: 174586},
-				exprs: []interface{}{
+				pos: position{line: 5852, col: 12, offset: 180187},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5661, col: 12, offset: 174586},
+						pos:        position{line: 5852, col: 12, offset: 180187},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5661, col: 18, offset: 174592},
+						pos:  position{line: 5852, col: 18, offset: 180193},
 						name: "SPACE",
 					},
 				},
@@ -14550,18 +14771,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5662, col: 1, offset: 174598},
+			pos:  position{line: 5853, col: 1, offset: 180199},
 			expr: &seqExpr{
-				pos: position{line: 5662, col: 13, offset: 174610},
-				exprs: []interface{}{
+				pos: position{line: 5853, col: 13, offset: 180211},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5662, col: 13, offset: 174610},
+						pos:        position{line: 5853, col: 13, offset: 180211},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5662, col: 20, offset: 174617},
+						pos:  position{line: 5853, col: 20, offset: 180218},
 						name: "SPACE",
 					},
 				},
@@ -14569,9 +14790,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5663, col: 1, offset: 174623},
+			pos:  position{line: 5854, col: 1, offset: 180224},
 			expr: &litMatcher{
-				pos:        position{line: 5663, col: 12, offset: 174634},
+				pos:        position{line: 5854, col: 12, offset: 180235},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -14579,9 +14800,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5664, col: 1, offset: 174640},
+			pos:  position{line: 5855, col: 1, offset: 180241},
 			expr: &litMatcher{
-				pos:        position{line: 5664, col: 13, offset: 174652},
+				pos:        position{line: 5855, col: 13, offset: 180253},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -14589,18 +14810,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5665, col: 1, offset: 174659},
+			pos:  position{line: 5856, col: 1, offset: 180260},
 			expr: &seqExpr{
-				pos: position{line: 5665, col: 15, offset: 174673},
-				exprs: []interface{}{
+				pos: position{line: 5856, col: 15, offset: 180274},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5665, col: 15, offset: 174673},
+						pos:        position{line: 5856, col: 15, offset: 180274},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5665, col: 24, offset: 174682},
+						pos:  position{line: 5856, col: 24, offset: 180283},
 						name: "SPACE",
 					},
 				},
@@ -14608,18 +14829,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5666, col: 1, offset: 174688},
+			pos:  position{line: 5857, col: 1, offset: 180289},
 			expr: &seqExpr{
-				pos: position{line: 5666, col: 18, offset: 174705},
-				exprs: []interface{}{
+				pos: position{line: 5857, col: 18, offset: 180306},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5666, col: 18, offset: 174705},
+						pos:        position{line: 5857, col: 18, offset: 180306},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5666, col: 30, offset: 174717},
+						pos:  position{line: 5857, col: 30, offset: 180318},
 						name: "SPACE",
 					},
 				},
@@ -14627,18 +14848,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5667, col: 1, offset: 174723},
+			pos:  position{line: 5858, col: 1, offset: 180324},
 			expr: &seqExpr{
-				pos: position{line: 5667, col: 12, offset: 174734},
-				exprs: []interface{}{
+				pos: position{line: 5858, col: 12, offset: 180335},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5667, col: 12, offset: 174734},
+						pos:        position{line: 5858, col: 12, offset: 180335},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5667, col: 18, offset: 174740},
+						pos:  position{line: 5858, col: 18, offset: 180341},
 						name: "SPACE",
 					},
 				},
@@ -14646,9 +14867,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5668, col: 1, offset: 174746},
+			pos:  position{line: 5859, col: 1, offset: 180347},
 			expr: &litMatcher{
-				pos:        position{line: 5668, col: 13, offset: 174758},
+				pos:        position{line: 5859, col: 13, offset: 180359},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -14656,18 +14877,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5669, col: 1, offset: 174765},
+			pos:  position{line: 5860, col: 1, offset: 180366},
 			expr: &seqExpr{
-				pos: position{line: 5669, col: 20, offset: 174784},
-				exprs: []interface{}{
+				pos: position{line: 5860, col: 20, offset: 180385},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5669, col: 20, offset: 174784},
+						pos:        position{line: 5860, col: 20, offset: 180385},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5669, col: 34, offset: 174798},
+						pos:  position{line: 5860, col: 34, offset: 180399},
 						name: "SPACE",
 					},
 				},
@@ -14675,9 +14896,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5670, col: 1, offset: 174804},
+			pos:  position{line: 5861, col: 1, offset: 180405},
 			expr: &litMatcher{
-				pos:        position{line: 5670, col: 14, offset: 174817},
+				pos:        position{line: 5861, col: 14, offset: 180418},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -14685,22 +14906,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5671, col: 1, offset: 174825},
+			pos:  position{line: 5862, col: 1, offset: 180426},
 			expr: &seqExpr{
-				pos: position{line: 5671, col: 21, offset: 174845},
-				exprs: []interface{}{
+				pos: position{line: 5862, col: 21, offset: 180446},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5671, col: 21, offset: 174845},
+						pos:  position{line: 5862, col: 21, offset: 180446},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5671, col: 27, offset: 174851},
+						pos:        position{line: 5862, col: 27, offset: 180452},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5671, col: 36, offset: 174860},
+						pos:  position{line: 5862, col: 36, offset: 180461},
 						name: "SPACE",
 					},
 				},
@@ -14708,9 +14929,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5672, col: 1, offset: 174866},
+			pos:  position{line: 5863, col: 1, offset: 180467},
 			expr: &litMatcher{
-				pos:        position{line: 5672, col: 15, offset: 174880},
+				pos:        position{line: 5863, col: 15, offset: 180481},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14718,9 +14939,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5673, col: 1, offset: 174889},
+			pos:  position{line: 5864, col: 1, offset: 180490},
 			expr: &litMatcher{
-				pos:        position{line: 5673, col: 14, offset: 174902},
+				pos:        position{line: 5864, col: 14, offset: 180503},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14728,9 +14949,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5674, col: 1, offset: 174910},
+			pos:  position{line: 5865, col: 1, offset: 180511},
 			expr: &litMatcher{
-				pos:        position{line: 5674, col: 15, offset: 174924},
+				pos:        position{line: 5865, col: 15, offset: 180525},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14738,9 +14959,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5675, col: 1, offset: 174933},
+			pos:  position{line: 5866, col: 1, offset: 180534},
 			expr: &litMatcher{
-				pos:        position{line: 5675, col: 17, offset: 174949},
+				pos:        position{line: 5866, col: 17, offset: 180550},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14748,9 +14969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5676, col: 1, offset: 174960},
+			pos:  position{line: 5867, col: 1, offset: 180561},
 			expr: &litMatcher{
-				pos:        position{line: 5676, col: 15, offset: 174974},
+				pos:        position{line: 5867, col: 15, offset: 180575},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14758,9 +14979,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5677, col: 1, offset: 174983},
+			pos:  position{line: 5868, col: 1, offset: 180584},
 			expr: &litMatcher{
-				pos:        position{line: 5677, col: 19, offset: 175001},
+				pos:        position{line: 5868, col: 19, offset: 180602},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14768,9 +14989,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5678, col: 1, offset: 175014},
+			pos:  position{line: 5869, col: 1, offset: 180615},
 			expr: &litMatcher{
-				pos:        position{line: 5678, col: 17, offset: 175030},
+				pos:        position{line: 5869, col: 17, offset: 180631},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14778,9 +14999,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5679, col: 1, offset: 175041},
+			pos:  position{line: 5870, col: 1, offset: 180642},
 			expr: &litMatcher{
-				pos:        position{line: 5679, col: 17, offset: 175057},
+				pos:        position{line: 5870, col: 17, offset: 180658},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -14788,18 +15009,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5680, col: 1, offset: 175068},
+			pos:  position{line: 5871, col: 1, offset: 180669},
 			expr: &seqExpr{
-				pos: position{line: 5680, col: 20, offset: 175087},
-				exprs: []interface{}{
+				pos: position{line: 5871, col: 20, offset: 180688},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5680, col: 20, offset: 175087},
+						pos:        position{line: 5871, col: 20, offset: 180688},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5680, col: 34, offset: 175101},
+						pos:  position{line: 5871, col: 34, offset: 180702},
 						name: "SPACE",
 					},
 				},
@@ -14807,28 +15028,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5681, col: 1, offset: 175107},
+			pos:  position{line: 5872, col: 1, offset: 180708},
 			expr: &seqExpr{
-				pos: position{line: 5681, col: 16, offset: 175122},
-				exprs: []interface{}{
+				pos: position{line: 5872, col: 16, offset: 180723},
+				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5681, col: 16, offset: 175122},
+						pos: position{line: 5872, col: 16, offset: 180723},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5681, col: 16, offset: 175122},
+							pos:  position{line: 5872, col: 16, offset: 180723},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5681, col: 24, offset: 175130},
-						alternatives: []interface{}{
+						pos: position{line: 5872, col: 24, offset: 180731},
+						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5681, col: 24, offset: 175130},
+								pos:        position{line: 5872, col: 24, offset: 180731},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5681, col: 30, offset: 175136},
+								pos:        position{line: 5872, col: 30, offset: 180737},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -14836,9 +15057,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5681, col: 35, offset: 175141},
+						pos: position{line: 5872, col: 35, offset: 180742},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5681, col: 35, offset: 175141},
+							pos:  position{line: 5872, col: 35, offset: 180742},
 							name: "SPACE",
 						},
 					},
@@ -14847,9 +15068,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5682, col: 1, offset: 175148},
+			pos:  position{line: 5873, col: 1, offset: 180749},
 			expr: &litMatcher{
-				pos:        position{line: 5682, col: 17, offset: 175164},
+				pos:        position{line: 5873, col: 17, offset: 180765},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -14857,18 +15078,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5683, col: 1, offset: 175175},
+			pos:  position{line: 5874, col: 1, offset: 180776},
 			expr: &seqExpr{
-				pos: position{line: 5683, col: 15, offset: 175189},
-				exprs: []interface{}{
+				pos: position{line: 5874, col: 15, offset: 180790},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5683, col: 15, offset: 175189},
+						pos:        position{line: 5874, col: 15, offset: 180790},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5683, col: 24, offset: 175198},
+						pos:  position{line: 5874, col: 24, offset: 180799},
 						name: "SPACE",
 					},
 				},
@@ -14876,9 +15097,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5684, col: 1, offset: 175204},
+			pos:  position{line: 5875, col: 1, offset: 180805},
 			expr: &litMatcher{
-				pos:        position{line: 5684, col: 15, offset: 175218},
+				pos:        position{line: 5875, col: 15, offset: 180819},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -14886,115 +15107,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5687, col: 1, offset: 175331},
+			pos:  position{line: 5878, col: 1, offset: 180932},
 			expr: &choiceExpr{
-				pos: position{line: 5687, col: 16, offset: 175346},
-				alternatives: []interface{}{
+				pos: position{line: 5878, col: 16, offset: 180947},
+				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5687, col: 16, offset: 175346},
+						pos:        position{line: 5878, col: 16, offset: 180947},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5687, col: 47, offset: 175377},
+						pos:        position{line: 5878, col: 47, offset: 180978},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5687, col: 55, offset: 175385},
+						pos:        position{line: 5878, col: 55, offset: 180986},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 16, offset: 175408},
+						pos:        position{line: 5879, col: 16, offset: 181009},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 26, offset: 175418},
+						pos:        position{line: 5879, col: 26, offset: 181019},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 34, offset: 175426},
+						pos:        position{line: 5879, col: 34, offset: 181027},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 42, offset: 175434},
+						pos:        position{line: 5879, col: 42, offset: 181035},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 50, offset: 175442},
+						pos:        position{line: 5879, col: 50, offset: 181043},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 58, offset: 175450},
+						pos:        position{line: 5879, col: 58, offset: 181051},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5688, col: 66, offset: 175458},
+						pos:        position{line: 5879, col: 66, offset: 181059},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 16, offset: 175480},
+						pos:        position{line: 5880, col: 16, offset: 181081},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 26, offset: 175490},
+						pos:        position{line: 5880, col: 26, offset: 181091},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 34, offset: 175498},
+						pos:        position{line: 5880, col: 34, offset: 181099},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 42, offset: 175506},
+						pos:        position{line: 5880, col: 42, offset: 181107},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 50, offset: 175514},
+						pos:        position{line: 5880, col: 50, offset: 181115},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 58, offset: 175522},
+						pos:        position{line: 5880, col: 58, offset: 181123},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 66, offset: 175530},
+						pos:        position{line: 5880, col: 66, offset: 181131},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5689, col: 74, offset: 175538},
+						pos:        position{line: 5880, col: 74, offset: 181139},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15004,25 +15225,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5690, col: 1, offset: 175544},
+			pos:  position{line: 5881, col: 1, offset: 181145},
 			expr: &choiceExpr{
-				pos: position{line: 5690, col: 16, offset: 175559},
-				alternatives: []interface{}{
+				pos: position{line: 5881, col: 16, offset: 181160},
+				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5690, col: 16, offset: 175559},
+						pos:        position{line: 5881, col: 16, offset: 181160},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5690, col: 30, offset: 175573},
+						pos:        position{line: 5881, col: 30, offset: 181174},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5690, col: 36, offset: 175579},
+						pos:        position{line: 5881, col: 36, offset: 181180},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15032,18 +15253,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5694, col: 1, offset: 175735},
+			pos:  position{line: 5885, col: 1, offset: 181336},
 			expr: &seqExpr{
-				pos: position{line: 5694, col: 8, offset: 175742},
-				exprs: []interface{}{
+				pos: position{line: 5885, col: 8, offset: 181343},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5694, col: 8, offset: 175742},
+						pos:        position{line: 5885, col: 8, offset: 181343},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5694, col: 14, offset: 175748},
+						pos:  position{line: 5885, col: 14, offset: 181349},
 						name: "SPACE",
 					},
 				},
@@ -15051,22 +15272,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5695, col: 1, offset: 175754},
+			pos:  position{line: 5886, col: 1, offset: 181355},
 			expr: &seqExpr{
-				pos: position{line: 5695, col: 7, offset: 175760},
-				exprs: []interface{}{
+				pos: position{line: 5886, col: 7, offset: 181361},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5695, col: 7, offset: 175760},
+						pos:  position{line: 5886, col: 7, offset: 181361},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5695, col: 13, offset: 175766},
+						pos:        position{line: 5886, col: 13, offset: 181367},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5695, col: 18, offset: 175771},
+						pos:  position{line: 5886, col: 18, offset: 181372},
 						name: "SPACE",
 					},
 				},
@@ -15074,22 +15295,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5696, col: 1, offset: 175777},
+			pos:  position{line: 5887, col: 1, offset: 181378},
 			expr: &seqExpr{
-				pos: position{line: 5696, col: 8, offset: 175784},
-				exprs: []interface{}{
+				pos: position{line: 5887, col: 8, offset: 181385},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5696, col: 8, offset: 175784},
+						pos:  position{line: 5887, col: 8, offset: 181385},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5696, col: 14, offset: 175790},
+						pos:        position{line: 5887, col: 14, offset: 181391},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5696, col: 20, offset: 175796},
+						pos:  position{line: 5887, col: 20, offset: 181397},
 						name: "SPACE",
 					},
 				},
@@ -15097,22 +15318,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5697, col: 1, offset: 175802},
+			pos:  position{line: 5888, col: 1, offset: 181403},
 			expr: &seqExpr{
-				pos: position{line: 5697, col: 9, offset: 175810},
-				exprs: []interface{}{
+				pos: position{line: 5888, col: 9, offset: 181411},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5697, col: 9, offset: 175810},
+						pos:  position{line: 5888, col: 9, offset: 181411},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5697, col: 24, offset: 175825},
+						pos:        position{line: 5888, col: 24, offset: 181426},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5697, col: 28, offset: 175829},
+						pos:  position{line: 5888, col: 28, offset: 181430},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15120,22 +15341,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5698, col: 1, offset: 175844},
+			pos:  position{line: 5889, col: 1, offset: 181445},
 			expr: &seqExpr{
-				pos: position{line: 5698, col: 7, offset: 175850},
-				exprs: []interface{}{
+				pos: position{line: 5889, col: 7, offset: 181451},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5698, col: 7, offset: 175850},
+						pos:  position{line: 5889, col: 7, offset: 181451},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5698, col: 13, offset: 175856},
+						pos:        position{line: 5889, col: 13, offset: 181457},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5698, col: 19, offset: 175862},
+						pos:  position{line: 5889, col: 19, offset: 181463},
 						name: "SPACE",
 					},
 				},
@@ -15143,22 +15364,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5699, col: 1, offset: 175888},
+			pos:  position{line: 5890, col: 1, offset: 181489},
 			expr: &seqExpr{
-				pos: position{line: 5699, col: 7, offset: 175894},
-				exprs: []interface{}{
+				pos: position{line: 5890, col: 7, offset: 181495},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5699, col: 7, offset: 175894},
+						pos:  position{line: 5890, col: 7, offset: 181495},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5699, col: 13, offset: 175900},
+						pos:        position{line: 5890, col: 13, offset: 181501},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5699, col: 19, offset: 175906},
+						pos:  position{line: 5890, col: 19, offset: 181507},
 						name: "SPACE",
 					},
 				},
@@ -15166,22 +15387,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5701, col: 1, offset: 175933},
+			pos:  position{line: 5892, col: 1, offset: 181534},
 			expr: &seqExpr{
-				pos: position{line: 5701, col: 10, offset: 175942},
-				exprs: []interface{}{
+				pos: position{line: 5892, col: 10, offset: 181543},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5701, col: 10, offset: 175942},
+						pos:  position{line: 5892, col: 10, offset: 181543},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5701, col: 25, offset: 175957},
+						pos:        position{line: 5892, col: 25, offset: 181558},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5701, col: 29, offset: 175961},
+						pos:  position{line: 5892, col: 29, offset: 181562},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15189,22 +15410,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5702, col: 1, offset: 175976},
+			pos:  position{line: 5893, col: 1, offset: 181577},
 			expr: &seqExpr{
-				pos: position{line: 5702, col: 10, offset: 175985},
-				exprs: []interface{}{
+				pos: position{line: 5893, col: 10, offset: 181586},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5702, col: 10, offset: 175985},
+						pos:  position{line: 5893, col: 10, offset: 181586},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5702, col: 25, offset: 176000},
+						pos:        position{line: 5893, col: 25, offset: 181601},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5702, col: 29, offset: 176004},
+						pos:  position{line: 5893, col: 29, offset: 181605},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15212,9 +15433,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5703, col: 1, offset: 176019},
+			pos:  position{line: 5894, col: 1, offset: 181620},
 			expr: &litMatcher{
-				pos:        position{line: 5703, col: 10, offset: 176028},
+				pos:        position{line: 5894, col: 10, offset: 181629},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15222,18 +15443,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5704, col: 1, offset: 176032},
+			pos:  position{line: 5895, col: 1, offset: 181633},
 			expr: &seqExpr{
-				pos: position{line: 5704, col: 12, offset: 176043},
-				exprs: []interface{}{
+				pos: position{line: 5895, col: 12, offset: 181644},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5704, col: 12, offset: 176043},
+						pos:        position{line: 5895, col: 12, offset: 181644},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5704, col: 16, offset: 176047},
+						pos:  position{line: 5895, col: 16, offset: 181648},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15241,16 +15462,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5705, col: 1, offset: 176062},
+			pos:  position{line: 5896, col: 1, offset: 181663},
 			expr: &seqExpr{
-				pos: position{line: 5705, col: 12, offset: 176073},
-				exprs: []interface{}{
+				pos: position{line: 5896, col: 12, offset: 181674},
+				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5705, col: 12, offset: 176073},
+						pos:  position{line: 5896, col: 12, offset: 181674},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5705, col: 27, offset: 176088},
+						pos:        position{line: 5896, col: 27, offset: 181689},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15260,40 +15481,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5707, col: 1, offset: 176093},
+			pos:  position{line: 5898, col: 1, offset: 181694},
 			expr: &notExpr{
-				pos: position{line: 5707, col: 8, offset: 176100},
+				pos: position{line: 5898, col: 8, offset: 181701},
 				expr: &anyMatcher{
-					line: 5707, col: 9, offset: 176101,
+					line: 5898, col: 9, offset: 181702,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5708, col: 1, offset: 176103},
+			pos:  position{line: 5899, col: 1, offset: 181704},
 			expr: &choiceExpr{
-				pos: position{line: 5708, col: 15, offset: 176117},
-				alternatives: []interface{}{
+				pos: position{line: 5899, col: 15, offset: 181718},
+				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5708, col: 15, offset: 176117},
+						pos:        position{line: 5899, col: 15, offset: 181718},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5708, col: 21, offset: 176123},
+						pos:        position{line: 5899, col: 21, offset: 181724},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5708, col: 28, offset: 176130},
+						pos:        position{line: 5899, col: 28, offset: 181731},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5708, col: 35, offset: 176137},
+						pos:        position{line: 5899, col: 35, offset: 181738},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15303,37 +15524,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5709, col: 1, offset: 176142},
+			pos:  position{line: 5900, col: 1, offset: 181743},
 			expr: &choiceExpr{
-				pos: position{line: 5709, col: 10, offset: 176151},
-				alternatives: []interface{}{
+				pos: position{line: 5900, col: 10, offset: 181752},
+				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5709, col: 11, offset: 176152},
-						exprs: []interface{}{
+						pos: position{line: 5900, col: 11, offset: 181753},
+						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5709, col: 11, offset: 176152},
+								pos: position{line: 5900, col: 11, offset: 181753},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5709, col: 11, offset: 176152},
+									pos:  position{line: 5900, col: 11, offset: 181753},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5709, col: 23, offset: 176164},
+								pos:  position{line: 5900, col: 23, offset: 181765},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5709, col: 31, offset: 176172},
+								pos: position{line: 5900, col: 31, offset: 181773},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5709, col: 31, offset: 176172},
+									pos:  position{line: 5900, col: 31, offset: 181773},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5709, col: 46, offset: 176187},
+						pos: position{line: 5900, col: 46, offset: 181788},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5709, col: 46, offset: 176187},
+							pos:  position{line: 5900, col: 46, offset: 181788},
 							name: "WHITESPACE",
 						},
 					},
@@ -15342,38 +15563,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5710, col: 1, offset: 176199},
+			pos:  position{line: 5901, col: 1, offset: 181800},
 			expr: &seqExpr{
-				pos: position{line: 5710, col: 12, offset: 176210},
-				exprs: []interface{}{
+				pos: position{line: 5901, col: 12, offset: 181811},
+				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5710, col: 12, offset: 176210},
+						pos:        position{line: 5901, col: 12, offset: 181811},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5710, col: 18, offset: 176216},
+						pos: position{line: 5901, col: 18, offset: 181817},
 						expr: &seqExpr{
-							pos: position{line: 5710, col: 19, offset: 176217},
-							exprs: []interface{}{
+							pos: position{line: 5901, col: 19, offset: 181818},
+							exprs: []any{
 								&notExpr{
-									pos: position{line: 5710, col: 19, offset: 176217},
+									pos: position{line: 5901, col: 19, offset: 181818},
 									expr: &litMatcher{
-										pos:        position{line: 5710, col: 21, offset: 176219},
+										pos:        position{line: 5901, col: 21, offset: 181820},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5710, col: 28, offset: 176226,
+									line: 5901, col: 28, offset: 181827,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5710, col: 32, offset: 176230},
+						pos:        position{line: 5901, col: 32, offset: 181831},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15383,16 +15604,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5711, col: 1, offset: 176236},
+			pos:  position{line: 5902, col: 1, offset: 181837},
 			expr: &choiceExpr{
-				pos: position{line: 5711, col: 20, offset: 176255},
-				alternatives: []interface{}{
+				pos: position{line: 5902, col: 20, offset: 181856},
+				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5711, col: 20, offset: 176255},
+						pos:  position{line: 5902, col: 20, offset: 181856},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5711, col: 28, offset: 176263},
+						pos:        position{line: 5902, col: 28, offset: 181864},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15402,16 +15623,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5712, col: 1, offset: 176266},
+			pos:  position{line: 5903, col: 1, offset: 181867},
 			expr: &choiceExpr{
-				pos: position{line: 5712, col: 19, offset: 176284},
-				alternatives: []interface{}{
+				pos: position{line: 5903, col: 19, offset: 181885},
+				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5712, col: 19, offset: 176284},
+						pos:  position{line: 5903, col: 19, offset: 181885},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5712, col: 27, offset: 176292},
+						pos:  position{line: 5903, col: 27, offset: 181893},
 						name: "SPACE",
 					},
 				},
@@ -15420,7 +15641,7 @@ var g = &grammar{
 	},
 }
 
-func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBlocks interface{}) (interface{}, error) {
+func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBlocks any) (any, error) {
 	var q ast.QueryStruct
 	q.SearchFilter = initialSearch.(*ast.Node)
 
@@ -15487,13 +15708,13 @@ func (c *current) onStart2(indexBlock, initialSearch, filterBlocks, queryAggBloc
 	return q, nil
 }
 
-func (p *parser) callonStart2() (interface{}, error) {
+func (p *parser) callonStart2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart2(stack["indexBlock"], stack["initialSearch"], stack["filterBlocks"], stack["queryAggBlocks"])
 }
 
-func (c *current) onStart20(genTimesOption, queryAggBlocks interface{}) (interface{}, error) {
+func (c *current) onStart20(genTimesOption, queryAggBlocks any) (any, error) {
 	var q ast.QueryStruct
 	q.PipeCommands = &structs.QueryAggregators{
 		PipeCommandType: structs.GenerateEventType,
@@ -15513,13 +15734,13 @@ func (c *current) onStart20(genTimesOption, queryAggBlocks interface{}) (interfa
 	return q, nil
 }
 
-func (p *parser) callonStart20() (interface{}, error) {
+func (p *parser) callonStart20() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart20(stack["genTimesOption"], stack["queryAggBlocks"])
 }
 
-func (c *current) onStart35(inputLookup, queryAggBlocks interface{}) (interface{}, error) {
+func (c *current) onStart35(inputLookup, queryAggBlocks any) (any, error) {
 	var q ast.QueryStruct
 	inpLookup := inputLookup.(*structs.QueryAggregators)
 	inpLookup.GenerateEvent.InputLookup.IsFirstCommand = true
@@ -15535,23 +15756,23 @@ func (c *current) onStart35(inputLookup, queryAggBlocks interface{}) (interface{
 	return q, nil
 }
 
-func (p *parser) callonStart35() (interface{}, error) {
+func (p *parser) callonStart35() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStart35(stack["inputLookup"], stack["queryAggBlocks"])
 }
 
-func (c *current) onIndexAssign1(index, indexName interface{}) (interface{}, error) {
+func (c *current) onIndexAssign1(index, indexName any) (any, error) {
 	return removeQuotes(indexName), nil
 }
 
-func (p *parser) callonIndexAssign1() (interface{}, error) {
+func (p *parser) callonIndexAssign1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexAssign1(stack["index"], stack["indexName"])
 }
 
-func (c *current) onIndexExpression1(first, rest interface{}) (interface{}, error) {
+func (c *current) onIndexExpression1(first, rest any) (any, error) {
 
 	if rest == nil {
 		if first.(string) == "" {
@@ -15576,36 +15797,36 @@ func (c *current) onIndexExpression1(first, rest interface{}) (interface{}, erro
 	return finalIndexes, nil
 }
 
-func (p *parser) callonIndexExpression1() (interface{}, error) {
+func (p *parser) callonIndexExpression1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexExpression1(stack["first"], stack["rest"])
 }
 
-func (c *current) onIndexBlock1(indexName interface{}) (interface{}, error) {
+func (c *current) onIndexBlock1(indexName any) (any, error) {
 	return indexName, nil
 }
 
-func (p *parser) callonIndexBlock1() (interface{}, error) {
+func (p *parser) callonIndexBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexBlock1(stack["indexName"])
 }
 
-func (c *current) onPartialTimestamp1() (interface{}, error) {
+func (c *current) onPartialTimestamp1() (any, error) {
 	timestamp := string(c.text)
 	completeTimestamp := fmt.Sprintf("%s:00:00:00", timestamp)
 
 	return completeTimestamp, nil
 }
 
-func (p *parser) callonPartialTimestamp1() (interface{}, error) {
+func (p *parser) callonPartialTimestamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPartialTimestamp1()
 }
 
-func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr interface{}) (interface{}, error) {
+func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr any) (any, error) {
 	timeOffset, err := strconv.ParseInt(intStr.(string), 10, 64)
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the integer: %v", err)
@@ -15623,13 +15844,13 @@ func (c *current) onIntegerAsTimeToUnixEpochMs1(intStr interface{}) (interface{}
 	return finalTime.UnixMilli(), nil
 }
 
-func (p *parser) callonIntegerAsTimeToUnixEpochMs1() (interface{}, error) {
+func (p *parser) callonIntegerAsTimeToUnixEpochMs1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIntegerAsTimeToUnixEpochMs1(stack["intStr"])
 }
 
-func (c *current) onDateTimeToUnixEpochMs1(timeStamp interface{}) (interface{}, error) {
+func (c *current) onDateTimeToUnixEpochMs1(timeStamp any) (any, error) {
 	unixEpochInMs, err := sutils.ConvertCustomDateTimeFormatToEpochMs(timeStamp.(string))
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the timestamp: %v", err)
@@ -15637,23 +15858,23 @@ func (c *current) onDateTimeToUnixEpochMs1(timeStamp interface{}) (interface{}, 
 	return unixEpochInMs, nil
 }
 
-func (p *parser) callonDateTimeToUnixEpochMs1() (interface{}, error) {
+func (p *parser) callonDateTimeToUnixEpochMs1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDateTimeToUnixEpochMs1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimestamp1(epochInMilli interface{}) (interface{}, error) {
+func (c *current) onGenTimestamp1(epochInMilli any) (any, error) {
 	return epochInMilli, nil
 }
 
-func (p *parser) callonGenTimestamp1() (interface{}, error) {
+func (p *parser) callonGenTimestamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimestamp1(stack["epochInMilli"])
 }
 
-func (c *current) onGenTimesOptionEnd1(timeStamp interface{}) (interface{}, error) {
+func (c *current) onGenTimesOptionEnd1(timeStamp any) (any, error) {
 	return &GenTimesOptionArgs{
 		argOption: "end",
 		genTimesOption: &structs.GenTimes{
@@ -15662,13 +15883,13 @@ func (c *current) onGenTimesOptionEnd1(timeStamp interface{}) (interface{}, erro
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionEnd1() (interface{}, error) {
+func (p *parser) callonGenTimesOptionEnd1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionEnd1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimesOptionStart1(timeStamp interface{}) (interface{}, error) {
+func (c *current) onGenTimesOptionStart1(timeStamp any) (any, error) {
 	return &GenTimesOptionArgs{
 		argOption: "start",
 		genTimesOption: &structs.GenTimes{
@@ -15677,13 +15898,13 @@ func (c *current) onGenTimesOptionStart1(timeStamp interface{}) (interface{}, er
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionStart1() (interface{}, error) {
+func (p *parser) callonGenTimesOptionStart1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionStart1(stack["timeStamp"])
 }
 
-func (c *current) onGenTimesOptionIncrement1(intStr, unitStr interface{}) (interface{}, error) {
+func (c *current) onGenTimesOptionIncrement1(intStr, unitStr any) (any, error) {
 	spanNum, err := strconv.ParseInt(intStr.(string), 10, 64)
 	if err != nil {
 		return "", fmt.Errorf("Spl peg: Error while converting the integer: %v", err)
@@ -15724,23 +15945,23 @@ func (c *current) onGenTimesOptionIncrement1(intStr, unitStr interface{}) (inter
 	}, nil
 }
 
-func (p *parser) callonGenTimesOptionIncrement1() (interface{}, error) {
+func (p *parser) callonGenTimesOptionIncrement1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionIncrement1(stack["intStr"], stack["unitStr"])
 }
 
-func (c *current) onGenTimesOption1(genTimesOption interface{}) (interface{}, error) {
+func (c *current) onGenTimesOption1(genTimesOption any) (any, error) {
 	return genTimesOption, nil
 }
 
-func (p *parser) callonGenTimesOption1() (interface{}, error) {
+func (p *parser) callonGenTimesOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOption1(stack["genTimesOption"])
 }
 
-func (c *current) onGenTimesOptionList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onGenTimesOptionList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 
@@ -15792,54 +16013,54 @@ func (c *current) onGenTimesOptionList1(first, rest interface{}) (interface{}, e
 	return genTimeOption, nil
 }
 
-func (p *parser) callonGenTimesOptionList1() (interface{}, error) {
+func (p *parser) callonGenTimesOptionList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGenTimesOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onInitialSearchBlock1(clause interface{}) (interface{}, error) {
+func (c *current) onInitialSearchBlock1(clause any) (any, error) {
 	return clause, nil
 }
 
-func (p *parser) callonInitialSearchBlock1() (interface{}, error) {
+func (p *parser) callonInitialSearchBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInitialSearchBlock1(stack["clause"])
 }
 
-func (c *current) onSearchBlock1(clause interface{}) (interface{}, error) {
+func (c *current) onSearchBlock1(clause any) (any, error) {
 	return clause, nil
 }
 
-func (p *parser) callonSearchBlock1() (interface{}, error) {
+func (p *parser) callonSearchBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSearchBlock1(stack["clause"])
 }
 
-func (c *current) onFilterBlock1(block interface{}) (interface{}, error) {
+func (c *current) onFilterBlock1(block any) (any, error) {
 	return block, nil
 }
 
-func (p *parser) callonFilterBlock1() (interface{}, error) {
+func (p *parser) callonFilterBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFilterBlock1(stack["block"])
 }
 
-func (c *current) onQueryAggergatorBlock1(block interface{}) (interface{}, error) {
+func (c *current) onQueryAggergatorBlock1(block any) (any, error) {
 	queryAgg := block.(*structs.QueryAggregators)
 	return queryAgg, nil
 }
 
-func (p *parser) callonQueryAggergatorBlock1() (interface{}, error) {
+func (p *parser) callonQueryAggergatorBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQueryAggergatorBlock1(stack["block"])
 }
 
-func (c *current) onFieldSelectBlock1(op, fields interface{}) (interface{}, error) {
+func (c *current) onFieldSelectBlock1(op, fields any) (any, error) {
 	columnsRequest := &structs.ColumnsRequest{}
 	if op == nil || string(op.([]byte)) == "+" {
 		columnsRequest.IncludeColumns = fields.([]string)
@@ -15858,13 +16079,13 @@ func (c *current) onFieldSelectBlock1(op, fields interface{}) (interface{}, erro
 	return queryAggregator, nil
 }
 
-func (p *parser) callonFieldSelectBlock1() (interface{}, error) {
+func (p *parser) callonFieldSelectBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldSelectBlock1(stack["op"], stack["fields"])
 }
 
-func (c *current) onCommonAggregatorBlock1(aggs, byFields interface{}) (interface{}, error) {
+func (c *current) onCommonAggregatorBlock1(aggs, byFields any) (any, error) {
 	aggNode := &structs.QueryAggregators{}
 
 	// Extract the MeasureAggregators and check if any of the aggregation fields
@@ -15927,13 +16148,13 @@ func (c *current) onCommonAggregatorBlock1(aggs, byFields interface{}) (interfac
 	return aggNode, nil
 }
 
-func (p *parser) callonCommonAggregatorBlock1() (interface{}, error) {
+func (p *parser) callonCommonAggregatorBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonAggregatorBlock1(stack["aggs"], stack["byFields"])
 }
 
-func (c *current) onAggregatorBlock1(aggs, options interface{}) (interface{}, error) {
+func (c *current) onAggregatorBlock1(aggs, options any) (any, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 
 	if options != nil {
@@ -15945,13 +16166,13 @@ func (c *current) onAggregatorBlock1(aggs, options interface{}) (interface{}, er
 	return aggNode, nil
 }
 
-func (p *parser) callonAggregatorBlock1() (interface{}, error) {
+func (p *parser) callonAggregatorBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregatorBlock1(stack["aggs"], stack["options"])
 }
 
-func (c *current) onStatsOptions1(option interface{}) (interface{}, error) {
+func (c *current) onStatsOptions1(option any) (any, error) {
 	//Default value
 	options := initializeStatsOptions()
 
@@ -15988,24 +16209,24 @@ func (c *current) onStatsOptions1(option interface{}) (interface{}, error) {
 	return options, nil
 }
 
-func (p *parser) callonStatsOptions1() (interface{}, error) {
+func (p *parser) callonStatsOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOptions1(stack["option"])
 }
 
-func (c *current) onStatsOption1(optionCMD, str interface{}) (interface{}, error) {
+func (c *current) onStatsOption1(optionCMD, str any) (any, error) {
 	optionArr := []string{optionCMD.(string), str.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonStatsOption1() (interface{}, error) {
+func (p *parser) callonStatsOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOption1(stack["optionCMD"], stack["str"])
 }
 
-func (c *current) onStatsOptionCMD1(option interface{}) (interface{}, error) {
+func (c *current) onStatsOptionCMD1(option any) (any, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: StatsOptionCMD: %v", err)
@@ -16013,13 +16234,13 @@ func (c *current) onStatsOptionCMD1(option interface{}) (interface{}, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonStatsOptionCMD1() (interface{}, error) {
+func (p *parser) callonStatsOptionCMD1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatsOptionCMD1(stack["option"])
 }
 
-func (c *current) onGroupbyBlock1(fields interface{}) (interface{}, error) {
+func (c *current) onGroupbyBlock1(fields any) (any, error) {
 	// Wildcard fields are not allowed. See https://docs.splunk.com/Documentation/Splunk/9.1.0/SearchReference/Stats
 	for _, field := range fields.([]string) {
 		if strings.Contains(field, "*") {
@@ -16030,13 +16251,13 @@ func (c *current) onGroupbyBlock1(fields interface{}) (interface{}, error) {
 	return fields, nil
 }
 
-func (p *parser) callonGroupbyBlock1() (interface{}, error) {
+func (p *parser) callonGroupbyBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onGroupbyBlock1(stack["fields"])
 }
 
-func (c *current) onStreamStatsOptionResetOnChange1(boolVal interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionResetOnChange1(boolVal any) (any, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetOnChange: boolVal.(bool),
 	}
@@ -16048,13 +16269,13 @@ func (c *current) onStreamStatsOptionResetOnChange1(boolVal interface{}) (interf
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetOnChange1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionResetOnChange1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetOnChange1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionCurrent1(boolVal interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionCurrent1(boolVal any) (any, error) {
 	ssOption := &structs.StreamStatsOptions{
 		Current: boolVal.(bool),
 	}
@@ -16066,13 +16287,13 @@ func (c *current) onStreamStatsOptionCurrent1(boolVal interface{}) (interface{},
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionCurrent1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionCurrent1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionCurrent1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionGlobal1(boolVal interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionGlobal1(boolVal any) (any, error) {
 	// TODO: Verify if needed, in splunk it does nothing as of now based on experiments.
 	ssOption := &structs.StreamStatsOptions{
 		Global: boolVal.(bool),
@@ -16085,13 +16306,13 @@ func (c *current) onStreamStatsOptionGlobal1(boolVal interface{}) (interface{}, 
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionGlobal1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionGlobal1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionGlobal1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionAllNum1(boolVal interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionAllNum1(boolVal any) (any, error) {
 	// TODO: Verify if needed, in splunk it does nothing as of now based on experiments.
 	ssOption := &structs.StreamStatsOptions{
 		AllNum: boolVal.(bool),
@@ -16104,13 +16325,13 @@ func (c *current) onStreamStatsOptionAllNum1(boolVal interface{}) (interface{}, 
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionAllNum1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionAllNum1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionAllNum1(stack["boolVal"])
 }
 
-func (c *current) onStreamStatsOptionWindow1(windowSize interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionWindow1(windowSize any) (any, error) {
 	window, err := strconv.ParseUint(windowSize.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid window size: %v, must be a positive integer", windowSize.(string))
@@ -16129,13 +16350,13 @@ func (c *current) onStreamStatsOptionWindow1(windowSize interface{}) (interface{
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionWindow1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionWindow1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionWindow1(stack["windowSize"])
 }
 
-func (c *current) onStreamStatsOptionResetBefore1(boolExpr interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionResetBefore1(boolExpr any) (any, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetBefore: boolExpr.(*structs.BoolExpr),
 	}
@@ -16147,13 +16368,13 @@ func (c *current) onStreamStatsOptionResetBefore1(boolExpr interface{}) (interfa
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetBefore1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionResetBefore1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetBefore1(stack["boolExpr"])
 }
 
-func (c *current) onStreamStatsOptionResetAfter1(boolExpr interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionResetAfter1(boolExpr any) (any, error) {
 	ssOption := &structs.StreamStatsOptions{
 		ResetAfter: boolExpr.(*structs.BoolExpr),
 	}
@@ -16165,13 +16386,13 @@ func (c *current) onStreamStatsOptionResetAfter1(boolExpr interface{}) (interfac
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionResetAfter1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionResetAfter1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionResetAfter1(stack["boolExpr"])
 }
 
-func (c *current) onStreamStatsOptionTimeWindow1(spanLength interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionTimeWindow1(spanLength any) (any, error) {
 	spanLen := spanLength.(*structs.BinSpanLength)
 	if spanLen.TimeScale == sutils.TMInvalid {
 		return nil, fmt.Errorf("Invalid Syntax, time_window option cannot be used without time scale")
@@ -16187,23 +16408,23 @@ func (c *current) onStreamStatsOptionTimeWindow1(spanLength interface{}) (interf
 	return ssOptionArg, nil
 }
 
-func (p *parser) callonStreamStatsOptionTimeWindow1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionTimeWindow1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionTimeWindow1(stack["spanLength"])
 }
 
-func (c *current) onStreamStatsOption1(ssOption interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOption1(ssOption any) (any, error) {
 	return ssOption, nil
 }
 
-func (p *parser) callonStreamStatsOption1() (interface{}, error) {
+func (p *parser) callonStreamStatsOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOption1(stack["ssOption"])
 }
 
-func (c *current) onStreamStatsOptionList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onStreamStatsOptionList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]bool)
 
@@ -16262,13 +16483,13 @@ func (c *current) onStreamStatsOptionList1(first, rest interface{}) (interface{}
 	return ssOption, nil
 }
 
-func (p *parser) callonStreamStatsOptionList1() (interface{}, error) {
+func (p *parser) callonStreamStatsOptionList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onStreamStatsBlock2(ssOptionList, aggs interface{}) (interface{}, error) {
+func (c *current) onStreamStatsBlock2(ssOptionList, aggs any) (any, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 	ssOptions := ssOptionList.(*structs.StreamStatsOptions)
 
@@ -16280,13 +16501,13 @@ func (c *current) onStreamStatsBlock2(ssOptionList, aggs interface{}) (interface
 	return aggNode, nil
 }
 
-func (p *parser) callonStreamStatsBlock2() (interface{}, error) {
+func (p *parser) callonStreamStatsBlock2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsBlock2(stack["ssOptionList"], stack["aggs"])
 }
 
-func (c *current) onStreamStatsBlock11(aggs interface{}) (interface{}, error) {
+func (c *current) onStreamStatsBlock11(aggs any) (any, error) {
 	aggNode := aggs.(*structs.QueryAggregators)
 	ssOptions := initializeStreamStatsOptions()
 
@@ -16298,13 +16519,13 @@ func (c *current) onStreamStatsBlock11(aggs interface{}) (interface{}, error) {
 	return aggNode, nil
 }
 
-func (p *parser) callonStreamStatsBlock11() (interface{}, error) {
+func (p *parser) callonStreamStatsBlock11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStreamStatsBlock11(stack["aggs"])
 }
 
-func (c *current) onRegexBlock1(keyAndOp, str interface{}) (interface{}, error) {
+func (c *current) onRegexBlock1(keyAndOp, str any) (any, error) {
 	var key, op string
 	if keyAndOp == nil {
 		key = "*"
@@ -16332,13 +16553,13 @@ func (c *current) onRegexBlock1(keyAndOp, str interface{}) (interface{}, error) 
 	return node, nil
 }
 
-func (p *parser) callonRegexBlock1() (interface{}, error) {
+func (p *parser) callonRegexBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexBlock1(stack["keyAndOp"], stack["str"])
 }
 
-func (c *current) onRegexAggBlock1(node interface{}) (interface{}, error) {
+func (c *current) onRegexAggBlock1(node any) (any, error) {
 
 	astNode, ok := node.(*ast.Node)
 	if !ok {
@@ -16366,13 +16587,13 @@ func (c *current) onRegexAggBlock1(node interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonRegexAggBlock1() (interface{}, error) {
+func (p *parser) callonRegexAggBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexAggBlock1(stack["node"])
 }
 
-func (c *current) onClauseLevel41(first, rest interface{}) (interface{}, error) {
+func (c *current) onClauseLevel41(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -16390,13 +16611,13 @@ func (c *current) onClauseLevel41(first, rest interface{}) (interface{}, error) 
 	return cur, nil
 }
 
-func (p *parser) callonClauseLevel41() (interface{}, error) {
+func (p *parser) callonClauseLevel41() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel41(stack["first"], stack["rest"])
 }
 
-func (c *current) onClauseLevel31(first, rest interface{}) (interface{}, error) {
+func (c *current) onClauseLevel31(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -16414,13 +16635,13 @@ func (c *current) onClauseLevel31(first, rest interface{}) (interface{}, error) 
 	return cur, nil
 }
 
-func (p *parser) callonClauseLevel31() (interface{}, error) {
+func (p *parser) callonClauseLevel31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onClauseLevel22(notList, first interface{}) (interface{}, error) {
+func (c *current) onClauseLevel22(notList, first any) (any, error) {
 	// There's an issue with how queries with AST Not nodes are run, so use
 	// De Morgan's law to manipulate the expression.
 	node := first.(*ast.Node)
@@ -16433,53 +16654,53 @@ func (c *current) onClauseLevel22(notList, first interface{}) (interface{}, erro
 	return node, nil
 }
 
-func (p *parser) callonClauseLevel22() (interface{}, error) {
+func (p *parser) callonClauseLevel22() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel22(stack["notList"], stack["first"])
 }
 
-func (c *current) onClauseLevel29(clause interface{}) (interface{}, error) {
+func (c *current) onClauseLevel29(clause any) (any, error) {
 	return clause, nil
 }
 
-func (p *parser) callonClauseLevel29() (interface{}, error) {
+func (p *parser) callonClauseLevel29() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel29(stack["clause"])
 }
 
-func (c *current) onClauseLevel12(clause interface{}) (interface{}, error) {
+func (c *current) onClauseLevel12(clause any) (any, error) {
 	return clause, nil
 }
 
-func (p *parser) callonClauseLevel12() (interface{}, error) {
+func (p *parser) callonClauseLevel12() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel12(stack["clause"])
 }
 
-func (c *current) onClauseLevel18(term interface{}) (interface{}, error) {
+func (c *current) onClauseLevel18(term any) (any, error) {
 	return term, nil
 }
 
-func (p *parser) callonClauseLevel18() (interface{}, error) {
+func (p *parser) callonClauseLevel18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onClauseLevel18(stack["term"])
 }
 
-func (c *current) onSearchTerm1(term interface{}) (interface{}, error) {
+func (c *current) onSearchTerm1(term any) (any, error) {
 	return term, nil
 }
 
-func (p *parser) callonSearchTerm1() (interface{}, error) {
+func (p *parser) callonSearchTerm1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSearchTerm1(stack["term"])
 }
 
-func (c *current) onTimechartBlock1(tcArgs, limitExpr interface{}) (interface{}, error) {
+func (c *current) onTimechartBlock1(tcArgs, limitExpr any) (any, error) {
 	aggNode := &structs.QueryAggregators{}
 
 	columnsRequest := &structs.ColumnsRequest{}
@@ -16568,13 +16789,13 @@ func (c *current) onTimechartBlock1(tcArgs, limitExpr interface{}) (interface{},
 	return aggNode, nil
 }
 
-func (p *parser) callonTimechartBlock1() (interface{}, error) {
+func (p *parser) callonTimechartBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartBlock1(stack["tcArgs"], stack["limitExpr"])
 }
 
-func (c *current) onTimechartArgumentsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onTimechartArgumentsList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	timechartArgs := &TimechartArgs{}
 
@@ -16603,23 +16824,23 @@ func (c *current) onTimechartArgumentsList1(first, rest interface{}) (interface{
 	return timechartArgs, nil
 }
 
-func (p *parser) callonTimechartArgumentsList1() (interface{}, error) {
+func (p *parser) callonTimechartArgumentsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onTimechartArgument1(tcArg interface{}) (interface{}, error) {
+func (c *current) onTimechartArgument1(tcArg any) (any, error) {
 	return tcArg, nil
 }
 
-func (p *parser) callonTimechartArgument1() (interface{}, error) {
+func (p *parser) callonTimechartArgument1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTimechartArgument1(stack["tcArg"])
 }
 
-func (c *current) onSingleAggExpr1(aggs, splitByClause interface{}) (interface{}, error) {
+func (c *current) onSingleAggExpr1(aggs, splitByClause any) (any, error) {
 	singleAggExpr := &singleAggTemp{
 		aggregators: aggs.([]*aggregator),
 	}
@@ -16631,13 +16852,13 @@ func (c *current) onSingleAggExpr1(aggs, splitByClause interface{}) (interface{}
 	return singleAggExpr, nil
 }
 
-func (p *parser) callonSingleAggExpr1() (interface{}, error) {
+func (p *parser) callonSingleAggExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleAggExpr1(stack["aggs"], stack["splitByClause"])
 }
 
-func (c *current) onSplitByClause1(field interface{}) (interface{}, error) {
+func (c *current) onSplitByClause1(field any) (any, error) {
 	splitByClause := &structs.SplitByClause{
 		Field: field.(string),
 	}
@@ -16645,13 +16866,13 @@ func (c *current) onSplitByClause1(field interface{}) (interface{}, error) {
 	return splitByClause, nil
 }
 
-func (p *parser) callonSplitByClause1() (interface{}, error) {
+func (p *parser) callonSplitByClause1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSplitByClause1(stack["field"])
 }
 
-func (c *current) onTcOptions1(option interface{}) (interface{}, error) {
+func (c *current) onTcOptions1(option any) (any, error) {
 	//Default value
 	tcOptions := &structs.TcOptions{
 		UseNull:  true,
@@ -16693,24 +16914,24 @@ func (c *current) onTcOptions1(option interface{}) (interface{}, error) {
 	return tcOptions, nil
 }
 
-func (p *parser) callonTcOptions1() (interface{}, error) {
+func (p *parser) callonTcOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOptions1(stack["option"])
 }
 
-func (c *current) onTcOption1(tcOptionCMD, val interface{}) (interface{}, error) {
+func (c *current) onTcOption1(tcOptionCMD, val any) (any, error) {
 	tcOptionArr := []string{tcOptionCMD.(string), val.(string)}
 	return tcOptionArr, nil
 }
 
-func (p *parser) callonTcOption1() (interface{}, error) {
+func (p *parser) callonTcOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOption1(stack["tcOptionCMD"], stack["val"])
 }
 
-func (c *current) onTcOptionCMD1(option interface{}) (interface{}, error) {
+func (c *current) onTcOptionCMD1(option any) (any, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Timechart: TcOptionCMD: %v", err)
@@ -16718,23 +16939,23 @@ func (c *current) onTcOptionCMD1(option interface{}) (interface{}, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonTcOptionCMD1() (interface{}, error) {
+func (p *parser) callonTcOptionCMD1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTcOptionCMD1(stack["option"])
 }
 
-func (c *current) onAllTimeScale1(timeUnit interface{}) (interface{}, error) {
+func (c *current) onAllTimeScale1(timeUnit any) (any, error) {
 	return timeUnit, nil
 }
 
-func (p *parser) callonAllTimeScale1() (interface{}, error) {
+func (p *parser) callonAllTimeScale1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAllTimeScale1(stack["timeUnit"])
 }
 
-func (c *current) onBinSpanLenOption1(number, timeScale interface{}) (interface{}, error) {
+func (c *current) onBinSpanLenOption1(number, timeScale any) (any, error) {
 	if timeScale != nil {
 		num, err := strconv.ParseInt(number.(string), 10, 64)
 		if err != nil {
@@ -16793,13 +17014,13 @@ func (c *current) onBinSpanLenOption1(number, timeScale interface{}) (interface{
 	return spanLength, nil
 }
 
-func (p *parser) callonBinSpanLenOption1() (interface{}, error) {
+func (p *parser) callonBinSpanLenOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinSpanLenOption1(stack["number"], stack["timeScale"])
 }
 
-func (c *current) onBinOptionMinSpan1(spanLength interface{}) (interface{}, error) {
+func (c *current) onBinOptionMinSpan1(spanLength any) (any, error) {
 
 	binOptionArgs := &BinOptionArgs{
 		argOption: "minspan",
@@ -16810,13 +17031,13 @@ func (c *current) onBinOptionMinSpan1(spanLength interface{}) (interface{}, erro
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionMinSpan1() (interface{}, error) {
+func (p *parser) callonBinOptionMinSpan1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionMinSpan1(stack["spanLength"])
 }
 
-func (c *current) onBinOptionMaxBins1(intAsStr interface{}) (interface{}, error) {
+func (c *current) onBinOptionMaxBins1(intAsStr any) (any, error) {
 	numBins, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -16833,13 +17054,13 @@ func (c *current) onBinOptionMaxBins1(intAsStr interface{}) (interface{}, error)
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionMaxBins1() (interface{}, error) {
+func (p *parser) callonBinOptionMaxBins1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionMaxBins1(stack["intAsStr"])
 }
 
-func (c *current) onBinOptionAlignTime2(utcEpoch interface{}) (interface{}, error) {
+func (c *current) onBinOptionAlignTime2(utcEpoch any) (any, error) {
 	epoch, err := strconv.ParseUint(utcEpoch.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid utc epoch value: %v for align time", utcEpoch.(string))
@@ -16854,13 +17075,13 @@ func (c *current) onBinOptionAlignTime2(utcEpoch interface{}) (interface{}, erro
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionAlignTime2() (interface{}, error) {
+func (p *parser) callonBinOptionAlignTime2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionAlignTime2(stack["utcEpoch"])
 }
 
-func (c *current) onBinOptionAlignTime8(timestamp interface{}) (interface{}, error) {
+func (c *current) onBinOptionAlignTime8(timestamp any) (any, error) {
 	var epoch uint64 = 0
 	var err error
 	relTimeModifier := timestamp.(ast.TimeModifier)
@@ -16880,13 +17101,13 @@ func (c *current) onBinOptionAlignTime8(timestamp interface{}) (interface{}, err
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionAlignTime8() (interface{}, error) {
+func (p *parser) callonBinOptionAlignTime8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionAlignTime8(stack["timestamp"])
 }
 
-func (c *current) onBinOptionStart1(number interface{}) (interface{}, error) {
+func (c *current) onBinOptionStart1(number any) (any, error) {
 	start, err := strconv.ParseFloat(number.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Cannot convert %v to float", number.(string))
@@ -16901,13 +17122,13 @@ func (c *current) onBinOptionStart1(number interface{}) (interface{}, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionStart1() (interface{}, error) {
+func (p *parser) callonBinOptionStart1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionStart1(stack["number"])
 }
 
-func (c *current) onBinOptionEnd1(number interface{}) (interface{}, error) {
+func (c *current) onBinOptionEnd1(number any) (any, error) {
 	end, err := strconv.ParseFloat(number.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Cannot convert %v to float", number.(string))
@@ -16922,13 +17143,13 @@ func (c *current) onBinOptionEnd1(number interface{}) (interface{}, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionEnd1() (interface{}, error) {
+func (p *parser) callonBinOptionEnd1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionEnd1(stack["number"])
 }
 
-func (c *current) onBinOptionSpan2(num1, num2 interface{}) (interface{}, error) {
+func (c *current) onBinOptionSpan2(num1, num2 any) (any, error) {
 	var coeff float64 = 1.0
 	var base float64 = 10.0
 	var err error
@@ -16972,13 +17193,13 @@ func (c *current) onBinOptionSpan2(num1, num2 interface{}) (interface{}, error) 
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionSpan2() (interface{}, error) {
+func (p *parser) callonBinOptionSpan2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionSpan2(stack["num1"], stack["num2"])
 }
 
-func (c *current) onBinOptionSpan17(spanLen interface{}) (interface{}, error) {
+func (c *current) onBinOptionSpan17(spanLen any) (any, error) {
 
 	spanOptions := &structs.BinSpanOptions{
 		BinSpanLength: spanLen.(*structs.BinSpanLength),
@@ -16993,23 +17214,23 @@ func (c *current) onBinOptionSpan17(spanLen interface{}) (interface{}, error) {
 	return binOptionArgs, nil
 }
 
-func (p *parser) callonBinOptionSpan17() (interface{}, error) {
+func (p *parser) callonBinOptionSpan17() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptionSpan17(stack["spanLen"])
 }
 
-func (c *current) onBinCmdOption1(option interface{}) (interface{}, error) {
+func (c *current) onBinCmdOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonBinCmdOption1() (interface{}, error) {
+func (p *parser) callonBinCmdOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinCmdOption1(stack["option"])
 }
 
-func (c *current) onBinCmdOptionsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onBinCmdOptionsList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]bool)
 
@@ -17054,13 +17275,13 @@ func (c *current) onBinCmdOptionsList1(first, rest interface{}) (interface{}, er
 	return binCmdOption, nil
 }
 
-func (p *parser) callonBinCmdOptionsList1() (interface{}, error) {
+func (p *parser) callonBinCmdOptionsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinCmdOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onBinBlock2(binCmdOption, field, newFieldName interface{}) (interface{}, error) {
+func (c *current) onBinBlock2(binCmdOption, field, newFieldName any) (any, error) {
 	letColReq := &structs.LetColumnsRequest{
 		NewColName: field.(string),
 	}
@@ -17088,13 +17309,13 @@ func (c *current) onBinBlock2(binCmdOption, field, newFieldName interface{}) (in
 	return queryAgg, nil
 }
 
-func (p *parser) callonBinBlock2() (interface{}, error) {
+func (p *parser) callonBinBlock2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinBlock2(stack["binCmdOption"], stack["field"], stack["newFieldName"])
 }
 
-func (c *current) onBinBlock14(field, newFieldName interface{}) (interface{}, error) {
+func (c *current) onBinBlock14(field, newFieldName any) (any, error) {
 	letColReq := &structs.LetColumnsRequest{
 		NewColName: field.(string),
 	}
@@ -17123,39 +17344,39 @@ func (c *current) onBinBlock14(field, newFieldName interface{}) (interface{}, er
 	return queryAgg, nil
 }
 
-func (p *parser) callonBinBlock14() (interface{}, error) {
+func (p *parser) callonBinBlock14() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinBlock14(stack["field"], stack["newFieldName"])
 }
 
-func (c *current) onBinOptions1(spanOptions interface{}) (interface{}, error) {
+func (c *current) onBinOptions1(spanOptions any) (any, error) {
 	binOptions := &structs.BinOptions{
 		SpanOptions: spanOptions.(*structs.SpanOptions),
 	}
 	return binOptions, nil
 }
 
-func (p *parser) callonBinOptions1() (interface{}, error) {
+func (p *parser) callonBinOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBinOptions1(stack["spanOptions"])
 }
 
-func (c *current) onSpanOptions1(spanLength interface{}) (interface{}, error) {
+func (c *current) onSpanOptions1(spanLength any) (any, error) {
 	spanOptions := &structs.SpanOptions{
 		SpanLength: spanLength.(*structs.SpanLength),
 	}
 	return spanOptions, nil
 }
 
-func (p *parser) callonSpanOptions1() (interface{}, error) {
+func (p *parser) callonSpanOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpanOptions1(stack["spanLength"])
 }
 
-func (c *current) onSpanLength1(intAsStr, timeScale interface{}) (interface{}, error) {
+func (c *current) onSpanLength1(intAsStr, timeScale any) (any, error) {
 	if timeScale.(sutils.TimeUnit) == sutils.TMYear {
 		return nil, fmt.Errorf("SpanLength: Invalid time unit, year is not supported")
 	}
@@ -17171,13 +17392,13 @@ func (c *current) onSpanLength1(intAsStr, timeScale interface{}) (interface{}, e
 	return spanLength, nil
 }
 
-func (p *parser) callonSpanLength1() (interface{}, error) {
+func (p *parser) callonSpanLength1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpanLength1(stack["intAsStr"], stack["timeScale"])
 }
 
-func (c *current) onLimitExpr1(sortBy, intAsStr interface{}) (interface{}, error) {
+func (c *current) onLimitExpr1(sortBy, intAsStr any) (any, error) {
 	num, err := strconv.Atoi(intAsStr.(string))
 	if err != nil {
 		return nil, fmt.Errorf("SpanLength: Invalid num (%v): %v", intAsStr.(string), err)
@@ -17201,13 +17422,13 @@ func (c *current) onLimitExpr1(sortBy, intAsStr interface{}) (interface{}, error
 	return limitExpr, nil
 }
 
-func (p *parser) callonLimitExpr1() (interface{}, error) {
+func (p *parser) callonLimitExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLimitExpr1(stack["sortBy"], stack["intAsStr"])
 }
 
-func (c *current) onStatisticBlock1(statisticExpr interface{}) (interface{}, error) {
+func (c *current) onStatisticBlock1(statisticExpr any) (any, error) {
 	letColReq := &structs.LetColumnsRequest{
 		StatisticColRequest: statisticExpr.(*structs.StatisticExpr),
 	}
@@ -17244,13 +17465,13 @@ func (c *current) onStatisticBlock1(statisticExpr interface{}) (interface{}, err
 
 }
 
-func (p *parser) callonStatisticBlock1() (interface{}, error) {
+func (p *parser) callonStatisticBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticBlock1(stack["statisticExpr"])
 }
 
-func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options interface{}) (interface{}, error) {
+func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options any) (any, error) {
 
 	statisticExpr := &structs.StatisticExpr{
 		FieldList: fieldList.([]interface{})[1].([]string),
@@ -17291,33 +17512,33 @@ func (c *current) onStatisticExpr1(cmd, limit, fieldList, byClause, options inte
 	return statisticExpr, nil
 }
 
-func (p *parser) callonStatisticExpr1() (interface{}, error) {
+func (p *parser) callonStatisticExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticExpr1(stack["cmd"], stack["limit"], stack["fieldList"], stack["byClause"], stack["options"])
 }
 
-func (c *current) onStatisticLimit2(number interface{}) (interface{}, error) {
+func (c *current) onStatisticLimit2(number any) (any, error) {
 	return number.(string), nil
 }
 
-func (p *parser) callonStatisticLimit2() (interface{}, error) {
+func (p *parser) callonStatisticLimit2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticLimit2(stack["number"])
 }
 
-func (c *current) onStatisticLimit7(limit interface{}) (interface{}, error) {
+func (c *current) onStatisticLimit7(limit any) (any, error) {
 	return limit.(string), nil
 }
 
-func (p *parser) callonStatisticLimit7() (interface{}, error) {
+func (p *parser) callonStatisticLimit7() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticLimit7(stack["limit"])
 }
 
-func (c *current) onStatisticOptions1(option interface{}) (interface{}, error) {
+func (c *current) onStatisticOptions1(option any) (any, error) {
 	//Default value
 	options := &structs.StatisticOptions{
 		ShowCount:    true,
@@ -17365,24 +17586,24 @@ func (c *current) onStatisticOptions1(option interface{}) (interface{}, error) {
 	return options, nil
 }
 
-func (p *parser) callonStatisticOptions1() (interface{}, error) {
+func (p *parser) callonStatisticOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOptions1(stack["option"])
 }
 
-func (c *current) onStatisticOption1(optionCMD, field interface{}) (interface{}, error) {
+func (c *current) onStatisticOption1(optionCMD, field any) (any, error) {
 	optionArr := []string{optionCMD.(string), field.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonStatisticOption1() (interface{}, error) {
+func (p *parser) callonStatisticOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOption1(stack["optionCMD"], stack["field"])
 }
 
-func (c *current) onStatisticOptionCMD1(option interface{}) (interface{}, error) {
+func (c *current) onStatisticOptionCMD1(option any) (any, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: StatisticExpr: %v", err)
@@ -17390,33 +17611,33 @@ func (c *current) onStatisticOptionCMD1(option interface{}) (interface{}, error)
 	return optionStr, nil
 }
 
-func (p *parser) callonStatisticOptionCMD1() (interface{}, error) {
+func (p *parser) callonStatisticOptionCMD1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStatisticOptionCMD1(stack["option"])
 }
 
-func (c *current) onByClause2(fieldList interface{}) (interface{}, error) {
+func (c *current) onByClause2(fieldList any) (any, error) {
 	return fieldList.([]string), nil
 }
 
-func (p *parser) callonByClause2() (interface{}, error) {
+func (p *parser) callonByClause2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onByClause2(stack["fieldList"])
 }
 
-func (c *current) onByClause7(groupByBlock interface{}) (interface{}, error) {
+func (c *current) onByClause7(groupByBlock any) (any, error) {
 	return groupByBlock.([]string), nil
 }
 
-func (p *parser) callonByClause7() (interface{}, error) {
+func (p *parser) callonByClause7() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onByClause7(stack["groupByBlock"])
 }
 
-func (c *current) onDedupBlock1(dedupExpr interface{}) (interface{}, error) {
+func (c *current) onDedupBlock1(dedupExpr any) (any, error) {
 
 	dedupExp := dedupExpr.(*structs.DedupExpr)
 
@@ -17458,13 +17679,13 @@ func (c *current) onDedupBlock1(dedupExpr interface{}) (interface{}, error) {
 	return root, nil
 }
 
-func (p *parser) callonDedupBlock1() (interface{}, error) {
+func (p *parser) callonDedupBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupBlock1(stack["dedupExpr"])
 }
 
-func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByClause interface{}) (interface{}, error) {
+func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByClause any) (any, error) {
 	dedupExpr := &structs.DedupExpr{
 		FieldList:         fieldList.([]string),
 		Limit:             1,
@@ -17521,23 +17742,23 @@ func (c *current) onDedupExpr1(limitArr, options1, fieldList, options2, sortByCl
 	return dedupExpr, nil
 }
 
-func (p *parser) callonDedupExpr1() (interface{}, error) {
+func (p *parser) callonDedupExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupExpr1(stack["limitArr"], stack["options1"], stack["fieldList"], stack["options2"], stack["sortByClause"])
 }
 
-func (c *current) onDedupFieldName1(field interface{}) (interface{}, error) {
+func (c *current) onDedupFieldName1(field any) (any, error) {
 	return field, nil
 }
 
-func (p *parser) callonDedupFieldName1() (interface{}, error) {
+func (p *parser) callonDedupFieldName1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupFieldName1(stack["field"])
 }
 
-func (c *current) onSpaceSeparatedFieldNameList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSpaceSeparatedFieldNameList1(first, rest any) (any, error) {
 	var fields []string
 	fields = append(fields, first.(string))
 	for _, r := range rest.([]any) {
@@ -17548,13 +17769,13 @@ func (c *current) onSpaceSeparatedFieldNameList1(first, rest interface{}) (inter
 	return fields, nil
 }
 
-func (p *parser) callonSpaceSeparatedFieldNameList1() (interface{}, error) {
+func (p *parser) callonSpaceSeparatedFieldNameList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSpaceSeparatedFieldNameList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onDedupFieldList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onDedupFieldList1(first, rest any) (any, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is " " and the second is a FieldName.
 	restSlice := rest.([]any)
@@ -17571,13 +17792,13 @@ func (c *current) onDedupFieldList1(first, rest interface{}) (interface{}, error
 	return fields, nil
 }
 
-func (p *parser) callonDedupFieldList1() (interface{}, error) {
+func (p *parser) callonDedupFieldList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupFieldList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onDedupOptions1(option interface{}) (interface{}, error) {
+func (c *current) onDedupOptions1(option any) (any, error) {
 	//Default value
 	options := &structs.DedupOptions{
 		Consecutive: false,
@@ -17616,24 +17837,24 @@ func (c *current) onDedupOptions1(option interface{}) (interface{}, error) {
 	return options, nil
 }
 
-func (p *parser) callonDedupOptions1() (interface{}, error) {
+func (p *parser) callonDedupOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOptions1(stack["option"])
 }
 
-func (c *current) onDedupOption1(optionCMD, field interface{}) (interface{}, error) {
+func (c *current) onDedupOption1(optionCMD, field any) (any, error) {
 	optionArr := []string{optionCMD.(string), field.(string)}
 	return optionArr, nil
 }
 
-func (p *parser) callonDedupOption1() (interface{}, error) {
+func (p *parser) callonDedupOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOption1(stack["optionCMD"], stack["field"])
 }
 
-func (c *current) onDedupOptionCMD1(option interface{}) (interface{}, error) {
+func (c *current) onDedupOptionCMD1(option any) (any, error) {
 	optionStr, err := transferUint8ToString(option)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: DedupExpr: %v", err)
@@ -17641,23 +17862,23 @@ func (c *current) onDedupOptionCMD1(option interface{}) (interface{}, error) {
 	return optionStr, nil
 }
 
-func (p *parser) callonDedupOptionCMD1() (interface{}, error) {
+func (p *parser) callonDedupOptionCMD1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupOptionCMD1(stack["option"])
 }
 
-func (c *current) onDedupSortByClause1(dedupSortEles interface{}) (interface{}, error) {
+func (c *current) onDedupSortByClause1(dedupSortEles any) (any, error) {
 	return dedupSortEles, nil
 }
 
-func (p *parser) callonDedupSortByClause1() (interface{}, error) {
+func (p *parser) callonDedupSortByClause1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDedupSortByClause1(stack["dedupSortEles"])
 }
 
-func (c *current) onSortElements1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSortElements1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 
 	length := 1 + len(restSlice)
@@ -17672,23 +17893,23 @@ func (c *current) onSortElements1(first, rest interface{}) (interface{}, error) 
 	return sortEles, nil
 }
 
-func (p *parser) callonSortElements1() (interface{}, error) {
+func (p *parser) callonSortElements1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortElements1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSingleSortElement1(element interface{}) (interface{}, error) {
+func (c *current) onSingleSortElement1(element any) (any, error) {
 	return element, nil
 }
 
-func (p *parser) callonSingleSortElement1() (interface{}, error) {
+func (p *parser) callonSingleSortElement1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElement1(stack["element"])
 }
 
-func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field interface{}) (interface{}, error) {
+func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field any) (any, error) {
 	sortByAsc := true
 
 	symbol := sortBySymbol.([]byte)
@@ -17703,13 +17924,13 @@ func (c *current) onSingleSortElementWithoutCast1(sortBySymbol, field interface{
 	}, nil
 }
 
-func (p *parser) callonSingleSortElementWithoutCast1() (interface{}, error) {
+func (p *parser) callonSingleSortElementWithoutCast1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElementWithoutCast1(stack["sortBySymbol"], stack["field"])
 }
 
-func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field interface{}) (interface{}, error) {
+func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field any) (any, error) {
 	sortByAsc := true
 
 	symbol := sortBySymbol.([]byte)
@@ -17729,13 +17950,13 @@ func (c *current) onSingleSortElementWithCast1(sortBySymbol, op, field interface
 	}, nil
 }
 
-func (p *parser) callonSingleSortElementWithCast1() (interface{}, error) {
+func (p *parser) callonSingleSortElementWithCast1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleSortElementWithCast1(stack["sortBySymbol"], stack["op"], stack["field"])
 }
 
-func (c *current) onRenameBlock1(renameExpr interface{}) (interface{}, error) {
+func (c *current) onRenameBlock1(renameExpr any) (any, error) {
 	letColReq := &structs.LetColumnsRequest{
 		RenameColRequest: renameExpr.(*structs.RenameExpr),
 	}
@@ -17757,13 +17978,13 @@ func (c *current) onRenameBlock1(renameExpr interface{}) (interface{}, error) {
 	return root, nil
 }
 
-func (p *parser) callonRenameBlock1() (interface{}, error) {
+func (p *parser) callonRenameBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameBlock1(stack["renameExpr"])
 }
 
-func (c *current) onRenameExpr2(originalPattern, newPattern interface{}) (interface{}, error) {
+func (c *current) onRenameExpr2(originalPattern, newPattern any) (any, error) {
 	renameExpr := &structs.RenameExpr{
 		RenameExprMode:  structs.REMPhrase,
 		OriginalPattern: originalPattern.(string),
@@ -17773,13 +17994,13 @@ func (c *current) onRenameExpr2(originalPattern, newPattern interface{}) (interf
 	return renameExpr, nil
 }
 
-func (p *parser) callonRenameExpr2() (interface{}, error) {
+func (p *parser) callonRenameExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameExpr2(stack["originalPattern"], stack["newPattern"])
 }
 
-func (c *current) onRenameExpr9(originalPattern, newPattern interface{}) (interface{}, error) {
+func (c *current) onRenameExpr9(originalPattern, newPattern any) (any, error) {
 	isRegex, err := isRegexRename(originalPattern.(string), newPattern.(string))
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: RenameExpr: %v", err)
@@ -17801,13 +18022,13 @@ func (c *current) onRenameExpr9(originalPattern, newPattern interface{}) (interf
 	return renameExpr, nil
 }
 
-func (p *parser) callonRenameExpr9() (interface{}, error) {
+func (p *parser) callonRenameExpr9() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenameExpr9(stack["originalPattern"], stack["newPattern"])
 }
 
-func (c *current) onRexBlock1(field, str interface{}) (interface{}, error) {
+func (c *current) onRexBlock1(field, str any) (any, error) {
 	pattern := removeQuotes(str)
 	rexColNames, err := getRexColNames(pattern)
 	if err != nil {
@@ -17834,13 +18055,13 @@ func (c *current) onRexBlock1(field, str interface{}) (interface{}, error) {
 	return root, nil
 }
 
-func (p *parser) callonRexBlock1() (interface{}, error) {
+func (p *parser) callonRexBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRexBlock1(stack["field"], stack["str"])
 }
 
-func (c *current) onSortBlock1(limit, sortByEles interface{}) (interface{}, error) {
+func (c *current) onSortBlock1(limit, sortByEles any) (any, error) {
 
 	sortExpr := &structs.SortExpr{
 		SortEles:    sortByEles.([]*structs.SortElement),
@@ -17878,13 +18099,13 @@ func (c *current) onSortBlock1(limit, sortByEles interface{}) (interface{}, erro
 	return root, nil
 }
 
-func (p *parser) callonSortBlock1() (interface{}, error) {
+func (p *parser) callonSortBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortBlock1(stack["limit"], stack["sortByEles"])
 }
 
-func (c *current) onSortLimit1(intAsStr interface{}) (interface{}, error) {
+func (c *current) onSortLimit1(intAsStr any) (any, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -17897,13 +18118,13 @@ func (c *current) onSortLimit1(intAsStr interface{}) (interface{}, error) {
 	return limit, nil
 }
 
-func (p *parser) callonSortLimit1() (interface{}, error) {
+func (p *parser) callonSortLimit1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSortLimit1(stack["intAsStr"])
 }
 
-func (c *current) onEvalBlock1(first, rest interface{}) (interface{}, error) {
+func (c *current) onEvalBlock1(first, rest any) (any, error) {
 	root := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -17937,13 +18158,13 @@ func (c *current) onEvalBlock1(first, rest interface{}) (interface{}, error) {
 	return root, nil
 }
 
-func (p *parser) callonEvalBlock1() (interface{}, error) {
+func (p *parser) callonEvalBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalBlock1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSingleEval1(field, expr interface{}) (interface{}, error) {
+func (c *current) onSingleEval1(field, expr any) (any, error) {
 	fieldStr := field.(string)
 	if strings.Contains(fieldStr, "*") {
 		return nil, fmt.Errorf("New fields must not contain wildcards; invalid field: %v", field)
@@ -17955,13 +18176,13 @@ func (c *current) onSingleEval1(field, expr interface{}) (interface{}, error) {
 	return letColumnsRequest, nil
 }
 
-func (p *parser) callonSingleEval1() (interface{}, error) {
+func (p *parser) callonSingleEval1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSingleEval1(stack["field"], stack["expr"])
 }
 
-func (c *current) onEvalExpression1(value interface{}) (interface{}, error) {
+func (c *current) onEvalExpression1(value any) (any, error) {
 	if value.(*structs.ValueExpr).ValueExprMode == structs.VEMBooleanExpr {
 		return nil, fmt.Errorf("Eval fields cannot be assigned a boolean result")
 	}
@@ -17972,13 +18193,13 @@ func (c *current) onEvalExpression1(value interface{}) (interface{}, error) {
 	return letColReq, nil
 }
 
-func (p *parser) callonEvalExpression1() (interface{}, error) {
+func (p *parser) callonEvalExpression1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalExpression1(stack["value"])
 }
 
-func (c *current) onConditionExpr2(condition, trueValue, falseValue interface{}) (interface{}, error) {
+func (c *current) onConditionExpr2(condition, trueValue, falseValue any) (any, error) {
 
 	node := &structs.ConditionExpr{
 		Op:         "if",
@@ -17990,13 +18211,13 @@ func (c *current) onConditionExpr2(condition, trueValue, falseValue interface{})
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr2() (interface{}, error) {
+func (p *parser) callonConditionExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr2(stack["condition"], stack["trueValue"], stack["falseValue"])
 }
 
-func (c *current) onConditionExpr15(opName, pair, rest interface{}) (interface{}, error) {
+func (c *current) onConditionExpr15(opName, pair, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: ConditionExpr: %v", err)
@@ -18020,13 +18241,13 @@ func (c *current) onConditionExpr15(opName, pair, rest interface{}) (interface{}
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr15() (interface{}, error) {
+func (p *parser) callonConditionExpr15() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr15(stack["opName"], stack["pair"], stack["rest"])
 }
 
-func (c *current) onConditionExpr30(valueExpr, rest interface{}) (interface{}, error) {
+func (c *current) onConditionExpr30(valueExpr, rest any) (any, error) {
 	restSlice := rest.([]any)
 	valueList := make([]*structs.ValueExpr, 1+len(restSlice))
 	valueList[0] = valueExpr.(*structs.ValueExpr)
@@ -18044,13 +18265,13 @@ func (c *current) onConditionExpr30(valueExpr, rest interface{}) (interface{}, e
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr30() (interface{}, error) {
+func (p *parser) callonConditionExpr30() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr30(stack["valueExpr"], stack["rest"])
 }
 
-func (c *current) onConditionExpr42(leftValue, rightValue interface{}) (interface{}, error) {
+func (c *current) onConditionExpr42(leftValue, rightValue any) (any, error) {
 	valueList := make([]*structs.ValueExpr, 2)
 	valueList[0] = leftValue.(*structs.ValueExpr)
 	valueList[1] = rightValue.(*structs.ValueExpr)
@@ -18063,26 +18284,26 @@ func (c *current) onConditionExpr42(leftValue, rightValue interface{}) (interfac
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr42() (interface{}, error) {
+func (p *parser) callonConditionExpr42() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr42(stack["leftValue"], stack["rightValue"])
 }
 
-func (c *current) onConditionExpr52() (interface{}, error) {
+func (c *current) onConditionExpr52() (any, error) {
 	node := &structs.ConditionExpr{
 		Op: "null",
 	}
 	return node, nil
 }
 
-func (p *parser) callonConditionExpr52() (interface{}, error) {
+func (p *parser) callonConditionExpr52() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionExpr52()
 }
 
-func (c *current) onConditionValuePair1(condition, value interface{}) (interface{}, error) {
+func (c *current) onConditionValuePair1(condition, value any) (any, error) {
 	conditionValuePair := &structs.ConditionValuePair{
 		Condition: condition.(*structs.BoolExpr),
 		Value:     value.(*structs.ValueExpr),
@@ -18090,13 +18311,13 @@ func (c *current) onConditionValuePair1(condition, value interface{}) (interface
 	return conditionValuePair, nil
 }
 
-func (p *parser) callonConditionValuePair1() (interface{}, error) {
+func (p *parser) callonConditionValuePair1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConditionValuePair1(stack["condition"], stack["value"])
 }
 
-func (c *current) onStringExprAsValueExpr1(stringExpr interface{}) (interface{}, error) {
+func (c *current) onStringExprAsValueExpr1(stringExpr any) (any, error) {
 	strExpr := stringExpr.(*structs.StringExpr)
 	valueExpr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -18106,13 +18327,13 @@ func (c *current) onStringExprAsValueExpr1(stringExpr interface{}) (interface{},
 	return valueExpr, nil
 }
 
-func (p *parser) callonStringExprAsValueExpr1() (interface{}, error) {
+func (p *parser) callonStringExprAsValueExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExprAsValueExpr1(stack["stringExpr"])
 }
 
-func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr interface{}) (interface{}, error) {
+func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr any) (any, error) {
 	valueExpr := &structs.ValueExpr{
 		ValueExprMode:  structs.VEMMultiValueExpr,
 		MultiValueExpr: multiValueExpr.(*structs.MultiValueExpr),
@@ -18121,23 +18342,23 @@ func (c *current) onMultiValueExprAsValueExpr1(multiValueExpr interface{}) (inte
 	return valueExpr, nil
 }
 
-func (p *parser) callonMultiValueExprAsValueExpr1() (interface{}, error) {
+func (p *parser) callonMultiValueExprAsValueExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExprAsValueExpr1(stack["multiValueExpr"])
 }
 
-func (c *current) onStringOrMultiValueExpr1(strOrMVExpr interface{}) (interface{}, error) {
+func (c *current) onStringOrMultiValueExpr1(strOrMVExpr any) (any, error) {
 	return strOrMVExpr.(*structs.ValueExpr), nil
 }
 
-func (p *parser) callonStringOrMultiValueExpr1() (interface{}, error) {
+func (p *parser) callonStringOrMultiValueExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringOrMultiValueExpr1(stack["strOrMVExpr"])
 }
 
-func (c *current) onMultiValueExpr2(opName, stringExpr, delim interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr2(opName, stringExpr, delim any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18150,13 +18371,13 @@ func (c *current) onMultiValueExpr2(opName, stringExpr, delim interface{}) (inte
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr2() (interface{}, error) {
+func (p *parser) callonMultiValueExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr2(stack["opName"], stack["stringExpr"], stack["delim"])
 }
 
-func (c *current) onMultiValueExpr13(opName, value, path interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr13(opName, value, path any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18169,13 +18390,13 @@ func (c *current) onMultiValueExpr13(opName, value, path interface{}) (interface
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr13() (interface{}, error) {
+func (p *parser) callonMultiValueExpr13() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr13(stack["opName"], stack["value"], stack["path"])
 }
 
-func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endIndex interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endIndex any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18192,13 +18413,13 @@ func (c *current) onMultiValueExpr24(opName, multiValueExpr, startIndex, endInde
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr24() (interface{}, error) {
+func (p *parser) callonMultiValueExpr24() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr24(stack["opName"], stack["multiValueExpr"], stack["startIndex"], stack["endIndex"])
 }
 
-func (c *current) onMultiValueExpr38(opName, multiValueExpr interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr38(opName, multiValueExpr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18211,13 +18432,13 @@ func (c *current) onMultiValueExpr38(opName, multiValueExpr interface{}) (interf
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr38() (interface{}, error) {
+func (p *parser) callonMultiValueExpr38() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr38(stack["opName"], stack["multiValueExpr"])
 }
 
-func (c *current) onMultiValueExpr48(opName, condition interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr48(opName, condition any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: Failed to recognize operator: %v, err= %v", opName, err)
@@ -18231,13 +18452,13 @@ func (c *current) onMultiValueExpr48(opName, condition interface{}) (interface{}
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr48() (interface{}, error) {
+func (p *parser) callonMultiValueExpr48() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr48(stack["opName"], stack["condition"])
 }
 
-func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18251,13 +18472,13 @@ func (c *current) onMultiValueExpr56(opName, multiValueExpr, expr interface{}) (
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr56() (interface{}, error) {
+func (p *parser) callonMultiValueExpr56() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr56(stack["opName"], stack["multiValueExpr"], stack["expr"])
 }
 
-func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18271,13 +18492,13 @@ func (c *current) onMultiValueExpr67(opName, startIndex, endIndex, stringExpr in
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr67() (interface{}, error) {
+func (p *parser) callonMultiValueExpr67() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr67(stack["opName"], stack["startIndex"], stack["endIndex"], stack["stringExpr"])
 }
 
-func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18295,13 +18516,13 @@ func (c *current) onMultiValueExpr82(opName, mvLeft, mvRight, rest interface{}) 
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr82() (interface{}, error) {
+func (p *parser) callonMultiValueExpr82() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr82(stack["opName"], stack["mvLeft"], stack["mvRight"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18327,13 +18548,13 @@ func (c *current) onMultiValueExpr98(opName, multiValueExpr, rest interface{}) (
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr98() (interface{}, error) {
+func (p *parser) callonMultiValueExpr98() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr98(stack["opName"], stack["multiValueExpr"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr114(opName, firstVal, rest interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr114(opName, firstVal, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: MultiValueExpr: %v", err)
@@ -18354,13 +18575,13 @@ func (c *current) onMultiValueExpr114(opName, firstVal, rest interface{}) (inter
 	return node, nil
 }
 
-func (p *parser) callonMultiValueExpr114() (interface{}, error) {
+func (p *parser) callonMultiValueExpr114() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr114(stack["opName"], stack["firstVal"], stack["rest"])
 }
 
-func (c *current) onMultiValueExpr127(field interface{}) (interface{}, error) {
+func (c *current) onMultiValueExpr127(field any) (any, error) {
 	expr := &structs.MultiValueExpr{
 		MultiValueExprMode: structs.MVEMField,
 		FieldName:          field.(string),
@@ -18369,13 +18590,13 @@ func (c *current) onMultiValueExpr127(field interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonMultiValueExpr127() (interface{}, error) {
+func (p *parser) callonMultiValueExpr127() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueExpr127(stack["field"])
 }
 
-func (c *current) onTextExpr2(opName, stringExpr interface{}) (interface{}, error) {
+func (c *current) onTextExpr2(opName, stringExpr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18388,13 +18609,13 @@ func (c *current) onTextExpr2(opName, stringExpr interface{}) (interface{}, erro
 	return node, nil
 }
 
-func (p *parser) callonTextExpr2() (interface{}, error) {
+func (p *parser) callonTextExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr2(stack["opName"], stack["stringExpr"])
 }
 
-func (c *current) onTextExpr13(opName, firstVal, rest interface{}) (interface{}, error) {
+func (c *current) onTextExpr13(opName, firstVal, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18417,13 +18638,13 @@ func (c *current) onTextExpr13(opName, firstVal, rest interface{}) (interface{},
 	return node, nil
 }
 
-func (p *parser) callonTextExpr13() (interface{}, error) {
+func (p *parser) callonTextExpr13() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr13(stack["opName"], stack["firstVal"], stack["rest"])
 }
 
-func (c *current) onTextExpr28(opName, multiValueExpr interface{}) (interface{}, error) {
+func (c *current) onTextExpr28(opName, multiValueExpr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18435,13 +18656,13 @@ func (c *current) onTextExpr28(opName, multiValueExpr interface{}) (interface{},
 	return node, nil
 }
 
-func (p *parser) callonTextExpr28() (interface{}, error) {
+func (p *parser) callonTextExpr28() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr28(stack["opName"], stack["multiValueExpr"])
 }
 
-func (c *current) onTextExpr36(opName, multiValueExpr, delim interface{}) (interface{}, error) {
+func (c *current) onTextExpr36(opName, multiValueExpr, delim any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18454,13 +18675,13 @@ func (c *current) onTextExpr36(opName, multiValueExpr, delim interface{}) (inter
 	return node, nil
 }
 
-func (p *parser) callonTextExpr36() (interface{}, error) {
+func (p *parser) callonTextExpr36() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr36(stack["opName"], stack["multiValueExpr"], stack["delim"])
 }
 
-func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern interface{}) (interface{}, error) {
+func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("spl peg: TextExpr: %v", err)
@@ -18484,13 +18705,13 @@ func (c *current) onTextExpr47(opName, multiValueExpr, regexPattern interface{})
 	return node, nil
 }
 
-func (p *parser) callonTextExpr47() (interface{}, error) {
+func (p *parser) callonTextExpr47() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr47(stack["opName"], stack["multiValueExpr"], stack["regexPattern"])
 }
 
-func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam interface{}) (interface{}, error) {
+func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18516,13 +18737,13 @@ func (c *current) onTextExpr58(opName, stringExpr, startIndex, lengthParam inter
 	return node, nil
 }
 
-func (p *parser) callonTextExpr58() (interface{}, error) {
+func (p *parser) callonTextExpr58() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr58(stack["opName"], stack["stringExpr"], stack["startIndex"], stack["lengthParam"])
 }
 
-func (c *current) onTextExpr74(value, format interface{}) (interface{}, error) {
+func (c *current) onTextExpr74(value, format any) (any, error) {
 	var formatExpr *structs.StringExpr
 	if format != nil {
 		formatSlice := format.([]interface{})
@@ -18536,13 +18757,13 @@ func (c *current) onTextExpr74(value, format interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr74() (interface{}, error) {
+func (p *parser) callonTextExpr74() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr74(stack["value"], stack["format"])
 }
 
-func (c *current) onTextExpr86(opName, expr, strToRemoveExpr interface{}) (interface{}, error) {
+func (c *current) onTextExpr86(opName, expr, strToRemoveExpr any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: TextExpr: %v", err)
@@ -18562,13 +18783,13 @@ func (c *current) onTextExpr86(opName, expr, strToRemoveExpr interface{}) (inter
 	return node, nil
 }
 
-func (p *parser) callonTextExpr86() (interface{}, error) {
+func (p *parser) callonTextExpr86() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr86(stack["opName"], stack["expr"], stack["strToRemoveExpr"])
 }
 
-func (c *current) onTextExpr100(mask, ip interface{}) (interface{}, error) {
+func (c *current) onTextExpr100(mask, ip any) (any, error) {
 	return &structs.TextExpr{
 		Op:    "ipmask",
 		Val:   ip.(*structs.ValueExpr),
@@ -18576,13 +18797,13 @@ func (c *current) onTextExpr100(mask, ip interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr100() (interface{}, error) {
+func (p *parser) callonTextExpr100() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr100(stack["mask"], stack["ip"])
 }
 
-func (c *current) onTextExpr110(obj, key, value interface{}) (interface{}, error) {
+func (c *current) onTextExpr110(obj, key, value any) (any, error) {
 	stringExpr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawStringList,
 		StringList:     []string{key.(string), value.(string)},
@@ -18594,13 +18815,13 @@ func (c *current) onTextExpr110(obj, key, value interface{}) (interface{}, error
 	}, nil
 }
 
-func (p *parser) callonTextExpr110() (interface{}, error) {
+func (p *parser) callonTextExpr110() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr110(stack["obj"], stack["key"], stack["value"])
 }
 
-func (c *current) onTextExpr123(format, rest interface{}) (interface{}, error) {
+func (c *current) onTextExpr123(format, rest any) (any, error) {
 	textExpr := &structs.TextExpr{
 		Op:    "printf",
 		Param: format.(*structs.StringExpr),
@@ -18619,13 +18840,13 @@ func (c *current) onTextExpr123(format, rest interface{}) (interface{}, error) {
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr123() (interface{}, error) {
+func (p *parser) callonTextExpr123() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr123(stack["format"], stack["rest"])
 }
 
-func (c *current) onTextExpr135(containInternalFields interface{}) (interface{}, error) {
+func (c *current) onTextExpr135(containInternalFields any) (any, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawString,
 		RawString:      "true", // default value
@@ -18648,13 +18869,13 @@ func (c *current) onTextExpr135(containInternalFields interface{}) (interface{},
 	}, nil
 }
 
-func (p *parser) callonTextExpr135() (interface{}, error) {
+func (p *parser) callonTextExpr135() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr135(stack["containInternalFields"])
 }
 
-func (c *current) onTextExpr147(field, threshold, match, delims interface{}) (interface{}, error) {
+func (c *current) onTextExpr147(field, threshold, match, delims any) (any, error) {
 	textExpr := &structs.TextExpr{
 		Op: "cluster",
 	}
@@ -18695,13 +18916,13 @@ func (c *current) onTextExpr147(field, threshold, match, delims interface{}) (in
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr147() (interface{}, error) {
+func (p *parser) callonTextExpr147() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr147(stack["field"], stack["threshold"], stack["match"], stack["delims"])
 }
 
-func (c *current) onTextExpr175(filter interface{}) (interface{}, error) {
+func (c *current) onTextExpr175(filter any) (any, error) {
 	textExpr := &structs.TextExpr{
 		Op: "getfields",
 	}
@@ -18713,26 +18934,26 @@ func (c *current) onTextExpr175(filter interface{}) (interface{}, error) {
 	return textExpr, nil
 }
 
-func (p *parser) callonTextExpr175() (interface{}, error) {
+func (p *parser) callonTextExpr175() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr175(stack["filter"])
 }
 
-func (c *current) onTextExpr183(valueExpr interface{}) (interface{}, error) {
+func (c *current) onTextExpr183(valueExpr any) (any, error) {
 	return &structs.TextExpr{
 		Op:  "typeof",
 		Val: valueExpr.(*structs.ValueExpr),
 	}, nil
 }
 
-func (p *parser) callonTextExpr183() (interface{}, error) {
+func (p *parser) callonTextExpr183() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr183(stack["valueExpr"])
 }
 
-func (c *current) onTextExpr190(val, regex, replacement interface{}) (interface{}, error) {
+func (c *current) onTextExpr190(val, regex, replacement any) (any, error) {
 	return &structs.TextExpr{
 		Op:        "replace",
 		Val:       val.(*structs.ValueExpr),
@@ -18740,13 +18961,13 @@ func (c *current) onTextExpr190(val, regex, replacement interface{}) (interface{
 	}, nil
 }
 
-func (p *parser) callonTextExpr190() (interface{}, error) {
+func (p *parser) callonTextExpr190() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr190(stack["val"], stack["regex"], stack["replacement"])
 }
 
-func (c *current) onTextExpr203(val, format interface{}) (interface{}, error) {
+func (c *current) onTextExpr203(val, format any) (any, error) {
 	return &structs.TextExpr{
 		Op:    "strftime",
 		Val:   val.(*structs.ValueExpr),
@@ -18754,13 +18975,13 @@ func (c *current) onTextExpr203(val, format interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr203() (interface{}, error) {
+func (p *parser) callonTextExpr203() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr203(stack["val"], stack["format"])
 }
 
-func (c *current) onTextExpr213(val, format interface{}) (interface{}, error) {
+func (c *current) onTextExpr213(val, format any) (any, error) {
 	return &structs.TextExpr{
 		Op:    "strptime",
 		Val:   val.(*structs.ValueExpr),
@@ -18768,69 +18989,69 @@ func (c *current) onTextExpr213(val, format interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonTextExpr213() (interface{}, error) {
+func (p *parser) callonTextExpr213() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTextExpr213(stack["val"], stack["format"])
 }
 
-func (c *current) onQuotedPathString1(str interface{}) (interface{}, error) {
+func (c *current) onQuotedPathString1(str any) (any, error) {
 	return &SPathFieldExpr{
 		PathValue:       removeQuotes(str),
 		IsPathFieldName: false,
 	}, nil
 }
 
-func (p *parser) callonQuotedPathString1() (interface{}, error) {
+func (p *parser) callonQuotedPathString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedPathString1(stack["str"])
 }
 
-func (c *current) onUnquotedPathValue1(str interface{}) (interface{}, error) {
+func (c *current) onUnquotedPathValue1(str any) (any, error) {
 	return &SPathFieldExpr{
 		PathValue:       removeQuotes(str),
 		IsPathFieldName: true,
 	}, nil
 }
 
-func (p *parser) callonUnquotedPathValue1() (interface{}, error) {
+func (p *parser) callonUnquotedPathValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedPathValue1(stack["str"])
 }
 
-func (c *current) onStrToRemoveExpr1(strToRemove interface{}) (interface{}, error) {
+func (c *current) onStrToRemoveExpr1(strToRemove any) (any, error) {
 	return strToRemove, nil
 }
 
-func (p *parser) callonStrToRemoveExpr1() (interface{}, error) {
+func (p *parser) callonStrToRemoveExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStrToRemoveExpr1(stack["strToRemove"])
 }
 
-func (c *current) onEvalFieldToRead2() (interface{}, error) {
+func (c *current) onEvalFieldToRead2() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonEvalFieldToRead2() (interface{}, error) {
+func (p *parser) callonEvalFieldToRead2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalFieldToRead2()
 }
 
-func (c *current) onEvalFieldToRead9(field interface{}) (interface{}, error) {
+func (c *current) onEvalFieldToRead9(field any) (any, error) {
 	return field, nil
 }
 
-func (p *parser) callonEvalFieldToRead9() (interface{}, error) {
+func (p *parser) callonEvalFieldToRead9() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalFieldToRead9(stack["field"])
 }
 
-func (c *current) onWhereBlock1(condition interface{}) (interface{}, error) {
+func (c *current) onWhereBlock1(condition any) (any, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -18842,23 +19063,23 @@ func (c *current) onWhereBlock1(condition interface{}) (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonWhereBlock1() (interface{}, error) {
+func (p *parser) callonWhereBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWhereBlock1(stack["condition"])
 }
 
-func (c *current) onBoolExpr1(expr interface{}) (interface{}, error) {
+func (c *current) onBoolExpr1(expr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonBoolExpr1() (interface{}, error) {
+func (p *parser) callonBoolExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExpr1(stack["expr"])
 }
 
-func (c *current) onBoolExprLevel41(first, rest interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel41(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -18877,13 +19098,13 @@ func (c *current) onBoolExprLevel41(first, rest interface{}) (interface{}, error
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel41() (interface{}, error) {
+func (p *parser) callonBoolExprLevel41() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel41(stack["first"], stack["rest"])
 }
 
-func (c *current) onBoolExprLevel31(first, rest interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel31(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -18902,13 +19123,13 @@ func (c *current) onBoolExprLevel31(first, rest interface{}) (interface{}, error
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel31() (interface{}, error) {
+func (p *parser) callonBoolExprLevel31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onBoolExprLevel22(first interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel22(first any) (any, error) {
 	cur := &structs.BoolExpr{
 		IsTerminal: false,
 		BoolOp:     structs.BoolOpNot,
@@ -18919,43 +19140,43 @@ func (c *current) onBoolExprLevel22(first interface{}) (interface{}, error) {
 	return cur, nil
 }
 
-func (p *parser) callonBoolExprLevel22() (interface{}, error) {
+func (p *parser) callonBoolExprLevel22() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel22(stack["first"])
 }
 
-func (c *current) onBoolExprLevel29(first interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel29(first any) (any, error) {
 	return first, nil
 }
 
-func (p *parser) callonBoolExprLevel29() (interface{}, error) {
+func (p *parser) callonBoolExprLevel29() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel29(stack["first"])
 }
 
-func (c *current) onBoolExprLevel12(first interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel12(first any) (any, error) {
 	return first, nil
 }
 
-func (p *parser) callonBoolExprLevel12() (interface{}, error) {
+func (p *parser) callonBoolExprLevel12() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel12(stack["first"])
 }
 
-func (c *current) onBoolExprLevel18(expr interface{}) (interface{}, error) {
+func (c *current) onBoolExprLevel18(expr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonBoolExprLevel18() (interface{}, error) {
+func (p *parser) callonBoolExprLevel18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolExprLevel18(stack["expr"])
 }
 
-func (c *current) onEvalComparisonExpr2(op, value interface{}) (interface{}, error) {
+func (c *current) onEvalComparisonExpr2(op, value any) (any, error) {
 	opNameStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: BoolExpr: %v", err)
@@ -18986,13 +19207,13 @@ func (c *current) onEvalComparisonExpr2(op, value interface{}) (interface{}, err
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr2() (interface{}, error) {
+func (p *parser) callonEvalComparisonExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr2(stack["op"], stack["value"])
 }
 
-func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue interface{}) (interface{}, error) {
+func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: BoolExpr: %v", err)
@@ -19006,13 +19227,13 @@ func (c *current) onEvalComparisonExpr19(opName, leftValue, rightValue interface
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr19() (interface{}, error) {
+func (p *parser) callonEvalComparisonExpr19() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr19(stack["opName"], stack["leftValue"], stack["rightValue"])
 }
 
-func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest interface{}) (interface{}, error) {
+func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest any) (any, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ValueExpr, 1+len(restSlice))
 	slice[0] = valueToJudge.(*structs.ValueExpr)
@@ -19031,13 +19252,13 @@ func (c *current) onEvalComparisonExpr34(left, valueToJudge, rest interface{}) (
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr34() (interface{}, error) {
+func (p *parser) callonEvalComparisonExpr34() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr34(stack["left"], stack["valueToJudge"], stack["rest"])
 }
 
-func (c *current) onEvalComparisonExpr49(valueToJudge, rest interface{}) (interface{}, error) {
+func (c *current) onEvalComparisonExpr49(valueToJudge, rest any) (any, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ValueExpr, len(restSlice))
 
@@ -19055,13 +19276,13 @@ func (c *current) onEvalComparisonExpr49(valueToJudge, rest interface{}) (interf
 	return expr, nil
 }
 
-func (p *parser) callonEvalComparisonExpr49() (interface{}, error) {
+func (p *parser) callonEvalComparisonExpr49() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEvalComparisonExpr49(stack["valueToJudge"], stack["rest"])
 }
 
-func (c *current) onBoolComparisonExpr1(left, op, right interface{}) (interface{}, error) {
+func (c *current) onBoolComparisonExpr1(left, op, right any) (any, error) {
 	expr := &structs.BoolExpr{
 		IsTerminal: true,
 		LeftValue:  left.(*structs.ValueExpr),
@@ -19072,13 +19293,13 @@ func (c *current) onBoolComparisonExpr1(left, op, right interface{}) (interface{
 	return expr, nil
 }
 
-func (p *parser) callonBoolComparisonExpr1() (interface{}, error) {
+func (p *parser) callonBoolComparisonExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolComparisonExpr1(stack["left"], stack["op"], stack["right"])
 }
 
-func (c *current) onValueExpr2(condition interface{}) (interface{}, error) {
+func (c *current) onValueExpr2(condition any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMConditionExpr,
@@ -19088,13 +19309,13 @@ func (c *current) onValueExpr2(condition interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr2() (interface{}, error) {
+func (p *parser) callonValueExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr2(stack["condition"])
 }
 
-func (c *current) onValueExpr5(condition interface{}) (interface{}, error) {
+func (c *current) onValueExpr5(condition any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMConditionExpr,
@@ -19104,13 +19325,13 @@ func (c *current) onValueExpr5(condition interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr5() (interface{}, error) {
+func (p *parser) callonValueExpr5() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr5(stack["condition"])
 }
 
-func (c *current) onValueExpr11(numeric interface{}) (interface{}, error) {
+func (c *current) onValueExpr11(numeric any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMNumericExpr,
@@ -19120,13 +19341,13 @@ func (c *current) onValueExpr11(numeric interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr11() (interface{}, error) {
+func (p *parser) callonValueExpr11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr11(stack["numeric"])
 }
 
-func (c *current) onValueExpr14(str interface{}) (interface{}, error) {
+func (c *current) onValueExpr14(str any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -19136,13 +19357,13 @@ func (c *current) onValueExpr14(str interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr14() (interface{}, error) {
+func (p *parser) callonValueExpr14() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr14(stack["str"])
 }
 
-func (c *current) onValueExpr17(str interface{}) (interface{}, error) {
+func (c *current) onValueExpr17(str any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMStringExpr,
@@ -19152,13 +19373,13 @@ func (c *current) onValueExpr17(str interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr17() (interface{}, error) {
+func (p *parser) callonValueExpr17() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr17(stack["str"])
 }
 
-func (c *current) onValueExpr23(boolean interface{}) (interface{}, error) {
+func (c *current) onValueExpr23(boolean any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode: structs.VEMBooleanExpr,
@@ -19168,13 +19389,13 @@ func (c *current) onValueExpr23(boolean interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr23() (interface{}, error) {
+func (p *parser) callonValueExpr23() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr23(stack["boolean"])
 }
 
-func (c *current) onValueExpr29(multiValueExpr interface{}) (interface{}, error) {
+func (c *current) onValueExpr29(multiValueExpr any) (any, error) {
 
 	expr := &structs.ValueExpr{
 		ValueExprMode:  structs.VEMMultiValueExpr,
@@ -19184,13 +19405,28 @@ func (c *current) onValueExpr29(multiValueExpr interface{}) (interface{}, error)
 	return expr, nil
 }
 
-func (p *parser) callonValueExpr29() (interface{}, error) {
+func (p *parser) callonValueExpr29() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onValueExpr29(stack["multiValueExpr"])
 }
 
-func (c *current) onStringExpr2(text interface{}) (interface{}, error) {
+func (c *current) onValueExpr32(jsonExpr any) (any, error) {
+	expr := &structs.ValueExpr{
+		ValueExprMode: structs.VEMJsonExpr,
+		JsonExpr:      jsonExpr.(*structs.JsonExpr),
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonValueExpr32() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onValueExpr32(stack["jsonExpr"])
+}
+
+func (c *current) onStringExpr2(text any) (any, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMTextExpr,
 		TextExpr:       text.(*structs.TextExpr),
@@ -19199,13 +19435,13 @@ func (c *current) onStringExpr2(text interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr2() (interface{}, error) {
+func (p *parser) callonStringExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr2(stack["text"])
 }
 
-func (c *current) onStringExpr8(str interface{}) (interface{}, error) {
+func (c *current) onStringExpr8(str any) (any, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMRawString,
 		RawString:      removeQuotes(str),
@@ -19214,13 +19450,13 @@ func (c *current) onStringExpr8(str interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr8() (interface{}, error) {
+func (p *parser) callonStringExpr8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr8(stack["str"])
 }
 
-func (c *current) onStringExpr14(field interface{}) (interface{}, error) {
+func (c *current) onStringExpr14(field any) (any, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMField,
 		FieldName:      field.(string),
@@ -19229,13 +19465,13 @@ func (c *current) onStringExpr14(field interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr14() (interface{}, error) {
+func (p *parser) callonStringExpr14() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr14(stack["field"])
 }
 
-func (c *current) onStringExpr27(concat interface{}) (interface{}, error) {
+func (c *current) onStringExpr27(concat any) (any, error) {
 	expr := &structs.StringExpr{
 		StringExprMode: structs.SEMConcatExpr,
 		ConcatExpr:     concat.(*structs.ConcatExpr),
@@ -19244,13 +19480,13 @@ func (c *current) onStringExpr27(concat interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonStringExpr27() (interface{}, error) {
+func (p *parser) callonStringExpr27() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringExpr27(stack["concat"])
 }
 
-func (c *current) onConcatExpr1(first, rest interface{}) (interface{}, error) {
+func (c *current) onConcatExpr1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	slice := make([]*structs.ConcatAtom, 1+len(restSlice))
 	slice[0] = first.(*structs.ConcatAtom)
@@ -19267,13 +19503,13 @@ func (c *current) onConcatExpr1(first, rest interface{}) (interface{}, error) {
 	return expr, nil
 }
 
-func (p *parser) callonConcatExpr1() (interface{}, error) {
+func (p *parser) callonConcatExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatExpr1(stack["first"], stack["rest"])
 }
 
-func (c *current) onConcatAtom2(text interface{}) (interface{}, error) {
+func (c *current) onConcatAtom2(text any) (any, error) {
 	atom := &structs.ConcatAtom{
 		IsField:  false,
 		Value:    "",
@@ -19283,13 +19519,13 @@ func (c *current) onConcatAtom2(text interface{}) (interface{}, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom2() (interface{}, error) {
+func (p *parser) callonConcatAtom2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom2(stack["text"])
 }
 
-func (c *current) onConcatAtom5(str interface{}) (interface{}, error) {
+func (c *current) onConcatAtom5(str any) (any, error) {
 	atom := &structs.ConcatAtom{
 		IsField: false,
 		Value:   removeQuotes(str),
@@ -19298,13 +19534,13 @@ func (c *current) onConcatAtom5(str interface{}) (interface{}, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom5() (interface{}, error) {
+func (p *parser) callonConcatAtom5() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom5(stack["str"])
 }
 
-func (c *current) onConcatAtom8(number interface{}) (interface{}, error) {
+func (c *current) onConcatAtom8(number any) (any, error) {
 	atom := &structs.ConcatAtom{
 		IsField: false,
 		Value:   number.(string),
@@ -19313,13 +19549,13 @@ func (c *current) onConcatAtom8(number interface{}) (interface{}, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom8() (interface{}, error) {
+func (p *parser) callonConcatAtom8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom8(stack["number"])
 }
 
-func (c *current) onConcatAtom11(field interface{}) (interface{}, error) {
+func (c *current) onConcatAtom11(field any) (any, error) {
 	atom := &structs.ConcatAtom{
 		IsField: true,
 		Value:   field.(string),
@@ -19328,23 +19564,23 @@ func (c *current) onConcatAtom11(field interface{}) (interface{}, error) {
 	return atom, nil
 }
 
-func (p *parser) callonConcatAtom11() (interface{}, error) {
+func (p *parser) callonConcatAtom11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onConcatAtom11(stack["field"])
 }
 
-func (c *current) onNumericExpr1(expr interface{}) (interface{}, error) {
+func (c *current) onNumericExpr1(expr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExpr1() (interface{}, error) {
+func (p *parser) callonNumericExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExpr1(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel31(first, rest interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel31(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -19364,13 +19600,13 @@ func (c *current) onNumericExprLevel31(first, rest interface{}) (interface{}, er
 	return cur, nil
 }
 
-func (p *parser) callonNumericExprLevel31() (interface{}, error) {
+func (p *parser) callonNumericExprLevel31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel31(stack["first"], stack["rest"])
 }
 
-func (c *current) onNumericExprLevel21(first, rest interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel21(first, rest any) (any, error) {
 	if rest == nil {
 		return first, nil
 	}
@@ -19390,13 +19626,13 @@ func (c *current) onNumericExprLevel21(first, rest interface{}) (interface{}, er
 	return cur, nil
 }
 
-func (p *parser) callonNumericExprLevel21() (interface{}, error) {
+func (p *parser) callonNumericExprLevel21() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel21(stack["first"], stack["rest"])
 }
 
-func (c *current) onNumericParamExpr1(expr interface{}) (interface{}, error) {
+func (c *current) onNumericParamExpr1(expr any) (any, error) {
 	rightNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19405,33 +19641,33 @@ func (c *current) onNumericParamExpr1(expr interface{}) (interface{}, error) {
 	return rightNumericExpr, nil
 }
 
-func (p *parser) callonNumericParamExpr1() (interface{}, error) {
+func (p *parser) callonNumericParamExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericParamExpr1(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel12(expr interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel12(expr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel12() (interface{}, error) {
+func (p *parser) callonNumericExprLevel12() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel12(stack["expr"])
 }
 
-func (c *current) onNumericExprLevel18(numericEvalExpr interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel18(numericEvalExpr any) (any, error) {
 	return numericEvalExpr, nil
 }
 
-func (p *parser) callonNumericExprLevel18() (interface{}, error) {
+func (p *parser) callonNumericExprLevel18() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel18(stack["numericEvalExpr"])
 }
 
-func (c *current) onNumericExprLevel111(field interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel111(field any) (any, error) {
 	expr := &structs.NumericExpr{
 		IsTerminal:      true,
 		ValueIsField:    true,
@@ -19442,13 +19678,13 @@ func (c *current) onNumericExprLevel111(field interface{}) (interface{}, error) 
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel111() (interface{}, error) {
+func (p *parser) callonNumericExprLevel111() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel111(stack["field"])
 }
 
-func (c *current) onNumericExprLevel114(number interface{}) (interface{}, error) {
+func (c *current) onNumericExprLevel114(number any) (any, error) {
 	expr := &structs.NumericExpr{
 		IsTerminal:      true,
 		ValueIsField:    false,
@@ -19459,13 +19695,13 @@ func (c *current) onNumericExprLevel114(number interface{}) (interface{}, error)
 	return expr, nil
 }
 
-func (p *parser) callonNumericExprLevel114() (interface{}, error) {
+func (p *parser) callonNumericExprLevel114() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericExprLevel114(stack["number"])
 }
 
-func (c *current) onNumericEvalExpr2(opName, expr interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr2(opName, expr any) (any, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19486,13 +19722,13 @@ func (c *current) onNumericEvalExpr2(opName, expr interface{}) (interface{}, err
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr2() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr2(stack["opName"], stack["expr"])
 }
 
-func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision any) (any, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19514,13 +19750,13 @@ func (c *current) onNumericEvalExpr31(roundExpr, expr, roundPrecision interface{
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr31() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr31(stack["roundExpr"], stack["expr"], stack["roundPrecision"])
 }
 
-func (c *current) onNumericEvalExpr42(opName interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr42(opName any) (any, error) {
 	//transfer []uint8 to string
 	strData, ok := opName.([]byte)
 	if !ok {
@@ -19534,13 +19770,13 @@ func (c *current) onNumericEvalExpr42(opName interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonNumericEvalExpr42() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr42() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr42(stack["opName"])
 }
 
-func (c *current) onNumericEvalExpr52(stringExpr, baseExpr interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr52(stringExpr, baseExpr any) (any, error) {
 	stringExprConverted, ok := stringExpr.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert stringExpr as *structs.StringExpr")
@@ -19569,13 +19805,13 @@ func (c *current) onNumericEvalExpr52(stringExpr, baseExpr interface{}) (interfa
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr52() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr52() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr52(stack["stringExpr"], stack["baseExpr"])
 }
 
-func (c *current) onNumericEvalExpr64(opName, firstArg, secondArg, rest interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr64(opName, firstArg, secondArg, rest any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: error in converting opName to str; err: %v", err)
@@ -19584,11 +19820,11 @@ func (c *current) onNumericEvalExpr64(opName, firstArg, secondArg, rest interfac
 	var ok bool
 	args[0], ok = firstArg.(*structs.NumericExpr)
 	if !ok {
-		return nil, fmt.Errorf("Failed to assert exprr as *structs.NumericExpr")
+		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
 	}
 	args[1], ok = secondArg.(*structs.NumericExpr)
 	if !ok {
-		return nil, fmt.Errorf("Failed to assert exprr as *structs.NumericExpr")
+		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
 	}
 
 	if rest != nil {
@@ -19597,10 +19833,6 @@ func (c *current) onNumericEvalExpr64(opName, firstArg, secondArg, rest interfac
 			argExpr := arg.([]any)[1].(*structs.NumericExpr)
 			args = append(args, argExpr)
 		}
-	}
-
-	if len(args) == 1 {
-		return args[0], nil
 	}
 
 	// build the ast tree
@@ -19616,13 +19848,13 @@ func (c *current) onNumericEvalExpr64(opName, firstArg, secondArg, rest interfac
 	return result, nil
 }
 
-func (p *parser) callonNumericEvalExpr64() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr64() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr64(stack["opName"], stack["firstArg"], stack["secondArg"], stack["rest"])
 }
 
-func (c *current) onNumericEvalExpr83(opName, expr, param interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr83(opName, expr, param any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: error in converting opName to str; err: %v", err)
@@ -19650,23 +19882,23 @@ func (c *current) onNumericEvalExpr83(opName, expr, param interface{}) (interfac
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr83() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr83() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr83(stack["opName"], stack["expr"], stack["param"])
 }
 
-func (c *current) onNumericEvalExpr99(lenExpr, expr interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr99(lenExpr, expr any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonNumericEvalExpr99() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr99() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr99(stack["lenExpr"], stack["expr"])
 }
 
-func (c *current) onNumericEvalExpr107(opName, expr, param interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr107(opName, expr, param any) (any, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19697,13 +19929,13 @@ func (c *current) onNumericEvalExpr107(opName, expr, param interface{}) (interfa
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr107() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr107() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr107(stack["opName"], stack["expr"], stack["param"])
 }
 
-func (c *current) onNumericEvalExpr120(opName, expr, param interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr120(opName, expr, param any) (any, error) {
 	leftNumericExpr, ok := expr.(*structs.NumericExpr)
 	if !ok {
 		return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
@@ -19733,13 +19965,13 @@ func (c *current) onNumericEvalExpr120(opName, expr, param interface{}) (interfa
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr120() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr120() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr120(stack["opName"], stack["expr"], stack["param"])
 }
 
-func (c *current) onNumericEvalExpr131(opName, expr, specifier interface{}) (interface{}, error) {
+func (c *current) onNumericEvalExpr131(opName, expr, specifier any) (any, error) {
 	opNameStr, err := transferUint8ToString(opName)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: NumericExpr: %v", err)
@@ -19756,13 +19988,246 @@ func (c *current) onNumericEvalExpr131(opName, expr, specifier interface{}) (int
 	return node, nil
 }
 
-func (p *parser) callonNumericEvalExpr131() (interface{}, error) {
+func (p *parser) callonNumericEvalExpr131() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumericEvalExpr131(stack["opName"], stack["expr"], stack["specifier"])
 }
 
-func (c *current) onLenExpr2(str interface{}) (interface{}, error) {
+func (c *current) onJsonExprLevel12(jsonExpr any) (any, error) {
+	return jsonExpr, nil
+}
+
+func (p *parser) callonJsonExprLevel12() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel12(stack["jsonExpr"])
+}
+
+func (c *current) onJsonExprLevel15(field any) (any, error) {
+	fieldStr, ok := field.(string)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: unable to assert EvalFieldToRead as string")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMField,
+		IsTerminal:   true,
+		ValueIsField: true,
+		FieldValue:   fieldStr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel15() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel15(stack["field"])
+}
+
+func (c *current) onJsonExprLevel18(value any) (any, error) {
+	numExpr, ok := value.(*structs.NumericExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMNumber,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputNumber:  numExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel18() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel18(stack["value"])
+}
+
+func (c *current) onJsonExprLevel111(value any) (any, error) {
+	numExpr, ok := value.(*structs.NumericExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMNumber,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputNumber:  numExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel111() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel111(stack["value"])
+}
+
+func (c *current) onJsonExprLevel114(value any) (any, error) {
+	multiExpr, ok := value.(*structs.MultiValueExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.MultiValueExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode:  structs.JEMMultiVal,
+		IsTerminal:    true,
+		ValueIsField:  false,
+		InputMultiVal: multiExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel114() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel114(stack["value"])
+}
+
+func (c *current) onJsonExprLevel117(value any) (any, error) {
+	boolExpr, ok := value.(*structs.BoolExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.BoolExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMBoolean,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputBoolean: boolExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel117() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel117(stack["value"])
+}
+
+func (c *current) onJsonExprLevel120(value any) (any, error) {
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMNull,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputIsNull:  true,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel120() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel120(stack["value"])
+}
+
+func (c *current) onJsonExprLevel126(value any) (any, error) {
+	stringExpr, ok := value.(*structs.StringExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert string as *structs.StringExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMString,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputString:  stringExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel126() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel126(stack["value"])
+}
+
+func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
+	isValidJsonObjectKey := func(key *structs.JsonExpr) error {
+		// key can only be a string => either a field or a StringExpr
+		// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
+		if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+			return fmt.Errorf("spl peg: key in json_object can only be a string")
+		}
+		return nil
+	}
+
+	astDs := make([]*structs.JsonExpr, 1, 5)
+
+	key, ok := firstKey.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the first argument of the function")
+	}
+
+	err := isValidJsonObjectKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	var value *structs.JsonExpr
+	value, ok = firstValue.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
+	}
+
+	astDs[0] = &structs.JsonExpr{
+		JsonExprMode: structs.JEMKeyVal,
+		Key:          key,
+		Value:        value,
+	}
+
+	var restKey *structs.JsonExpr
+	var restValue *structs.JsonExpr
+	if rest != nil {
+		for idx, arg := range rest.([]any) {
+			// Each item in rest is [",", Key, ",", Value]
+			restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
+			}
+
+			err := isValidJsonObjectKey(key)
+			if err != nil {
+				return nil, err
+			}
+
+			restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+			}
+			astDs = append(astDs, &structs.JsonExpr{
+				JsonExprMode: structs.JEMKeyVal,
+				Key:          restKey,
+				Value:        restValue,
+			})
+		}
+	}
+
+	// build ast tree
+	result := astDs[0]
+	for i := 1; i < len(astDs); i++ {
+		var err error
+		result, err = createJsonExprAst("json_object", result, astDs[i], structs.JEMExpr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr1() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr1(stack["firstKey"], stack["firstValue"], stack["rest"])
+}
+
+func (c *current) onLenExpr2(str any) (any, error) {
 
 	leftNumericExpr := &structs.NumericExpr{
 		IsTerminal:      true,
@@ -19779,13 +20244,13 @@ func (c *current) onLenExpr2(str interface{}) (interface{}, error) {
 	return node, nil
 }
 
-func (p *parser) callonLenExpr2() (interface{}, error) {
+func (p *parser) callonLenExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLenExpr2(stack["str"])
 }
 
-func (c *current) onLenExpr8(field interface{}) (interface{}, error) {
+func (c *current) onLenExpr8(field any) (any, error) {
 
 	leftNumericExpr := &structs.NumericExpr{
 		IsTerminal:      true,
@@ -19802,13 +20267,13 @@ func (c *current) onLenExpr8(field interface{}) (interface{}, error) {
 	return node, nil
 }
 
-func (p *parser) callonLenExpr8() (interface{}, error) {
+func (p *parser) callonLenExpr8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onLenExpr8(stack["field"])
 }
 
-func (c *current) onHeadOptionNull1(boolVal interface{}) (interface{}, error) {
+func (c *current) onHeadOptionNull1(boolVal any) (any, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "null",
 		headExpr: &structs.HeadExpr{
@@ -19819,13 +20284,13 @@ func (c *current) onHeadOptionNull1(boolVal interface{}) (interface{}, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionNull1() (interface{}, error) {
+func (p *parser) callonHeadOptionNull1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionNull1(stack["boolVal"])
 }
 
-func (c *current) onHeadOptionKeeplast1(boolVal interface{}) (interface{}, error) {
+func (c *current) onHeadOptionKeeplast1(boolVal any) (any, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "keeplast",
 		headExpr: &structs.HeadExpr{
@@ -19836,13 +20301,13 @@ func (c *current) onHeadOptionKeeplast1(boolVal interface{}) (interface{}, error
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionKeeplast1() (interface{}, error) {
+func (p *parser) callonHeadOptionKeeplast1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionKeeplast1(stack["boolVal"])
 }
 
-func (c *current) onHeadOptionLimit1(intAsStr interface{}) (interface{}, error) {
+func (c *current) onHeadOptionLimit1(intAsStr any) (any, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -19857,13 +20322,13 @@ func (c *current) onHeadOptionLimit1(intAsStr interface{}) (interface{}, error) 
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionLimit1() (interface{}, error) {
+func (p *parser) callonHeadOptionLimit1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionLimit1(stack["intAsStr"])
 }
 
-func (c *current) onHeadOptionExpr1(boolExpr interface{}) (interface{}, error) {
+func (c *current) onHeadOptionExpr1(boolExpr any) (any, error) {
 	optionArg := &HeadOptionArgs{
 		argOption: "boolexpr",
 		headExpr: &structs.HeadExpr{
@@ -19874,23 +20339,23 @@ func (c *current) onHeadOptionExpr1(boolExpr interface{}) (interface{}, error) {
 	return optionArg, nil
 }
 
-func (p *parser) callonHeadOptionExpr1() (interface{}, error) {
+func (p *parser) callonHeadOptionExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionExpr1(stack["boolExpr"])
 }
 
-func (c *current) onHeadOption1(option interface{}) (interface{}, error) {
+func (c *current) onHeadOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonHeadOption1() (interface{}, error) {
+func (p *parser) callonHeadOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOption1(stack["option"])
 }
 
-func (c *current) onHeadOptionList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onHeadOptionList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 
@@ -19945,13 +20410,13 @@ func (c *current) onHeadOptionList1(first, rest interface{}) (interface{}, error
 	return headExpr, nil
 }
 
-func (p *parser) callonHeadOptionList1() (interface{}, error) {
+func (p *parser) callonHeadOptionList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onHeadBlock2(headExpr interface{}) (interface{}, error) {
+func (c *current) onHeadBlock2(headExpr any) (any, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType: structs.OutputTransformType,
 		OutputTransforms: &structs.OutputTransforms{
@@ -19963,13 +20428,13 @@ func (c *current) onHeadBlock2(headExpr interface{}) (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock2() (interface{}, error) {
+func (p *parser) callonHeadBlock2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock2(stack["headExpr"])
 }
 
-func (c *current) onHeadBlock8(intAsStr interface{}) (interface{}, error) {
+func (c *current) onHeadBlock8(intAsStr any) (any, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -19990,13 +20455,13 @@ func (c *current) onHeadBlock8(intAsStr interface{}) (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock8() (interface{}, error) {
+func (p *parser) callonHeadBlock8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock8(stack["intAsStr"])
 }
 
-func (c *current) onHeadBlock14() (interface{}, error) {
+func (c *current) onHeadBlock14() (any, error) {
 
 	headExpr := &structs.HeadExpr{
 		MaxRows: uint64(10), // From https://docs.splunk.com/Documentation/Splunk/9.1.0/SearchReference/Head
@@ -20013,13 +20478,13 @@ func (c *current) onHeadBlock14() (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonHeadBlock14() (interface{}, error) {
+func (p *parser) callonHeadBlock14() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHeadBlock14()
 }
 
-func (c *current) onTailBlock2(intAsStr interface{}) (interface{}, error) {
+func (c *current) onTailBlock2(intAsStr any) (any, error) {
 	limit, err := strconv.ParseUint(intAsStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid limit (%v): %v", intAsStr.(string), err)
@@ -20041,13 +20506,13 @@ func (c *current) onTailBlock2(intAsStr interface{}) (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonTailBlock2() (interface{}, error) {
+func (p *parser) callonTailBlock2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTailBlock2(stack["intAsStr"])
 }
 
-func (c *current) onTailBlock8() (interface{}, error) {
+func (c *current) onTailBlock8() (any, error) {
 
 	tExpr := &structs.TailExpr{
 		TailRecords: make(map[string]map[string]interface{}, 0),
@@ -20065,13 +20530,13 @@ func (c *current) onTailBlock8() (interface{}, error) {
 	return queryAgg, nil
 }
 
-func (p *parser) callonTailBlock8() (interface{}, error) {
+func (p *parser) callonTailBlock8() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTailBlock8()
 }
 
-func (c *current) onAggregationList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onAggregationList1(first, rest any) (any, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is ", " and the second is an Aggregator.
 	restSlice := rest.([]any)
@@ -20088,13 +20553,13 @@ func (c *current) onAggregationList1(first, rest interface{}) (interface{}, erro
 	return aggsSlice, nil
 }
 
-func (p *parser) callonAggregationList1() (interface{}, error) {
+func (p *parser) callonAggregationList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregationList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onAggregator1(aggFunc, asField interface{}) (interface{}, error) {
+func (c *current) onAggregator1(aggFunc, asField any) (any, error) {
 	agg := &aggregator{}
 	agg.measureAgg = aggFunc.(*structs.MeasureAggregator)
 
@@ -20106,43 +20571,43 @@ func (c *current) onAggregator1(aggFunc, asField interface{}) (interface{}, erro
 	return agg, nil
 }
 
-func (p *parser) callonAggregator1() (interface{}, error) {
+func (p *parser) callonAggregator1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggregator1(stack["aggFunc"], stack["asField"])
 }
 
-func (c *current) onAggFunction1(agg interface{}) (interface{}, error) {
+func (c *current) onAggFunction1(agg any) (any, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggFunction1() (interface{}, error) {
+func (p *parser) callonAggFunction1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggFunction1(stack["agg"])
 }
 
-func (c *current) onCommonAggName1() (interface{}, error) {
+func (c *current) onCommonAggName1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonCommonAggName1() (interface{}, error) {
+func (p *parser) callonCommonAggName1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonAggName1()
 }
 
-func (c *current) onCommonPercAggName1() (interface{}, error) {
+func (c *current) onCommonPercAggName1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonCommonPercAggName1() (interface{}, error) {
+func (p *parser) callonCommonPercAggName1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCommonPercAggName1()
 }
 
-func (c *current) onAsField1(field interface{}) (interface{}, error) {
+func (c *current) onAsField1(field any) (any, error) {
 	fieldStr := field.(string)
 
 	if strings.Contains(fieldStr, "*") {
@@ -20156,13 +20621,13 @@ func (c *current) onAsField1(field interface{}) (interface{}, error) {
 	return fieldStr, nil
 }
 
-func (p *parser) callonAsField1() (interface{}, error) {
+func (p *parser) callonAsField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAsField1(stack["field"])
 }
 
-func (c *current) onAggCount2(valueExpr interface{}) (interface{}, error) {
+func (c *current) onAggCount2(valueExpr any) (any, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:      "",
 		MeasureFunc:     sutils.Count,
@@ -20173,13 +20638,13 @@ func (c *current) onAggCount2(valueExpr interface{}) (interface{}, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount2() (interface{}, error) {
+func (p *parser) callonAggCount2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount2(stack["valueExpr"])
 }
 
-func (c *current) onAggCount12(field interface{}) (interface{}, error) {
+func (c *current) onAggCount12(field any) (any, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:  field.(string),
 		MeasureFunc: sutils.Count,
@@ -20188,13 +20653,13 @@ func (c *current) onAggCount12(field interface{}) (interface{}, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount12() (interface{}, error) {
+func (p *parser) callonAggCount12() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount12(stack["field"])
 }
 
-func (c *current) onAggCount21() (interface{}, error) {
+func (c *current) onAggCount21() (any, error) {
 	agg := &structs.MeasureAggregator{
 		MeasureCol:  "*",
 		MeasureFunc: sutils.Count,
@@ -20203,13 +20668,13 @@ func (c *current) onAggCount21() (interface{}, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggCount21() (interface{}, error) {
+func (p *parser) callonAggCount21() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCount21()
 }
 
-func (c *current) onAggCommon2(aggName, valueExpr interface{}) (interface{}, error) {
+func (c *current) onAggCommon2(aggName, valueExpr any) (any, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20225,13 +20690,13 @@ func (c *current) onAggCommon2(aggName, valueExpr interface{}) (interface{}, err
 	return agg, nil
 }
 
-func (p *parser) callonAggCommon2() (interface{}, error) {
+func (p *parser) callonAggCommon2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCommon2(stack["aggName"], stack["valueExpr"])
 }
 
-func (c *current) onAggCommon11(aggName, field interface{}) (interface{}, error) {
+func (c *current) onAggCommon11(aggName, field any) (any, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20261,13 +20726,13 @@ func (c *current) onAggCommon11(aggName, field interface{}) (interface{}, error)
 	return agg, nil
 }
 
-func (p *parser) callonAggCommon11() (interface{}, error) {
+func (p *parser) callonAggCommon11() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggCommon11(stack["aggName"], stack["field"])
 }
 
-func (c *current) onPercentileVal1(numStr interface{}) (interface{}, error) {
+func (c *current) onPercentileVal1(numStr any) (any, error) {
 	floatVal, err := strconv.ParseFloat(numStr.(string), 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid percentage value: %v", numStr.(string))
@@ -20279,13 +20744,13 @@ func (c *current) onPercentileVal1(numStr interface{}) (interface{}, error) {
 	return floatVal, nil
 }
 
-func (p *parser) callonPercentileVal1() (interface{}, error) {
+func (p *parser) callonPercentileVal1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPercentileVal1(stack["numStr"])
 }
 
-func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr interface{}) (interface{}, error) {
+func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr any) (any, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20302,13 +20767,13 @@ func (c *current) onAggPercCommon2(aggName, percentileVal, valueExpr interface{}
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon2() (interface{}, error) {
+func (p *parser) callonAggPercCommon2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon2(stack["aggName"], stack["percentileVal"], stack["valueExpr"])
 }
 
-func (c *current) onAggPercCommon13(aggName, percentileVal, field interface{}) (interface{}, error) {
+func (c *current) onAggPercCommon13(aggName, percentileVal, field any) (any, error) {
 	measureFunc := GetAggregateFunction(aggName.(string))
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20324,13 +20789,13 @@ func (c *current) onAggPercCommon13(aggName, percentileVal, field interface{}) (
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon13() (interface{}, error) {
+func (p *parser) callonAggPercCommon13() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon13(stack["aggName"], stack["percentileVal"], stack["field"])
 }
 
-func (c *current) onAggPercCommon23(field interface{}) (interface{}, error) {
+func (c *current) onAggPercCommon23(field any) (any, error) {
 	measureFunc := GetAggregateFunction("median")
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20346,13 +20811,13 @@ func (c *current) onAggPercCommon23(field interface{}) (interface{}, error) {
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon23() (interface{}, error) {
+func (p *parser) callonAggPercCommon23() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon23(stack["field"])
 }
 
-func (c *current) onAggPercCommon30(valueExpr interface{}) (interface{}, error) {
+func (c *current) onAggPercCommon30(valueExpr any) (any, error) {
 	measureFunc := GetAggregateFunction("median")
 	if measureFunc == sutils.Invalid {
 		return nil, fmt.Errorf("Invalid measure function: %v", string(c.text))
@@ -20369,23 +20834,23 @@ func (c *current) onAggPercCommon30(valueExpr interface{}) (interface{}, error) 
 	return agg, nil
 }
 
-func (p *parser) callonAggPercCommon30() (interface{}, error) {
+func (p *parser) callonAggPercCommon30() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAggPercCommon30(stack["valueExpr"])
 }
 
-func (c *current) onFieldWithNumberValue1(keyValuePair interface{}) (interface{}, error) {
+func (c *current) onFieldWithNumberValue1(keyValuePair any) (any, error) {
 	return keyValuePair, nil
 }
 
-func (p *parser) callonFieldWithNumberValue1() (interface{}, error) {
+func (p *parser) callonFieldWithNumberValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithNumberValue1(stack["keyValuePair"])
 }
 
-func (c *current) onNamedFieldWithNumberValue1(key, op, value interface{}) (interface{}, error) {
+func (c *current) onNamedFieldWithNumberValue1(key, op, value any) (any, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20398,13 +20863,13 @@ func (c *current) onNamedFieldWithNumberValue1(key, op, value interface{}) (inte
 	return node, nil
 }
 
-func (p *parser) callonNamedFieldWithNumberValue1() (interface{}, error) {
+func (p *parser) callonNamedFieldWithNumberValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNamedFieldWithNumberValue1(stack["key"], stack["op"], stack["value"])
 }
 
-func (c *current) onUnnamedFieldWithNumberValue1(value interface{}) (interface{}, error) {
+func (c *current) onUnnamedFieldWithNumberValue1(value any) (any, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20417,13 +20882,13 @@ func (c *current) onUnnamedFieldWithNumberValue1(value interface{}) (interface{}
 	return node, nil
 }
 
-func (p *parser) callonUnnamedFieldWithNumberValue1() (interface{}, error) {
+func (p *parser) callonUnnamedFieldWithNumberValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnnamedFieldWithNumberValue1(stack["value"])
 }
 
-func (c *current) onFieldWithBooleanValue1(key, op, value interface{}) (interface{}, error) {
+func (c *current) onFieldWithBooleanValue1(key, op, value any) (any, error) {
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
 		Comparison: ast.Comparison{
@@ -20436,23 +20901,23 @@ func (c *current) onFieldWithBooleanValue1(key, op, value interface{}) (interfac
 	return node, nil
 }
 
-func (p *parser) callonFieldWithBooleanValue1() (interface{}, error) {
+func (p *parser) callonFieldWithBooleanValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithBooleanValue1(stack["key"], stack["op"], stack["value"])
 }
 
-func (c *current) onFieldWithStringValue1(keyValuePair interface{}) (interface{}, error) {
+func (c *current) onFieldWithStringValue1(keyValuePair any) (any, error) {
 	return keyValuePair, nil
 }
 
-func (p *parser) callonFieldWithStringValue1() (interface{}, error) {
+func (p *parser) callonFieldWithStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldWithStringValue1(stack["keyValuePair"])
 }
 
-func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq interface{}) (interface{}, error) {
+func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq any) (any, error) {
 	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
@@ -20468,13 +20933,13 @@ func (c *current) onNamedFieldWithStringValue1(key, op, stringSearchReq interfac
 	return node, nil
 }
 
-func (p *parser) callonNamedFieldWithStringValue1() (interface{}, error) {
+func (p *parser) callonNamedFieldWithStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNamedFieldWithStringValue1(stack["key"], stack["op"], stack["stringSearchReq"])
 }
 
-func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq interface{}) (interface{}, error) {
+func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq any) (any, error) {
 	ssr := stringSearchReq.(*StringSearchRequest)
 	node := &ast.Node{
 		NodeType: ast.NodeTerminal,
@@ -20490,13 +20955,13 @@ func (c *current) onUnnamedFieldWithStringValue1(stringSearchReq interface{}) (i
 	return node, nil
 }
 
-func (p *parser) callonUnnamedFieldWithStringValue1() (interface{}, error) {
+func (p *parser) callonUnnamedFieldWithStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnnamedFieldWithStringValue1(stack["stringSearchReq"])
 }
 
-func (c *current) onCaseSensitiveString1(value interface{}) (interface{}, error) {
+func (c *current) onCaseSensitiveString1(value any) (any, error) {
 	return &StringSearchRequest{
 		value:           value,
 		originalValue:   value,
@@ -20504,13 +20969,13 @@ func (c *current) onCaseSensitiveString1(value interface{}) (interface{}, error)
 	}, nil
 }
 
-func (p *parser) callonCaseSensitiveString1() (interface{}, error) {
+func (p *parser) callonCaseSensitiveString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseSensitiveString1(stack["value"])
 }
 
-func (c *current) onCaseInsensitiveString2(value interface{}) (interface{}, error) {
+func (c *current) onCaseInsensitiveString2(value any) (any, error) {
 	return &StringSearchRequest{
 		value:           strings.ToLower(value.(string)),
 		originalValue:   value,
@@ -20519,13 +20984,13 @@ func (c *current) onCaseInsensitiveString2(value interface{}) (interface{}, erro
 	}, nil
 }
 
-func (p *parser) callonCaseInsensitiveString2() (interface{}, error) {
+func (p *parser) callonCaseInsensitiveString2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseInsensitiveString2(stack["value"])
 }
 
-func (c *current) onCaseInsensitiveString9(value interface{}) (interface{}, error) {
+func (c *current) onCaseInsensitiveString9(value any) (any, error) {
 	return &StringSearchRequest{
 		value:           strings.ToLower(value.(string)),
 		originalValue:   value,
@@ -20533,13 +20998,13 @@ func (c *current) onCaseInsensitiveString9(value interface{}) (interface{}, erro
 	}, nil
 }
 
-func (p *parser) callonCaseInsensitiveString9() (interface{}, error) {
+func (p *parser) callonCaseInsensitiveString9() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCaseInsensitiveString9(stack["value"])
 }
 
-func (c *current) onFieldNameList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onFieldNameList1(first, rest any) (any, error) {
 	// Convert `rest` to a slice. Each element of the slice will be a 2-element
 	// slice where the first element is ", " and the second is a FieldName.
 	restSlice := rest.([]any)
@@ -20556,13 +21021,13 @@ func (c *current) onFieldNameList1(first, rest interface{}) (interface{}, error)
 	return fields, nil
 }
 
-func (p *parser) callonFieldNameList1() (interface{}, error) {
+func (p *parser) callonFieldNameList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldNameList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onEarliestAndLatest1(earliestTime, latestTime interface{}) (interface{}, error) {
+func (c *current) onEarliestAndLatest1(earliestTime, latestTime any) (any, error) {
 	var startEpoch int64 = 0
 	var endEpoch int64 = 0
 	var err error
@@ -20603,13 +21068,13 @@ func (c *current) onEarliestAndLatest1(earliestTime, latestTime interface{}) (in
 	return node, nil
 }
 
-func (p *parser) callonEarliestAndLatest1() (interface{}, error) {
+func (p *parser) callonEarliestAndLatest1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEarliestAndLatest1(stack["earliestTime"], stack["latestTime"])
 }
 
-func (c *current) onEarliestOnly1(earliestTime interface{}) (interface{}, error) {
+func (c *current) onEarliestOnly1(earliestTime any) (any, error) {
 	var startEpoch int64 = 0
 	var err error
 
@@ -20637,56 +21102,56 @@ func (c *current) onEarliestOnly1(earliestTime interface{}) (interface{}, error)
 	return node, nil
 }
 
-func (p *parser) callonEarliestOnly1() (interface{}, error) {
+func (p *parser) callonEarliestOnly1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEarliestOnly1(stack["earliestTime"])
 }
 
-func (c *current) onRelIntegerAsString1() (interface{}, error) {
+func (c *current) onRelIntegerAsString1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonRelIntegerAsString1() (interface{}, error) {
+func (p *parser) callonRelIntegerAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelIntegerAsString1()
 }
 
-func (c *current) onWeekSnap1() (interface{}, error) {
+func (c *current) onWeekSnap1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonWeekSnap1() (interface{}, error) {
+func (p *parser) callonWeekSnap1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWeekSnap1()
 }
 
-func (c *current) onRelTimeUnit1(timeUnit interface{}) (interface{}, error) {
+func (c *current) onRelTimeUnit1(timeUnit any) (any, error) {
 	if sutils.IsSubseconds(timeUnit.(sutils.TimeUnit)) {
 		return nil, fmt.Errorf("Relative Time Format does not support subseconds")
 	}
 	return strconv.Itoa(int(timeUnit.(sutils.TimeUnit))), nil
 }
 
-func (p *parser) callonRelTimeUnit1() (interface{}, error) {
+func (p *parser) callonRelTimeUnit1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelTimeUnit1(stack["timeUnit"])
 }
 
-func (c *current) onSnap1(snap interface{}) (interface{}, error) {
+func (c *current) onSnap1(snap any) (any, error) {
 	return snap.(string), nil
 }
 
-func (p *parser) callonSnap1() (interface{}, error) {
+func (p *parser) callonSnap1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSnap1(stack["snap"])
 }
 
-func (c *current) onOffset1(off, tuOff interface{}) (interface{}, error) {
+func (c *current) onOffset1(off, tuOff any) (any, error) {
 	var offsetNum int64 = 0
 	var err error
 	offStr := off.(string)
@@ -20714,13 +21179,13 @@ func (c *current) onOffset1(off, tuOff interface{}) (interface{}, error) {
 	return relTimeOffset, nil
 }
 
-func (p *parser) callonOffset1() (interface{}, error) {
+func (p *parser) callonOffset1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOffset1(stack["off"], stack["tuOff"])
 }
 
-func (c *current) onChainedRelativeTimestamp1(first, rest interface{}) (interface{}, error) {
+func (c *current) onChainedRelativeTimestamp1(first, rest any) (any, error) {
 	var offsets []ast.RelativeTimeOffset
 	var snaps []string
 
@@ -20767,13 +21232,13 @@ func (c *current) onChainedRelativeTimestamp1(first, rest interface{}) (interfac
 	return timeModifier, nil
 }
 
-func (p *parser) callonChainedRelativeTimestamp1() (interface{}, error) {
+func (p *parser) callonChainedRelativeTimestamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onChainedRelativeTimestamp1(stack["first"], stack["rest"])
 }
 
-func (c *current) onRelativeTimestamp1(defaultTime, chained interface{}) (interface{}, error) {
+func (c *current) onRelativeTimestamp1(defaultTime, chained any) (any, error) {
 
 	if defaultTime != nil {
 		if chained != nil {
@@ -20798,13 +21263,13 @@ func (c *current) onRelativeTimestamp1(defaultTime, chained interface{}) (interf
 	return chained, nil
 }
 
-func (p *parser) callonRelativeTimestamp1() (interface{}, error) {
+func (p *parser) callonRelativeTimestamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelativeTimestamp1(stack["defaultTime"], stack["chained"])
 }
 
-func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam interface{}) (interface{}, error) {
+func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam any) (any, error) {
 
 	if offset == nil && snapParam == nil {
 		return nil, fmt.Errorf("Invalid Relative Time Format: Need either offset or snap param")
@@ -20830,180 +21295,180 @@ func (c *current) onRelativeTimeCommandTimestampFormat1(offset, snapParam interf
 	return timeModifier, nil
 }
 
-func (p *parser) callonRelativeTimeCommandTimestampFormat1() (interface{}, error) {
+func (p *parser) callonRelativeTimeCommandTimestampFormat1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRelativeTimeCommandTimestampFormat1(stack["offset"], stack["snapParam"])
 }
 
-func (c *current) onFullTimeStamp1() (interface{}, error) {
+func (c *current) onFullTimeStamp1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFullTimeStamp1() (interface{}, error) {
+func (p *parser) callonFullTimeStamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFullTimeStamp1()
 }
 
-func (c *current) onAbsoluteTimestamp1(timestamp interface{}) (interface{}, error) {
+func (c *current) onAbsoluteTimestamp1(timestamp any) (any, error) {
 	relTimeModifier := ast.TimeModifier{
 		AbsoluteTime: timestamp.(string),
 	}
 	return relTimeModifier, nil
 }
 
-func (p *parser) callonAbsoluteTimestamp1() (interface{}, error) {
+func (p *parser) callonAbsoluteTimestamp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAbsoluteTimestamp1(stack["timestamp"])
 }
 
-func (c *current) onFieldName2() (interface{}, error) {
+func (c *current) onFieldName2() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFieldName2() (interface{}, error) {
+func (p *parser) callonFieldName2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldName2()
 }
 
-func (c *current) onFieldName7() (interface{}, error) {
+func (c *current) onFieldName7() (any, error) {
 	return removeQuotes(string(c.text)), nil
 }
 
-func (p *parser) callonFieldName7() (interface{}, error) {
+func (p *parser) callonFieldName7() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldName7()
 }
 
-func (c *current) onFieldNameStartWith_1() (interface{}, error) {
+func (c *current) onFieldNameStartWith_1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFieldNameStartWith_1() (interface{}, error) {
+func (p *parser) callonFieldNameStartWith_1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFieldNameStartWith_1()
 }
 
-func (c *current) onString1(str interface{}) (interface{}, error) {
+func (c *current) onString1(str any) (any, error) {
 	return str, nil
 }
 
-func (p *parser) callonString1() (interface{}, error) {
+func (p *parser) callonString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onString1(stack["str"])
 }
 
-func (c *current) onQuotedString1() (interface{}, error) {
+func (c *current) onQuotedString1() (any, error) {
 	// The returned string has quotes as the first and last character.
 	return string(c.text), nil
 }
 
-func (p *parser) callonQuotedString1() (interface{}, error) {
+func (p *parser) callonQuotedString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedString1()
 }
 
-func (c *current) onUnquotedString1() (interface{}, error) {
+func (c *current) onUnquotedString1() (any, error) {
 	// Return the string wrapped in quotes.
 	str := "\"" + string(c.text) + "\""
 	return str, nil
 }
 
-func (p *parser) callonUnquotedString1() (interface{}, error) {
+func (p *parser) callonUnquotedString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedString1()
 }
 
-func (c *current) onUnquotedStringWithTemplateWildCard1() (interface{}, error) {
+func (c *current) onUnquotedStringWithTemplateWildCard1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonUnquotedStringWithTemplateWildCard1() (interface{}, error) {
+func (p *parser) callonUnquotedStringWithTemplateWildCard1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onUnquotedStringWithTemplateWildCard1()
 }
 
-func (c *current) onBoolean1() (interface{}, error) {
+func (c *current) onBoolean1() (any, error) {
 	boolValue, _ := strconv.ParseBool(string(c.text))
 	return boolValue, nil
 }
 
-func (p *parser) callonBoolean1() (interface{}, error) {
+func (p *parser) callonBoolean1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onBoolean1()
 }
 
-func (c *current) onRenamePattern1() (interface{}, error) {
+func (c *current) onRenamePattern1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonRenamePattern1() (interface{}, error) {
+func (p *parser) callonRenamePattern1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRenamePattern1()
 }
 
-func (c *current) onNumber1(number interface{}) (interface{}, error) {
+func (c *current) onNumber1(number any) (any, error) {
 	return json.Number(number.(string)), nil
 }
 
-func (p *parser) callonNumber1() (interface{}, error) {
+func (p *parser) callonNumber1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumber1(stack["number"])
 }
 
-func (c *current) onNumberAsString1(number interface{}) (interface{}, error) {
+func (c *current) onNumberAsString1(number any) (any, error) {
 	return number, nil
 }
 
-func (p *parser) callonNumberAsString1() (interface{}, error) {
+func (p *parser) callonNumberAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onNumberAsString1(stack["number"])
 }
 
-func (c *current) onFloatAsString1() (interface{}, error) {
+func (c *current) onFloatAsString1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonFloatAsString1() (interface{}, error) {
+func (p *parser) callonFloatAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFloatAsString1()
 }
 
-func (c *current) onIntegerAsString1() (interface{}, error) {
+func (c *current) onIntegerAsString1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonIntegerAsString1() (interface{}, error) {
+func (p *parser) callonIntegerAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIntegerAsString1()
 }
 
-func (c *current) onPositiveIntegerAsString1() (interface{}, error) {
+func (c *current) onPositiveIntegerAsString1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonPositiveIntegerAsString1() (interface{}, error) {
+func (p *parser) callonPositiveIntegerAsString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPositiveIntegerAsString1()
 }
 
-func (c *current) onPositiveInteger1(intStr interface{}) (interface{}, error) {
+func (c *current) onPositiveInteger1(intStr any) (any, error) {
 	num, err := strconv.ParseUint(intStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Invalid Positive Integer value: (%v): , err: %v", intStr.(string), err)
@@ -21011,13 +21476,13 @@ func (c *current) onPositiveInteger1(intStr interface{}) (interface{}, error) {
 	return num, nil
 }
 
-func (p *parser) callonPositiveInteger1() (interface{}, error) {
+func (p *parser) callonPositiveInteger1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPositiveInteger1(stack["intStr"])
 }
 
-func (c *current) onEqualityOperator1(op interface{}) (interface{}, error) {
+func (c *current) onEqualityOperator1(op any) (any, error) {
 	opStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: EqualityOperator: %v", err)
@@ -21028,13 +21493,13 @@ func (c *current) onEqualityOperator1(op interface{}) (interface{}, error) {
 	return opStr, nil
 }
 
-func (p *parser) callonEqualityOperator1() (interface{}, error) {
+func (p *parser) callonEqualityOperator1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOperator1(stack["op"])
 }
 
-func (c *current) onInequalityOperator1(op interface{}) (interface{}, error) {
+func (c *current) onInequalityOperator1(op any) (any, error) {
 	opStr, err := transferUint8ToString(op)
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: InequalityOperator: %v", err)
@@ -21042,163 +21507,163 @@ func (c *current) onInequalityOperator1(op interface{}) (interface{}, error) {
 	return opStr, nil
 }
 
-func (p *parser) callonInequalityOperator1() (interface{}, error) {
+func (p *parser) callonInequalityOperator1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInequalityOperator1(stack["op"])
 }
 
-func (c *current) onEqualityOrInequality2(op interface{}) (interface{}, error) {
+func (c *current) onEqualityOrInequality2(op any) (any, error) {
 	return op, nil
 }
 
-func (p *parser) callonEqualityOrInequality2() (interface{}, error) {
+func (p *parser) callonEqualityOrInequality2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOrInequality2(stack["op"])
 }
 
-func (c *current) onEqualityOrInequality5(op interface{}) (interface{}, error) {
+func (c *current) onEqualityOrInequality5(op any) (any, error) {
 	return op, nil
 }
 
-func (p *parser) callonEqualityOrInequality5() (interface{}, error) {
+func (p *parser) callonEqualityOrInequality5() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEqualityOrInequality5(stack["op"])
 }
 
-func (c *current) onOpPlus1() (interface{}, error) {
+func (c *current) onOpPlus1() (any, error) {
 	return "+", nil
 }
 
-func (p *parser) callonOpPlus1() (interface{}, error) {
+func (p *parser) callonOpPlus1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpPlus1()
 }
 
-func (c *current) onOpMinus1() (interface{}, error) {
+func (c *current) onOpMinus1() (any, error) {
 	return "-", nil
 }
 
-func (p *parser) callonOpMinus1() (interface{}, error) {
+func (p *parser) callonOpMinus1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMinus1()
 }
 
-func (c *current) onOpMul1() (interface{}, error) {
+func (c *current) onOpMul1() (any, error) {
 	return "*", nil
 }
 
-func (p *parser) callonOpMul1() (interface{}, error) {
+func (p *parser) callonOpMul1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMul1()
 }
 
-func (c *current) onOpDiv1() (interface{}, error) {
+func (c *current) onOpDiv1() (any, error) {
 	return "/", nil
 }
 
-func (p *parser) callonOpDiv1() (interface{}, error) {
+func (p *parser) callonOpDiv1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpDiv1()
 }
 
-func (c *current) onOpMod1() (interface{}, error) {
+func (c *current) onOpMod1() (any, error) {
 	return "%", nil
 }
 
-func (p *parser) callonOpMod1() (interface{}, error) {
+func (p *parser) callonOpMod1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOpMod1()
 }
 
-func (c *current) onSecond1() (interface{}, error) {
+func (c *current) onSecond1() (any, error) {
 	return sutils.TMSecond, nil
 }
 
-func (p *parser) callonSecond1() (interface{}, error) {
+func (p *parser) callonSecond1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSecond1()
 }
 
-func (c *current) onMinute1() (interface{}, error) {
+func (c *current) onMinute1() (any, error) {
 	return sutils.TMMinute, nil
 }
 
-func (p *parser) callonMinute1() (interface{}, error) {
+func (p *parser) callonMinute1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMinute1()
 }
 
-func (c *current) onHour1() (interface{}, error) {
+func (c *current) onHour1() (any, error) {
 	return sutils.TMHour, nil
 }
 
-func (p *parser) callonHour1() (interface{}, error) {
+func (p *parser) callonHour1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onHour1()
 }
 
-func (c *current) onDay1() (interface{}, error) {
+func (c *current) onDay1() (any, error) {
 	return sutils.TMDay, nil
 }
 
-func (p *parser) callonDay1() (interface{}, error) {
+func (p *parser) callonDay1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDay1()
 }
 
-func (c *current) onWeek1() (interface{}, error) {
+func (c *current) onWeek1() (any, error) {
 	return sutils.TMWeek, nil
 }
 
-func (p *parser) callonWeek1() (interface{}, error) {
+func (p *parser) callonWeek1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWeek1()
 }
 
-func (c *current) onMonth1() (interface{}, error) {
+func (c *current) onMonth1() (any, error) {
 	return sutils.TMMonth, nil
 }
 
-func (p *parser) callonMonth1() (interface{}, error) {
+func (p *parser) callonMonth1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMonth1()
 }
 
-func (c *current) onQuarter1() (interface{}, error) {
+func (c *current) onQuarter1() (any, error) {
 	return sutils.TMQuarter, nil
 }
 
-func (p *parser) callonQuarter1() (interface{}, error) {
+func (p *parser) callonQuarter1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuarter1()
 }
 
-func (c *current) onYear1() (interface{}, error) {
+func (c *current) onYear1() (any, error) {
 	return sutils.TMYear, nil
 }
 
-func (p *parser) callonYear1() (interface{}, error) {
+func (p *parser) callonYear1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onYear1()
 }
 
-func (c *current) onSubseconds1() (interface{}, error) {
+func (c *current) onSubseconds1() (any, error) {
 	timeUnit, err := sutils.ConvertSubseconds(string(c.text))
 	if err != nil {
 		return nil, fmt.Errorf("Spl peg: Subseconds: %v", err)
@@ -21206,13 +21671,13 @@ func (c *current) onSubseconds1() (interface{}, error) {
 	return timeUnit, nil
 }
 
-func (p *parser) callonSubseconds1() (interface{}, error) {
+func (p *parser) callonSubseconds1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSubseconds1()
 }
 
-func (c *current) onTransactionBlock1(txnOptions interface{}) (interface{}, error) {
+func (c *current) onTransactionBlock1(txnOptions any) (any, error) {
 	queryAgg := &structs.QueryAggregators{
 		PipeCommandType:      structs.TransactionType,
 		TransactionArguments: txnOptions.(*structs.TransactionArguments),
@@ -21221,13 +21686,13 @@ func (c *current) onTransactionBlock1(txnOptions interface{}) (interface{}, erro
 	return queryAgg, nil
 }
 
-func (p *parser) callonTransactionBlock1() (interface{}, error) {
+func (p *parser) callonTransactionBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionBlock1(stack["txnOptions"])
 }
 
-func (c *current) onTransactionOptions1(txnOptions interface{}) (interface{}, error) {
+func (c *current) onTransactionOptions1(txnOptions any) (any, error) {
 
 	transactionRequest := &structs.TransactionArguments{}
 
@@ -21241,13 +21706,13 @@ func (c *current) onTransactionOptions1(txnOptions interface{}) (interface{}, er
 	return transactionRequest, nil
 }
 
-func (p *parser) callonTransactionOptions1() (interface{}, error) {
+func (p *parser) callonTransactionOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionOptions1(stack["txnOptions"])
 }
 
-func (c *current) onTransactionDefinitionOptionsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onTransactionDefinitionOptionsList1(first, rest any) (any, error) {
 
 	restSlice := rest.([]any)
 	txnArgs := &TxnArgs{
@@ -21282,23 +21747,23 @@ func (c *current) onTransactionDefinitionOptionsList1(first, rest interface{}) (
 	return txnArgs, nil
 }
 
-func (p *parser) callonTransactionDefinitionOptionsList1() (interface{}, error) {
+func (p *parser) callonTransactionDefinitionOptionsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionDefinitionOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onTransactionDefinitionOption1(option interface{}) (interface{}, error) {
+func (c *current) onTransactionDefinitionOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonTransactionDefinitionOption1() (interface{}, error) {
+func (p *parser) callonTransactionDefinitionOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionDefinitionOption1(stack["option"])
 }
 
-func (c *current) onTransactionSpaceSeparatedFieldList1(fields interface{}) (interface{}, error) {
+func (c *current) onTransactionSpaceSeparatedFieldList1(fields any) (any, error) {
 	txnArg := &TxnArgs{
 		argOption: "fields",
 		arguments: &structs.TransactionArguments{
@@ -21309,13 +21774,13 @@ func (c *current) onTransactionSpaceSeparatedFieldList1(fields interface{}) (int
 	return txnArg, nil
 }
 
-func (p *parser) callonTransactionSpaceSeparatedFieldList1() (interface{}, error) {
+func (p *parser) callonTransactionSpaceSeparatedFieldList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionSpaceSeparatedFieldList1(stack["fields"])
 }
 
-func (c *current) onStartsWithOption1(strExpr interface{}) (interface{}, error) {
+func (c *current) onStartsWithOption1(strExpr any) (any, error) {
 	txnArg := &TxnArgs{
 		argOption: "startswith",
 		arguments: &structs.TransactionArguments{
@@ -21325,13 +21790,13 @@ func (c *current) onStartsWithOption1(strExpr interface{}) (interface{}, error) 
 	return txnArg, nil
 }
 
-func (p *parser) callonStartsWithOption1() (interface{}, error) {
+func (p *parser) callonStartsWithOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStartsWithOption1(stack["strExpr"])
 }
 
-func (c *current) onEndsWithOption1(strExpr interface{}) (interface{}, error) {
+func (c *current) onEndsWithOption1(strExpr any) (any, error) {
 	txnArg := &TxnArgs{
 		argOption: "endswith",
 		arguments: &structs.TransactionArguments{
@@ -21341,33 +21806,33 @@ func (c *current) onEndsWithOption1(strExpr interface{}) (interface{}, error) {
 	return txnArg, nil
 }
 
-func (p *parser) callonEndsWithOption1() (interface{}, error) {
+func (p *parser) callonEndsWithOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEndsWithOption1(stack["strExpr"])
 }
 
-func (c *current) onTransactionFilterString1(strExpr interface{}) (interface{}, error) {
+func (c *current) onTransactionFilterString1(strExpr any) (any, error) {
 	return strExpr, nil
 }
 
-func (p *parser) callonTransactionFilterString1() (interface{}, error) {
+func (p *parser) callonTransactionFilterString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionFilterString1(stack["strExpr"])
 }
 
-func (c *current) onTransactionQuotedString1(str interface{}) (interface{}, error) {
+func (c *current) onTransactionQuotedString1(str any) (any, error) {
 	return str, nil
 }
 
-func (p *parser) callonTransactionQuotedString1() (interface{}, error) {
+func (p *parser) callonTransactionQuotedString1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedString1(stack["str"])
 }
 
-func (c *current) onTransactionQuotedStringSearchExpr1(searchClause interface{}) (interface{}, error) {
+func (c *current) onTransactionQuotedStringSearchExpr1(searchClause any) (any, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		SearchNode: searchClause.(*ast.Node),
 	}
@@ -21375,24 +21840,24 @@ func (c *current) onTransactionQuotedStringSearchExpr1(searchClause interface{})
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionQuotedStringSearchExpr1() (interface{}, error) {
+func (p *parser) callonTransactionQuotedStringSearchExpr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedStringSearchExpr1(stack["searchClause"])
 }
 
-func (c *current) onQuotedStringNoOp1() (interface{}, error) {
+func (c *current) onQuotedStringNoOp1() (any, error) {
 	// The returned string has quotes as the first and last character.
 	return string(c.text), nil
 }
 
-func (p *parser) callonQuotedStringNoOp1() (interface{}, error) {
+func (p *parser) callonQuotedStringNoOp1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onQuotedStringNoOp1()
 }
 
-func (c *current) onTransactionQuotedStringValue1(str interface{}) (interface{}, error) {
+func (c *current) onTransactionQuotedStringValue1(str any) (any, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		StringValue: removeQuotes(str.(string)),
 	}
@@ -21400,13 +21865,13 @@ func (c *current) onTransactionQuotedStringValue1(str interface{}) (interface{},
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionQuotedStringValue1() (interface{}, error) {
+func (p *parser) callonTransactionQuotedStringValue1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionQuotedStringValue1(stack["str"])
 }
 
-func (c *current) onTransactionSearch1(expr interface{}) (interface{}, error) {
+func (c *current) onTransactionSearch1(expr any) (any, error) {
 
 	filterStrExpr := &structs.FilterStringExpr{
 		SearchNode: expr.(*ast.Node),
@@ -21415,13 +21880,13 @@ func (c *current) onTransactionSearch1(expr interface{}) (interface{}, error) {
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionSearch1() (interface{}, error) {
+func (p *parser) callonTransactionSearch1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionSearch1(stack["expr"])
 }
 
-func (c *current) onTransactionEval1(condition interface{}) (interface{}, error) {
+func (c *current) onTransactionEval1(condition any) (any, error) {
 	filterStrExpr := &structs.FilterStringExpr{
 		EvalBoolExpr: condition.(*structs.BoolExpr),
 	}
@@ -21429,23 +21894,23 @@ func (c *current) onTransactionEval1(condition interface{}) (interface{}, error)
 	return filterStrExpr, nil
 }
 
-func (p *parser) callonTransactionEval1() (interface{}, error) {
+func (p *parser) callonTransactionEval1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onTransactionEval1(stack["condition"])
 }
 
-func (c *current) onMultiValueBlock1(mvQueryAggNode interface{}) (interface{}, error) {
+func (c *current) onMultiValueBlock1(mvQueryAggNode any) (any, error) {
 	return mvQueryAggNode, nil
 }
 
-func (p *parser) callonMultiValueBlock1() (interface{}, error) {
+func (p *parser) callonMultiValueBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMultiValueBlock1(stack["mvQueryAggNode"])
 }
 
-func (c *current) onMakeMVBlock1(mvColOptionExpr, field interface{}) (interface{}, error) {
+func (c *current) onMakeMVBlock1(mvColOptionExpr, field any) (any, error) {
 	var mvColExpr *structs.MultiValueColLetRequest
 
 	if mvColOptionExpr != nil {
@@ -21474,13 +21939,13 @@ func (c *current) onMakeMVBlock1(mvColOptionExpr, field interface{}) (interface{
 	return queryAgg, nil
 }
 
-func (p *parser) callonMakeMVBlock1() (interface{}, error) {
+func (p *parser) callonMakeMVBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMakeMVBlock1(stack["mvColOptionExpr"], stack["field"])
 }
 
-func (c *current) onMVBlockOptionsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onMVBlockOptionsList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 
 	numOptions := 1 + len(restSlice)
@@ -21514,33 +21979,33 @@ func (c *current) onMVBlockOptionsList1(first, rest interface{}) (interface{}, e
 	return mvColExpr, nil
 }
 
-func (p *parser) callonMVBlockOptionsList1() (interface{}, error) {
+func (p *parser) callonMVBlockOptionsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMVBlockOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onMVBlockOption1(option interface{}) (interface{}, error) {
+func (c *current) onMVBlockOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonMVBlockOption1() (interface{}, error) {
+func (p *parser) callonMVBlockOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMVBlockOption1(stack["option"])
 }
 
-func (c *current) onDelimOption1(delimExpr interface{}) (interface{}, error) {
+func (c *current) onDelimOption1(delimExpr any) (any, error) {
 	return delimExpr, nil
 }
 
-func (p *parser) callonDelimOption1() (interface{}, error) {
+func (p *parser) callonDelimOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDelimOption1(stack["delimExpr"])
 }
 
-func (c *current) onStringDelimiter1(str interface{}) (interface{}, error) {
+func (c *current) onStringDelimiter1(str any) (any, error) {
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "delimiter",
 		mvColExpr: &structs.MultiValueColLetRequest{
@@ -21551,13 +22016,13 @@ func (c *current) onStringDelimiter1(str interface{}) (interface{}, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonStringDelimiter1() (interface{}, error) {
+func (p *parser) callonStringDelimiter1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onStringDelimiter1(stack["str"])
 }
 
-func (c *current) onRegexDelimiter1(str interface{}) (interface{}, error) {
+func (c *current) onRegexDelimiter1(str any) (any, error) {
 	pattern := removeQuotes(str)
 	_, err := regexp.Compile(pattern)
 	if err != nil {
@@ -21575,13 +22040,13 @@ func (c *current) onRegexDelimiter1(str interface{}) (interface{}, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonRegexDelimiter1() (interface{}, error) {
+func (p *parser) callonRegexDelimiter1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onRegexDelimiter1(stack["str"])
 }
 
-func (c *current) onAllowEmptyOption1(boolVal interface{}) (interface{}, error) {
+func (c *current) onAllowEmptyOption1(boolVal any) (any, error) {
 
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "allowempty",
@@ -21593,13 +22058,13 @@ func (c *current) onAllowEmptyOption1(boolVal interface{}) (interface{}, error) 
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonAllowEmptyOption1() (interface{}, error) {
+func (p *parser) callonAllowEmptyOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAllowEmptyOption1(stack["boolVal"])
 }
 
-func (c *current) onSetSvOption1(boolVal interface{}) (interface{}, error) {
+func (c *current) onSetSvOption1(boolVal any) (any, error) {
 	mvColOptionArgs := &MultiValueColOptionArgs{
 		argOption: "setsv",
 		mvColExpr: &structs.MultiValueColLetRequest{
@@ -21610,26 +22075,26 @@ func (c *current) onSetSvOption1(boolVal interface{}) (interface{}, error) {
 	return mvColOptionArgs, nil
 }
 
-func (p *parser) callonSetSvOption1() (interface{}, error) {
+func (p *parser) callonSetSvOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSetSvOption1(stack["boolVal"])
 }
 
-func (c *current) onSPathBlock1(spathExpr interface{}) (interface{}, error) {
+func (c *current) onSPathBlock1(spathExpr any) (any, error) {
 	if spathExpr == nil {
 		return createSPathExpr("", "", "")
 	}
 	return spathExpr, nil
 }
 
-func (p *parser) callonSPathBlock1() (interface{}, error) {
+func (p *parser) callonSPathBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathBlock1(stack["spathExpr"])
 }
 
-func (c *current) onSPathArgumentsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onSPathArgumentsList1(first, rest any) (any, error) {
 
 	restSlice := rest.([]any)
 
@@ -21661,43 +22126,43 @@ func (c *current) onSPathArgumentsList1(first, rest interface{}) (interface{}, e
 	return createSPathExpr(inputField, pathField, outputField)
 }
 
-func (p *parser) callonSPathArgumentsList1() (interface{}, error) {
+func (p *parser) callonSPathArgumentsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onSPathArgument1(arg interface{}) (interface{}, error) {
+func (c *current) onSPathArgument1(arg any) (any, error) {
 	return arg, nil
 }
 
-func (p *parser) callonSPathArgument1() (interface{}, error) {
+func (p *parser) callonSPathArgument1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSPathArgument1(stack["arg"])
 }
 
-func (c *current) onInputField1(field interface{}) (interface{}, error) {
+func (c *current) onInputField1(field any) (any, error) {
 	return "input=" + field.(string), nil
 }
 
-func (p *parser) callonInputField1() (interface{}, error) {
+func (p *parser) callonInputField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputField1(stack["field"])
 }
 
-func (c *current) onOutputField1(field interface{}) (interface{}, error) {
+func (c *current) onOutputField1(field any) (any, error) {
 	return "output=" + field.(string), nil
 }
 
-func (p *parser) callonOutputField1() (interface{}, error) {
+func (p *parser) callonOutputField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOutputField1(stack["field"])
 }
 
-func (c *current) onPathField1() (interface{}, error) {
+func (c *current) onPathField1() (any, error) {
 	pathField := string(c.text)
 	if strings.HasPrefix(pathField, "path") {
 		pathField = strings.TrimSpace(strings.TrimPrefix(pathField, "path="))
@@ -21709,13 +22174,13 @@ func (c *current) onPathField1() (interface{}, error) {
 	return "path=" + pathField, nil
 }
 
-func (p *parser) callonPathField1() (interface{}, error) {
+func (p *parser) callonPathField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onPathField1()
 }
 
-func (c *current) onFormatBlock1(formatArgExpr interface{}) (interface{}, error) {
+func (c *current) onFormatBlock1(formatArgExpr any) (any, error) {
 	var formatResultExpr *structs.FormatResultsRequest
 
 	if formatArgExpr != nil {
@@ -21737,13 +22202,13 @@ func (c *current) onFormatBlock1(formatArgExpr interface{}) (interface{}, error)
 	return queryAgg, nil
 }
 
-func (p *parser) callonFormatBlock1() (interface{}, error) {
+func (p *parser) callonFormatBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatBlock1(stack["formatArgExpr"])
 }
 
-func (c *current) onFormatArgumentsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onFormatArgumentsList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 
 	numOptions := 1 + len(restSlice)
@@ -21777,23 +22242,23 @@ func (c *current) onFormatArgumentsList1(first, rest interface{}) (interface{}, 
 	return formatResultExpr, nil
 }
 
-func (p *parser) callonFormatArgumentsList1() (interface{}, error) {
+func (p *parser) callonFormatArgumentsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onFormatArgument1(argExpr interface{}) (interface{}, error) {
+func (c *current) onFormatArgument1(argExpr any) (any, error) {
 	return argExpr, nil
 }
 
-func (p *parser) callonFormatArgument1() (interface{}, error) {
+func (p *parser) callonFormatArgument1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatArgument1(stack["argExpr"])
 }
 
-func (c *current) onFormatSeparator1(str interface{}) (interface{}, error) {
+func (c *current) onFormatSeparator1(str any) (any, error) {
 	return &FormatResultsRequestArguments{
 		argOption: "mvsep",
 		formatResultExpr: &structs.FormatResultsRequest{
@@ -21802,13 +22267,13 @@ func (c *current) onFormatSeparator1(str interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatSeparator1() (interface{}, error) {
+func (p *parser) callonFormatSeparator1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatSeparator1(stack["str"])
 }
 
-func (c *current) onFormatMaxResults1(numStr interface{}) (interface{}, error) {
+func (c *current) onFormatMaxResults1(numStr any) (any, error) {
 	num, err := strconv.ParseUint(numStr.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid Max results value is set for format: (%v): Error=%v", numStr.(string), err)
@@ -21821,13 +22286,13 @@ func (c *current) onFormatMaxResults1(numStr interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatMaxResults1() (interface{}, error) {
+func (p *parser) callonFormatMaxResults1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatMaxResults1(stack["numStr"])
 }
 
-func (c *current) onFormatEmptyStr1(str interface{}) (interface{}, error) {
+func (c *current) onFormatEmptyStr1(str any) (any, error) {
 	return &FormatResultsRequestArguments{
 		argOption: "emptystr",
 		formatResultExpr: &structs.FormatResultsRequest{
@@ -21836,13 +22301,13 @@ func (c *current) onFormatEmptyStr1(str interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonFormatEmptyStr1() (interface{}, error) {
+func (p *parser) callonFormatEmptyStr1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatEmptyStr1(stack["str"])
 }
 
-func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, colEnd, rowSeparator, rowEnd interface{}) (interface{}, error) {
+func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, colEnd, rowSeparator, rowEnd any) (any, error) {
 	rowColOptions := &structs.RowColOptions{
 		RowPrefix:       removeQuotes(rowPrefix),
 		ColumnPrefix:    removeQuotes(colPrefix),
@@ -21860,26 +22325,26 @@ func (c *current) onFormatRowColOptions1(rowPrefix, colPrefix, colSeparator, col
 	}, nil
 }
 
-func (p *parser) callonFormatRowColOptions1() (interface{}, error) {
+func (p *parser) callonFormatRowColOptions1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFormatRowColOptions1(stack["rowPrefix"], stack["colPrefix"], stack["colSeparator"], stack["colEnd"], stack["rowSeparator"], stack["rowEnd"])
 }
 
-func (c *current) onEventCountBlock1(eventCountExpr interface{}) (interface{}, error) {
+func (c *current) onEventCountBlock1(eventCountExpr any) (any, error) {
 	if eventCountExpr == nil {
 		return createEventCountExpr([]string{"*"}, true, false, true)
 	}
 	return eventCountExpr, nil
 }
 
-func (p *parser) callonEventCountBlock1() (interface{}, error) {
+func (p *parser) callonEventCountBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountBlock1(stack["eventCountExpr"])
 }
 
-func (c *current) onEventCountArgumentsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onEventCountArgumentsList1(first, rest any) (any, error) {
 
 	restSlice := rest.([]any)
 
@@ -21935,73 +22400,73 @@ func (c *current) onEventCountArgumentsList1(first, rest interface{}) (interface
 	return createEventCountExpr(indices, list_vix, report_size, summarize)
 }
 
-func (p *parser) callonEventCountArgumentsList1() (interface{}, error) {
+func (p *parser) callonEventCountArgumentsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountArgumentsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onEventCountArgument1(arg interface{}) (interface{}, error) {
+func (c *current) onEventCountArgument1(arg any) (any, error) {
 	return arg, nil
 }
 
-func (p *parser) callonEventCountArgument1() (interface{}, error) {
+func (p *parser) callonEventCountArgument1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onEventCountArgument1(stack["arg"])
 }
 
-func (c *current) onIndexField1(index interface{}) (interface{}, error) {
+func (c *current) onIndexField1(index any) (any, error) {
 	return "index=" + index.(string), nil
 }
 
-func (p *parser) callonIndexField1() (interface{}, error) {
+func (p *parser) callonIndexField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexField1(stack["index"])
 }
 
-func (c *current) onSummarizeField1(field interface{}) (interface{}, error) {
+func (c *current) onSummarizeField1(field any) (any, error) {
 	return "summarize=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonSummarizeField1() (interface{}, error) {
+func (p *parser) callonSummarizeField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSummarizeField1(stack["field"])
 }
 
-func (c *current) onReportSizeField1(field interface{}) (interface{}, error) {
+func (c *current) onReportSizeField1(field any) (any, error) {
 	return "report_size=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonReportSizeField1() (interface{}, error) {
+func (p *parser) callonReportSizeField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onReportSizeField1(stack["field"])
 }
 
-func (c *current) onListVixField1(field interface{}) (interface{}, error) {
+func (c *current) onListVixField1(field any) (any, error) {
 	return "list_vix=" + strconv.FormatBool(field.(bool)), nil
 }
 
-func (p *parser) callonListVixField1() (interface{}, error) {
+func (p *parser) callonListVixField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onListVixField1(stack["field"])
 }
 
-func (c *current) onIndexName1() (interface{}, error) {
+func (c *current) onIndexName1() (any, error) {
 	return string(c.text), nil
 }
 
-func (p *parser) callonIndexName1() (interface{}, error) {
+func (p *parser) callonIndexName1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIndexName1()
 }
 
-func (c *current) onFillNullBlock1(valueOption, fields interface{}) (interface{}, error) {
+func (c *current) onFillNullBlock1(valueOption, fields any) (any, error) {
 	valueStr := "0"
 	fieldList := make([]string, 0)
 
@@ -22031,33 +22496,33 @@ func (c *current) onFillNullBlock1(valueOption, fields interface{}) (interface{}
 	}, nil
 }
 
-func (p *parser) callonFillNullBlock1() (interface{}, error) {
+func (p *parser) callonFillNullBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullBlock1(stack["valueOption"], stack["fields"])
 }
 
-func (c *current) onFillNullValueOption1(str interface{}) (interface{}, error) {
+func (c *current) onFillNullValueOption1(str any) (any, error) {
 	return removeQuotes(str), nil
 }
 
-func (p *parser) callonFillNullValueOption1() (interface{}, error) {
+func (p *parser) callonFillNullValueOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullValueOption1(stack["str"])
 }
 
-func (c *current) onFillNullFieldList1(fieldList interface{}) (interface{}, error) {
+func (c *current) onFillNullFieldList1(fieldList any) (any, error) {
 	return fieldList, nil
 }
 
-func (p *parser) callonFillNullFieldList1() (interface{}, error) {
+func (p *parser) callonFillNullFieldList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullFieldList1(stack["fieldList"])
 }
 
-func (c *current) onMvexpandBlock1(field, limitStr interface{}) (interface{}, error) {
+func (c *current) onMvexpandBlock1(field, limitStr any) (any, error) {
 	limit := utils.None[int64]()
 	if limitStr != nil {
 		value, err := strconv.ParseInt(limitStr.(string), 10, 64)
@@ -22086,43 +22551,43 @@ func (c *current) onMvexpandBlock1(field, limitStr interface{}) (interface{}, er
 	return queryAgg, nil
 }
 
-func (p *parser) callonMvexpandBlock1() (interface{}, error) {
+func (p *parser) callonMvexpandBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandBlock1(stack["field"], stack["limitStr"])
 }
 
-func (c *current) onMvexpandField1(fieldName interface{}) (interface{}, error) {
+func (c *current) onMvexpandField1(fieldName any) (any, error) {
 	return fieldName, nil
 }
 
-func (p *parser) callonMvexpandField1() (interface{}, error) {
+func (p *parser) callonMvexpandField1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandField1(stack["fieldName"])
 }
 
-func (c *current) onMvexpandLimit1(intValue interface{}) (interface{}, error) {
+func (c *current) onMvexpandLimit1(intValue any) (any, error) {
 	return intValue, nil
 }
 
-func (p *parser) callonMvexpandLimit1() (interface{}, error) {
+func (p *parser) callonMvexpandLimit1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMvexpandLimit1(stack["intValue"])
 }
 
-func (c *current) onWhereClause1(condition interface{}) (interface{}, error) {
+func (c *current) onWhereClause1(condition any) (any, error) {
 	return condition.(*structs.BoolExpr), nil
 }
 
-func (p *parser) callonWhereClause1() (interface{}, error) {
+func (p *parser) callonWhereClause1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onWhereClause1(stack["condition"])
 }
 
-func (c *current) onInputLookupOptionAppend1(boolVal interface{}) (interface{}, error) {
+func (c *current) onInputLookupOptionAppend1(boolVal any) (any, error) {
 	return &InputLookupOptionArgs{
 		argOption: "append",
 		inputLookupOption: &structs.InputLookup{
@@ -22131,13 +22596,13 @@ func (c *current) onInputLookupOptionAppend1(boolVal interface{}) (interface{}, 
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionAppend1() (interface{}, error) {
+func (p *parser) callonInputLookupOptionAppend1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionAppend1(stack["boolVal"])
 }
 
-func (c *current) onInputLookupOptionStrict1(boolVal interface{}) (interface{}, error) {
+func (c *current) onInputLookupOptionStrict1(boolVal any) (any, error) {
 	return &InputLookupOptionArgs{
 		argOption: "strict",
 		inputLookupOption: &structs.InputLookup{
@@ -22146,13 +22611,13 @@ func (c *current) onInputLookupOptionStrict1(boolVal interface{}) (interface{}, 
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionStrict1() (interface{}, error) {
+func (p *parser) callonInputLookupOptionStrict1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionStrict1(stack["boolVal"])
 }
 
-func (c *current) onInputLookupOptionStart1(posInt interface{}) (interface{}, error) {
+func (c *current) onInputLookupOptionStart1(posInt any) (any, error) {
 	return &InputLookupOptionArgs{
 		argOption: "start",
 		inputLookupOption: &structs.InputLookup{
@@ -22161,13 +22626,13 @@ func (c *current) onInputLookupOptionStart1(posInt interface{}) (interface{}, er
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionStart1() (interface{}, error) {
+func (p *parser) callonInputLookupOptionStart1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionStart1(stack["posInt"])
 }
 
-func (c *current) onInputLookupOptionMax1(posInt interface{}) (interface{}, error) {
+func (c *current) onInputLookupOptionMax1(posInt any) (any, error) {
 	return &InputLookupOptionArgs{
 		argOption: "max",
 		inputLookupOption: &structs.InputLookup{
@@ -22176,23 +22641,23 @@ func (c *current) onInputLookupOptionMax1(posInt interface{}) (interface{}, erro
 	}, nil
 }
 
-func (p *parser) callonInputLookupOptionMax1() (interface{}, error) {
+func (p *parser) callonInputLookupOptionMax1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionMax1(stack["posInt"])
 }
 
-func (c *current) onInputLookupOption1(inputLookupOption interface{}) (interface{}, error) {
+func (c *current) onInputLookupOption1(inputLookupOption any) (any, error) {
 	return inputLookupOption, nil
 }
 
-func (p *parser) callonInputLookupOption1() (interface{}, error) {
+func (p *parser) callonInputLookupOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOption1(stack["inputLookupOption"])
 }
 
-func (c *current) onInputLookupOptionList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onInputLookupOptionList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	optionWasSpecified := make(map[string]struct{})
 	numOptions := 1 + len(restSlice)
@@ -22232,13 +22697,13 @@ func (c *current) onInputLookupOptionList1(first, rest interface{}) (interface{}
 	return inputLookupOption, nil
 }
 
-func (p *parser) callonInputLookupOptionList1() (interface{}, error) {
+func (p *parser) callonInputLookupOptionList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupOptionList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause interface{}) (interface{}, error) {
+func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause any) (any, error) {
 	inputLookup := &structs.InputLookup{}
 	if inputLookupOption != nil {
 		inputLookupOption := inputLookupOption.([]any)
@@ -22261,13 +22726,13 @@ func (c *current) onInputLookupBlock1(inputLookupOption, filename, whereClause i
 	}, nil
 }
 
-func (p *parser) callonInputLookupBlock1() (interface{}, error) {
+func (p *parser) callonInputLookupBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupBlock1(stack["inputLookupOption"], stack["filename"], stack["whereClause"])
 }
 
-func (c *current) onInputLookupAggBlock1(inputLookupBlock interface{}) (interface{}, error) {
+func (c *current) onInputLookupAggBlock1(inputLookupBlock any) (any, error) {
 	inputLookup := inputLookupBlock.(*structs.QueryAggregators)
 	if !inputLookup.GenerateEvent.InputLookup.Append {
 		return nil, fmt.Errorf("An Inputlookup command which is not the first command must have append as true")
@@ -22277,36 +22742,36 @@ func (c *current) onInputLookupAggBlock1(inputLookupBlock interface{}) (interfac
 	return inputLookup, nil
 }
 
-func (p *parser) callonInputLookupAggBlock1() (interface{}, error) {
+func (p *parser) callonInputLookupAggBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onInputLookupAggBlock1(stack["inputLookupBlock"])
 }
 
-func (c *current) onAppendCmdOption1(option interface{}) (interface{}, error) {
+func (c *current) onAppendCmdOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonAppendCmdOption1() (interface{}, error) {
+func (p *parser) callonAppendCmdOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendCmdOption1(stack["option"])
 }
 
-func (c *current) onExtendTimeRangeOption1(boolean interface{}) (interface{}, error) {
+func (c *current) onExtendTimeRangeOption1(boolean any) (any, error) {
 	return &structs.AppendCmdOption{
 		OptionType: "extendtimerange",
 		Value:      boolean == "true",
 	}, nil
 }
 
-func (p *parser) callonExtendTimeRangeOption1() (interface{}, error) {
+func (p *parser) callonExtendTimeRangeOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onExtendTimeRangeOption1(stack["boolean"])
 }
 
-func (c *current) onMaxTimeOption1(time interface{}) (interface{}, error) {
+func (c *current) onMaxTimeOption1(time any) (any, error) {
 	maxTimeInt, err := strconv.ParseUint(time.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid maxtime (%v): %v", time.(string), err)
@@ -22317,13 +22782,13 @@ func (c *current) onMaxTimeOption1(time interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonMaxTimeOption1() (interface{}, error) {
+func (p *parser) callonMaxTimeOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMaxTimeOption1(stack["time"])
 }
 
-func (c *current) onMaxOutOption1(max interface{}) (interface{}, error) {
+func (c *current) onMaxOutOption1(max any) (any, error) {
 	maxOutInt, err := strconv.ParseUint(max.(string), 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid maxout (%v): %v", max.(string), err)
@@ -22334,23 +22799,23 @@ func (c *current) onMaxOutOption1(max interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonMaxOutOption1() (interface{}, error) {
+func (p *parser) callonMaxOutOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onMaxOutOption1(stack["max"])
 }
 
-func (c *current) onSubsearch1(search interface{}) (interface{}, error) {
+func (c *current) onSubsearch1(search any) (any, error) {
 	return search, nil
 }
 
-func (p *parser) callonSubsearch1() (interface{}, error) {
+func (p *parser) callonSubsearch1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onSubsearch1(stack["search"])
 }
 
-func (c *current) onAppendCmdOptionsList1(first, rest interface{}) (interface{}, error) {
+func (c *current) onAppendCmdOptionsList1(first, rest any) (any, error) {
 	restSlice := rest.([]any)
 	numOptions := 1 + len(restSlice)
 	appendCmdOptions := &structs.AppendCmdOptions{}
@@ -22376,13 +22841,13 @@ func (c *current) onAppendCmdOptionsList1(first, rest interface{}) (interface{},
 	return appendCmdOptions, nil
 }
 
-func (p *parser) callonAppendCmdOptionsList1() (interface{}, error) {
+func (p *parser) callonAppendCmdOptionsList1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendCmdOptionsList1(stack["first"], stack["rest"])
 }
 
-func (c *current) onAppendBlock1(options, subsearch interface{}) (interface{}, error) {
+func (c *current) onAppendBlock1(options, subsearch any) (any, error) {
 	appendOptions := &structs.AppendCmdOptions{
 		ExtendTimeRange: false,
 		MaxTime:         60,
@@ -22424,23 +22889,23 @@ func (c *current) onAppendBlock1(options, subsearch interface{}) (interface{}, e
 	}, nil
 }
 
-func (p *parser) callonAppendBlock1() (interface{}, error) {
+func (p *parser) callonAppendBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onAppendBlock1(stack["options"], stack["subsearch"])
 }
 
-func (c *current) onToJsonOption1(option interface{}) (interface{}, error) {
+func (c *current) onToJsonOption1(option any) (any, error) {
 	return option, nil
 }
 
-func (p *parser) callonToJsonOption1() (interface{}, error) {
+func (p *parser) callonToJsonOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonOption1(stack["option"])
 }
 
-func (c *current) onToJsonFunctionOption1(dtype, regexPattern interface{}) (interface{}, error) {
+func (c *current) onToJsonFunctionOption1(dtype, regexPattern any) (any, error) {
 	regex, ok := regexPattern.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: regexPattern type assertion to StringExpr failed")
@@ -22466,13 +22931,13 @@ func (c *current) onToJsonFunctionOption1(dtype, regexPattern interface{}) (inte
 	}, nil
 }
 
-func (p *parser) callonToJsonFunctionOption1() (interface{}, error) {
+func (p *parser) callonToJsonFunctionOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonFunctionOption1(stack["dtype"], stack["regexPattern"])
 }
 
-func (c *current) onToJsonFunctionPostProcess1(regexPattern interface{}) (interface{}, error) {
+func (c *current) onToJsonFunctionPostProcess1(regexPattern any) (any, error) {
 	regex, ok := regexPattern.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: regexPattern type assertion to StringExpr failed")
@@ -22497,13 +22962,13 @@ func (c *current) onToJsonFunctionPostProcess1(regexPattern interface{}) (interf
 	}, nil
 }
 
-func (p *parser) callonToJsonFunctionPostProcess1() (interface{}, error) {
+func (p *parser) callonToJsonFunctionPostProcess1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonFunctionPostProcess1(stack["regexPattern"])
 }
 
-func (c *current) onDefaultTypeOption1(dtype interface{}) (interface{}, error) {
+func (c *current) onDefaultTypeOption1(dtype any) (any, error) {
 	optionDtype := stringToToJsonDtype(string(dtype.([]byte)))
 	gobRegex := utils.GobbableRegex{}
 	option := &structs.ToJsonFieldsDtypeOptions{
@@ -22516,52 +22981,52 @@ func (c *current) onDefaultTypeOption1(dtype interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonDefaultTypeOption1() (interface{}, error) {
+func (p *parser) callonDefaultTypeOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onDefaultTypeOption1(stack["dtype"])
 }
 
-func (c *current) onFillNullOption1(boolVal interface{}) (interface{}, error) {
+func (c *current) onFillNullOption1(boolVal any) (any, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_FILL_NULL,
 		Value:      boolVal.(bool),
 	}, nil
 }
 
-func (p *parser) callonFillNullOption1() (interface{}, error) {
+func (p *parser) callonFillNullOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onFillNullOption1(stack["boolVal"])
 }
 
-func (c *current) onIncludeInternalOption1(boolVal interface{}) (interface{}, error) {
+func (c *current) onIncludeInternalOption1(boolVal any) (any, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_INCLUDE_INTERNAL,
 		Value:      boolVal.(bool),
 	}, nil
 }
 
-func (p *parser) callonIncludeInternalOption1() (interface{}, error) {
+func (p *parser) callonIncludeInternalOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onIncludeInternalOption1(stack["boolVal"])
 }
 
-func (c *current) onOutputFieldOption1(strVal interface{}) (interface{}, error) {
+func (c *current) onOutputFieldOption1(strVal any) (any, error) {
 	return &ToJsonCmdOption{
 		OptionType: TJ_CMD_OUTPUT_FIELD,
 		Value:      strVal.(string),
 	}, nil
 }
 
-func (p *parser) callonOutputFieldOption1() (interface{}, error) {
+func (p *parser) callonOutputFieldOption1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onOutputFieldOption1(stack["strVal"])
 }
 
-func (c *current) onToJsonBlock1(options interface{}) (interface{}, error) {
+func (c *current) onToJsonBlock1(options any) (any, error) {
 	defaultDtypeRegex := utils.GobbableRegex{}
 	err := defaultDtypeRegex.SetRegex(`.*`)
 	if err != nil {
@@ -22612,7 +23077,7 @@ func (c *current) onToJsonBlock1(options interface{}) (interface{}, error) {
 	}, nil
 }
 
-func (p *parser) callonToJsonBlock1() (interface{}, error) {
+func (p *parser) callonToJsonBlock1() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onToJsonBlock1(stack["options"])
@@ -22632,7 +23097,7 @@ var (
 
 	// errMaxExprCnt is used to signal that the maximum number of
 	// expressions have been parsed.
-	errMaxExprCnt = errors.New("max number of expresssions parsed")
+	errMaxExprCnt = errors.New("max number of expressions parsed")
 )
 
 // Option is a function that can set an option on the parser. It returns
@@ -22756,7 +23221,7 @@ func Recover(b bool) Option {
 
 // GlobalStore creates an Option to set a key to a certain value in
 // the globalStore.
-func GlobalStore(key string, value interface{}) Option {
+func GlobalStore(key string, value any) Option {
 	return func(p *parser) Option {
 		old := p.cur.globalStore[key]
 		p.cur.globalStore[key] = value
@@ -22766,7 +23231,7 @@ func GlobalStore(key string, value interface{}) Option {
 
 // InitState creates an Option to set a key to a certain value in
 // the global "state" store.
-func InitState(key string, value interface{}) Option {
+func InitState(key string, value any) Option {
 	return func(p *parser) Option {
 		old := p.cur.state[key]
 		p.cur.state[key] = value
@@ -22775,7 +23240,7 @@ func InitState(key string, value interface{}) Option {
 }
 
 // ParseFile parses the file identified by filename.
-func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
+func ParseFile(filename string, opts ...Option) (i any, err error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
@@ -22790,8 +23255,8 @@ func ParseFile(filename string, opts ...Option) (i interface{}, err error) {
 
 // ParseReader parses the data from r using filename as information in the
 // error messages.
-func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, error) {
-	b, err := ioutil.ReadAll(r)
+func ParseReader(filename string, r io.Reader, opts ...Option) (any, error) {
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -22801,7 +23266,7 @@ func ParseReader(filename string, r io.Reader, opts ...Option) (interface{}, err
 
 // Parse parses the data from b using filename as information in the
 // error messages.
-func Parse(filename string, b []byte, opts ...Option) (interface{}, error) {
+func Parse(filename string, b []byte, opts ...Option) (any, error) {
 	return newParser(filename, b, opts...).parse(g)
 }
 
@@ -22839,7 +23304,7 @@ type current struct {
 	globalStore storeDict
 }
 
-type storeDict map[string]interface{}
+type storeDict map[string]any
 
 // the AST types...
 
@@ -22852,30 +23317,30 @@ type rule struct {
 	pos         position
 	name        string
 	displayName string
-	expr        interface{}
+	expr        any
 }
 
 type choiceExpr struct {
 	pos          position
-	alternatives []interface{}
+	alternatives []any
 }
 
 type actionExpr struct {
 	pos  position
-	expr interface{}
-	run  func(*parser) (interface{}, error)
+	expr any
+	run  func(*parser) (any, error)
 }
 
 type recoveryExpr struct {
 	pos          position
-	expr         interface{}
-	recoverExpr  interface{}
+	expr         any
+	recoverExpr  any
 	failureLabel []string
 }
 
 type seqExpr struct {
 	pos   position
-	exprs []interface{}
+	exprs []any
 }
 
 type throwExpr struct {
@@ -22886,19 +23351,21 @@ type throwExpr struct {
 type labeledExpr struct {
 	pos   position
 	label string
-	expr  interface{}
+	expr  any
 }
 
 type expr struct {
 	pos  position
-	expr interface{}
+	expr any
 }
 
-type andExpr expr
-type notExpr expr
-type zeroOrOneExpr expr
-type zeroOrMoreExpr expr
-type oneOrMoreExpr expr
+type (
+	andExpr        expr
+	notExpr        expr
+	zeroOrOneExpr  expr
+	zeroOrMoreExpr expr
+	oneOrMoreExpr  expr
+)
 
 type ruleRefExpr struct {
 	pos  position
@@ -23039,7 +23506,7 @@ func (p *parser) setOptions(opts []Option) {
 }
 
 type resultTuple struct {
-	v   interface{}
+	v   any
 	b   bool
 	end savepoint
 }
@@ -23083,12 +23550,12 @@ type parser struct {
 	memoize bool
 	// memoization table for the packrat algorithm:
 	// map[offset in source] map[expression or rule] {value, match}
-	memo map[int]map[interface{}]resultTuple
+	memo map[int]map[any]resultTuple
 
 	// rules table, maps the rule identifier to the rule node
 	rules map[string]*rule
 	// variables stack, map of label to value
-	vstack []map[string]interface{}
+	vstack []map[string]any
 	// rule stack, allows identification of the current rule in errors
 	rstack []*rule
 
@@ -23108,7 +23575,7 @@ type parser struct {
 
 	choiceNoMatch string
 	// recovery expression stack, keeps track of the currently available recovery expression, these are traversed in reverse
-	recoveryStack []map[string]interface{}
+	recoveryStack []map[string]any
 }
 
 // push a variable set on the vstack.
@@ -23128,7 +23595,7 @@ func (p *parser) pushV() {
 		return
 	}
 
-	m = make(map[string]interface{})
+	m = make(map[string]any)
 	p.vstack[len(p.vstack)-1] = m
 }
 
@@ -23144,7 +23611,7 @@ func (p *parser) popV() {
 }
 
 // push a recovery expression with its labels to the recoveryStack
-func (p *parser) pushRecovery(labels []string, expr interface{}) {
+func (p *parser) pushRecovery(labels []string, expr any) {
 	if cap(p.recoveryStack) == len(p.recoveryStack) {
 		// create new empty slot in the stack
 		p.recoveryStack = append(p.recoveryStack, nil)
@@ -23153,7 +23620,7 @@ func (p *parser) pushRecovery(labels []string, expr interface{}) {
 		p.recoveryStack = p.recoveryStack[:len(p.recoveryStack)+1]
 	}
 
-	m := make(map[string]interface{}, len(labels))
+	m := make(map[string]any, len(labels))
 	for _, fl := range labels {
 		m[fl] = expr
 	}
@@ -23178,14 +23645,19 @@ func (p *parser) print(prefix, s string) string {
 	return s
 }
 
+func (p *parser) printIndent(mark string, s string) string {
+	return p.print(strings.Repeat(" ", p.depth)+mark, s)
+}
+
 func (p *parser) in(s string) string {
+	res := p.printIndent(">", s)
 	p.depth++
-	return p.print(strings.Repeat(" ", p.depth)+">", s)
+	return res
 }
 
 func (p *parser) out(s string) string {
 	p.depth--
-	return p.print(strings.Repeat(" ", p.depth)+"<", s)
+	return p.printIndent("<", s)
 }
 
 func (p *parser) addErr(err error) {
@@ -23273,11 +23745,11 @@ func (p *parser) restore(pt savepoint) {
 // copies of the state to allow the parser to properly restore the state in
 // the case of backtracking.
 type Cloner interface {
-	Clone() interface{}
+	Clone() any
 }
 
 var statePool = &sync.Pool{
-	New: func() interface{} { return make(storeDict) },
+	New: func() any { return make(storeDict) },
 }
 
 func (sd storeDict) Discard() {
@@ -23319,7 +23791,7 @@ func (p *parser) sliceFrom(start savepoint) []byte {
 	return p.data[start.position.offset:p.pt.position.offset]
 }
 
-func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
+func (p *parser) getMemoized(node any) (resultTuple, bool) {
 	if len(p.memo) == 0 {
 		return resultTuple{}, false
 	}
@@ -23331,13 +23803,13 @@ func (p *parser) getMemoized(node interface{}) (resultTuple, bool) {
 	return res, ok
 }
 
-func (p *parser) setMemoized(pt savepoint, node interface{}, tuple resultTuple) {
+func (p *parser) setMemoized(pt savepoint, node any, tuple resultTuple) {
 	if p.memo == nil {
-		p.memo = make(map[int]map[interface{}]resultTuple)
+		p.memo = make(map[int]map[any]resultTuple)
 	}
 	m := p.memo[pt.offset]
 	if m == nil {
-		m = make(map[interface{}]resultTuple)
+		m = make(map[any]resultTuple)
 		p.memo[pt.offset] = m
 	}
 	m[node] = tuple
@@ -23350,7 +23822,7 @@ func (p *parser) buildRulesTable(g *grammar) {
 	}
 }
 
-func (p *parser) parse(g *grammar) (val interface{}, err error) {
+func (p *parser) parse(g *grammar) (val any, err error) {
 	if len(g.rules) == 0 {
 		p.addErr(errNoRule)
 		return nil, p.errs.err()
@@ -23386,7 +23858,7 @@ func (p *parser) parse(g *grammar) (val interface{}, err error) {
 	}
 
 	p.read() // advance to first rune
-	val, ok = p.parseRule(startRule)
+	val, ok = p.parseRuleWrap(startRule)
 	if !ok {
 		if len(*p.errs) == 0 {
 			// If parsing fails, but no errors have been recorded, the expected values
@@ -23427,36 +23899,52 @@ func listJoin(list []string, sep string, lastSep string) string {
 	}
 }
 
-func (p *parser) parseRule(rule *rule) (interface{}, bool) {
+func (p *parser) parseRuleMemoize(rule *rule) (any, bool) {
+	res, ok := p.getMemoized(rule)
+	if ok {
+		p.restore(res.end)
+		return res.v, res.b
+	}
+
+	startMark := p.pt
+	val, ok := p.parseRule(rule)
+	p.setMemoized(startMark, rule, resultTuple{val, ok, p.pt})
+
+	return val, ok
+}
+
+func (p *parser) parseRuleWrap(rule *rule) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRule " + rule.name))
 	}
+	var (
+		val       any
+		ok        bool
+		startMark = p.pt
+	)
 
 	if p.memoize {
-		res, ok := p.getMemoized(rule)
-		if ok {
-			p.restore(res.end)
-			return res.v, res.b
-		}
+		val, ok = p.parseRuleMemoize(rule)
+	} else {
+		val, ok = p.parseRule(rule)
 	}
 
-	start := p.pt
-	p.rstack = append(p.rstack, rule)
-	p.pushV()
-	val, ok := p.parseExpr(rule.expr)
-	p.popV()
-	p.rstack = p.rstack[:len(p.rstack)-1]
 	if ok && p.debug {
-		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
-	}
-
-	if p.memoize {
-		p.setMemoized(start, rule, resultTuple{val, ok, p.pt})
+		p.printIndent("MATCH", string(p.sliceFrom(startMark)))
 	}
 	return val, ok
 }
 
-func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
+func (p *parser) parseRule(rule *rule) (any, bool) {
+	p.rstack = append(p.rstack, rule)
+	p.pushV()
+	val, ok := p.parseExprWrap(rule.expr)
+	p.popV()
+	p.rstack = p.rstack[:len(p.rstack)-1]
+	return val, ok
+}
+
+func (p *parser) parseExprWrap(expr any) (any, bool) {
 	var pt savepoint
 
 	if p.memoize {
@@ -23468,12 +23956,21 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 		pt = p.pt
 	}
 
+	val, ok := p.parseExpr(expr)
+
+	if p.memoize {
+		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
+	}
+	return val, ok
+}
+
+func (p *parser) parseExpr(expr any) (any, bool) {
 	p.ExprCnt++
 	if p.ExprCnt > p.maxExprCnt {
 		panic(errMaxExprCnt)
 	}
 
-	var val interface{}
+	var val any
 	var ok bool
 	switch expr := expr.(type) {
 	case *actionExpr:
@@ -23515,19 +24012,16 @@ func (p *parser) parseExpr(expr interface{}) (interface{}, bool) {
 	default:
 		panic(fmt.Sprintf("unknown expression type %T", expr))
 	}
-	if p.memoize {
-		p.setMemoized(pt, expr, resultTuple{val, ok, p.pt})
-	}
 	return val, ok
 }
 
-func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
+func (p *parser) parseActionExpr(act *actionExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseActionExpr"))
 	}
 
 	start := p.pt
-	val, ok := p.parseExpr(act.expr)
+	val, ok := p.parseExprWrap(act.expr)
 	if ok {
 		p.cur.pos = start.position
 		p.cur.text = p.sliceFrom(start)
@@ -23541,12 +24035,12 @@ func (p *parser) parseActionExpr(act *actionExpr) (interface{}, bool) {
 		val = actVal
 	}
 	if ok && p.debug {
-		p.print(strings.Repeat(" ", p.depth)+"MATCH", string(p.sliceFrom(start)))
+		p.printIndent("MATCH", string(p.sliceFrom(start)))
 	}
 	return val, ok
 }
 
-func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
+func (p *parser) parseAndCodeExpr(and *andCodeExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAndCodeExpr"))
 	}
@@ -23562,7 +24056,7 @@ func (p *parser) parseAndCodeExpr(and *andCodeExpr) (interface{}, bool) {
 	return nil, ok
 }
 
-func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
+func (p *parser) parseAndExpr(and *andExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAndExpr"))
 	}
@@ -23570,7 +24064,7 @@ func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
 	pt := p.pt
 	state := p.cloneState()
 	p.pushV()
-	_, ok := p.parseExpr(and.expr)
+	_, ok := p.parseExprWrap(and.expr)
 	p.popV()
 	p.restoreState(state)
 	p.restore(pt)
@@ -23578,7 +24072,7 @@ func (p *parser) parseAndExpr(and *andExpr) (interface{}, bool) {
 	return nil, ok
 }
 
-func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
+func (p *parser) parseAnyMatcher(any *anyMatcher) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseAnyMatcher"))
 	}
@@ -23594,7 +24088,7 @@ func (p *parser) parseAnyMatcher(any *anyMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
-func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (interface{}, bool) {
+func (p *parser) parseCharClassMatcher(chr *charClassMatcher) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseCharClassMatcher"))
 	}
@@ -23675,7 +24169,7 @@ func (p *parser) incChoiceAltCnt(ch *choiceExpr, altI int) {
 	m[alt]++
 }
 
-func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
+func (p *parser) parseChoiceExpr(ch *choiceExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseChoiceExpr"))
 	}
@@ -23687,7 +24181,7 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 		state := p.cloneState()
 
 		p.pushV()
-		val, ok := p.parseExpr(alt)
+		val, ok := p.parseExprWrap(alt)
 		p.popV()
 		if ok {
 			p.incChoiceAltCnt(ch, altI)
@@ -23699,13 +24193,13 @@ func (p *parser) parseChoiceExpr(ch *choiceExpr) (interface{}, bool) {
 	return nil, false
 }
 
-func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
+func (p *parser) parseLabeledExpr(lab *labeledExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseLabeledExpr"))
 	}
 
 	p.pushV()
-	val, ok := p.parseExpr(lab.expr)
+	val, ok := p.parseExprWrap(lab.expr)
 	p.popV()
 	if ok && lab.label != "" {
 		m := p.vstack[len(p.vstack)-1]
@@ -23714,7 +24208,7 @@ func (p *parser) parseLabeledExpr(lab *labeledExpr) (interface{}, bool) {
 	return val, ok
 }
 
-func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
+func (p *parser) parseLitMatcher(lit *litMatcher) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseLitMatcher"))
 	}
@@ -23736,7 +24230,7 @@ func (p *parser) parseLitMatcher(lit *litMatcher) (interface{}, bool) {
 	return p.sliceFrom(start), true
 }
 
-func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
+func (p *parser) parseNotCodeExpr(not *notCodeExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseNotCodeExpr"))
 	}
@@ -23752,7 +24246,7 @@ func (p *parser) parseNotCodeExpr(not *notCodeExpr) (interface{}, bool) {
 	return nil, !ok
 }
 
-func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
+func (p *parser) parseNotExpr(not *notExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseNotExpr"))
 	}
@@ -23761,7 +24255,7 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 	state := p.cloneState()
 	p.pushV()
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
-	_, ok := p.parseExpr(not.expr)
+	_, ok := p.parseExprWrap(not.expr)
 	p.maxFailInvertExpected = !p.maxFailInvertExpected
 	p.popV()
 	p.restoreState(state)
@@ -23770,16 +24264,16 @@ func (p *parser) parseNotExpr(not *notExpr) (interface{}, bool) {
 	return nil, !ok
 }
 
-func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
+func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseOneOrMoreExpr"))
 	}
 
-	var vals []interface{}
+	var vals []any
 
 	for {
 		p.pushV()
-		val, ok := p.parseExpr(expr.expr)
+		val, ok := p.parseExprWrap(expr.expr)
 		p.popV()
 		if !ok {
 			if len(vals) == 0 {
@@ -23792,19 +24286,19 @@ func (p *parser) parseOneOrMoreExpr(expr *oneOrMoreExpr) (interface{}, bool) {
 	}
 }
 
-func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (interface{}, bool) {
+func (p *parser) parseRecoveryExpr(recover *recoveryExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRecoveryExpr (" + strings.Join(recover.failureLabel, ",") + ")"))
 	}
 
 	p.pushRecovery(recover.failureLabel, recover.recoverExpr)
-	val, ok := p.parseExpr(recover.expr)
+	val, ok := p.parseExprWrap(recover.expr)
 	p.popRecovery()
 
 	return val, ok
 }
 
-func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
+func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseRuleRefExpr " + ref.name))
 	}
@@ -23818,20 +24312,20 @@ func (p *parser) parseRuleRefExpr(ref *ruleRefExpr) (interface{}, bool) {
 		p.addErr(fmt.Errorf("undefined rule: %s", ref.name))
 		return nil, false
 	}
-	return p.parseRule(rule)
+	return p.parseRuleWrap(rule)
 }
 
-func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
+func (p *parser) parseSeqExpr(seq *seqExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseSeqExpr"))
 	}
 
-	vals := make([]interface{}, 0, len(seq.exprs))
+	vals := make([]any, 0, len(seq.exprs))
 
 	pt := p.pt
 	state := p.cloneState()
 	for _, expr := range seq.exprs {
-		val, ok := p.parseExpr(expr)
+		val, ok := p.parseExprWrap(expr)
 		if !ok {
 			p.restoreState(state)
 			p.restore(pt)
@@ -23842,7 +24336,7 @@ func (p *parser) parseSeqExpr(seq *seqExpr) (interface{}, bool) {
 	return vals, true
 }
 
-func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
+func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseStateCodeExpr"))
 	}
@@ -23854,14 +24348,14 @@ func (p *parser) parseStateCodeExpr(state *stateCodeExpr) (interface{}, bool) {
 	return nil, true
 }
 
-func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
+func (p *parser) parseThrowExpr(expr *throwExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseThrowExpr"))
 	}
 
 	for i := len(p.recoveryStack) - 1; i >= 0; i-- {
 		if recoverExpr, ok := p.recoveryStack[i][expr.label]; ok {
-			if val, ok := p.parseExpr(recoverExpr); ok {
+			if val, ok := p.parseExprWrap(recoverExpr); ok {
 				return val, ok
 			}
 		}
@@ -23870,16 +24364,16 @@ func (p *parser) parseThrowExpr(expr *throwExpr) (interface{}, bool) {
 	return nil, false
 }
 
-func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
+func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseZeroOrMoreExpr"))
 	}
 
-	var vals []interface{}
+	var vals []any
 
 	for {
 		p.pushV()
-		val, ok := p.parseExpr(expr.expr)
+		val, ok := p.parseExprWrap(expr.expr)
 		p.popV()
 		if !ok {
 			return vals, true
@@ -23888,13 +24382,13 @@ func (p *parser) parseZeroOrMoreExpr(expr *zeroOrMoreExpr) (interface{}, bool) {
 	}
 }
 
-func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (interface{}, bool) {
+func (p *parser) parseZeroOrOneExpr(expr *zeroOrOneExpr) (any, bool) {
 	if p.debug {
 		defer p.out(p.in("parseZeroOrOneExpr"))
 	}
 
 	p.pushV()
-	val, _ := p.parseExpr(expr.expr)
+	val, _ := p.parseExprWrap(expr.expr)
 	p.popV()
 	// whether it matched or not, consider it a match
 	return val, true

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -298,11 +298,14 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
 	}, nil
 }
 
-func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
-	if leftExpr.Op == "" {
+func createJsonExprSingleNodeAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+	if leftExpr == nil && rightExpr == nil {
+		return nil, fmt.Errorf("spl peg: both left and right expressions can not be nil at the same time; %v", op)
+	}
+	if leftExpr != nil && leftExpr.Op == "" {
 		leftExpr.Op = op
 	}
-	if rightExpr.Op == "" {
+	if rightExpr != nil && rightExpr.Op == "" {
 		rightExpr.Op = op
 	}
 	return &structs.JsonExpr{
@@ -327,12 +330,19 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 		// key can only be a string => either a field or a StringExpr
 		// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
 		if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
-			return fmt.Errorf("spl peg: key in json_object can only be a string")
+			return fmt.Errorf("spl peg: key can only be a string")
 		}
 		return nil
 	}
 
-	astDs := make([]*structs.JsonExpr, 1, 5)
+	var capacityOfAstDs int = 1
+	if rest != nil {
+		// each key value pair in rest is accompanied by two commas
+		// [",", "key", ",", "value"]
+		// therefore we divide by 4 to get the actual length. (key+value = 1 node)
+		capacityOfAstDs = len(rest.([]any))/4 + 1
+	}
+	astDs := make([]*structs.JsonExpr, 1, capacityOfAstDs)
 	keyToIdxMap := make(map[string]int)
 
 	key, ok := firstKey.(*structs.JsonExpr)
@@ -361,6 +371,7 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 
 	keyToIdxMap[rawKey] = 0
 
+	// the node is not a terminal node if the JsonExpr is a nested Expr
 	astDs[0] = &structs.JsonExpr{
 		Op:           opNameStr,
 		JsonExprMode: structs.JEMKeyVal,
@@ -405,9 +416,10 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 				Value:        restValue,
 			}
 
-			var v int
-			if v, ok = keyToIdxMap[rawKey]; ok {
-				astDs[v] = keyValueStruct
+			// deduplication of keys, last/latest key overwrites the previous key if exists
+			var indexInStructure int
+			if indexInStructure, ok = keyToIdxMap[rawKey]; ok {
+				astDs[indexInStructure] = keyValueStruct
 			} else {
 				keyToIdxMap[rawKey] = len(astDs)
 				astDs = append(astDs, keyValueStruct)
@@ -419,7 +431,49 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 	result := astDs[0]
 	for i := 1; i < len(astDs); i++ {
 		var err error
-		result, err = createJsonExprAst(opNameStr, result, astDs[i], structs.JEMExpr)
+		result, err = createJsonExprSingleNodeAst(opNameStr, result, astDs[i], structs.JEMExpr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func createJsonExprAst(opNameStr string, firstValue any, rest any, argumentOffset int) (*structs.JsonExpr, error) {
+	castedValue, ok := firstValue.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
+	}
+
+	var capacityArgs int = 1
+	if rest != nil {
+		// each value in rest is of the type - [",", "value"]
+		// therefore we divide by two to get the actual length.
+		// + 1 is for firstValue
+		capacityArgs = len(rest.([]any))/2 + 1
+	}
+
+	args := make([]*structs.JsonExpr, 1, capacityArgs)
+	args[0] = castedValue
+
+	if rest != nil {
+		var restValue *structs.JsonExpr
+		for idx, arg := range rest.([]any) {
+			restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1+argumentOffset)
+			}
+			args = append(args, restValue)
+		}
+	}
+
+	var result *structs.JsonExpr
+	var err error
+
+	result = args[0]
+	for i := 1; i < len(args); i++ {
+		result, err = createJsonExprSingleNodeAst(opNameStr, result, args[i], structs.JEMExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -674,177 +728,177 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 662, col: 1, offset: 19078},
+			pos:  position{line: 716, col: 1, offset: 21161},
 			expr: &choiceExpr{
-				pos: position{line: 662, col: 10, offset: 19087},
+				pos: position{line: 716, col: 10, offset: 21170},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 662, col: 10, offset: 19087},
+						pos: position{line: 716, col: 10, offset: 21170},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 662, col: 10, offset: 19087},
+							pos: position{line: 716, col: 10, offset: 21170},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 662, col: 10, offset: 19087},
+									pos:   position{line: 716, col: 10, offset: 21170},
 									label: "indexBlock",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 662, col: 21, offset: 19098},
+										pos: position{line: 716, col: 21, offset: 21181},
 										expr: &ruleRefExpr{
-											pos:  position{line: 662, col: 22, offset: 19099},
+											pos:  position{line: 716, col: 22, offset: 21182},
 											name: "IndexBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 662, col: 35, offset: 19112},
+									pos: position{line: 716, col: 35, offset: 21195},
 									expr: &ruleRefExpr{
-										pos:  position{line: 662, col: 35, offset: 19112},
+										pos:  position{line: 716, col: 35, offset: 21195},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 662, col: 42, offset: 19119},
+									pos:   position{line: 716, col: 42, offset: 21202},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 662, col: 57, offset: 19134},
+										pos:  position{line: 716, col: 57, offset: 21217},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 662, col: 77, offset: 19154},
+									pos:   position{line: 716, col: 77, offset: 21237},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 662, col: 90, offset: 19167},
+										pos: position{line: 716, col: 90, offset: 21250},
 										expr: &ruleRefExpr{
-											pos:  position{line: 662, col: 91, offset: 19168},
+											pos:  position{line: 716, col: 91, offset: 21251},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 662, col: 105, offset: 19182},
+									pos:   position{line: 716, col: 105, offset: 21265},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 662, col: 120, offset: 19197},
+										pos: position{line: 716, col: 120, offset: 21280},
 										expr: &ruleRefExpr{
-											pos:  position{line: 662, col: 121, offset: 19198},
+											pos:  position{line: 716, col: 121, offset: 21281},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 662, col: 144, offset: 19221},
+									pos: position{line: 716, col: 144, offset: 21304},
 									expr: &ruleRefExpr{
-										pos:  position{line: 662, col: 144, offset: 19221},
+										pos:  position{line: 716, col: 144, offset: 21304},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 662, col: 151, offset: 19228},
+									pos:  position{line: 716, col: 151, offset: 21311},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 728, col: 3, offset: 21151},
+						pos: position{line: 782, col: 3, offset: 23234},
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
-							pos: position{line: 728, col: 3, offset: 21151},
+							pos: position{line: 782, col: 3, offset: 23234},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 728, col: 3, offset: 21151},
+									pos: position{line: 782, col: 3, offset: 23234},
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 3, offset: 21151},
+										pos:  position{line: 782, col: 3, offset: 23234},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 10, offset: 21158},
+									pos:  position{line: 782, col: 10, offset: 23241},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 15, offset: 21163},
+									pos:  position{line: 782, col: 15, offset: 23246},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 28, offset: 21176},
+									pos:  position{line: 782, col: 28, offset: 23259},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 34, offset: 21182},
+									pos:   position{line: 782, col: 34, offset: 23265},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 50, offset: 21198},
+										pos:  position{line: 782, col: 50, offset: 23281},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 728, col: 70, offset: 21218},
+									pos:   position{line: 782, col: 70, offset: 23301},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 728, col: 85, offset: 21233},
+										pos: position{line: 782, col: 85, offset: 23316},
 										expr: &ruleRefExpr{
-											pos:  position{line: 728, col: 86, offset: 21234},
+											pos:  position{line: 782, col: 86, offset: 23317},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 728, col: 109, offset: 21257},
+									pos: position{line: 782, col: 109, offset: 23340},
 									expr: &ruleRefExpr{
-										pos:  position{line: 728, col: 109, offset: 21257},
+										pos:  position{line: 782, col: 109, offset: 23340},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 728, col: 116, offset: 21264},
+									pos:  position{line: 782, col: 116, offset: 23347},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 747, col: 3, offset: 21777},
+						pos: position{line: 801, col: 3, offset: 23860},
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
-							pos: position{line: 747, col: 3, offset: 21777},
+							pos: position{line: 801, col: 3, offset: 23860},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 747, col: 3, offset: 21777},
+									pos: position{line: 801, col: 3, offset: 23860},
 									expr: &ruleRefExpr{
-										pos:  position{line: 747, col: 3, offset: 21777},
+										pos:  position{line: 801, col: 3, offset: 23860},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 747, col: 10, offset: 21784},
+									pos:   position{line: 801, col: 10, offset: 23867},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 747, col: 22, offset: 21796},
+										pos:  position{line: 801, col: 22, offset: 23879},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 747, col: 39, offset: 21813},
+									pos:   position{line: 801, col: 39, offset: 23896},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 747, col: 54, offset: 21828},
+										pos: position{line: 801, col: 54, offset: 23911},
 										expr: &ruleRefExpr{
-											pos:  position{line: 747, col: 55, offset: 21829},
+											pos:  position{line: 801, col: 55, offset: 23912},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 747, col: 78, offset: 21852},
+									pos: position{line: 801, col: 78, offset: 23935},
 									expr: &ruleRefExpr{
-										pos:  position{line: 747, col: 78, offset: 21852},
+										pos:  position{line: 801, col: 78, offset: 23935},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 747, col: 85, offset: 21859},
+									pos:  position{line: 801, col: 85, offset: 23942},
 									name: "EOF",
 								},
 							},
@@ -855,32 +909,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexAssign",
-			pos:  position{line: 763, col: 1, offset: 22241},
+			pos:  position{line: 817, col: 1, offset: 24324},
 			expr: &actionExpr{
-				pos: position{line: 763, col: 16, offset: 22256},
+				pos: position{line: 817, col: 16, offset: 24339},
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
-					pos: position{line: 763, col: 16, offset: 22256},
+					pos: position{line: 817, col: 16, offset: 24339},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 763, col: 16, offset: 22256},
+							pos:   position{line: 817, col: 16, offset: 24339},
 							label: "index",
 							expr: &litMatcher{
-								pos:        position{line: 763, col: 23, offset: 22263},
+								pos:        position{line: 817, col: 23, offset: 24346},
 								val:        "_index",
 								ignoreCase: false,
 								want:       "\"_index\"",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 763, col: 33, offset: 22273},
+							pos:  position{line: 817, col: 33, offset: 24356},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 763, col: 39, offset: 22279},
+							pos:   position{line: 817, col: 39, offset: 24362},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 763, col: 49, offset: 22289},
+								pos:  position{line: 817, col: 49, offset: 24372},
 								name: "String",
 							},
 						},
@@ -890,35 +944,35 @@ var g = &grammar{
 		},
 		{
 			name: "IndexExpression",
-			pos:  position{line: 768, col: 1, offset: 22478},
+			pos:  position{line: 822, col: 1, offset: 24561},
 			expr: &actionExpr{
-				pos: position{line: 768, col: 20, offset: 22497},
+				pos: position{line: 822, col: 20, offset: 24580},
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
-					pos: position{line: 768, col: 20, offset: 22497},
+					pos: position{line: 822, col: 20, offset: 24580},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 768, col: 20, offset: 22497},
+							pos:   position{line: 822, col: 20, offset: 24580},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 768, col: 27, offset: 22504},
+								pos:  position{line: 822, col: 27, offset: 24587},
 								name: "IndexAssign",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 768, col: 40, offset: 22517},
+							pos:   position{line: 822, col: 40, offset: 24600},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 768, col: 45, offset: 22522},
+								pos: position{line: 822, col: 45, offset: 24605},
 								expr: &seqExpr{
-									pos: position{line: 768, col: 46, offset: 22523},
+									pos: position{line: 822, col: 46, offset: 24606},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 768, col: 46, offset: 22523},
+											pos:  position{line: 822, col: 46, offset: 24606},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 768, col: 49, offset: 22526},
+											pos:  position{line: 822, col: 49, offset: 24609},
 											name: "IndexAssign",
 										},
 									},
@@ -931,32 +985,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexBlock",
-			pos:  position{line: 793, col: 1, offset: 23107},
+			pos:  position{line: 847, col: 1, offset: 25190},
 			expr: &actionExpr{
-				pos: position{line: 793, col: 15, offset: 23121},
+				pos: position{line: 847, col: 15, offset: 25204},
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 793, col: 15, offset: 23121},
+					pos: position{line: 847, col: 15, offset: 25204},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 793, col: 15, offset: 23121},
+							pos: position{line: 847, col: 15, offset: 25204},
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 15, offset: 23121},
+								pos:  position{line: 847, col: 15, offset: 25204},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 793, col: 22, offset: 23128},
+							pos:   position{line: 847, col: 22, offset: 25211},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 33, offset: 23139},
+								pos:  position{line: 847, col: 33, offset: 25222},
 								name: "IndexExpression",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 793, col: 50, offset: 23156},
+							pos: position{line: 847, col: 50, offset: 25239},
 							expr: &ruleRefExpr{
-								pos:  position{line: 793, col: 50, offset: 23156},
+								pos:  position{line: 847, col: 50, offset: 25239},
 								name: "PIPE",
 							},
 						},
@@ -966,76 +1020,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 797, col: 1, offset: 23193},
+			pos:  position{line: 851, col: 1, offset: 25276},
 			expr: &actionExpr{
-				pos: position{line: 797, col: 21, offset: 23213},
+				pos: position{line: 851, col: 21, offset: 25296},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 797, col: 21, offset: 23213},
+					pos: position{line: 851, col: 21, offset: 25296},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 797, col: 21, offset: 23213},
+							pos:        position{line: 851, col: 21, offset: 25296},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 797, col: 26, offset: 23218},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 797, col: 32, offset: 23224},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 797, col: 36, offset: 23228},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 797, col: 41, offset: 23233},
+							pos:        position{line: 851, col: 26, offset: 25301},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 797, col: 47, offset: 23239},
+							pos:        position{line: 851, col: 32, offset: 25307},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 797, col: 51, offset: 23243},
+							pos:        position{line: 851, col: 36, offset: 25311},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 797, col: 56, offset: 23248},
+							pos:        position{line: 851, col: 41, offset: 25316},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 851, col: 47, offset: 25322},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 851, col: 51, offset: 25326},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 797, col: 61, offset: 23253},
+							pos:        position{line: 851, col: 56, offset: 25331},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 797, col: 66, offset: 23258},
+							pos:        position{line: 851, col: 61, offset: 25336},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 851, col: 66, offset: 25341},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -1047,15 +1101,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 804, col: 1, offset: 23399},
+			pos:  position{line: 858, col: 1, offset: 25482},
 			expr: &actionExpr{
-				pos: position{line: 804, col: 31, offset: 23429},
+				pos: position{line: 858, col: 31, offset: 25512},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 804, col: 31, offset: 23429},
+					pos:   position{line: 858, col: 31, offset: 25512},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 804, col: 38, offset: 23436},
+						pos:  position{line: 858, col: 38, offset: 25519},
 						name: "IntegerAsString",
 					},
 				},
@@ -1063,22 +1117,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 822, col: 1, offset: 24079},
+			pos:  position{line: 876, col: 1, offset: 26162},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 26, offset: 24104},
+				pos: position{line: 876, col: 26, offset: 26187},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 822, col: 26, offset: 24104},
+					pos:   position{line: 876, col: 26, offset: 26187},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 822, col: 37, offset: 24115},
+						pos: position{line: 876, col: 37, offset: 26198},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 822, col: 37, offset: 24115},
+								pos:  position{line: 876, col: 37, offset: 26198},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 822, col: 53, offset: 24131},
+								pos:  position{line: 876, col: 53, offset: 26214},
 								name: "PartialTimestamp",
 							},
 						},
@@ -1088,22 +1142,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 831, col: 1, offset: 24389},
+			pos:  position{line: 885, col: 1, offset: 26472},
 			expr: &actionExpr{
-				pos: position{line: 831, col: 17, offset: 24405},
+				pos: position{line: 885, col: 17, offset: 26488},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 831, col: 17, offset: 24405},
+					pos:   position{line: 885, col: 17, offset: 26488},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 831, col: 31, offset: 24419},
+						pos: position{line: 885, col: 31, offset: 26502},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 831, col: 31, offset: 24419},
+								pos:  position{line: 885, col: 31, offset: 26502},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 831, col: 55, offset: 24443},
+								pos:  position{line: 885, col: 55, offset: 26526},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -1113,28 +1167,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 835, col: 1, offset: 24505},
+			pos:  position{line: 889, col: 1, offset: 26588},
 			expr: &actionExpr{
-				pos: position{line: 835, col: 22, offset: 24526},
+				pos: position{line: 889, col: 22, offset: 26609},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 835, col: 22, offset: 24526},
+					pos: position{line: 889, col: 22, offset: 26609},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 835, col: 22, offset: 24526},
+							pos:        position{line: 889, col: 22, offset: 26609},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 835, col: 28, offset: 24532},
+							pos:  position{line: 889, col: 28, offset: 26615},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 835, col: 34, offset: 24538},
+							pos:   position{line: 889, col: 34, offset: 26621},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 835, col: 45, offset: 24549},
+								pos:  position{line: 889, col: 45, offset: 26632},
 								name: "GenTimestamp",
 							},
 						},
@@ -1144,28 +1198,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 844, col: 1, offset: 24739},
+			pos:  position{line: 898, col: 1, offset: 26822},
 			expr: &actionExpr{
-				pos: position{line: 844, col: 24, offset: 24762},
+				pos: position{line: 898, col: 24, offset: 26845},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 844, col: 24, offset: 24762},
+					pos: position{line: 898, col: 24, offset: 26845},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 844, col: 24, offset: 24762},
+							pos:        position{line: 898, col: 24, offset: 26845},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 844, col: 32, offset: 24770},
+							pos:  position{line: 898, col: 32, offset: 26853},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 844, col: 38, offset: 24776},
+							pos:   position{line: 898, col: 38, offset: 26859},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 844, col: 49, offset: 24787},
+								pos:  position{line: 898, col: 49, offset: 26870},
 								name: "GenTimestamp",
 							},
 						},
@@ -1175,59 +1229,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 853, col: 1, offset: 24981},
+			pos:  position{line: 907, col: 1, offset: 27064},
 			expr: &actionExpr{
-				pos: position{line: 853, col: 28, offset: 25008},
+				pos: position{line: 907, col: 28, offset: 27091},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 853, col: 28, offset: 25008},
+					pos: position{line: 907, col: 28, offset: 27091},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 853, col: 28, offset: 25008},
+							pos:        position{line: 907, col: 28, offset: 27091},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 853, col: 40, offset: 25020},
+							pos:  position{line: 907, col: 40, offset: 27103},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 46, offset: 25026},
+							pos:   position{line: 907, col: 46, offset: 27109},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 853, col: 53, offset: 25033},
+								pos:  position{line: 907, col: 53, offset: 27116},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 853, col: 69, offset: 25049},
+							pos:   position{line: 907, col: 69, offset: 27132},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 853, col: 77, offset: 25057},
+								pos: position{line: 907, col: 77, offset: 27140},
 								expr: &choiceExpr{
-									pos: position{line: 853, col: 78, offset: 25058},
+									pos: position{line: 907, col: 78, offset: 27141},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 853, col: 78, offset: 25058},
+											pos:        position{line: 907, col: 78, offset: 27141},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 84, offset: 25064},
+											pos:        position{line: 907, col: 84, offset: 27147},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 90, offset: 25070},
+											pos:        position{line: 907, col: 90, offset: 27153},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 853, col: 96, offset: 25076},
+											pos:        position{line: 907, col: 96, offset: 27159},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -1242,26 +1296,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 894, col: 1, offset: 26228},
+			pos:  position{line: 948, col: 1, offset: 28311},
 			expr: &actionExpr{
-				pos: position{line: 894, col: 19, offset: 26246},
+				pos: position{line: 948, col: 19, offset: 28329},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 894, col: 19, offset: 26246},
+					pos:   position{line: 948, col: 19, offset: 28329},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 894, col: 35, offset: 26262},
+						pos: position{line: 948, col: 35, offset: 28345},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 894, col: 35, offset: 26262},
+								pos:  position{line: 948, col: 35, offset: 28345},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 894, col: 55, offset: 26282},
+								pos:  position{line: 948, col: 55, offset: 28365},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 894, col: 77, offset: 26304},
+								pos:  position{line: 948, col: 77, offset: 28387},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -1271,35 +1325,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 898, col: 1, offset: 26365},
+			pos:  position{line: 952, col: 1, offset: 28448},
 			expr: &actionExpr{
-				pos: position{line: 898, col: 23, offset: 26387},
+				pos: position{line: 952, col: 23, offset: 28470},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 898, col: 23, offset: 26387},
+					pos: position{line: 952, col: 23, offset: 28470},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 898, col: 23, offset: 26387},
+							pos:   position{line: 952, col: 23, offset: 28470},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 898, col: 29, offset: 26393},
+								pos:  position{line: 952, col: 29, offset: 28476},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 898, col: 44, offset: 26408},
+							pos:   position{line: 952, col: 44, offset: 28491},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 898, col: 49, offset: 26413},
+								pos: position{line: 952, col: 49, offset: 28496},
 								expr: &seqExpr{
-									pos: position{line: 898, col: 50, offset: 26414},
+									pos: position{line: 952, col: 50, offset: 28497},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 898, col: 50, offset: 26414},
+											pos:  position{line: 952, col: 50, offset: 28497},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 898, col: 56, offset: 26420},
+											pos:  position{line: 952, col: 56, offset: 28503},
 											name: "GenTimesOption",
 										},
 									},
@@ -1312,25 +1366,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 950, col: 1, offset: 28173},
+			pos:  position{line: 1004, col: 1, offset: 30256},
 			expr: &actionExpr{
-				pos: position{line: 950, col: 23, offset: 28195},
+				pos: position{line: 1004, col: 23, offset: 30278},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 950, col: 23, offset: 28195},
+					pos: position{line: 1004, col: 23, offset: 30278},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 950, col: 23, offset: 28195},
+							pos: position{line: 1004, col: 23, offset: 30278},
 							expr: &ruleRefExpr{
-								pos:  position{line: 950, col: 23, offset: 28195},
+								pos:  position{line: 1004, col: 23, offset: 30278},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 950, col: 35, offset: 28207},
+							pos:   position{line: 1004, col: 35, offset: 30290},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 950, col: 42, offset: 28214},
+								pos:  position{line: 1004, col: 42, offset: 30297},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1340,32 +1394,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 954, col: 1, offset: 28255},
+			pos:  position{line: 1008, col: 1, offset: 30338},
 			expr: &actionExpr{
-				pos: position{line: 954, col: 16, offset: 28270},
+				pos: position{line: 1008, col: 16, offset: 30353},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 954, col: 16, offset: 28270},
+					pos: position{line: 1008, col: 16, offset: 30353},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 954, col: 16, offset: 28270},
+							pos: position{line: 1008, col: 16, offset: 30353},
 							expr: &ruleRefExpr{
-								pos:  position{line: 954, col: 18, offset: 28272},
+								pos:  position{line: 1008, col: 18, offset: 30355},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 954, col: 26, offset: 28280},
+							pos: position{line: 1008, col: 26, offset: 30363},
 							expr: &ruleRefExpr{
-								pos:  position{line: 954, col: 26, offset: 28280},
+								pos:  position{line: 1008, col: 26, offset: 30363},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 954, col: 38, offset: 28292},
+							pos:   position{line: 1008, col: 38, offset: 30375},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 954, col: 45, offset: 28299},
+								pos:  position{line: 1008, col: 45, offset: 30382},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1375,33 +1429,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 958, col: 1, offset: 28340},
+			pos:  position{line: 1012, col: 1, offset: 30423},
 			expr: &actionExpr{
-				pos: position{line: 958, col: 16, offset: 28355},
+				pos: position{line: 1012, col: 16, offset: 30438},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 958, col: 16, offset: 28355},
+					pos: position{line: 1012, col: 16, offset: 30438},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 958, col: 16, offset: 28355},
+							pos:  position{line: 1012, col: 16, offset: 30438},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 958, col: 21, offset: 28360},
+							pos:   position{line: 1012, col: 21, offset: 30443},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 958, col: 28, offset: 28367},
+								pos: position{line: 1012, col: 28, offset: 30450},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 958, col: 28, offset: 28367},
+										pos:  position{line: 1012, col: 28, offset: 30450},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 958, col: 42, offset: 28381},
+										pos:  position{line: 1012, col: 42, offset: 30464},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 958, col: 55, offset: 28394},
+										pos:  position{line: 1012, col: 55, offset: 30477},
 										name: "TimeModifiers",
 									},
 								},
@@ -1413,114 +1467,114 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 963, col: 1, offset: 28473},
+			pos:  position{line: 1017, col: 1, offset: 30556},
 			expr: &actionExpr{
-				pos: position{line: 963, col: 25, offset: 28497},
+				pos: position{line: 1017, col: 25, offset: 30580},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 963, col: 25, offset: 28497},
+					pos:   position{line: 1017, col: 25, offset: 30580},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 963, col: 32, offset: 28504},
+						pos: position{line: 1017, col: 32, offset: 30587},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 32, offset: 28504},
+								pos:  position{line: 1017, col: 32, offset: 30587},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 51, offset: 28523},
+								pos:  position{line: 1017, col: 51, offset: 30606},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 69, offset: 28541},
+								pos:  position{line: 1017, col: 69, offset: 30624},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 81, offset: 28553},
+								pos:  position{line: 1017, col: 81, offset: 30636},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 94, offset: 28566},
+								pos:  position{line: 1017, col: 94, offset: 30649},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 106, offset: 28578},
+								pos:  position{line: 1017, col: 106, offset: 30661},
 								name: "RegexAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 122, offset: 28594},
+								pos:  position{line: 1017, col: 122, offset: 30677},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 133, offset: 28605},
+								pos:  position{line: 1017, col: 133, offset: 30688},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 150, offset: 28622},
+								pos:  position{line: 1017, col: 150, offset: 30705},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 164, offset: 28636},
+								pos:  position{line: 1017, col: 164, offset: 30719},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 181, offset: 28653},
+								pos:  position{line: 1017, col: 181, offset: 30736},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 200, offset: 28672},
+								pos:  position{line: 1017, col: 200, offset: 30755},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 213, offset: 28685},
+								pos:  position{line: 1017, col: 213, offset: 30768},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 225, offset: 28697},
+								pos:  position{line: 1017, col: 225, offset: 30780},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 243, offset: 28715},
+								pos:  position{line: 1017, col: 243, offset: 30798},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 256, offset: 28728},
+								pos:  position{line: 1017, col: 256, offset: 30811},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 270, offset: 28742},
+								pos:  position{line: 1017, col: 270, offset: 30825},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 288, offset: 28760},
+								pos:  position{line: 1017, col: 288, offset: 30843},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 300, offset: 28772},
+								pos:  position{line: 1017, col: 300, offset: 30855},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 311, offset: 28783},
+								pos:  position{line: 1017, col: 311, offset: 30866},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 330, offset: 28802},
+								pos:  position{line: 1017, col: 330, offset: 30885},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 346, offset: 28818},
+								pos:  position{line: 1017, col: 346, offset: 30901},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 362, offset: 28834},
+								pos:  position{line: 1017, col: 362, offset: 30917},
 								name: "InputLookupAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 384, offset: 28856},
+								pos:  position{line: 1017, col: 384, offset: 30939},
 								name: "AppendBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 963, col: 398, offset: 28870},
+								pos:  position{line: 1017, col: 398, offset: 30953},
 								name: "ToJsonBlock",
 							},
 						},
@@ -1530,37 +1584,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 968, col: 1, offset: 28963},
+			pos:  position{line: 1022, col: 1, offset: 31046},
 			expr: &actionExpr{
-				pos: position{line: 968, col: 21, offset: 28983},
+				pos: position{line: 1022, col: 21, offset: 31066},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 968, col: 21, offset: 28983},
+					pos: position{line: 1022, col: 21, offset: 31066},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 21, offset: 28983},
+							pos:  position{line: 1022, col: 21, offset: 31066},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 26, offset: 28988},
+							pos:  position{line: 1022, col: 26, offset: 31071},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 37, offset: 28999},
+							pos:   position{line: 1022, col: 37, offset: 31082},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 968, col: 40, offset: 29002},
+								pos: position{line: 1022, col: 40, offset: 31085},
 								expr: &choiceExpr{
-									pos: position{line: 968, col: 41, offset: 29003},
+									pos: position{line: 1022, col: 41, offset: 31086},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 968, col: 41, offset: 29003},
+											pos:        position{line: 1022, col: 41, offset: 31086},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 968, col: 47, offset: 29009},
+											pos:        position{line: 1022, col: 47, offset: 31092},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1570,14 +1624,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 968, col: 53, offset: 29015},
+							pos:  position{line: 1022, col: 53, offset: 31098},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 968, col: 68, offset: 29030},
+							pos:   position{line: 1022, col: 68, offset: 31113},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 968, col: 75, offset: 29037},
+								pos:  position{line: 1022, col: 75, offset: 31120},
 								name: "FieldNameList",
 							},
 						},
@@ -1587,28 +1641,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 987, col: 1, offset: 29577},
+			pos:  position{line: 1041, col: 1, offset: 31660},
 			expr: &actionExpr{
-				pos: position{line: 987, col: 26, offset: 29602},
+				pos: position{line: 1041, col: 26, offset: 31685},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 987, col: 26, offset: 29602},
+					pos: position{line: 1041, col: 26, offset: 31685},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 987, col: 26, offset: 29602},
+							pos:   position{line: 1041, col: 26, offset: 31685},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 987, col: 31, offset: 29607},
+								pos:  position{line: 1041, col: 31, offset: 31690},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 987, col: 47, offset: 29623},
+							pos:   position{line: 1041, col: 47, offset: 31706},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 987, col: 56, offset: 29632},
+								pos: position{line: 1041, col: 56, offset: 31715},
 								expr: &ruleRefExpr{
-									pos:  position{line: 987, col: 57, offset: 29633},
+									pos:  position{line: 1041, col: 57, offset: 31716},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1619,36 +1673,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 1051, col: 1, offset: 31926},
+			pos:  position{line: 1105, col: 1, offset: 34009},
 			expr: &actionExpr{
-				pos: position{line: 1051, col: 20, offset: 31945},
+				pos: position{line: 1105, col: 20, offset: 34028},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1051, col: 20, offset: 31945},
+					pos: position{line: 1105, col: 20, offset: 34028},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1051, col: 20, offset: 31945},
+							pos:  position{line: 1105, col: 20, offset: 34028},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1051, col: 25, offset: 31950},
+							pos:  position{line: 1105, col: 25, offset: 34033},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1051, col: 35, offset: 31960},
+							pos:   position{line: 1105, col: 35, offset: 34043},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1051, col: 41, offset: 31966},
+								pos:  position{line: 1105, col: 41, offset: 34049},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1051, col: 64, offset: 31989},
+							pos:   position{line: 1105, col: 64, offset: 34072},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1051, col: 72, offset: 31997},
+								pos: position{line: 1105, col: 72, offset: 34080},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1051, col: 73, offset: 31998},
+									pos:  position{line: 1105, col: 73, offset: 34081},
 									name: "StatsOptions",
 								},
 							},
@@ -1659,17 +1713,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 1065, col: 1, offset: 32331},
+			pos:  position{line: 1119, col: 1, offset: 34414},
 			expr: &actionExpr{
-				pos: position{line: 1065, col: 17, offset: 32347},
+				pos: position{line: 1119, col: 17, offset: 34430},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1065, col: 17, offset: 32347},
+					pos:   position{line: 1119, col: 17, offset: 34430},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1065, col: 24, offset: 32354},
+						pos: position{line: 1119, col: 24, offset: 34437},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1065, col: 25, offset: 32355},
+							pos:  position{line: 1119, col: 25, offset: 34438},
 							name: "StatsOption",
 						},
 					},
@@ -1678,45 +1732,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 1103, col: 1, offset: 33796},
+			pos:  position{line: 1157, col: 1, offset: 35879},
 			expr: &actionExpr{
-				pos: position{line: 1103, col: 16, offset: 33811},
+				pos: position{line: 1157, col: 16, offset: 35894},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 1103, col: 16, offset: 33811},
+					pos: position{line: 1157, col: 16, offset: 35894},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 16, offset: 33811},
+							pos:  position{line: 1157, col: 16, offset: 35894},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 22, offset: 33817},
+							pos:   position{line: 1157, col: 22, offset: 35900},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1103, col: 32, offset: 33827},
+								pos:  position{line: 1157, col: 32, offset: 35910},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1103, col: 47, offset: 33842},
+							pos:  position{line: 1157, col: 47, offset: 35925},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1103, col: 53, offset: 33848},
+							pos:   position{line: 1157, col: 53, offset: 35931},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 1103, col: 58, offset: 33853},
+								pos: position{line: 1157, col: 58, offset: 35936},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 58, offset: 33853},
+										pos:  position{line: 1157, col: 58, offset: 35936},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 76, offset: 33871},
+										pos:  position{line: 1157, col: 76, offset: 35954},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1103, col: 94, offset: 33889},
+										pos:  position{line: 1157, col: 94, offset: 35972},
 										name: "QuotedString",
 									},
 								},
@@ -1728,36 +1782,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 1108, col: 1, offset: 33994},
+			pos:  position{line: 1162, col: 1, offset: 36077},
 			expr: &actionExpr{
-				pos: position{line: 1108, col: 19, offset: 34012},
+				pos: position{line: 1162, col: 19, offset: 36095},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1108, col: 19, offset: 34012},
+					pos:   position{line: 1162, col: 19, offset: 36095},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1108, col: 27, offset: 34020},
+						pos: position{line: 1162, col: 27, offset: 36103},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1108, col: 27, offset: 34020},
+								pos:        position{line: 1162, col: 27, offset: 36103},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1108, col: 38, offset: 34031},
+								pos:        position{line: 1162, col: 38, offset: 36114},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1108, col: 58, offset: 34051},
+								pos:        position{line: 1162, col: 58, offset: 36134},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1108, col: 68, offset: 34061},
+								pos:        position{line: 1162, col: 68, offset: 36144},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1769,22 +1823,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 1116, col: 1, offset: 34251},
+			pos:  position{line: 1170, col: 1, offset: 36334},
 			expr: &actionExpr{
-				pos: position{line: 1116, col: 17, offset: 34267},
+				pos: position{line: 1170, col: 17, offset: 36350},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1116, col: 17, offset: 34267},
+					pos: position{line: 1170, col: 17, offset: 36350},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1116, col: 17, offset: 34267},
+							pos:  position{line: 1170, col: 17, offset: 36350},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1116, col: 20, offset: 34270},
+							pos:   position{line: 1170, col: 20, offset: 36353},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1116, col: 27, offset: 34277},
+								pos:  position{line: 1170, col: 27, offset: 36360},
 								name: "FieldNameList",
 							},
 						},
@@ -1794,28 +1848,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 1128, col: 1, offset: 34627},
+			pos:  position{line: 1182, col: 1, offset: 36710},
 			expr: &actionExpr{
-				pos: position{line: 1128, col: 35, offset: 34661},
+				pos: position{line: 1182, col: 35, offset: 36744},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 1128, col: 35, offset: 34661},
+					pos: position{line: 1182, col: 35, offset: 36744},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1128, col: 35, offset: 34661},
+							pos:        position{line: 1182, col: 35, offset: 36744},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1128, col: 53, offset: 34679},
+							pos:  position{line: 1182, col: 53, offset: 36762},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1128, col: 59, offset: 34685},
+							pos:   position{line: 1182, col: 59, offset: 36768},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1128, col: 67, offset: 34693},
+								pos:  position{line: 1182, col: 67, offset: 36776},
 								name: "Boolean",
 							},
 						},
@@ -1825,28 +1879,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 1140, col: 1, offset: 34954},
+			pos:  position{line: 1194, col: 1, offset: 37037},
 			expr: &actionExpr{
-				pos: position{line: 1140, col: 29, offset: 34982},
+				pos: position{line: 1194, col: 29, offset: 37065},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 1140, col: 29, offset: 34982},
+					pos: position{line: 1194, col: 29, offset: 37065},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1140, col: 29, offset: 34982},
+							pos:        position{line: 1194, col: 29, offset: 37065},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1140, col: 39, offset: 34992},
+							pos:  position{line: 1194, col: 39, offset: 37075},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1140, col: 45, offset: 34998},
+							pos:   position{line: 1194, col: 45, offset: 37081},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1140, col: 53, offset: 35006},
+								pos:  position{line: 1194, col: 53, offset: 37089},
 								name: "Boolean",
 							},
 						},
@@ -1856,28 +1910,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 1152, col: 1, offset: 35253},
+			pos:  position{line: 1206, col: 1, offset: 37336},
 			expr: &actionExpr{
-				pos: position{line: 1152, col: 28, offset: 35280},
+				pos: position{line: 1206, col: 28, offset: 37363},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 1152, col: 28, offset: 35280},
+					pos: position{line: 1206, col: 28, offset: 37363},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1152, col: 28, offset: 35280},
+							pos:        position{line: 1206, col: 28, offset: 37363},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1152, col: 37, offset: 35289},
+							pos:  position{line: 1206, col: 37, offset: 37372},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1152, col: 43, offset: 35295},
+							pos:   position{line: 1206, col: 43, offset: 37378},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1152, col: 51, offset: 35303},
+								pos:  position{line: 1206, col: 51, offset: 37386},
 								name: "Boolean",
 							},
 						},
@@ -1887,28 +1941,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 1165, col: 1, offset: 35637},
+			pos:  position{line: 1219, col: 1, offset: 37720},
 			expr: &actionExpr{
-				pos: position{line: 1165, col: 28, offset: 35664},
+				pos: position{line: 1219, col: 28, offset: 37747},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 1165, col: 28, offset: 35664},
+					pos: position{line: 1219, col: 28, offset: 37747},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1165, col: 28, offset: 35664},
+							pos:        position{line: 1219, col: 28, offset: 37747},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1165, col: 37, offset: 35673},
+							pos:  position{line: 1219, col: 37, offset: 37756},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1165, col: 43, offset: 35679},
+							pos:   position{line: 1219, col: 43, offset: 37762},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1165, col: 51, offset: 35687},
+								pos:  position{line: 1219, col: 51, offset: 37770},
 								name: "Boolean",
 							},
 						},
@@ -1918,28 +1972,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 1178, col: 1, offset: 36021},
+			pos:  position{line: 1232, col: 1, offset: 38104},
 			expr: &actionExpr{
-				pos: position{line: 1178, col: 28, offset: 36048},
+				pos: position{line: 1232, col: 28, offset: 38131},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1178, col: 28, offset: 36048},
+					pos: position{line: 1232, col: 28, offset: 38131},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1178, col: 28, offset: 36048},
+							pos:        position{line: 1232, col: 28, offset: 38131},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1178, col: 37, offset: 36057},
+							pos:  position{line: 1232, col: 37, offset: 38140},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1178, col: 43, offset: 36063},
+							pos:   position{line: 1232, col: 43, offset: 38146},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1178, col: 54, offset: 36074},
+								pos:  position{line: 1232, col: 54, offset: 38157},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1949,37 +2003,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1198, col: 1, offset: 36678},
+			pos:  position{line: 1252, col: 1, offset: 38761},
 			expr: &actionExpr{
-				pos: position{line: 1198, col: 33, offset: 36710},
+				pos: position{line: 1252, col: 33, offset: 38793},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1198, col: 33, offset: 36710},
+					pos: position{line: 1252, col: 33, offset: 38793},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1198, col: 33, offset: 36710},
+							pos:        position{line: 1252, col: 33, offset: 38793},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 48, offset: 36725},
+							pos:  position{line: 1252, col: 48, offset: 38808},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 54, offset: 36731},
+							pos:  position{line: 1252, col: 54, offset: 38814},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1198, col: 62, offset: 36739},
+							pos:   position{line: 1252, col: 62, offset: 38822},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1198, col: 71, offset: 36748},
+								pos:  position{line: 1252, col: 71, offset: 38831},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1198, col: 80, offset: 36757},
+							pos:  position{line: 1252, col: 80, offset: 38840},
 							name: "R_PAREN",
 						},
 					},
@@ -1988,37 +2042,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1210, col: 1, offset: 37027},
+			pos:  position{line: 1264, col: 1, offset: 39110},
 			expr: &actionExpr{
-				pos: position{line: 1210, col: 32, offset: 37058},
+				pos: position{line: 1264, col: 32, offset: 39141},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1210, col: 32, offset: 37058},
+					pos: position{line: 1264, col: 32, offset: 39141},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1210, col: 32, offset: 37058},
+							pos:        position{line: 1264, col: 32, offset: 39141},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1210, col: 46, offset: 37072},
+							pos:  position{line: 1264, col: 46, offset: 39155},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1210, col: 52, offset: 37078},
+							pos:  position{line: 1264, col: 52, offset: 39161},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1210, col: 60, offset: 37086},
+							pos:   position{line: 1264, col: 60, offset: 39169},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1210, col: 69, offset: 37095},
+								pos:  position{line: 1264, col: 69, offset: 39178},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1210, col: 78, offset: 37104},
+							pos:  position{line: 1264, col: 78, offset: 39187},
 							name: "R_PAREN",
 						},
 					},
@@ -2027,28 +2081,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1222, col: 1, offset: 37372},
+			pos:  position{line: 1276, col: 1, offset: 39455},
 			expr: &actionExpr{
-				pos: position{line: 1222, col: 32, offset: 37403},
+				pos: position{line: 1276, col: 32, offset: 39486},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1222, col: 32, offset: 37403},
+					pos: position{line: 1276, col: 32, offset: 39486},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1222, col: 32, offset: 37403},
+							pos:        position{line: 1276, col: 32, offset: 39486},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1222, col: 46, offset: 37417},
+							pos:  position{line: 1276, col: 46, offset: 39500},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1222, col: 52, offset: 37423},
+							pos:   position{line: 1276, col: 52, offset: 39506},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1222, col: 63, offset: 37434},
+								pos:  position{line: 1276, col: 63, offset: 39517},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2058,46 +2112,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1238, col: 1, offset: 37897},
+			pos:  position{line: 1292, col: 1, offset: 39980},
 			expr: &actionExpr{
-				pos: position{line: 1238, col: 22, offset: 37918},
+				pos: position{line: 1292, col: 22, offset: 40001},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1238, col: 22, offset: 37918},
+					pos:   position{line: 1292, col: 22, offset: 40001},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1238, col: 32, offset: 37928},
+						pos: position{line: 1292, col: 32, offset: 40011},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 32, offset: 37928},
+								pos:  position{line: 1292, col: 32, offset: 40011},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 65, offset: 37961},
+								pos:  position{line: 1292, col: 65, offset: 40044},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 92, offset: 37988},
+								pos:  position{line: 1292, col: 92, offset: 40071},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 118, offset: 38014},
+								pos:  position{line: 1292, col: 118, offset: 40097},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 144, offset: 38040},
+								pos:  position{line: 1292, col: 144, offset: 40123},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 170, offset: 38066},
+								pos:  position{line: 1292, col: 170, offset: 40149},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 201, offset: 38097},
+								pos:  position{line: 1292, col: 201, offset: 40180},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1238, col: 231, offset: 38127},
+								pos:  position{line: 1292, col: 231, offset: 40210},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -2107,35 +2161,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1242, col: 1, offset: 38186},
+			pos:  position{line: 1296, col: 1, offset: 40269},
 			expr: &actionExpr{
-				pos: position{line: 1242, col: 26, offset: 38211},
+				pos: position{line: 1296, col: 26, offset: 40294},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1242, col: 26, offset: 38211},
+					pos: position{line: 1296, col: 26, offset: 40294},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1242, col: 26, offset: 38211},
+							pos:   position{line: 1296, col: 26, offset: 40294},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1242, col: 32, offset: 38217},
+								pos:  position{line: 1296, col: 32, offset: 40300},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1242, col: 50, offset: 38235},
+							pos:   position{line: 1296, col: 50, offset: 40318},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1242, col: 55, offset: 38240},
+								pos: position{line: 1296, col: 55, offset: 40323},
 								expr: &seqExpr{
-									pos: position{line: 1242, col: 56, offset: 38241},
+									pos: position{line: 1296, col: 56, offset: 40324},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1242, col: 56, offset: 38241},
+											pos:  position{line: 1296, col: 56, offset: 40324},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1242, col: 62, offset: 38247},
+											pos:  position{line: 1296, col: 62, offset: 40330},
 											name: "StreamStatsOption",
 										},
 									},
@@ -2148,41 +2202,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1301, col: 1, offset: 40436},
+			pos:  position{line: 1355, col: 1, offset: 42519},
 			expr: &choiceExpr{
-				pos: position{line: 1301, col: 21, offset: 40456},
+				pos: position{line: 1355, col: 21, offset: 42539},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1301, col: 21, offset: 40456},
+						pos: position{line: 1355, col: 21, offset: 42539},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1301, col: 21, offset: 40456},
+							pos: position{line: 1355, col: 21, offset: 42539},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1301, col: 21, offset: 40456},
+									pos:  position{line: 1355, col: 21, offset: 42539},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1301, col: 26, offset: 40461},
+									pos:  position{line: 1355, col: 26, offset: 42544},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1301, col: 42, offset: 40477},
+									pos:   position{line: 1355, col: 42, offset: 42560},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1301, col: 56, offset: 40491},
+										pos:  position{line: 1355, col: 56, offset: 42574},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1301, col: 79, offset: 40514},
+									pos:  position{line: 1355, col: 79, offset: 42597},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1301, col: 85, offset: 40520},
+									pos:   position{line: 1355, col: 85, offset: 42603},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1301, col: 91, offset: 40526},
+										pos:  position{line: 1355, col: 91, offset: 42609},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2190,24 +2244,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1312, col: 3, offset: 40911},
+						pos: position{line: 1366, col: 3, offset: 42994},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1312, col: 3, offset: 40911},
+							pos: position{line: 1366, col: 3, offset: 42994},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1312, col: 3, offset: 40911},
+									pos:  position{line: 1366, col: 3, offset: 42994},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1312, col: 8, offset: 40916},
+									pos:  position{line: 1366, col: 8, offset: 42999},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1312, col: 24, offset: 40932},
+									pos:   position{line: 1366, col: 24, offset: 43015},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1312, col: 30, offset: 40938},
+										pos:  position{line: 1366, col: 30, offset: 43021},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2219,31 +2273,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1324, col: 1, offset: 41310},
+			pos:  position{line: 1378, col: 1, offset: 43393},
 			expr: &actionExpr{
-				pos: position{line: 1324, col: 15, offset: 41324},
+				pos: position{line: 1378, col: 15, offset: 43407},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1324, col: 15, offset: 41324},
+					pos: position{line: 1378, col: 15, offset: 43407},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1324, col: 15, offset: 41324},
+							pos:  position{line: 1378, col: 15, offset: 43407},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1324, col: 25, offset: 41334},
+							pos:   position{line: 1378, col: 25, offset: 43417},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1324, col: 34, offset: 41343},
+								pos: position{line: 1378, col: 34, offset: 43426},
 								expr: &seqExpr{
-									pos: position{line: 1324, col: 35, offset: 41344},
+									pos: position{line: 1378, col: 35, offset: 43427},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1324, col: 35, offset: 41344},
+											pos:  position{line: 1378, col: 35, offset: 43427},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1324, col: 45, offset: 41354},
+											pos:  position{line: 1378, col: 45, offset: 43437},
 											name: "EqualityOperator",
 										},
 									},
@@ -2251,10 +2305,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1324, col: 64, offset: 41373},
+							pos:   position{line: 1378, col: 64, offset: 43456},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1324, col: 68, offset: 41377},
+								pos:  position{line: 1378, col: 68, offset: 43460},
 								name: "QuotedString",
 							},
 						},
@@ -2264,22 +2318,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1352, col: 1, offset: 41956},
+			pos:  position{line: 1406, col: 1, offset: 44039},
 			expr: &actionExpr{
-				pos: position{line: 1352, col: 18, offset: 41973},
+				pos: position{line: 1406, col: 18, offset: 44056},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1352, col: 18, offset: 41973},
+					pos: position{line: 1406, col: 18, offset: 44056},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1352, col: 18, offset: 41973},
+							pos:  position{line: 1406, col: 18, offset: 44056},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1352, col: 23, offset: 41978},
+							pos:   position{line: 1406, col: 23, offset: 44061},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1352, col: 28, offset: 41983},
+								pos:  position{line: 1406, col: 28, offset: 44066},
 								name: "RegexBlock",
 							},
 						},
@@ -2289,44 +2343,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1380, col: 1, offset: 42765},
+			pos:  position{line: 1434, col: 1, offset: 44848},
 			expr: &actionExpr{
-				pos: position{line: 1380, col: 17, offset: 42781},
+				pos: position{line: 1434, col: 17, offset: 44864},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1380, col: 17, offset: 42781},
+					pos: position{line: 1434, col: 17, offset: 44864},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1380, col: 17, offset: 42781},
+							pos:   position{line: 1434, col: 17, offset: 44864},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1380, col: 23, offset: 42787},
+								pos:  position{line: 1434, col: 23, offset: 44870},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1380, col: 36, offset: 42800},
+							pos:   position{line: 1434, col: 36, offset: 44883},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1380, col: 41, offset: 42805},
+								pos: position{line: 1434, col: 41, offset: 44888},
 								expr: &seqExpr{
-									pos: position{line: 1380, col: 42, offset: 42806},
+									pos: position{line: 1434, col: 42, offset: 44889},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1380, col: 43, offset: 42807},
+											pos: position{line: 1434, col: 43, offset: 44890},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1380, col: 43, offset: 42807},
+													pos:  position{line: 1434, col: 43, offset: 44890},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1380, col: 49, offset: 42813},
+													pos:  position{line: 1434, col: 49, offset: 44896},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1380, col: 56, offset: 42820},
+											pos:  position{line: 1434, col: 56, offset: 44903},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2339,35 +2393,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1398, col: 1, offset: 43197},
+			pos:  position{line: 1452, col: 1, offset: 45280},
 			expr: &actionExpr{
-				pos: position{line: 1398, col: 17, offset: 43213},
+				pos: position{line: 1452, col: 17, offset: 45296},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1398, col: 17, offset: 43213},
+					pos: position{line: 1452, col: 17, offset: 45296},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1398, col: 17, offset: 43213},
+							pos:   position{line: 1452, col: 17, offset: 45296},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1398, col: 23, offset: 43219},
+								pos:  position{line: 1452, col: 23, offset: 45302},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1398, col: 36, offset: 43232},
+							pos:   position{line: 1452, col: 36, offset: 45315},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1398, col: 41, offset: 43237},
+								pos: position{line: 1452, col: 41, offset: 45320},
 								expr: &seqExpr{
-									pos: position{line: 1398, col: 42, offset: 43238},
+									pos: position{line: 1452, col: 42, offset: 45321},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1398, col: 42, offset: 43238},
+											pos:  position{line: 1452, col: 42, offset: 45321},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1398, col: 45, offset: 43241},
+											pos:  position{line: 1452, col: 45, offset: 45324},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2380,32 +2434,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1416, col: 1, offset: 43606},
+			pos:  position{line: 1470, col: 1, offset: 45689},
 			expr: &choiceExpr{
-				pos: position{line: 1416, col: 17, offset: 43622},
+				pos: position{line: 1470, col: 17, offset: 45705},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1416, col: 17, offset: 43622},
+						pos: position{line: 1470, col: 17, offset: 45705},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1416, col: 17, offset: 43622},
+							pos: position{line: 1470, col: 17, offset: 45705},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1416, col: 17, offset: 43622},
+									pos:   position{line: 1470, col: 17, offset: 45705},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1416, col: 25, offset: 43630},
+										pos: position{line: 1470, col: 25, offset: 45713},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1416, col: 25, offset: 43630},
+											pos:  position{line: 1470, col: 25, offset: 45713},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1416, col: 30, offset: 43635},
+									pos:   position{line: 1470, col: 30, offset: 45718},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1416, col: 36, offset: 43641},
+										pos:  position{line: 1470, col: 36, offset: 45724},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2413,13 +2467,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1427, col: 5, offset: 43937},
+						pos: position{line: 1481, col: 5, offset: 46020},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1427, col: 5, offset: 43937},
+							pos:   position{line: 1481, col: 5, offset: 46020},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1427, col: 12, offset: 43944},
+								pos:  position{line: 1481, col: 12, offset: 46027},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2429,43 +2483,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1431, col: 1, offset: 43985},
+			pos:  position{line: 1485, col: 1, offset: 46068},
 			expr: &choiceExpr{
-				pos: position{line: 1431, col: 17, offset: 44001},
+				pos: position{line: 1485, col: 17, offset: 46084},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1431, col: 17, offset: 44001},
+						pos: position{line: 1485, col: 17, offset: 46084},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1431, col: 17, offset: 44001},
+							pos: position{line: 1485, col: 17, offset: 46084},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1431, col: 17, offset: 44001},
+									pos:  position{line: 1485, col: 17, offset: 46084},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1431, col: 25, offset: 44009},
+									pos:   position{line: 1485, col: 25, offset: 46092},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1431, col: 32, offset: 44016},
+										pos:  position{line: 1485, col: 32, offset: 46099},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1431, col: 45, offset: 44029},
+									pos:  position{line: 1485, col: 45, offset: 46112},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1433, col: 5, offset: 44066},
+						pos: position{line: 1487, col: 5, offset: 46149},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1433, col: 5, offset: 44066},
+							pos:   position{line: 1487, col: 5, offset: 46149},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1433, col: 10, offset: 44071},
+								pos:  position{line: 1487, col: 10, offset: 46154},
 								name: "SearchTerm",
 							},
 						},
@@ -2475,26 +2529,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1439, col: 1, offset: 44229},
+			pos:  position{line: 1493, col: 1, offset: 46312},
 			expr: &actionExpr{
-				pos: position{line: 1439, col: 15, offset: 44243},
+				pos: position{line: 1493, col: 15, offset: 46326},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1439, col: 15, offset: 44243},
+					pos:   position{line: 1493, col: 15, offset: 46326},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1439, col: 21, offset: 44249},
+						pos: position{line: 1493, col: 21, offset: 46332},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1439, col: 21, offset: 44249},
+								pos:  position{line: 1493, col: 21, offset: 46332},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1439, col: 44, offset: 44272},
+								pos:  position{line: 1493, col: 44, offset: 46355},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1439, col: 68, offset: 44296},
+								pos:  position{line: 1493, col: 68, offset: 46379},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2504,36 +2558,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1444, col: 1, offset: 44437},
+			pos:  position{line: 1498, col: 1, offset: 46520},
 			expr: &actionExpr{
-				pos: position{line: 1444, col: 19, offset: 44455},
+				pos: position{line: 1498, col: 19, offset: 46538},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1444, col: 19, offset: 44455},
+					pos: position{line: 1498, col: 19, offset: 46538},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1444, col: 19, offset: 44455},
+							pos:  position{line: 1498, col: 19, offset: 46538},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1444, col: 24, offset: 44460},
+							pos:  position{line: 1498, col: 24, offset: 46543},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1444, col: 38, offset: 44474},
+							pos:   position{line: 1498, col: 38, offset: 46557},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1444, col: 45, offset: 44481},
+								pos:  position{line: 1498, col: 45, offset: 46564},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1444, col: 68, offset: 44504},
+							pos:   position{line: 1498, col: 68, offset: 46587},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1444, col: 78, offset: 44514},
+								pos: position{line: 1498, col: 78, offset: 46597},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1444, col: 79, offset: 44515},
+									pos:  position{line: 1498, col: 79, offset: 46598},
 									name: "LimitExpr",
 								},
 							},
@@ -2544,35 +2598,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1537, col: 1, offset: 47486},
+			pos:  position{line: 1591, col: 1, offset: 49569},
 			expr: &actionExpr{
-				pos: position{line: 1537, col: 27, offset: 47512},
+				pos: position{line: 1591, col: 27, offset: 49595},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1537, col: 27, offset: 47512},
+					pos: position{line: 1591, col: 27, offset: 49595},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1537, col: 27, offset: 47512},
+							pos:   position{line: 1591, col: 27, offset: 49595},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1537, col: 33, offset: 47518},
+								pos:  position{line: 1591, col: 33, offset: 49601},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1537, col: 51, offset: 47536},
+							pos:   position{line: 1591, col: 51, offset: 49619},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1537, col: 56, offset: 47541},
+								pos: position{line: 1591, col: 56, offset: 49624},
 								expr: &seqExpr{
-									pos: position{line: 1537, col: 57, offset: 47542},
+									pos: position{line: 1591, col: 57, offset: 49625},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1537, col: 57, offset: 47542},
+											pos:  position{line: 1591, col: 57, offset: 49625},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1537, col: 63, offset: 47548},
+											pos:  position{line: 1591, col: 63, offset: 49631},
 											name: "TimechartArgument",
 										},
 									},
@@ -2585,22 +2639,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1566, col: 1, offset: 48282},
+			pos:  position{line: 1620, col: 1, offset: 50365},
 			expr: &actionExpr{
-				pos: position{line: 1566, col: 22, offset: 48303},
+				pos: position{line: 1620, col: 22, offset: 50386},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1566, col: 22, offset: 48303},
+					pos:   position{line: 1620, col: 22, offset: 50386},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1566, col: 29, offset: 48310},
+						pos: position{line: 1620, col: 29, offset: 50393},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1566, col: 29, offset: 48310},
+								pos:  position{line: 1620, col: 29, offset: 50393},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1566, col: 45, offset: 48326},
+								pos:  position{line: 1620, col: 45, offset: 50409},
 								name: "TcOptions",
 							},
 						},
@@ -2610,28 +2664,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1570, col: 1, offset: 48364},
+			pos:  position{line: 1624, col: 1, offset: 50447},
 			expr: &actionExpr{
-				pos: position{line: 1570, col: 18, offset: 48381},
+				pos: position{line: 1624, col: 18, offset: 50464},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1570, col: 18, offset: 48381},
+					pos: position{line: 1624, col: 18, offset: 50464},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1570, col: 18, offset: 48381},
+							pos:   position{line: 1624, col: 18, offset: 50464},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1570, col: 23, offset: 48386},
+								pos:  position{line: 1624, col: 23, offset: 50469},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1570, col: 39, offset: 48402},
+							pos:   position{line: 1624, col: 39, offset: 50485},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1570, col: 53, offset: 48416},
+								pos: position{line: 1624, col: 53, offset: 50499},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1570, col: 53, offset: 48416},
+									pos:  position{line: 1624, col: 53, offset: 50499},
 									name: "SplitByClause",
 								},
 							},
@@ -2642,22 +2696,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1584, col: 1, offset: 48755},
+			pos:  position{line: 1638, col: 1, offset: 50838},
 			expr: &actionExpr{
-				pos: position{line: 1584, col: 18, offset: 48772},
+				pos: position{line: 1638, col: 18, offset: 50855},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1584, col: 18, offset: 48772},
+					pos: position{line: 1638, col: 18, offset: 50855},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1584, col: 18, offset: 48772},
+							pos:  position{line: 1638, col: 18, offset: 50855},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1584, col: 21, offset: 48775},
+							pos:   position{line: 1638, col: 21, offset: 50858},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1584, col: 27, offset: 48781},
+								pos:  position{line: 1638, col: 27, offset: 50864},
 								name: "FieldName",
 							},
 						},
@@ -2667,24 +2721,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1592, col: 1, offset: 48910},
+			pos:  position{line: 1646, col: 1, offset: 50993},
 			expr: &actionExpr{
-				pos: position{line: 1592, col: 14, offset: 48923},
+				pos: position{line: 1646, col: 14, offset: 51006},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1592, col: 14, offset: 48923},
+					pos:   position{line: 1646, col: 14, offset: 51006},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1592, col: 22, offset: 48931},
+						pos: position{line: 1646, col: 22, offset: 51014},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1592, col: 22, offset: 48931},
+								pos:  position{line: 1646, col: 22, offset: 51014},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1592, col: 35, offset: 48944},
+								pos: position{line: 1646, col: 35, offset: 51027},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1592, col: 36, offset: 48945},
+									pos:  position{line: 1646, col: 36, offset: 51028},
 									name: "TcOption",
 								},
 							},
@@ -2695,34 +2749,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1634, col: 1, offset: 50465},
+			pos:  position{line: 1688, col: 1, offset: 52548},
 			expr: &actionExpr{
-				pos: position{line: 1634, col: 13, offset: 50477},
+				pos: position{line: 1688, col: 13, offset: 52560},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1634, col: 13, offset: 50477},
+					pos: position{line: 1688, col: 13, offset: 52560},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1634, col: 13, offset: 50477},
+							pos:  position{line: 1688, col: 13, offset: 52560},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1634, col: 19, offset: 50483},
+							pos:   position{line: 1688, col: 19, offset: 52566},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 31, offset: 50495},
+								pos:  position{line: 1688, col: 31, offset: 52578},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1634, col: 43, offset: 50507},
+							pos:  position{line: 1688, col: 43, offset: 52590},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1634, col: 49, offset: 50513},
+							pos:   position{line: 1688, col: 49, offset: 52596},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1634, col: 53, offset: 50517},
+								pos:  position{line: 1688, col: 53, offset: 52600},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2732,36 +2786,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1639, col: 1, offset: 50630},
+			pos:  position{line: 1693, col: 1, offset: 52713},
 			expr: &actionExpr{
-				pos: position{line: 1639, col: 16, offset: 50645},
+				pos: position{line: 1693, col: 16, offset: 52728},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1639, col: 16, offset: 50645},
+					pos:   position{line: 1693, col: 16, offset: 52728},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1639, col: 24, offset: 50653},
+						pos: position{line: 1693, col: 24, offset: 52736},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1639, col: 24, offset: 50653},
+								pos:        position{line: 1693, col: 24, offset: 52736},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1639, col: 36, offset: 50665},
+								pos:        position{line: 1693, col: 36, offset: 52748},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1639, col: 49, offset: 50678},
+								pos:        position{line: 1693, col: 49, offset: 52761},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1639, col: 61, offset: 50690},
+								pos:        position{line: 1693, col: 61, offset: 52773},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2773,50 +2827,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1647, col: 1, offset: 50886},
+			pos:  position{line: 1701, col: 1, offset: 52969},
 			expr: &actionExpr{
-				pos: position{line: 1647, col: 17, offset: 50902},
+				pos: position{line: 1701, col: 17, offset: 52985},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1647, col: 17, offset: 50902},
+					pos:   position{line: 1701, col: 17, offset: 52985},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1647, col: 27, offset: 50912},
+						pos: position{line: 1701, col: 27, offset: 52995},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 27, offset: 50912},
+								pos:  position{line: 1701, col: 27, offset: 52995},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 36, offset: 50921},
+								pos:  position{line: 1701, col: 36, offset: 53004},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 44, offset: 50929},
+								pos:  position{line: 1701, col: 44, offset: 53012},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 57, offset: 50942},
+								pos:  position{line: 1701, col: 57, offset: 53025},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 66, offset: 50951},
+								pos:  position{line: 1701, col: 66, offset: 53034},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 73, offset: 50958},
+								pos:  position{line: 1701, col: 73, offset: 53041},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 79, offset: 50964},
+								pos:  position{line: 1701, col: 79, offset: 53047},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 86, offset: 50971},
+								pos:  position{line: 1701, col: 86, offset: 53054},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1647, col: 96, offset: 50981},
+								pos:  position{line: 1701, col: 96, offset: 53064},
 								name: "Year",
 							},
 						},
@@ -2826,37 +2880,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1651, col: 1, offset: 51017},
+			pos:  position{line: 1705, col: 1, offset: 53100},
 			expr: &actionExpr{
-				pos: position{line: 1651, col: 21, offset: 51037},
+				pos: position{line: 1705, col: 21, offset: 53120},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1651, col: 21, offset: 51037},
+					pos: position{line: 1705, col: 21, offset: 53120},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1651, col: 21, offset: 51037},
+							pos:   position{line: 1705, col: 21, offset: 53120},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1651, col: 29, offset: 51045},
+								pos: position{line: 1705, col: 29, offset: 53128},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1651, col: 29, offset: 51045},
+										pos:  position{line: 1705, col: 29, offset: 53128},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1651, col: 45, offset: 51061},
+										pos:  position{line: 1705, col: 45, offset: 53144},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1651, col: 62, offset: 51078},
+							pos:   position{line: 1705, col: 62, offset: 53161},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1651, col: 72, offset: 51088},
+								pos: position{line: 1705, col: 72, offset: 53171},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1651, col: 73, offset: 51089},
+									pos:  position{line: 1705, col: 73, offset: 53172},
 									name: "AllTimeScale",
 								},
 							},
@@ -2867,28 +2921,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1710, col: 1, offset: 53780},
+			pos:  position{line: 1764, col: 1, offset: 55863},
 			expr: &actionExpr{
-				pos: position{line: 1710, col: 21, offset: 53800},
+				pos: position{line: 1764, col: 21, offset: 55883},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1710, col: 21, offset: 53800},
+					pos: position{line: 1764, col: 21, offset: 55883},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1710, col: 21, offset: 53800},
+							pos:        position{line: 1764, col: 21, offset: 55883},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1710, col: 31, offset: 53810},
+							pos:  position{line: 1764, col: 31, offset: 55893},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1710, col: 37, offset: 53816},
+							pos:   position{line: 1764, col: 37, offset: 55899},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1710, col: 48, offset: 53827},
+								pos:  position{line: 1764, col: 48, offset: 55910},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2898,28 +2952,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1721, col: 1, offset: 54068},
+			pos:  position{line: 1775, col: 1, offset: 56151},
 			expr: &actionExpr{
-				pos: position{line: 1721, col: 21, offset: 54088},
+				pos: position{line: 1775, col: 21, offset: 56171},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1721, col: 21, offset: 54088},
+					pos: position{line: 1775, col: 21, offset: 56171},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1721, col: 21, offset: 54088},
+							pos:        position{line: 1775, col: 21, offset: 56171},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1721, col: 28, offset: 54095},
+							pos:  position{line: 1775, col: 28, offset: 56178},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1721, col: 34, offset: 54101},
+							pos:   position{line: 1775, col: 34, offset: 56184},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1721, col: 43, offset: 54110},
+								pos:  position{line: 1775, col: 43, offset: 56193},
 								name: "IntegerAsString",
 							},
 						},
@@ -2929,31 +2983,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1742, col: 1, offset: 54689},
+			pos:  position{line: 1796, col: 1, offset: 56772},
 			expr: &choiceExpr{
-				pos: position{line: 1742, col: 23, offset: 54711},
+				pos: position{line: 1796, col: 23, offset: 56794},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1742, col: 23, offset: 54711},
+						pos: position{line: 1796, col: 23, offset: 56794},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1742, col: 23, offset: 54711},
+							pos: position{line: 1796, col: 23, offset: 56794},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1742, col: 23, offset: 54711},
+									pos:        position{line: 1796, col: 23, offset: 56794},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1742, col: 35, offset: 54723},
+									pos:  position{line: 1796, col: 35, offset: 56806},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1742, col: 41, offset: 54729},
+									pos:   position{line: 1796, col: 41, offset: 56812},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1742, col: 51, offset: 54739},
+										pos:  position{line: 1796, col: 51, offset: 56822},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2961,33 +3015,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1756, col: 3, offset: 55158},
+						pos: position{line: 1810, col: 3, offset: 57241},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1756, col: 3, offset: 55158},
+							pos: position{line: 1810, col: 3, offset: 57241},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1756, col: 3, offset: 55158},
+									pos:        position{line: 1810, col: 3, offset: 57241},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1756, col: 15, offset: 55170},
+									pos:  position{line: 1810, col: 15, offset: 57253},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1756, col: 21, offset: 55176},
+									pos:   position{line: 1810, col: 21, offset: 57259},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1756, col: 32, offset: 55187},
+										pos: position{line: 1810, col: 32, offset: 57270},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1756, col: 32, offset: 55187},
+												pos:  position{line: 1810, col: 32, offset: 57270},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1756, col: 52, offset: 55207},
+												pos:  position{line: 1810, col: 52, offset: 57290},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -3001,35 +3055,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1776, col: 1, offset: 55676},
+			pos:  position{line: 1830, col: 1, offset: 57759},
 			expr: &actionExpr{
-				pos: position{line: 1776, col: 19, offset: 55694},
+				pos: position{line: 1830, col: 19, offset: 57777},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1776, col: 19, offset: 55694},
+					pos: position{line: 1830, col: 19, offset: 57777},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1776, col: 19, offset: 55694},
+							pos:        position{line: 1830, col: 19, offset: 57777},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1776, col: 27, offset: 55702},
+							pos:  position{line: 1830, col: 27, offset: 57785},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1776, col: 33, offset: 55708},
+							pos:   position{line: 1830, col: 33, offset: 57791},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1776, col: 41, offset: 55716},
+								pos: position{line: 1830, col: 41, offset: 57799},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1776, col: 41, offset: 55716},
+										pos:  position{line: 1830, col: 41, offset: 57799},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1776, col: 57, offset: 55732},
+										pos:  position{line: 1830, col: 57, offset: 57815},
 										name: "IntegerAsString",
 									},
 								},
@@ -3041,35 +3095,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1791, col: 1, offset: 56111},
+			pos:  position{line: 1845, col: 1, offset: 58194},
 			expr: &actionExpr{
-				pos: position{line: 1791, col: 17, offset: 56127},
+				pos: position{line: 1845, col: 17, offset: 58210},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1791, col: 17, offset: 56127},
+					pos: position{line: 1845, col: 17, offset: 58210},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1791, col: 17, offset: 56127},
+							pos:        position{line: 1845, col: 17, offset: 58210},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1791, col: 23, offset: 56133},
+							pos:  position{line: 1845, col: 23, offset: 58216},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1791, col: 29, offset: 56139},
+							pos:   position{line: 1845, col: 29, offset: 58222},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1791, col: 37, offset: 56147},
+								pos: position{line: 1845, col: 37, offset: 58230},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1791, col: 37, offset: 56147},
+										pos:  position{line: 1845, col: 37, offset: 58230},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1791, col: 53, offset: 56163},
+										pos:  position{line: 1845, col: 53, offset: 58246},
 										name: "IntegerAsString",
 									},
 								},
@@ -3081,40 +3135,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1806, col: 1, offset: 56534},
+			pos:  position{line: 1860, col: 1, offset: 58617},
 			expr: &choiceExpr{
-				pos: position{line: 1806, col: 18, offset: 56551},
+				pos: position{line: 1860, col: 18, offset: 58634},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1806, col: 18, offset: 56551},
+						pos: position{line: 1860, col: 18, offset: 58634},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1806, col: 18, offset: 56551},
+							pos: position{line: 1860, col: 18, offset: 58634},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1806, col: 18, offset: 56551},
+									pos:        position{line: 1860, col: 18, offset: 58634},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1806, col: 25, offset: 56558},
+									pos:  position{line: 1860, col: 25, offset: 58641},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1806, col: 31, offset: 56564},
+									pos:   position{line: 1860, col: 31, offset: 58647},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1806, col: 36, offset: 56569},
+										pos: position{line: 1860, col: 36, offset: 58652},
 										expr: &choiceExpr{
-											pos: position{line: 1806, col: 37, offset: 56570},
+											pos: position{line: 1860, col: 37, offset: 58653},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1806, col: 37, offset: 56570},
+													pos:  position{line: 1860, col: 37, offset: 58653},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1806, col: 53, offset: 56586},
+													pos:  position{line: 1860, col: 53, offset: 58669},
 													name: "IntegerAsString",
 												},
 											},
@@ -3122,25 +3176,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1806, col: 71, offset: 56604},
+									pos:        position{line: 1860, col: 71, offset: 58687},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1806, col: 77, offset: 56610},
+									pos:   position{line: 1860, col: 77, offset: 58693},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1806, col: 82, offset: 56615},
+										pos: position{line: 1860, col: 82, offset: 58698},
 										expr: &choiceExpr{
-											pos: position{line: 1806, col: 83, offset: 56616},
+											pos: position{line: 1860, col: 83, offset: 58699},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1806, col: 83, offset: 56616},
+													pos:  position{line: 1860, col: 83, offset: 58699},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1806, col: 99, offset: 56632},
+													pos:  position{line: 1860, col: 99, offset: 58715},
 													name: "IntegerAsString",
 												},
 											},
@@ -3151,26 +3205,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1849, col: 3, offset: 58068},
+						pos: position{line: 1903, col: 3, offset: 60151},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1849, col: 3, offset: 58068},
+							pos: position{line: 1903, col: 3, offset: 60151},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1849, col: 3, offset: 58068},
+									pos:        position{line: 1903, col: 3, offset: 60151},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1849, col: 10, offset: 58075},
+									pos:  position{line: 1903, col: 10, offset: 60158},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1849, col: 16, offset: 58081},
+									pos:   position{line: 1903, col: 16, offset: 60164},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1849, col: 24, offset: 58089},
+										pos:  position{line: 1903, col: 24, offset: 60172},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3182,38 +3236,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1864, col: 1, offset: 58420},
+			pos:  position{line: 1918, col: 1, offset: 60503},
 			expr: &actionExpr{
-				pos: position{line: 1864, col: 17, offset: 58436},
+				pos: position{line: 1918, col: 17, offset: 60519},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1864, col: 17, offset: 58436},
+					pos:   position{line: 1918, col: 17, offset: 60519},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1864, col: 25, offset: 58444},
+						pos: position{line: 1918, col: 25, offset: 60527},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 25, offset: 58444},
+								pos:  position{line: 1918, col: 25, offset: 60527},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 46, offset: 58465},
+								pos:  position{line: 1918, col: 46, offset: 60548},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 65, offset: 58484},
+								pos:  position{line: 1918, col: 65, offset: 60567},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 84, offset: 58503},
+								pos:  position{line: 1918, col: 84, offset: 60586},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 101, offset: 58520},
+								pos:  position{line: 1918, col: 101, offset: 60603},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1864, col: 116, offset: 58535},
+								pos:  position{line: 1918, col: 116, offset: 60618},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3223,35 +3277,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1868, col: 1, offset: 58578},
+			pos:  position{line: 1922, col: 1, offset: 60661},
 			expr: &actionExpr{
-				pos: position{line: 1868, col: 22, offset: 58599},
+				pos: position{line: 1922, col: 22, offset: 60682},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1868, col: 22, offset: 58599},
+					pos: position{line: 1922, col: 22, offset: 60682},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1868, col: 22, offset: 58599},
+							pos:   position{line: 1922, col: 22, offset: 60682},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 29, offset: 58606},
+								pos:  position{line: 1922, col: 29, offset: 60689},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 42, offset: 58619},
+							pos:   position{line: 1922, col: 42, offset: 60702},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1868, col: 48, offset: 58625},
+								pos: position{line: 1922, col: 48, offset: 60708},
 								expr: &seqExpr{
-									pos: position{line: 1868, col: 49, offset: 58626},
+									pos: position{line: 1922, col: 49, offset: 60709},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1868, col: 49, offset: 58626},
+											pos:  position{line: 1922, col: 49, offset: 60709},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1868, col: 55, offset: 58632},
+											pos:  position{line: 1922, col: 55, offset: 60715},
 											name: "BinCmdOption",
 										},
 									},
@@ -3264,51 +3318,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1914, col: 1, offset: 60116},
+			pos:  position{line: 1968, col: 1, offset: 62199},
 			expr: &choiceExpr{
-				pos: position{line: 1914, col: 13, offset: 60128},
+				pos: position{line: 1968, col: 13, offset: 62211},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1914, col: 13, offset: 60128},
+						pos: position{line: 1968, col: 13, offset: 62211},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1914, col: 13, offset: 60128},
+							pos: position{line: 1968, col: 13, offset: 62211},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1914, col: 13, offset: 60128},
+									pos:  position{line: 1968, col: 13, offset: 62211},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1914, col: 18, offset: 60133},
+									pos:  position{line: 1968, col: 18, offset: 62216},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1914, col: 26, offset: 60141},
+									pos:   position{line: 1968, col: 26, offset: 62224},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1914, col: 40, offset: 60155},
+										pos:  position{line: 1968, col: 40, offset: 62238},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1914, col: 59, offset: 60174},
+									pos:  position{line: 1968, col: 59, offset: 62257},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1914, col: 65, offset: 60180},
+									pos:   position{line: 1968, col: 65, offset: 62263},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1914, col: 71, offset: 60186},
+										pos:  position{line: 1968, col: 71, offset: 62269},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1914, col: 81, offset: 60196},
+									pos:   position{line: 1968, col: 81, offset: 62279},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1914, col: 94, offset: 60209},
+										pos: position{line: 1968, col: 94, offset: 62292},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1914, col: 95, offset: 60210},
+											pos:  position{line: 1968, col: 95, offset: 62293},
 											name: "AsField",
 										},
 									},
@@ -3317,34 +3371,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1941, col: 3, offset: 61036},
+						pos: position{line: 1995, col: 3, offset: 63119},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1941, col: 3, offset: 61036},
+							pos: position{line: 1995, col: 3, offset: 63119},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1941, col: 3, offset: 61036},
+									pos:  position{line: 1995, col: 3, offset: 63119},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1941, col: 8, offset: 61041},
+									pos:  position{line: 1995, col: 8, offset: 63124},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1941, col: 16, offset: 61049},
+									pos:   position{line: 1995, col: 16, offset: 63132},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1941, col: 22, offset: 61055},
+										pos:  position{line: 1995, col: 22, offset: 63138},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1941, col: 32, offset: 61065},
+									pos:   position{line: 1995, col: 32, offset: 63148},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1941, col: 45, offset: 61078},
+										pos: position{line: 1995, col: 45, offset: 63161},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1941, col: 46, offset: 61079},
+											pos:  position{line: 1995, col: 46, offset: 63162},
 											name: "AsField",
 										},
 									},
@@ -3357,15 +3411,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1972, col: 1, offset: 61936},
+			pos:  position{line: 2026, col: 1, offset: 64019},
 			expr: &actionExpr{
-				pos: position{line: 1972, col: 15, offset: 61950},
+				pos: position{line: 2026, col: 15, offset: 64033},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1972, col: 15, offset: 61950},
+					pos:   position{line: 2026, col: 15, offset: 64033},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1972, col: 27, offset: 61962},
+						pos:  position{line: 2026, col: 27, offset: 64045},
 						name: "SpanOptions",
 					},
 				},
@@ -3373,26 +3427,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1980, col: 1, offset: 62187},
+			pos:  position{line: 2034, col: 1, offset: 64270},
 			expr: &actionExpr{
-				pos: position{line: 1980, col: 16, offset: 62202},
+				pos: position{line: 2034, col: 16, offset: 64285},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1980, col: 16, offset: 62202},
+					pos: position{line: 2034, col: 16, offset: 64285},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1980, col: 16, offset: 62202},
+							pos:  position{line: 2034, col: 16, offset: 64285},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1980, col: 25, offset: 62211},
+							pos:  position{line: 2034, col: 25, offset: 64294},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1980, col: 31, offset: 62217},
+							pos:   position{line: 2034, col: 31, offset: 64300},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1980, col: 42, offset: 62228},
+								pos:  position{line: 2034, col: 42, offset: 64311},
 								name: "SpanLength",
 							},
 						},
@@ -3402,26 +3456,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1987, col: 1, offset: 62374},
+			pos:  position{line: 2041, col: 1, offset: 64457},
 			expr: &actionExpr{
-				pos: position{line: 1987, col: 15, offset: 62388},
+				pos: position{line: 2041, col: 15, offset: 64471},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1987, col: 15, offset: 62388},
+					pos: position{line: 2041, col: 15, offset: 64471},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1987, col: 15, offset: 62388},
+							pos:   position{line: 2041, col: 15, offset: 64471},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 24, offset: 62397},
+								pos:  position{line: 2041, col: 24, offset: 64480},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1987, col: 40, offset: 62413},
+							pos:   position{line: 2041, col: 40, offset: 64496},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1987, col: 50, offset: 62423},
+								pos:  position{line: 2041, col: 50, offset: 64506},
 								name: "AllTimeScale",
 							},
 						},
@@ -3431,43 +3485,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 2004, col: 1, offset: 62972},
+			pos:  position{line: 2058, col: 1, offset: 65055},
 			expr: &actionExpr{
-				pos: position{line: 2004, col: 14, offset: 62985},
+				pos: position{line: 2058, col: 14, offset: 65068},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2004, col: 14, offset: 62985},
+					pos: position{line: 2058, col: 14, offset: 65068},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2004, col: 14, offset: 62985},
+							pos:  position{line: 2058, col: 14, offset: 65068},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2004, col: 20, offset: 62991},
+							pos:        position{line: 2058, col: 20, offset: 65074},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2004, col: 28, offset: 62999},
+							pos:  position{line: 2058, col: 28, offset: 65082},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2004, col: 34, offset: 63005},
+							pos:   position{line: 2058, col: 34, offset: 65088},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2004, col: 41, offset: 63012},
+								pos: position{line: 2058, col: 41, offset: 65095},
 								expr: &choiceExpr{
-									pos: position{line: 2004, col: 42, offset: 63013},
+									pos: position{line: 2058, col: 42, offset: 65096},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 2004, col: 42, offset: 63013},
+											pos:        position{line: 2058, col: 42, offset: 65096},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 2004, col: 50, offset: 63021},
+											pos:        position{line: 2058, col: 50, offset: 65104},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3477,14 +3531,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2004, col: 61, offset: 63032},
+							pos:  position{line: 2058, col: 61, offset: 65115},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2004, col: 76, offset: 63047},
+							pos:   position{line: 2058, col: 76, offset: 65130},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2004, col: 86, offset: 63057},
+								pos:  position{line: 2058, col: 86, offset: 65140},
 								name: "IntegerAsString",
 							},
 						},
@@ -3494,22 +3548,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 2028, col: 1, offset: 63638},
+			pos:  position{line: 2082, col: 1, offset: 65721},
 			expr: &actionExpr{
-				pos: position{line: 2028, col: 19, offset: 63656},
+				pos: position{line: 2082, col: 19, offset: 65739},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2028, col: 19, offset: 63656},
+					pos: position{line: 2082, col: 19, offset: 65739},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2028, col: 19, offset: 63656},
+							pos:  position{line: 2082, col: 19, offset: 65739},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2028, col: 24, offset: 63661},
+							pos:   position{line: 2082, col: 24, offset: 65744},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2028, col: 38, offset: 63675},
+								pos:  position{line: 2082, col: 38, offset: 65758},
 								name: "StatisticExpr",
 							},
 						},
@@ -3519,76 +3573,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 2065, col: 1, offset: 64813},
+			pos:  position{line: 2119, col: 1, offset: 66896},
 			expr: &actionExpr{
-				pos: position{line: 2065, col: 18, offset: 64830},
+				pos: position{line: 2119, col: 18, offset: 66913},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2065, col: 18, offset: 64830},
+					pos: position{line: 2119, col: 18, offset: 66913},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2065, col: 18, offset: 64830},
+							pos:   position{line: 2119, col: 18, offset: 66913},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 2065, col: 23, offset: 64835},
+								pos: position{line: 2119, col: 23, offset: 66918},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 23, offset: 64835},
+										pos:  position{line: 2119, col: 23, offset: 66918},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 33, offset: 64845},
+										pos:  position{line: 2119, col: 33, offset: 66928},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2065, col: 43, offset: 64855},
+							pos:   position{line: 2119, col: 43, offset: 66938},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2065, col: 49, offset: 64861},
+								pos: position{line: 2119, col: 49, offset: 66944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2065, col: 50, offset: 64862},
+									pos:  position{line: 2119, col: 50, offset: 66945},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2065, col: 67, offset: 64879},
+							pos:   position{line: 2119, col: 67, offset: 66962},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 2065, col: 78, offset: 64890},
+								pos: position{line: 2119, col: 78, offset: 66973},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 78, offset: 64890},
+										pos:  position{line: 2119, col: 78, offset: 66973},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2065, col: 84, offset: 64896},
+										pos:  position{line: 2119, col: 84, offset: 66979},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2065, col: 99, offset: 64911},
+							pos:   position{line: 2119, col: 99, offset: 66994},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2065, col: 108, offset: 64920},
+								pos: position{line: 2119, col: 108, offset: 67003},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2065, col: 109, offset: 64921},
+									pos:  position{line: 2119, col: 109, offset: 67004},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2065, col: 120, offset: 64932},
+							pos:   position{line: 2119, col: 120, offset: 67015},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2065, col: 128, offset: 64940},
+								pos: position{line: 2119, col: 128, offset: 67023},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2065, col: 129, offset: 64941},
+									pos:  position{line: 2119, col: 129, offset: 67024},
 									name: "StatisticOptions",
 								},
 							},
@@ -3599,25 +3653,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 2107, col: 1, offset: 66026},
+			pos:  position{line: 2161, col: 1, offset: 68109},
 			expr: &choiceExpr{
-				pos: position{line: 2107, col: 19, offset: 66044},
+				pos: position{line: 2161, col: 19, offset: 68127},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2107, col: 19, offset: 66044},
+						pos: position{line: 2161, col: 19, offset: 68127},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2107, col: 19, offset: 66044},
+							pos: position{line: 2161, col: 19, offset: 68127},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2107, col: 19, offset: 66044},
+									pos:  position{line: 2161, col: 19, offset: 68127},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 2107, col: 25, offset: 66050},
+									pos:   position{line: 2161, col: 25, offset: 68133},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2107, col: 32, offset: 66057},
+										pos:  position{line: 2161, col: 32, offset: 68140},
 										name: "IntegerAsString",
 									},
 								},
@@ -3625,30 +3679,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2110, col: 3, offset: 66111},
+						pos: position{line: 2164, col: 3, offset: 68194},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 2110, col: 3, offset: 66111},
+							pos: position{line: 2164, col: 3, offset: 68194},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 3, offset: 66111},
+									pos:  position{line: 2164, col: 3, offset: 68194},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2110, col: 9, offset: 66117},
+									pos:        position{line: 2164, col: 9, offset: 68200},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2110, col: 17, offset: 66125},
+									pos:  position{line: 2164, col: 17, offset: 68208},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 2110, col: 23, offset: 66131},
+									pos:   position{line: 2164, col: 23, offset: 68214},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2110, col: 30, offset: 66138},
+										pos:  position{line: 2164, col: 30, offset: 68221},
 										name: "IntegerAsString",
 									},
 								},
@@ -3660,17 +3714,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 2115, col: 1, offset: 66236},
+			pos:  position{line: 2169, col: 1, offset: 68319},
 			expr: &actionExpr{
-				pos: position{line: 2115, col: 21, offset: 66256},
+				pos: position{line: 2169, col: 21, offset: 68339},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2115, col: 21, offset: 66256},
+					pos:   position{line: 2169, col: 21, offset: 68339},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2115, col: 28, offset: 66263},
+						pos: position{line: 2169, col: 28, offset: 68346},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2115, col: 29, offset: 66264},
+							pos:  position{line: 2169, col: 29, offset: 68347},
 							name: "StatisticOption",
 						},
 					},
@@ -3679,34 +3733,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 2164, col: 1, offset: 67826},
+			pos:  position{line: 2218, col: 1, offset: 69909},
 			expr: &actionExpr{
-				pos: position{line: 2164, col: 20, offset: 67845},
+				pos: position{line: 2218, col: 20, offset: 69928},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 2164, col: 20, offset: 67845},
+					pos: position{line: 2218, col: 20, offset: 69928},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2164, col: 20, offset: 67845},
+							pos:  position{line: 2218, col: 20, offset: 69928},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2164, col: 26, offset: 67851},
+							pos:   position{line: 2218, col: 26, offset: 69934},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2164, col: 36, offset: 67861},
+								pos:  position{line: 2218, col: 36, offset: 69944},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2164, col: 55, offset: 67880},
+							pos:  position{line: 2218, col: 55, offset: 69963},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2164, col: 61, offset: 67886},
+							pos:   position{line: 2218, col: 61, offset: 69969},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2164, col: 67, offset: 67892},
+								pos:  position{line: 2218, col: 67, offset: 69975},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3716,48 +3770,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 2169, col: 1, offset: 68001},
+			pos:  position{line: 2223, col: 1, offset: 70084},
 			expr: &actionExpr{
-				pos: position{line: 2169, col: 23, offset: 68023},
+				pos: position{line: 2223, col: 23, offset: 70106},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2169, col: 23, offset: 68023},
+					pos:   position{line: 2223, col: 23, offset: 70106},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2169, col: 31, offset: 68031},
+						pos: position{line: 2223, col: 31, offset: 70114},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2169, col: 31, offset: 68031},
+								pos:        position{line: 2223, col: 31, offset: 70114},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2169, col: 46, offset: 68046},
+								pos:        position{line: 2223, col: 46, offset: 70129},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2169, col: 60, offset: 68060},
+								pos:        position{line: 2223, col: 60, offset: 70143},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2169, col: 73, offset: 68073},
+								pos:        position{line: 2223, col: 73, offset: 70156},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2169, col: 85, offset: 68085},
+								pos:        position{line: 2223, col: 85, offset: 70168},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2169, col: 102, offset: 68102},
+								pos:        position{line: 2223, col: 102, offset: 70185},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3769,25 +3823,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2177, col: 1, offset: 68289},
+			pos:  position{line: 2231, col: 1, offset: 70372},
 			expr: &choiceExpr{
-				pos: position{line: 2177, col: 13, offset: 68301},
+				pos: position{line: 2231, col: 13, offset: 70384},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2177, col: 13, offset: 68301},
+						pos: position{line: 2231, col: 13, offset: 70384},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2177, col: 13, offset: 68301},
+							pos: position{line: 2231, col: 13, offset: 70384},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2177, col: 13, offset: 68301},
+									pos:  position{line: 2231, col: 13, offset: 70384},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2177, col: 16, offset: 68304},
+									pos:   position{line: 2231, col: 16, offset: 70387},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2177, col: 26, offset: 68314},
+										pos:  position{line: 2231, col: 26, offset: 70397},
 										name: "FieldNameList",
 									},
 								},
@@ -3795,13 +3849,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2180, col: 3, offset: 68371},
+						pos: position{line: 2234, col: 3, offset: 70454},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2180, col: 3, offset: 68371},
+							pos:   position{line: 2234, col: 3, offset: 70454},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2180, col: 16, offset: 68384},
+								pos:  position{line: 2234, col: 16, offset: 70467},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3811,26 +3865,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2184, col: 1, offset: 68442},
+			pos:  position{line: 2238, col: 1, offset: 70525},
 			expr: &actionExpr{
-				pos: position{line: 2184, col: 15, offset: 68456},
+				pos: position{line: 2238, col: 15, offset: 70539},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2184, col: 15, offset: 68456},
+					pos: position{line: 2238, col: 15, offset: 70539},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 15, offset: 68456},
+							pos:  position{line: 2238, col: 15, offset: 70539},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2184, col: 20, offset: 68461},
+							pos:  position{line: 2238, col: 20, offset: 70544},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2184, col: 30, offset: 68471},
+							pos:   position{line: 2238, col: 30, offset: 70554},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2184, col: 40, offset: 68481},
+								pos:  position{line: 2238, col: 40, offset: 70564},
 								name: "DedupExpr",
 							},
 						},
@@ -3840,27 +3894,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2230, col: 1, offset: 69810},
+			pos:  position{line: 2284, col: 1, offset: 71893},
 			expr: &actionExpr{
-				pos: position{line: 2230, col: 14, offset: 69823},
+				pos: position{line: 2284, col: 14, offset: 71906},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2230, col: 14, offset: 69823},
+					pos: position{line: 2284, col: 14, offset: 71906},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2230, col: 14, offset: 69823},
+							pos:   position{line: 2284, col: 14, offset: 71906},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2230, col: 23, offset: 69832},
+								pos: position{line: 2284, col: 23, offset: 71915},
 								expr: &seqExpr{
-									pos: position{line: 2230, col: 24, offset: 69833},
+									pos: position{line: 2284, col: 24, offset: 71916},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2230, col: 24, offset: 69833},
+											pos:  position{line: 2284, col: 24, offset: 71916},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2230, col: 30, offset: 69839},
+											pos:  position{line: 2284, col: 30, offset: 71922},
 											name: "IntegerAsString",
 										},
 									},
@@ -3868,45 +3922,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2230, col: 48, offset: 69857},
+							pos:   position{line: 2284, col: 48, offset: 71940},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2230, col: 57, offset: 69866},
+								pos: position{line: 2284, col: 57, offset: 71949},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2230, col: 58, offset: 69867},
+									pos:  position{line: 2284, col: 58, offset: 71950},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2230, col: 73, offset: 69882},
+							pos:   position{line: 2284, col: 73, offset: 71965},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2230, col: 83, offset: 69892},
+								pos: position{line: 2284, col: 83, offset: 71975},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2230, col: 84, offset: 69893},
+									pos:  position{line: 2284, col: 84, offset: 71976},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2230, col: 101, offset: 69910},
+							pos:   position{line: 2284, col: 101, offset: 71993},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2230, col: 110, offset: 69919},
+								pos: position{line: 2284, col: 110, offset: 72002},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2230, col: 111, offset: 69920},
+									pos:  position{line: 2284, col: 111, offset: 72003},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2230, col: 126, offset: 69935},
+							pos:   position{line: 2284, col: 126, offset: 72018},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2230, col: 139, offset: 69948},
+								pos: position{line: 2284, col: 139, offset: 72031},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2230, col: 140, offset: 69949},
+									pos:  position{line: 2284, col: 140, offset: 72032},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3917,27 +3971,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2287, col: 1, offset: 71687},
+			pos:  position{line: 2341, col: 1, offset: 73770},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 19, offset: 71705},
+				pos: position{line: 2341, col: 19, offset: 73788},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 19, offset: 71705},
+					pos: position{line: 2341, col: 19, offset: 73788},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2287, col: 19, offset: 71705},
+							pos: position{line: 2341, col: 19, offset: 73788},
 							expr: &litMatcher{
-								pos:        position{line: 2287, col: 21, offset: 71707},
+								pos:        position{line: 2341, col: 21, offset: 73790},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2287, col: 31, offset: 71717},
+							pos:   position{line: 2341, col: 31, offset: 73800},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 37, offset: 71723},
+								pos:  position{line: 2341, col: 37, offset: 73806},
 								name: "FieldName",
 							},
 						},
@@ -3947,48 +4001,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2293, col: 1, offset: 71862},
+			pos:  position{line: 2347, col: 1, offset: 73945},
 			expr: &actionExpr{
-				pos: position{line: 2293, col: 32, offset: 71893},
+				pos: position{line: 2347, col: 32, offset: 73976},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2293, col: 32, offset: 71893},
+					pos: position{line: 2347, col: 32, offset: 73976},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2293, col: 32, offset: 71893},
+							pos:   position{line: 2347, col: 32, offset: 73976},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2293, col: 38, offset: 71899},
+								pos:  position{line: 2347, col: 38, offset: 73982},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2293, col: 48, offset: 71909},
+							pos: position{line: 2347, col: 48, offset: 73992},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2293, col: 50, offset: 71911},
+								pos:  position{line: 2347, col: 50, offset: 73994},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2293, col: 57, offset: 71918},
+							pos:   position{line: 2347, col: 57, offset: 74001},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2293, col: 62, offset: 71923},
+								pos: position{line: 2347, col: 62, offset: 74006},
 								expr: &seqExpr{
-									pos: position{line: 2293, col: 63, offset: 71924},
+									pos: position{line: 2347, col: 63, offset: 74007},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2293, col: 63, offset: 71924},
+											pos:  position{line: 2347, col: 63, offset: 74007},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2293, col: 69, offset: 71930},
+											pos:  position{line: 2347, col: 69, offset: 74013},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2293, col: 79, offset: 71940},
+											pos: position{line: 2347, col: 79, offset: 74023},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2293, col: 81, offset: 71942},
+												pos:  position{line: 2347, col: 81, offset: 74025},
 												name: "EQUAL",
 											},
 										},
@@ -4002,45 +4056,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2304, col: 1, offset: 72217},
+			pos:  position{line: 2358, col: 1, offset: 74300},
 			expr: &actionExpr{
-				pos: position{line: 2304, col: 19, offset: 72235},
+				pos: position{line: 2358, col: 19, offset: 74318},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2304, col: 19, offset: 72235},
+					pos: position{line: 2358, col: 19, offset: 74318},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2304, col: 19, offset: 72235},
+							pos:  position{line: 2358, col: 19, offset: 74318},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2304, col: 25, offset: 72241},
+							pos:   position{line: 2358, col: 25, offset: 74324},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2304, col: 31, offset: 72247},
+								pos:  position{line: 2358, col: 31, offset: 74330},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2304, col: 46, offset: 72262},
+							pos:   position{line: 2358, col: 46, offset: 74345},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2304, col: 51, offset: 72267},
+								pos: position{line: 2358, col: 51, offset: 74350},
 								expr: &seqExpr{
-									pos: position{line: 2304, col: 52, offset: 72268},
+									pos: position{line: 2358, col: 52, offset: 74351},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2304, col: 52, offset: 72268},
+											pos:  position{line: 2358, col: 52, offset: 74351},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2304, col: 58, offset: 72274},
+											pos:  position{line: 2358, col: 58, offset: 74357},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2304, col: 73, offset: 72289},
+											pos: position{line: 2358, col: 73, offset: 74372},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2304, col: 74, offset: 72290},
+												pos:  position{line: 2358, col: 74, offset: 74373},
 												name: "EQUAL",
 											},
 										},
@@ -4054,17 +4108,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2322, col: 1, offset: 72818},
+			pos:  position{line: 2376, col: 1, offset: 74901},
 			expr: &actionExpr{
-				pos: position{line: 2322, col: 17, offset: 72834},
+				pos: position{line: 2376, col: 17, offset: 74917},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2322, col: 17, offset: 72834},
+					pos:   position{line: 2376, col: 17, offset: 74917},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2322, col: 24, offset: 72841},
+						pos: position{line: 2376, col: 24, offset: 74924},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2322, col: 25, offset: 72842},
+							pos:  position{line: 2376, col: 25, offset: 74925},
 							name: "DedupOption",
 						},
 					},
@@ -4073,36 +4127,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2362, col: 1, offset: 74108},
+			pos:  position{line: 2416, col: 1, offset: 76191},
 			expr: &actionExpr{
-				pos: position{line: 2362, col: 16, offset: 74123},
+				pos: position{line: 2416, col: 16, offset: 76206},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2362, col: 16, offset: 74123},
+					pos: position{line: 2416, col: 16, offset: 76206},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2362, col: 16, offset: 74123},
+							pos:  position{line: 2416, col: 16, offset: 76206},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2362, col: 22, offset: 74129},
+							pos:   position{line: 2416, col: 22, offset: 76212},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2362, col: 32, offset: 74139},
+								pos:  position{line: 2416, col: 32, offset: 76222},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2362, col: 47, offset: 74154},
+							pos:        position{line: 2416, col: 47, offset: 76237},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2362, col: 51, offset: 74158},
+							pos:   position{line: 2416, col: 51, offset: 76241},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2362, col: 57, offset: 74164},
+								pos:  position{line: 2416, col: 57, offset: 76247},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -4112,30 +4166,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2367, col: 1, offset: 74273},
+			pos:  position{line: 2421, col: 1, offset: 76356},
 			expr: &actionExpr{
-				pos: position{line: 2367, col: 19, offset: 74291},
+				pos: position{line: 2421, col: 19, offset: 76374},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2367, col: 19, offset: 74291},
+					pos:   position{line: 2421, col: 19, offset: 76374},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2367, col: 27, offset: 74299},
+						pos: position{line: 2421, col: 27, offset: 76382},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2367, col: 27, offset: 74299},
+								pos:        position{line: 2421, col: 27, offset: 76382},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2367, col: 43, offset: 74315},
+								pos:        position{line: 2421, col: 43, offset: 76398},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2367, col: 57, offset: 74329},
+								pos:        position{line: 2421, col: 57, offset: 76412},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -4147,22 +4201,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2375, col: 1, offset: 74514},
+			pos:  position{line: 2429, col: 1, offset: 76597},
 			expr: &actionExpr{
-				pos: position{line: 2375, col: 22, offset: 74535},
+				pos: position{line: 2429, col: 22, offset: 76618},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2375, col: 22, offset: 74535},
+					pos: position{line: 2429, col: 22, offset: 76618},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2375, col: 22, offset: 74535},
+							pos:  position{line: 2429, col: 22, offset: 76618},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2375, col: 39, offset: 74552},
+							pos:   position{line: 2429, col: 39, offset: 76635},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2375, col: 53, offset: 74566},
+								pos:  position{line: 2429, col: 53, offset: 76649},
 								name: "SortElements",
 							},
 						},
@@ -4172,35 +4226,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2380, col: 1, offset: 74674},
+			pos:  position{line: 2434, col: 1, offset: 76757},
 			expr: &actionExpr{
-				pos: position{line: 2380, col: 17, offset: 74690},
+				pos: position{line: 2434, col: 17, offset: 76773},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2380, col: 17, offset: 74690},
+					pos: position{line: 2434, col: 17, offset: 76773},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2380, col: 17, offset: 74690},
+							pos:   position{line: 2434, col: 17, offset: 76773},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2380, col: 23, offset: 74696},
+								pos:  position{line: 2434, col: 23, offset: 76779},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2380, col: 41, offset: 74714},
+							pos:   position{line: 2434, col: 41, offset: 76797},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2380, col: 46, offset: 74719},
+								pos: position{line: 2434, col: 46, offset: 76802},
 								expr: &seqExpr{
-									pos: position{line: 2380, col: 47, offset: 74720},
+									pos: position{line: 2434, col: 47, offset: 76803},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2380, col: 47, offset: 74720},
+											pos:  position{line: 2434, col: 47, offset: 76803},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2380, col: 62, offset: 74735},
+											pos:  position{line: 2434, col: 62, offset: 76818},
 											name: "SingleSortElement",
 										},
 									},
@@ -4213,22 +4267,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2395, col: 1, offset: 75093},
+			pos:  position{line: 2449, col: 1, offset: 77176},
 			expr: &actionExpr{
-				pos: position{line: 2395, col: 22, offset: 75114},
+				pos: position{line: 2449, col: 22, offset: 77197},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2395, col: 22, offset: 75114},
+					pos:   position{line: 2449, col: 22, offset: 77197},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2395, col: 31, offset: 75123},
+						pos: position{line: 2449, col: 31, offset: 77206},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2395, col: 31, offset: 75123},
+								pos:  position{line: 2449, col: 31, offset: 77206},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2395, col: 59, offset: 75151},
+								pos:  position{line: 2449, col: 59, offset: 77234},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4238,33 +4292,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2399, col: 1, offset: 75210},
+			pos:  position{line: 2453, col: 1, offset: 77293},
 			expr: &actionExpr{
-				pos: position{line: 2399, col: 33, offset: 75242},
+				pos: position{line: 2453, col: 33, offset: 77325},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2399, col: 33, offset: 75242},
+					pos: position{line: 2453, col: 33, offset: 77325},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2399, col: 33, offset: 75242},
+							pos:   position{line: 2453, col: 33, offset: 77325},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2399, col: 47, offset: 75256},
+								pos: position{line: 2453, col: 47, offset: 77339},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2399, col: 47, offset: 75256},
+										pos:        position{line: 2453, col: 47, offset: 77339},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2399, col: 53, offset: 75262},
+										pos:        position{line: 2453, col: 53, offset: 77345},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2399, col: 59, offset: 75268},
+										pos:        position{line: 2453, col: 59, offset: 77351},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4273,10 +4327,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2399, col: 63, offset: 75272},
+							pos:   position{line: 2453, col: 63, offset: 77355},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2399, col: 69, offset: 75278},
+								pos:  position{line: 2453, col: 69, offset: 77361},
 								name: "FieldName",
 							},
 						},
@@ -4286,33 +4340,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2414, col: 1, offset: 75553},
+			pos:  position{line: 2468, col: 1, offset: 77636},
 			expr: &actionExpr{
-				pos: position{line: 2414, col: 30, offset: 75582},
+				pos: position{line: 2468, col: 30, offset: 77665},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2414, col: 30, offset: 75582},
+					pos: position{line: 2468, col: 30, offset: 77665},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2414, col: 30, offset: 75582},
+							pos:   position{line: 2468, col: 30, offset: 77665},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2414, col: 44, offset: 75596},
+								pos: position{line: 2468, col: 44, offset: 77679},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2414, col: 44, offset: 75596},
+										pos:        position{line: 2468, col: 44, offset: 77679},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2414, col: 50, offset: 75602},
+										pos:        position{line: 2468, col: 50, offset: 77685},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2414, col: 56, offset: 75608},
+										pos:        position{line: 2468, col: 56, offset: 77691},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4321,31 +4375,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2414, col: 60, offset: 75612},
+							pos:   position{line: 2468, col: 60, offset: 77695},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2414, col: 64, offset: 75616},
+								pos: position{line: 2468, col: 64, offset: 77699},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2414, col: 64, offset: 75616},
+										pos:        position{line: 2468, col: 64, offset: 77699},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2414, col: 73, offset: 75625},
+										pos:        position{line: 2468, col: 73, offset: 77708},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2414, col: 81, offset: 75633},
+										pos:        position{line: 2468, col: 81, offset: 77716},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2414, col: 88, offset: 75640},
+										pos:        position{line: 2468, col: 88, offset: 77723},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4354,19 +4408,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2414, col: 95, offset: 75647},
+							pos:  position{line: 2468, col: 95, offset: 77730},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2414, col: 103, offset: 75655},
+							pos:   position{line: 2468, col: 103, offset: 77738},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2414, col: 109, offset: 75661},
+								pos:  position{line: 2468, col: 109, offset: 77744},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2414, col: 119, offset: 75671},
+							pos:  position{line: 2468, col: 119, offset: 77754},
 							name: "R_PAREN",
 						},
 					},
@@ -4375,26 +4429,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2434, col: 1, offset: 76096},
+			pos:  position{line: 2488, col: 1, offset: 78179},
 			expr: &actionExpr{
-				pos: position{line: 2434, col: 16, offset: 76111},
+				pos: position{line: 2488, col: 16, offset: 78194},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2434, col: 16, offset: 76111},
+					pos: position{line: 2488, col: 16, offset: 78194},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2434, col: 16, offset: 76111},
+							pos:  position{line: 2488, col: 16, offset: 78194},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2434, col: 21, offset: 76116},
+							pos:  position{line: 2488, col: 21, offset: 78199},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2434, col: 32, offset: 76127},
+							pos:   position{line: 2488, col: 32, offset: 78210},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2434, col: 43, offset: 76138},
+								pos:  position{line: 2488, col: 43, offset: 78221},
 								name: "RenameExpr",
 							},
 						},
@@ -4404,33 +4458,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2457, col: 1, offset: 76802},
+			pos:  position{line: 2511, col: 1, offset: 78885},
 			expr: &choiceExpr{
-				pos: position{line: 2457, col: 15, offset: 76816},
+				pos: position{line: 2511, col: 15, offset: 78899},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2457, col: 15, offset: 76816},
+						pos: position{line: 2511, col: 15, offset: 78899},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2457, col: 15, offset: 76816},
+							pos: position{line: 2511, col: 15, offset: 78899},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2457, col: 15, offset: 76816},
+									pos:   position{line: 2511, col: 15, offset: 78899},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2457, col: 31, offset: 76832},
+										pos:  position{line: 2511, col: 31, offset: 78915},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2457, col: 41, offset: 76842},
+									pos:  position{line: 2511, col: 41, offset: 78925},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2457, col: 44, offset: 76845},
+									pos:   position{line: 2511, col: 44, offset: 78928},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2457, col: 55, offset: 76856},
+										pos:  position{line: 2511, col: 55, offset: 78939},
 										name: "QuotedString",
 									},
 								},
@@ -4438,28 +4492,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2468, col: 3, offset: 77175},
+						pos: position{line: 2522, col: 3, offset: 79258},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2468, col: 3, offset: 77175},
+							pos: position{line: 2522, col: 3, offset: 79258},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2468, col: 3, offset: 77175},
+									pos:   position{line: 2522, col: 3, offset: 79258},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2468, col: 19, offset: 77191},
+										pos:  position{line: 2522, col: 19, offset: 79274},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2468, col: 29, offset: 77201},
+									pos:  position{line: 2522, col: 29, offset: 79284},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2468, col: 32, offset: 77204},
+									pos:   position{line: 2522, col: 32, offset: 79287},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2468, col: 43, offset: 77215},
+										pos:  position{line: 2522, col: 43, offset: 79298},
 										name: "RenamePattern",
 									},
 								},
@@ -4471,48 +4525,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2490, col: 1, offset: 77781},
+			pos:  position{line: 2544, col: 1, offset: 79864},
 			expr: &actionExpr{
-				pos: position{line: 2490, col: 13, offset: 77793},
+				pos: position{line: 2544, col: 13, offset: 79876},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2490, col: 13, offset: 77793},
+					pos: position{line: 2544, col: 13, offset: 79876},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2490, col: 13, offset: 77793},
+							pos:  position{line: 2544, col: 13, offset: 79876},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2490, col: 18, offset: 77798},
+							pos:  position{line: 2544, col: 18, offset: 79881},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2490, col: 26, offset: 77806},
+							pos:        position{line: 2544, col: 26, offset: 79889},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2490, col: 34, offset: 77814},
+							pos:  position{line: 2544, col: 34, offset: 79897},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2490, col: 40, offset: 77820},
+							pos:   position{line: 2544, col: 40, offset: 79903},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2490, col: 46, offset: 77826},
+								pos:  position{line: 2544, col: 46, offset: 79909},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2490, col: 62, offset: 77842},
+							pos:  position{line: 2544, col: 62, offset: 79925},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2490, col: 68, offset: 77848},
+							pos:   position{line: 2544, col: 68, offset: 79931},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2490, col: 72, offset: 77852},
+								pos:  position{line: 2544, col: 72, offset: 79935},
 								name: "QuotedString",
 							},
 						},
@@ -4522,37 +4576,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2519, col: 1, offset: 78581},
+			pos:  position{line: 2573, col: 1, offset: 80664},
 			expr: &actionExpr{
-				pos: position{line: 2519, col: 14, offset: 78594},
+				pos: position{line: 2573, col: 14, offset: 80677},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2519, col: 14, offset: 78594},
+					pos: position{line: 2573, col: 14, offset: 80677},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2519, col: 14, offset: 78594},
+							pos:  position{line: 2573, col: 14, offset: 80677},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2519, col: 19, offset: 78599},
+							pos:  position{line: 2573, col: 19, offset: 80682},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2519, col: 28, offset: 78608},
+							pos:   position{line: 2573, col: 28, offset: 80691},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2519, col: 34, offset: 78614},
+								pos: position{line: 2573, col: 34, offset: 80697},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2519, col: 35, offset: 78615},
+									pos:  position{line: 2573, col: 35, offset: 80698},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2519, col: 47, offset: 78627},
+							pos:   position{line: 2573, col: 47, offset: 80710},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2519, col: 58, offset: 78638},
+								pos:  position{line: 2573, col: 58, offset: 80721},
 								name: "SortElements",
 							},
 						},
@@ -4562,41 +4616,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2557, col: 1, offset: 79517},
+			pos:  position{line: 2611, col: 1, offset: 81600},
 			expr: &actionExpr{
-				pos: position{line: 2557, col: 14, offset: 79530},
+				pos: position{line: 2611, col: 14, offset: 81613},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2557, col: 14, offset: 79530},
+					pos: position{line: 2611, col: 14, offset: 81613},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2557, col: 14, offset: 79530},
+							pos: position{line: 2611, col: 14, offset: 81613},
 							expr: &seqExpr{
-								pos: position{line: 2557, col: 15, offset: 79531},
+								pos: position{line: 2611, col: 15, offset: 81614},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2557, col: 15, offset: 79531},
+										pos:        position{line: 2611, col: 15, offset: 81614},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2557, col: 23, offset: 79539},
+										pos:  position{line: 2611, col: 23, offset: 81622},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2557, col: 31, offset: 79547},
+							pos:   position{line: 2611, col: 31, offset: 81630},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2557, col: 40, offset: 79556},
+								pos:  position{line: 2611, col: 40, offset: 81639},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2557, col: 56, offset: 79572},
+							pos:  position{line: 2611, col: 56, offset: 81655},
 							name: "SPACE",
 						},
 					},
@@ -4605,43 +4659,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2571, col: 1, offset: 79871},
+			pos:  position{line: 2625, col: 1, offset: 81954},
 			expr: &actionExpr{
-				pos: position{line: 2571, col: 14, offset: 79884},
+				pos: position{line: 2625, col: 14, offset: 81967},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2571, col: 14, offset: 79884},
+					pos: position{line: 2625, col: 14, offset: 81967},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2571, col: 14, offset: 79884},
+							pos:  position{line: 2625, col: 14, offset: 81967},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2571, col: 19, offset: 79889},
+							pos:  position{line: 2625, col: 19, offset: 81972},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2571, col: 28, offset: 79898},
+							pos:   position{line: 2625, col: 28, offset: 81981},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2571, col: 34, offset: 79904},
+								pos:  position{line: 2625, col: 34, offset: 81987},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2571, col: 45, offset: 79915},
+							pos:   position{line: 2625, col: 45, offset: 81998},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2571, col: 50, offset: 79920},
+								pos: position{line: 2625, col: 50, offset: 82003},
 								expr: &seqExpr{
-									pos: position{line: 2571, col: 51, offset: 79921},
+									pos: position{line: 2625, col: 51, offset: 82004},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2571, col: 51, offset: 79921},
+											pos:  position{line: 2625, col: 51, offset: 82004},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2571, col: 57, offset: 79927},
+											pos:  position{line: 2625, col: 57, offset: 82010},
 											name: "SingleEval",
 										},
 									},
@@ -4654,30 +4708,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2606, col: 1, offset: 81160},
+			pos:  position{line: 2660, col: 1, offset: 83243},
 			expr: &actionExpr{
-				pos: position{line: 2606, col: 15, offset: 81174},
+				pos: position{line: 2660, col: 15, offset: 83257},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2606, col: 15, offset: 81174},
+					pos: position{line: 2660, col: 15, offset: 83257},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2606, col: 15, offset: 81174},
+							pos:   position{line: 2660, col: 15, offset: 83257},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2606, col: 21, offset: 81180},
+								pos:  position{line: 2660, col: 21, offset: 83263},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2606, col: 31, offset: 81190},
+							pos:  position{line: 2660, col: 31, offset: 83273},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2606, col: 37, offset: 81196},
+							pos:   position{line: 2660, col: 37, offset: 83279},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2606, col: 42, offset: 81201},
+								pos:  position{line: 2660, col: 42, offset: 83284},
 								name: "EvalExpression",
 							},
 						},
@@ -4687,15 +4741,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2619, col: 1, offset: 81602},
+			pos:  position{line: 2673, col: 1, offset: 83685},
 			expr: &actionExpr{
-				pos: position{line: 2619, col: 19, offset: 81620},
+				pos: position{line: 2673, col: 19, offset: 83703},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2619, col: 19, offset: 81620},
+					pos:   position{line: 2673, col: 19, offset: 83703},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2619, col: 25, offset: 81626},
+						pos:  position{line: 2673, col: 25, offset: 83709},
 						name: "ValueExpr",
 					},
 				},
@@ -4703,85 +4757,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2631, col: 1, offset: 82014},
+			pos:  position{line: 2685, col: 1, offset: 84097},
 			expr: &choiceExpr{
-				pos: position{line: 2631, col: 18, offset: 82031},
+				pos: position{line: 2685, col: 18, offset: 84114},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2631, col: 18, offset: 82031},
+						pos: position{line: 2685, col: 18, offset: 84114},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2631, col: 18, offset: 82031},
+							pos: position{line: 2685, col: 18, offset: 84114},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2631, col: 18, offset: 82031},
+									pos:        position{line: 2685, col: 18, offset: 84114},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2631, col: 23, offset: 82036},
+									pos:  position{line: 2685, col: 23, offset: 84119},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2631, col: 31, offset: 82044},
+									pos:   position{line: 2685, col: 31, offset: 84127},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2631, col: 41, offset: 82054},
+										pos:  position{line: 2685, col: 41, offset: 84137},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2631, col: 50, offset: 82063},
+									pos:  position{line: 2685, col: 50, offset: 84146},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2631, col: 56, offset: 82069},
+									pos:   position{line: 2685, col: 56, offset: 84152},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2631, col: 66, offset: 82079},
+										pos:  position{line: 2685, col: 66, offset: 84162},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2631, col: 76, offset: 82089},
+									pos:  position{line: 2685, col: 76, offset: 84172},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2631, col: 82, offset: 82095},
+									pos:   position{line: 2685, col: 82, offset: 84178},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2631, col: 93, offset: 82106},
+										pos:  position{line: 2685, col: 93, offset: 84189},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2631, col: 103, offset: 82116},
+									pos:  position{line: 2685, col: 103, offset: 84199},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2642, col: 3, offset: 82367},
+						pos: position{line: 2696, col: 3, offset: 84450},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2642, col: 3, offset: 82367},
+							pos: position{line: 2696, col: 3, offset: 84450},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2642, col: 3, offset: 82367},
+									pos:   position{line: 2696, col: 3, offset: 84450},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2642, col: 11, offset: 82375},
+										pos: position{line: 2696, col: 11, offset: 84458},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2642, col: 11, offset: 82375},
+												pos:        position{line: 2696, col: 11, offset: 84458},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2642, col: 20, offset: 82384},
+												pos:        position{line: 2696, col: 20, offset: 84467},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4790,31 +4844,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2642, col: 32, offset: 82396},
+									pos:  position{line: 2696, col: 32, offset: 84479},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2642, col: 40, offset: 82404},
+									pos:   position{line: 2696, col: 40, offset: 84487},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2642, col: 45, offset: 82409},
+										pos:  position{line: 2696, col: 45, offset: 84492},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2642, col: 64, offset: 82428},
+									pos:   position{line: 2696, col: 64, offset: 84511},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2642, col: 69, offset: 82433},
+										pos: position{line: 2696, col: 69, offset: 84516},
 										expr: &seqExpr{
-											pos: position{line: 2642, col: 70, offset: 82434},
+											pos: position{line: 2696, col: 70, offset: 84517},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2642, col: 70, offset: 82434},
+													pos:  position{line: 2696, col: 70, offset: 84517},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2642, col: 76, offset: 82440},
+													pos:  position{line: 2696, col: 76, offset: 84523},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4822,50 +4876,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2642, col: 97, offset: 82461},
+									pos:  position{line: 2696, col: 97, offset: 84544},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2665, col: 3, offset: 83065},
+						pos: position{line: 2719, col: 3, offset: 85148},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2665, col: 3, offset: 83065},
+							pos: position{line: 2719, col: 3, offset: 85148},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2665, col: 3, offset: 83065},
+									pos:        position{line: 2719, col: 3, offset: 85148},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2665, col: 14, offset: 83076},
+									pos:  position{line: 2719, col: 14, offset: 85159},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2665, col: 22, offset: 83084},
+									pos:   position{line: 2719, col: 22, offset: 85167},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2665, col: 32, offset: 83094},
+										pos:  position{line: 2719, col: 32, offset: 85177},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2665, col: 42, offset: 83104},
+									pos:   position{line: 2719, col: 42, offset: 85187},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2665, col: 47, offset: 83109},
+										pos: position{line: 2719, col: 47, offset: 85192},
 										expr: &seqExpr{
-											pos: position{line: 2665, col: 48, offset: 83110},
+											pos: position{line: 2719, col: 48, offset: 85193},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2665, col: 48, offset: 83110},
+													pos:  position{line: 2719, col: 48, offset: 85193},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2665, col: 54, offset: 83116},
+													pos:  position{line: 2719, col: 54, offset: 85199},
 													name: "ValueExpr",
 												},
 											},
@@ -4873,73 +4927,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2665, col: 66, offset: 83128},
+									pos:  position{line: 2719, col: 66, offset: 85211},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2682, col: 3, offset: 83547},
+						pos: position{line: 2736, col: 3, offset: 85630},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2682, col: 3, offset: 83547},
+							pos: position{line: 2736, col: 3, offset: 85630},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2682, col: 3, offset: 83547},
+									pos:        position{line: 2736, col: 3, offset: 85630},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 12, offset: 83556},
+									pos:  position{line: 2736, col: 12, offset: 85639},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2682, col: 20, offset: 83564},
+									pos:   position{line: 2736, col: 20, offset: 85647},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2682, col: 30, offset: 83574},
+										pos:  position{line: 2736, col: 30, offset: 85657},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 40, offset: 83584},
+									pos:  position{line: 2736, col: 40, offset: 85667},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2682, col: 46, offset: 83590},
+									pos:   position{line: 2736, col: 46, offset: 85673},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2682, col: 57, offset: 83601},
+										pos:  position{line: 2736, col: 57, offset: 85684},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2682, col: 67, offset: 83611},
+									pos:  position{line: 2736, col: 67, offset: 85694},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2694, col: 3, offset: 83891},
+						pos: position{line: 2748, col: 3, offset: 85974},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2694, col: 3, offset: 83891},
+							pos: position{line: 2748, col: 3, offset: 85974},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2694, col: 3, offset: 83891},
+									pos:        position{line: 2748, col: 3, offset: 85974},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 10, offset: 83898},
+									pos:  position{line: 2748, col: 10, offset: 85981},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2694, col: 18, offset: 83906},
+									pos:  position{line: 2748, col: 18, offset: 85989},
 									name: "R_PAREN",
 								},
 							},
@@ -4950,30 +5004,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2701, col: 1, offset: 84003},
+			pos:  position{line: 2755, col: 1, offset: 86086},
 			expr: &actionExpr{
-				pos: position{line: 2701, col: 23, offset: 84025},
+				pos: position{line: 2755, col: 23, offset: 86108},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2701, col: 23, offset: 84025},
+					pos: position{line: 2755, col: 23, offset: 86108},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2701, col: 23, offset: 84025},
+							pos:   position{line: 2755, col: 23, offset: 86108},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2701, col: 33, offset: 84035},
+								pos:  position{line: 2755, col: 33, offset: 86118},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2701, col: 42, offset: 84044},
+							pos:  position{line: 2755, col: 42, offset: 86127},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2701, col: 48, offset: 84050},
+							pos:   position{line: 2755, col: 48, offset: 86133},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2701, col: 54, offset: 84056},
+								pos:  position{line: 2755, col: 54, offset: 86139},
 								name: "ValueExpr",
 							},
 						},
@@ -4983,15 +5037,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2709, col: 1, offset: 84261},
+			pos:  position{line: 2763, col: 1, offset: 86344},
 			expr: &actionExpr{
-				pos: position{line: 2709, col: 26, offset: 84286},
+				pos: position{line: 2763, col: 26, offset: 86369},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2709, col: 26, offset: 84286},
+					pos:   position{line: 2763, col: 26, offset: 86369},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2709, col: 37, offset: 84297},
+						pos:  position{line: 2763, col: 37, offset: 86380},
 						name: "StringExpr",
 					},
 				},
@@ -4999,15 +5053,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2719, col: 1, offset: 84506},
+			pos:  position{line: 2773, col: 1, offset: 86589},
 			expr: &actionExpr{
-				pos: position{line: 2719, col: 30, offset: 84535},
+				pos: position{line: 2773, col: 30, offset: 86618},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2719, col: 30, offset: 84535},
+					pos:   position{line: 2773, col: 30, offset: 86618},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2719, col: 45, offset: 84550},
+						pos:  position{line: 2773, col: 45, offset: 86633},
 						name: "MultiValueExpr",
 					},
 				},
@@ -5015,22 +5069,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2728, col: 1, offset: 84756},
+			pos:  position{line: 2782, col: 1, offset: 86839},
 			expr: &actionExpr{
-				pos: position{line: 2728, col: 27, offset: 84782},
+				pos: position{line: 2782, col: 27, offset: 86865},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2728, col: 27, offset: 84782},
+					pos:   position{line: 2782, col: 27, offset: 86865},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2728, col: 40, offset: 84795},
+						pos: position{line: 2782, col: 40, offset: 86878},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2728, col: 40, offset: 84795},
+								pos:  position{line: 2782, col: 40, offset: 86878},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2728, col: 68, offset: 84823},
+								pos:  position{line: 2782, col: 68, offset: 86906},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -5040,182 +5094,182 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2732, col: 1, offset: 84900},
+			pos:  position{line: 2786, col: 1, offset: 86983},
 			expr: &choiceExpr{
-				pos: position{line: 2732, col: 19, offset: 84918},
+				pos: position{line: 2786, col: 19, offset: 87001},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2732, col: 19, offset: 84918},
+						pos: position{line: 2786, col: 19, offset: 87001},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2732, col: 20, offset: 84919},
+							pos: position{line: 2786, col: 20, offset: 87002},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2732, col: 20, offset: 84919},
+									pos:   position{line: 2786, col: 20, offset: 87002},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2732, col: 28, offset: 84927},
+										pos:        position{line: 2786, col: 28, offset: 87010},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 37, offset: 84936},
+									pos:  position{line: 2786, col: 37, offset: 87019},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2732, col: 45, offset: 84944},
+									pos:   position{line: 2786, col: 45, offset: 87027},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2732, col: 56, offset: 84955},
+										pos:  position{line: 2786, col: 56, offset: 87038},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 67, offset: 84966},
+									pos:  position{line: 2786, col: 67, offset: 87049},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2732, col: 73, offset: 84972},
+									pos:   position{line: 2786, col: 73, offset: 87055},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2732, col: 79, offset: 84978},
+										pos:  position{line: 2786, col: 79, offset: 87061},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2732, col: 90, offset: 84989},
+									pos:  position{line: 2786, col: 90, offset: 87072},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2744, col: 3, offset: 85350},
+						pos: position{line: 2798, col: 3, offset: 87433},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2744, col: 4, offset: 85351},
+							pos: position{line: 2798, col: 4, offset: 87434},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2744, col: 4, offset: 85351},
+									pos:   position{line: 2798, col: 4, offset: 87434},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2744, col: 12, offset: 85359},
+										pos:        position{line: 2798, col: 12, offset: 87442},
 										val:        "spath",
 										ignoreCase: false,
 										want:       "\"spath\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2744, col: 21, offset: 85368},
+									pos:  position{line: 2798, col: 21, offset: 87451},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2744, col: 29, offset: 85376},
+									pos:   position{line: 2798, col: 29, offset: 87459},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2744, col: 35, offset: 85382},
+										pos:  position{line: 2798, col: 35, offset: 87465},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2744, col: 46, offset: 85393},
+									pos:  position{line: 2798, col: 46, offset: 87476},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2744, col: 52, offset: 85399},
+									pos:   position{line: 2798, col: 52, offset: 87482},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2744, col: 57, offset: 85404},
+										pos:  position{line: 2798, col: 57, offset: 87487},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2744, col: 68, offset: 85415},
+									pos:  position{line: 2798, col: 68, offset: 87498},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2756, col: 3, offset: 85770},
+						pos: position{line: 2810, col: 3, offset: 87853},
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
-							pos: position{line: 2756, col: 4, offset: 85771},
+							pos: position{line: 2810, col: 4, offset: 87854},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2756, col: 4, offset: 85771},
+									pos:   position{line: 2810, col: 4, offset: 87854},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2756, col: 12, offset: 85779},
+										pos:        position{line: 2810, col: 12, offset: 87862},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2756, col: 23, offset: 85790},
+									pos:  position{line: 2810, col: 23, offset: 87873},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2756, col: 31, offset: 85798},
+									pos:   position{line: 2810, col: 31, offset: 87881},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2756, col: 46, offset: 85813},
+										pos:  position{line: 2810, col: 46, offset: 87896},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2756, col: 61, offset: 85828},
+									pos:  position{line: 2810, col: 61, offset: 87911},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2756, col: 67, offset: 85834},
+									pos:   position{line: 2810, col: 67, offset: 87917},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2756, col: 78, offset: 85845},
+										pos:  position{line: 2810, col: 78, offset: 87928},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2756, col: 90, offset: 85857},
+									pos:   position{line: 2810, col: 90, offset: 87940},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2756, col: 99, offset: 85866},
+										pos: position{line: 2810, col: 99, offset: 87949},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2756, col: 100, offset: 85867},
+											pos:  position{line: 2810, col: 100, offset: 87950},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2756, col: 119, offset: 85886},
+									pos:  position{line: 2810, col: 119, offset: 87969},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2772, col: 3, offset: 86448},
+						pos: position{line: 2826, col: 3, offset: 88531},
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
-							pos: position{line: 2772, col: 4, offset: 86449},
+							pos: position{line: 2826, col: 4, offset: 88532},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2772, col: 4, offset: 86449},
+									pos:   position{line: 2826, col: 4, offset: 88532},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2772, col: 12, offset: 86457},
+										pos: position{line: 2826, col: 12, offset: 88540},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2772, col: 12, offset: 86457},
+												pos:        position{line: 2826, col: 12, offset: 88540},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2772, col: 24, offset: 86469},
+												pos:        position{line: 2826, col: 24, offset: 88552},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -5224,222 +5278,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2772, col: 34, offset: 86479},
+									pos:  position{line: 2826, col: 34, offset: 88562},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2772, col: 42, offset: 86487},
+									pos:   position{line: 2826, col: 42, offset: 88570},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2772, col: 57, offset: 86502},
+										pos:  position{line: 2826, col: 57, offset: 88585},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2772, col: 72, offset: 86517},
+									pos:  position{line: 2826, col: 72, offset: 88600},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2784, col: 3, offset: 86865},
+						pos: position{line: 2838, col: 3, offset: 88948},
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
-							pos: position{line: 2784, col: 4, offset: 86866},
+							pos: position{line: 2838, col: 4, offset: 88949},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2784, col: 4, offset: 86866},
+									pos:   position{line: 2838, col: 4, offset: 88949},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2784, col: 12, offset: 86874},
+										pos:        position{line: 2838, col: 12, offset: 88957},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2784, col: 24, offset: 86886},
+									pos:  position{line: 2838, col: 24, offset: 88969},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2784, col: 32, offset: 86894},
+									pos:   position{line: 2838, col: 32, offset: 88977},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2784, col: 42, offset: 86904},
+										pos:  position{line: 2838, col: 42, offset: 88987},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2784, col: 51, offset: 86913},
+									pos:  position{line: 2838, col: 51, offset: 88996},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2797, col: 3, offset: 87260},
+						pos: position{line: 2851, col: 3, offset: 89343},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2797, col: 4, offset: 87261},
+							pos: position{line: 2851, col: 4, offset: 89344},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2797, col: 4, offset: 87261},
+									pos:   position{line: 2851, col: 4, offset: 89344},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2797, col: 12, offset: 87269},
+										pos:        position{line: 2851, col: 12, offset: 89352},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 21, offset: 87278},
+									pos:  position{line: 2851, col: 21, offset: 89361},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 29, offset: 87286},
+									pos:   position{line: 2851, col: 29, offset: 89369},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2797, col: 44, offset: 87301},
+										pos:  position{line: 2851, col: 44, offset: 89384},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 59, offset: 87316},
+									pos:  position{line: 2851, col: 59, offset: 89399},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 65, offset: 87322},
+									pos:   position{line: 2851, col: 65, offset: 89405},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2797, col: 70, offset: 87327},
+										pos:  position{line: 2851, col: 70, offset: 89410},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 80, offset: 87337},
+									pos:  position{line: 2851, col: 80, offset: 89420},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2810, col: 3, offset: 87759},
+						pos: position{line: 2864, col: 3, offset: 89842},
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
-							pos: position{line: 2810, col: 4, offset: 87760},
+							pos: position{line: 2864, col: 4, offset: 89843},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2810, col: 4, offset: 87760},
+									pos:   position{line: 2864, col: 4, offset: 89843},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2810, col: 12, offset: 87768},
+										pos:        position{line: 2864, col: 12, offset: 89851},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 23, offset: 87779},
+									pos:  position{line: 2864, col: 23, offset: 89862},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 31, offset: 87787},
+									pos:   position{line: 2864, col: 31, offset: 89870},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 42, offset: 87798},
+										pos:  position{line: 2864, col: 42, offset: 89881},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 54, offset: 87810},
+									pos:  position{line: 2864, col: 54, offset: 89893},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 60, offset: 87816},
+									pos:   position{line: 2864, col: 60, offset: 89899},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 69, offset: 87825},
+										pos:  position{line: 2864, col: 69, offset: 89908},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 81, offset: 87837},
+									pos:  position{line: 2864, col: 81, offset: 89920},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 87, offset: 87843},
+									pos:   position{line: 2864, col: 87, offset: 89926},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2810, col: 98, offset: 87854},
+										pos: position{line: 2864, col: 98, offset: 89937},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2810, col: 99, offset: 87855},
+											pos:  position{line: 2864, col: 99, offset: 89938},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 112, offset: 87868},
+									pos:  position{line: 2864, col: 112, offset: 89951},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2823, col: 3, offset: 88319},
+						pos: position{line: 2877, col: 3, offset: 90402},
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
-							pos: position{line: 2823, col: 4, offset: 88320},
+							pos: position{line: 2877, col: 4, offset: 90403},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2823, col: 4, offset: 88320},
+									pos:   position{line: 2877, col: 4, offset: 90403},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2823, col: 12, offset: 88328},
+										pos:        position{line: 2877, col: 12, offset: 90411},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 21, offset: 88337},
+									pos:  position{line: 2877, col: 21, offset: 90420},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 29, offset: 88345},
+									pos:   position{line: 2877, col: 29, offset: 90428},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2823, col: 36, offset: 88352},
+										pos:  position{line: 2877, col: 36, offset: 90435},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 51, offset: 88367},
+									pos:  position{line: 2877, col: 51, offset: 90450},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 57, offset: 88373},
+									pos:   position{line: 2877, col: 57, offset: 90456},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2823, col: 65, offset: 88381},
+										pos:  position{line: 2877, col: 65, offset: 90464},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2823, col: 80, offset: 88396},
+									pos:   position{line: 2877, col: 80, offset: 90479},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2823, col: 85, offset: 88401},
+										pos: position{line: 2877, col: 85, offset: 90484},
 										expr: &seqExpr{
-											pos: position{line: 2823, col: 86, offset: 88402},
+											pos: position{line: 2877, col: 86, offset: 90485},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2823, col: 86, offset: 88402},
+													pos:  position{line: 2877, col: 86, offset: 90485},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2823, col: 92, offset: 88408},
+													pos:  position{line: 2877, col: 92, offset: 90491},
 													name: "StringExpr",
 												},
 											},
@@ -5447,63 +5501,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2823, col: 105, offset: 88421},
+									pos:  position{line: 2877, col: 105, offset: 90504},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2840, col: 3, offset: 88949},
+						pos: position{line: 2894, col: 3, offset: 91032},
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
-							pos: position{line: 2840, col: 4, offset: 88950},
+							pos: position{line: 2894, col: 4, offset: 91033},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2840, col: 4, offset: 88950},
+									pos:   position{line: 2894, col: 4, offset: 91033},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2840, col: 12, offset: 88958},
+										pos:        position{line: 2894, col: 12, offset: 91041},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2840, col: 32, offset: 88978},
+									pos:  position{line: 2894, col: 32, offset: 91061},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2840, col: 40, offset: 88986},
+									pos:   position{line: 2894, col: 40, offset: 91069},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2840, col: 55, offset: 89001},
+										pos:  position{line: 2894, col: 55, offset: 91084},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2840, col: 70, offset: 89016},
+									pos:   position{line: 2894, col: 70, offset: 91099},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2840, col: 75, offset: 89021},
+										pos: position{line: 2894, col: 75, offset: 91104},
 										expr: &seqExpr{
-											pos: position{line: 2840, col: 76, offset: 89022},
+											pos: position{line: 2894, col: 76, offset: 91105},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2840, col: 76, offset: 89022},
+													pos:  position{line: 2894, col: 76, offset: 91105},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2840, col: 83, offset: 89029},
+													pos: position{line: 2894, col: 83, offset: 91112},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2840, col: 83, offset: 89029},
+															pos:        position{line: 2894, col: 83, offset: 91112},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2840, col: 92, offset: 89038},
+															pos:        position{line: 2894, col: 92, offset: 91121},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5511,7 +5565,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2840, col: 101, offset: 89047},
+													pos:        position{line: 2894, col: 101, offset: 91130},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5521,54 +5575,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2840, col: 108, offset: 89054},
+									pos:  position{line: 2894, col: 108, offset: 91137},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2865, col: 3, offset: 89757},
+						pos: position{line: 2919, col: 3, offset: 91840},
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
-							pos: position{line: 2865, col: 4, offset: 89758},
+							pos: position{line: 2919, col: 4, offset: 91841},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2865, col: 4, offset: 89758},
+									pos:   position{line: 2919, col: 4, offset: 91841},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2865, col: 12, offset: 89766},
+										pos:        position{line: 2919, col: 12, offset: 91849},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2865, col: 24, offset: 89778},
+									pos:  position{line: 2919, col: 24, offset: 91861},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2865, col: 32, offset: 89786},
+									pos:   position{line: 2919, col: 32, offset: 91869},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2865, col: 41, offset: 89795},
+										pos:  position{line: 2919, col: 41, offset: 91878},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2865, col: 64, offset: 89818},
+									pos:   position{line: 2919, col: 64, offset: 91901},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2865, col: 69, offset: 89823},
+										pos: position{line: 2919, col: 69, offset: 91906},
 										expr: &seqExpr{
-											pos: position{line: 2865, col: 70, offset: 89824},
+											pos: position{line: 2919, col: 70, offset: 91907},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2865, col: 70, offset: 89824},
+													pos:  position{line: 2919, col: 70, offset: 91907},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2865, col: 76, offset: 89830},
+													pos:  position{line: 2919, col: 76, offset: 91913},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5576,57 +5630,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2865, col: 101, offset: 89855},
+									pos:  position{line: 2919, col: 101, offset: 91938},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2885, col: 3, offset: 90443},
+						pos: position{line: 2939, col: 3, offset: 92526},
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
-							pos: position{line: 2885, col: 3, offset: 90443},
+							pos: position{line: 2939, col: 3, offset: 92526},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2885, col: 3, offset: 90443},
+									pos:   position{line: 2939, col: 3, offset: 92526},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2885, col: 9, offset: 90449},
+										pos:  position{line: 2939, col: 9, offset: 92532},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2885, col: 25, offset: 90465},
+									pos: position{line: 2939, col: 25, offset: 92548},
 									expr: &choiceExpr{
-										pos: position{line: 2885, col: 27, offset: 90467},
+										pos: position{line: 2939, col: 27, offset: 92550},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 27, offset: 90467},
+												pos:  position{line: 2939, col: 27, offset: 92550},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 36, offset: 90476},
+												pos:  position{line: 2939, col: 36, offset: 92559},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 46, offset: 90486},
+												pos:  position{line: 2939, col: 46, offset: 92569},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 54, offset: 90494},
+												pos:  position{line: 2939, col: 54, offset: 92577},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 62, offset: 90502},
+												pos:  position{line: 2939, col: 62, offset: 92585},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2885, col: 70, offset: 90510},
+												pos:  position{line: 2939, col: 70, offset: 92593},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2885, col: 84, offset: 90524},
+												pos:        position{line: 2939, col: 84, offset: 92607},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5642,36 +5696,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2897, col: 1, offset: 90919},
+			pos:  position{line: 2951, col: 1, offset: 93002},
 			expr: &choiceExpr{
-				pos: position{line: 2897, col: 13, offset: 90931},
+				pos: position{line: 2951, col: 13, offset: 93014},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2897, col: 13, offset: 90931},
+						pos: position{line: 2951, col: 13, offset: 93014},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2897, col: 14, offset: 90932},
+							pos: position{line: 2951, col: 14, offset: 93015},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2897, col: 14, offset: 90932},
+									pos:   position{line: 2951, col: 14, offset: 93015},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2897, col: 22, offset: 90940},
+										pos: position{line: 2951, col: 22, offset: 93023},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2897, col: 22, offset: 90940},
+												pos:        position{line: 2951, col: 22, offset: 93023},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2897, col: 32, offset: 90950},
+												pos:        position{line: 2951, col: 32, offset: 93033},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2897, col: 42, offset: 90960},
+												pos:        position{line: 2951, col: 42, offset: 93043},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5680,44 +5734,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2897, col: 55, offset: 90973},
+									pos:  position{line: 2951, col: 55, offset: 93056},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2897, col: 63, offset: 90981},
+									pos:   position{line: 2951, col: 63, offset: 93064},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2897, col: 74, offset: 90992},
+										pos:  position{line: 2951, col: 74, offset: 93075},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2897, col: 85, offset: 91003},
+									pos:  position{line: 2951, col: 85, offset: 93086},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2909, col: 3, offset: 91317},
+						pos: position{line: 2963, col: 3, offset: 93400},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2909, col: 4, offset: 91318},
+							pos: position{line: 2963, col: 4, offset: 93401},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2909, col: 4, offset: 91318},
+									pos:   position{line: 2963, col: 4, offset: 93401},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2909, col: 12, offset: 91326},
+										pos: position{line: 2963, col: 12, offset: 93409},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2909, col: 12, offset: 91326},
+												pos:        position{line: 2963, col: 12, offset: 93409},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2909, col: 20, offset: 91334},
+												pos:        position{line: 2963, col: 20, offset: 93417},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5726,31 +5780,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2909, col: 27, offset: 91341},
+									pos:  position{line: 2963, col: 27, offset: 93424},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2909, col: 35, offset: 91349},
+									pos:   position{line: 2963, col: 35, offset: 93432},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2909, col: 44, offset: 91358},
+										pos:  position{line: 2963, col: 44, offset: 93441},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2909, col: 55, offset: 91369},
+									pos:   position{line: 2963, col: 55, offset: 93452},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2909, col: 60, offset: 91374},
+										pos: position{line: 2963, col: 60, offset: 93457},
 										expr: &seqExpr{
-											pos: position{line: 2909, col: 61, offset: 91375},
+											pos: position{line: 2963, col: 61, offset: 93458},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2909, col: 61, offset: 91375},
+													pos:  position{line: 2963, col: 61, offset: 93458},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2909, col: 67, offset: 91381},
+													pos:  position{line: 2963, col: 67, offset: 93464},
 													name: "StringExpr",
 												},
 											},
@@ -5758,195 +5812,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2909, col: 80, offset: 91394},
+									pos:  position{line: 2963, col: 80, offset: 93477},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2931, col: 3, offset: 91994},
+						pos: position{line: 2985, col: 3, offset: 94077},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2931, col: 4, offset: 91995},
+							pos: position{line: 2985, col: 4, offset: 94078},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2931, col: 4, offset: 91995},
+									pos:   position{line: 2985, col: 4, offset: 94078},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2931, col: 12, offset: 92003},
+										pos:        position{line: 2985, col: 12, offset: 94086},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2931, col: 23, offset: 92014},
+									pos:  position{line: 2985, col: 23, offset: 94097},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2931, col: 31, offset: 92022},
+									pos:   position{line: 2985, col: 31, offset: 94105},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2931, col: 46, offset: 92037},
+										pos:  position{line: 2985, col: 46, offset: 94120},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2931, col: 61, offset: 92052},
+									pos:  position{line: 2985, col: 61, offset: 94135},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2942, col: 3, offset: 92354},
+						pos: position{line: 2996, col: 3, offset: 94437},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2942, col: 4, offset: 92355},
+							pos: position{line: 2996, col: 4, offset: 94438},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2942, col: 4, offset: 92355},
+									pos:   position{line: 2996, col: 4, offset: 94438},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2942, col: 12, offset: 92363},
+										pos:        position{line: 2996, col: 12, offset: 94446},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2942, col: 22, offset: 92373},
+									pos:  position{line: 2996, col: 22, offset: 94456},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2942, col: 30, offset: 92381},
+									pos:   position{line: 2996, col: 30, offset: 94464},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2942, col: 45, offset: 92396},
+										pos:  position{line: 2996, col: 45, offset: 94479},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2942, col: 60, offset: 92411},
+									pos:  position{line: 2996, col: 60, offset: 94494},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2942, col: 66, offset: 92417},
+									pos:   position{line: 2996, col: 66, offset: 94500},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2942, col: 72, offset: 92423},
+										pos:  position{line: 2996, col: 72, offset: 94506},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2942, col: 83, offset: 92434},
+									pos:  position{line: 2996, col: 83, offset: 94517},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2954, col: 3, offset: 92784},
+						pos: position{line: 3008, col: 3, offset: 94867},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2954, col: 4, offset: 92785},
+							pos: position{line: 3008, col: 4, offset: 94868},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2954, col: 4, offset: 92785},
+									pos:   position{line: 3008, col: 4, offset: 94868},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2954, col: 12, offset: 92793},
+										pos:        position{line: 3008, col: 12, offset: 94876},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2954, col: 22, offset: 92803},
+									pos:  position{line: 3008, col: 22, offset: 94886},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2954, col: 30, offset: 92811},
+									pos:   position{line: 3008, col: 30, offset: 94894},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2954, col: 45, offset: 92826},
+										pos:  position{line: 3008, col: 45, offset: 94909},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2954, col: 60, offset: 92841},
+									pos:  position{line: 3008, col: 60, offset: 94924},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2954, col: 66, offset: 92847},
+									pos:   position{line: 3008, col: 66, offset: 94930},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2954, col: 79, offset: 92860},
+										pos:  position{line: 3008, col: 79, offset: 94943},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2954, col: 90, offset: 92871},
+									pos:  position{line: 3008, col: 90, offset: 94954},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2978, col: 3, offset: 93537},
+						pos: position{line: 3032, col: 3, offset: 95620},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2978, col: 4, offset: 93538},
+							pos: position{line: 3032, col: 4, offset: 95621},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2978, col: 4, offset: 93538},
+									pos:   position{line: 3032, col: 4, offset: 95621},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2978, col: 12, offset: 93546},
+										pos:        position{line: 3032, col: 12, offset: 95629},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2978, col: 22, offset: 93556},
+									pos:  position{line: 3032, col: 22, offset: 95639},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2978, col: 30, offset: 93564},
+									pos:   position{line: 3032, col: 30, offset: 95647},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2978, col: 41, offset: 93575},
+										pos:  position{line: 3032, col: 41, offset: 95658},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2978, col: 52, offset: 93586},
+									pos:  position{line: 3032, col: 52, offset: 95669},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2978, col: 58, offset: 93592},
+									pos:   position{line: 3032, col: 58, offset: 95675},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2978, col: 69, offset: 93603},
+										pos:  position{line: 3032, col: 69, offset: 95686},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2978, col: 81, offset: 93615},
+									pos:   position{line: 3032, col: 81, offset: 95698},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2978, col: 93, offset: 93627},
+										pos: position{line: 3032, col: 93, offset: 95710},
 										expr: &seqExpr{
-											pos: position{line: 2978, col: 94, offset: 93628},
+											pos: position{line: 3032, col: 94, offset: 95711},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2978, col: 94, offset: 93628},
+													pos:  position{line: 3032, col: 94, offset: 95711},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2978, col: 100, offset: 93634},
+													pos:  position{line: 3032, col: 100, offset: 95717},
 													name: "NumericExpr",
 												},
 											},
@@ -5954,50 +6008,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2978, col: 114, offset: 93648},
+									pos:  position{line: 3032, col: 114, offset: 95731},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3003, col: 3, offset: 94478},
+						pos: position{line: 3057, col: 3, offset: 96561},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 3003, col: 3, offset: 94478},
+							pos: position{line: 3057, col: 3, offset: 96561},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3003, col: 3, offset: 94478},
+									pos:        position{line: 3057, col: 3, offset: 96561},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3003, col: 14, offset: 94489},
+									pos:  position{line: 3057, col: 14, offset: 96572},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3003, col: 22, offset: 94497},
+									pos:   position{line: 3057, col: 22, offset: 96580},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3003, col: 28, offset: 94503},
+										pos:  position{line: 3057, col: 28, offset: 96586},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3003, col: 38, offset: 94513},
+									pos:   position{line: 3057, col: 38, offset: 96596},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3003, col: 45, offset: 94520},
+										pos: position{line: 3057, col: 45, offset: 96603},
 										expr: &seqExpr{
-											pos: position{line: 3003, col: 46, offset: 94521},
+											pos: position{line: 3057, col: 46, offset: 96604},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3003, col: 46, offset: 94521},
+													pos:  position{line: 3057, col: 46, offset: 96604},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3003, col: 52, offset: 94527},
+													pos:  position{line: 3057, col: 52, offset: 96610},
 													name: "StringExpr",
 												},
 											},
@@ -6005,38 +6059,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3003, col: 65, offset: 94540},
+									pos:  position{line: 3057, col: 65, offset: 96623},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3016, col: 3, offset: 94908},
+						pos: position{line: 3070, col: 3, offset: 96991},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 3016, col: 4, offset: 94909},
+							pos: position{line: 3070, col: 4, offset: 96992},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3016, col: 4, offset: 94909},
+									pos:   position{line: 3070, col: 4, offset: 96992},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3016, col: 12, offset: 94917},
+										pos: position{line: 3070, col: 12, offset: 97000},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3016, col: 12, offset: 94917},
+												pos:        position{line: 3070, col: 12, offset: 97000},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3016, col: 22, offset: 94927},
+												pos:        position{line: 3070, col: 22, offset: 97010},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3016, col: 32, offset: 94937},
+												pos:        position{line: 3070, col: 32, offset: 97020},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -6045,171 +6099,171 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3016, col: 40, offset: 94945},
+									pos:  position{line: 3070, col: 40, offset: 97028},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3016, col: 48, offset: 94953},
+									pos:   position{line: 3070, col: 48, offset: 97036},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3016, col: 54, offset: 94959},
+										pos:  position{line: 3070, col: 54, offset: 97042},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3016, col: 66, offset: 94971},
+									pos:   position{line: 3070, col: 66, offset: 97054},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3016, col: 82, offset: 94987},
+										pos: position{line: 3070, col: 82, offset: 97070},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3016, col: 83, offset: 94988},
+											pos:  position{line: 3070, col: 83, offset: 97071},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3016, col: 101, offset: 95006},
+									pos:  position{line: 3070, col: 101, offset: 97089},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3035, col: 3, offset: 95446},
+						pos: position{line: 3089, col: 3, offset: 97529},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 3035, col: 3, offset: 95446},
+							pos: position{line: 3089, col: 3, offset: 97529},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3035, col: 3, offset: 95446},
+									pos:        position{line: 3089, col: 3, offset: 97529},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3035, col: 12, offset: 95455},
+									pos:  position{line: 3089, col: 12, offset: 97538},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3035, col: 20, offset: 95463},
+									pos:   position{line: 3089, col: 20, offset: 97546},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3035, col: 25, offset: 95468},
+										pos:  position{line: 3089, col: 25, offset: 97551},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3035, col: 36, offset: 95479},
+									pos:  position{line: 3089, col: 36, offset: 97562},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3035, col: 42, offset: 95485},
+									pos:   position{line: 3089, col: 42, offset: 97568},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3035, col: 45, offset: 95488},
+										pos:  position{line: 3089, col: 45, offset: 97571},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3035, col: 55, offset: 95498},
+									pos:  position{line: 3089, col: 55, offset: 97581},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3042, col: 3, offset: 95656},
+						pos: position{line: 3096, col: 3, offset: 97739},
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
-							pos: position{line: 3042, col: 3, offset: 95656},
+							pos: position{line: 3096, col: 3, offset: 97739},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3042, col: 3, offset: 95656},
+									pos:        position{line: 3096, col: 3, offset: 97739},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3042, col: 21, offset: 95674},
+									pos:  position{line: 3096, col: 21, offset: 97757},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3042, col: 29, offset: 95682},
+									pos:   position{line: 3096, col: 29, offset: 97765},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3042, col: 33, offset: 95686},
+										pos:  position{line: 3096, col: 33, offset: 97769},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3042, col: 43, offset: 95696},
+									pos:  position{line: 3096, col: 43, offset: 97779},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3042, col: 49, offset: 95702},
+									pos:   position{line: 3096, col: 49, offset: 97785},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3042, col: 53, offset: 95706},
+										pos:  position{line: 3096, col: 53, offset: 97789},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3042, col: 66, offset: 95719},
+									pos:  position{line: 3096, col: 66, offset: 97802},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3042, col: 72, offset: 95725},
+									pos:   position{line: 3096, col: 72, offset: 97808},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3042, col: 78, offset: 95731},
+										pos:  position{line: 3096, col: 78, offset: 97814},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3042, col: 91, offset: 95744},
+									pos:  position{line: 3096, col: 91, offset: 97827},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3053, col: 3, offset: 96052},
+						pos: position{line: 3107, col: 3, offset: 98135},
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
-							pos: position{line: 3053, col: 3, offset: 96052},
+							pos: position{line: 3107, col: 3, offset: 98135},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3053, col: 3, offset: 96052},
+									pos:        position{line: 3107, col: 3, offset: 98135},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3053, col: 12, offset: 96061},
+									pos:  position{line: 3107, col: 12, offset: 98144},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3053, col: 20, offset: 96069},
+									pos:   position{line: 3107, col: 20, offset: 98152},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3053, col: 27, offset: 96076},
+										pos:  position{line: 3107, col: 27, offset: 98159},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3053, col: 38, offset: 96087},
+									pos:   position{line: 3107, col: 38, offset: 98170},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3053, col: 43, offset: 96092},
+										pos: position{line: 3107, col: 43, offset: 98175},
 										expr: &seqExpr{
-											pos: position{line: 3053, col: 44, offset: 96093},
+											pos: position{line: 3107, col: 44, offset: 98176},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3053, col: 44, offset: 96093},
+													pos:  position{line: 3107, col: 44, offset: 98176},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3053, col: 50, offset: 96099},
+													pos:  position{line: 3107, col: 50, offset: 98182},
 													name: "StringExpr",
 												},
 											},
@@ -6217,47 +6271,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3053, col: 63, offset: 96112},
+									pos:  position{line: 3107, col: 63, offset: 98195},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3071, col: 3, offset: 96579},
+						pos: position{line: 3125, col: 3, offset: 98662},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 3071, col: 3, offset: 96579},
+							pos: position{line: 3125, col: 3, offset: 98662},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3071, col: 3, offset: 96579},
+									pos:        position{line: 3125, col: 3, offset: 98662},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3071, col: 12, offset: 96588},
+									pos:  position{line: 3125, col: 12, offset: 98671},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3071, col: 20, offset: 96596},
+									pos:   position{line: 3125, col: 20, offset: 98679},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3071, col: 42, offset: 96618},
+										pos: position{line: 3125, col: 42, offset: 98701},
 										expr: &seqExpr{
-											pos: position{line: 3071, col: 43, offset: 96619},
+											pos: position{line: 3125, col: 43, offset: 98702},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 3071, col: 44, offset: 96620},
+													pos: position{line: 3125, col: 44, offset: 98703},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 3071, col: 44, offset: 96620},
+															pos:        position{line: 3125, col: 44, offset: 98703},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3071, col: 53, offset: 96629},
+															pos:        position{line: 3125, col: 53, offset: 98712},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6265,7 +6319,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 3071, col: 62, offset: 96638},
+													pos:        position{line: 3125, col: 62, offset: 98721},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6275,56 +6329,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3071, col: 69, offset: 96645},
+									pos:  position{line: 3125, col: 69, offset: 98728},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3093, col: 3, offset: 97242},
+						pos: position{line: 3147, col: 3, offset: 99325},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 3093, col: 3, offset: 97242},
+							pos: position{line: 3147, col: 3, offset: 99325},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3093, col: 3, offset: 97242},
+									pos:        position{line: 3147, col: 3, offset: 99325},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3093, col: 13, offset: 97252},
+									pos:  position{line: 3147, col: 13, offset: 99335},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3093, col: 21, offset: 97260},
+									pos:   position{line: 3147, col: 21, offset: 99343},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3093, col: 27, offset: 97266},
+										pos:  position{line: 3147, col: 27, offset: 99349},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3093, col: 43, offset: 97282},
+									pos:   position{line: 3147, col: 43, offset: 99365},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3093, col: 53, offset: 97292},
+										pos: position{line: 3147, col: 53, offset: 99375},
 										expr: &seqExpr{
-											pos: position{line: 3093, col: 54, offset: 97293},
+											pos: position{line: 3147, col: 54, offset: 99376},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3093, col: 54, offset: 97293},
+													pos:  position{line: 3147, col: 54, offset: 99376},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3093, col: 60, offset: 97299},
+													pos:        position{line: 3147, col: 60, offset: 99382},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3093, col: 73, offset: 97312},
+													pos:  position{line: 3147, col: 73, offset: 99395},
 													name: "FloatAsString",
 												},
 											},
@@ -6332,40 +6386,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3093, col: 89, offset: 97328},
+									pos:   position{line: 3147, col: 89, offset: 99411},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3093, col: 95, offset: 97334},
+										pos: position{line: 3147, col: 95, offset: 99417},
 										expr: &seqExpr{
-											pos: position{line: 3093, col: 96, offset: 97335},
+											pos: position{line: 3147, col: 96, offset: 99418},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3093, col: 96, offset: 97335},
+													pos:  position{line: 3147, col: 96, offset: 99418},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3093, col: 102, offset: 97341},
+													pos:        position{line: 3147, col: 102, offset: 99424},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 3093, col: 112, offset: 97351},
+													pos: position{line: 3147, col: 112, offset: 99434},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 3093, col: 112, offset: 97351},
+															pos:        position{line: 3147, col: 112, offset: 99434},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3093, col: 125, offset: 97364},
+															pos:        position{line: 3147, col: 125, offset: 99447},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3093, col: 137, offset: 97376},
+															pos:        position{line: 3147, col: 137, offset: 99459},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6377,25 +6431,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3093, col: 151, offset: 97390},
+									pos:   position{line: 3147, col: 151, offset: 99473},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3093, col: 158, offset: 97397},
+										pos: position{line: 3147, col: 158, offset: 99480},
 										expr: &seqExpr{
-											pos: position{line: 3093, col: 159, offset: 97398},
+											pos: position{line: 3147, col: 159, offset: 99481},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3093, col: 159, offset: 97398},
+													pos:  position{line: 3147, col: 159, offset: 99481},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3093, col: 165, offset: 97404},
+													pos:        position{line: 3147, col: 165, offset: 99487},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3093, col: 175, offset: 97414},
+													pos:  position{line: 3147, col: 175, offset: 99497},
 													name: "QuotedString",
 												},
 											},
@@ -6403,213 +6457,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3093, col: 190, offset: 97429},
+									pos:  position{line: 3147, col: 190, offset: 99512},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3133, col: 3, offset: 98424},
+						pos: position{line: 3187, col: 3, offset: 100507},
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
-							pos: position{line: 3133, col: 3, offset: 98424},
+							pos: position{line: 3187, col: 3, offset: 100507},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3133, col: 3, offset: 98424},
+									pos:        position{line: 3187, col: 3, offset: 100507},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3133, col: 15, offset: 98436},
+									pos:  position{line: 3187, col: 15, offset: 100519},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3133, col: 23, offset: 98444},
+									pos:   position{line: 3187, col: 23, offset: 100527},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3133, col: 30, offset: 98451},
+										pos: position{line: 3187, col: 30, offset: 100534},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3133, col: 31, offset: 98452},
+											pos:  position{line: 3187, col: 31, offset: 100535},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3133, col: 44, offset: 98465},
+									pos:  position{line: 3187, col: 44, offset: 100548},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3144, col: 3, offset: 98656},
+						pos: position{line: 3198, col: 3, offset: 100739},
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
-							pos: position{line: 3144, col: 3, offset: 98656},
+							pos: position{line: 3198, col: 3, offset: 100739},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3144, col: 3, offset: 98656},
+									pos:        position{line: 3198, col: 3, offset: 100739},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3144, col: 12, offset: 98665},
+									pos:  position{line: 3198, col: 12, offset: 100748},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3144, col: 20, offset: 98673},
+									pos:   position{line: 3198, col: 20, offset: 100756},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3144, col: 30, offset: 98683},
+										pos:  position{line: 3198, col: 30, offset: 100766},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3144, col: 40, offset: 98693},
+									pos:  position{line: 3198, col: 40, offset: 100776},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3150, col: 3, offset: 98816},
+						pos: position{line: 3204, col: 3, offset: 100899},
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
-							pos: position{line: 3150, col: 3, offset: 98816},
+							pos: position{line: 3204, col: 3, offset: 100899},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3150, col: 3, offset: 98816},
+									pos:        position{line: 3204, col: 3, offset: 100899},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 13, offset: 98826},
+									pos:  position{line: 3204, col: 13, offset: 100909},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3150, col: 21, offset: 98834},
+									pos:   position{line: 3204, col: 21, offset: 100917},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3150, col: 25, offset: 98838},
+										pos:  position{line: 3204, col: 25, offset: 100921},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 35, offset: 98848},
+									pos:  position{line: 3204, col: 35, offset: 100931},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3150, col: 41, offset: 98854},
+									pos:   position{line: 3204, col: 41, offset: 100937},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3150, col: 47, offset: 98860},
+										pos:  position{line: 3204, col: 47, offset: 100943},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 58, offset: 98871},
+									pos:  position{line: 3204, col: 58, offset: 100954},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3150, col: 64, offset: 98877},
+									pos:   position{line: 3204, col: 64, offset: 100960},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3150, col: 76, offset: 98889},
+										pos:  position{line: 3204, col: 76, offset: 100972},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3150, col: 87, offset: 98900},
+									pos:  position{line: 3204, col: 87, offset: 100983},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3157, col: 3, offset: 99124},
+						pos: position{line: 3211, col: 3, offset: 101207},
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
-							pos: position{line: 3157, col: 3, offset: 99124},
+							pos: position{line: 3211, col: 3, offset: 101207},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3157, col: 3, offset: 99124},
+									pos:        position{line: 3211, col: 3, offset: 101207},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3157, col: 14, offset: 99135},
+									pos:  position{line: 3211, col: 14, offset: 101218},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3157, col: 22, offset: 99143},
+									pos:   position{line: 3211, col: 22, offset: 101226},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3157, col: 26, offset: 99147},
+										pos:  position{line: 3211, col: 26, offset: 101230},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3157, col: 36, offset: 99157},
+									pos:  position{line: 3211, col: 36, offset: 101240},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3157, col: 42, offset: 99163},
+									pos:   position{line: 3211, col: 42, offset: 101246},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3157, col: 49, offset: 99170},
+										pos:  position{line: 3211, col: 49, offset: 101253},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3157, col: 60, offset: 99181},
+									pos:  position{line: 3211, col: 60, offset: 101264},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3165, col: 3, offset: 99345},
+						pos: position{line: 3219, col: 3, offset: 101428},
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
-							pos: position{line: 3165, col: 3, offset: 99345},
+							pos: position{line: 3219, col: 3, offset: 101428},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3165, col: 3, offset: 99345},
+									pos:        position{line: 3219, col: 3, offset: 101428},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3165, col: 14, offset: 99356},
+									pos:  position{line: 3219, col: 14, offset: 101439},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3165, col: 22, offset: 99364},
+									pos:   position{line: 3219, col: 22, offset: 101447},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3165, col: 26, offset: 99368},
+										pos:  position{line: 3219, col: 26, offset: 101451},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3165, col: 36, offset: 99378},
+									pos:  position{line: 3219, col: 36, offset: 101461},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3165, col: 42, offset: 99384},
+									pos:   position{line: 3219, col: 42, offset: 101467},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3165, col: 49, offset: 99391},
+										pos:  position{line: 3219, col: 49, offset: 101474},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3165, col: 60, offset: 99402},
+									pos:  position{line: 3219, col: 60, offset: 101485},
 									name: "R_PAREN",
 								},
 							},
@@ -6620,15 +6674,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 3173, col: 1, offset: 99564},
+			pos:  position{line: 3227, col: 1, offset: 101647},
 			expr: &actionExpr{
-				pos: position{line: 3173, col: 21, offset: 99584},
+				pos: position{line: 3227, col: 21, offset: 101667},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3173, col: 21, offset: 99584},
+					pos:   position{line: 3227, col: 21, offset: 101667},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3173, col: 25, offset: 99588},
+						pos:  position{line: 3227, col: 25, offset: 101671},
 						name: "QuotedString",
 					},
 				},
@@ -6636,15 +6690,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3180, col: 1, offset: 99715},
+			pos:  position{line: 3234, col: 1, offset: 101798},
 			expr: &actionExpr{
-				pos: position{line: 3180, col: 22, offset: 99736},
+				pos: position{line: 3234, col: 22, offset: 101819},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3180, col: 22, offset: 99736},
+					pos:   position{line: 3234, col: 22, offset: 101819},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3180, col: 26, offset: 99740},
+						pos:  position{line: 3234, col: 26, offset: 101823},
 						name: "UnquotedString",
 					},
 				},
@@ -6652,22 +6706,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3187, col: 1, offset: 99868},
+			pos:  position{line: 3241, col: 1, offset: 101951},
 			expr: &actionExpr{
-				pos: position{line: 3187, col: 20, offset: 99887},
+				pos: position{line: 3241, col: 20, offset: 101970},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3187, col: 20, offset: 99887},
+					pos: position{line: 3241, col: 20, offset: 101970},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3187, col: 20, offset: 99887},
+							pos:  position{line: 3241, col: 20, offset: 101970},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3187, col: 26, offset: 99893},
+							pos:   position{line: 3241, col: 26, offset: 101976},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3187, col: 38, offset: 99905},
+								pos:  position{line: 3241, col: 38, offset: 101988},
 								name: "String",
 							},
 						},
@@ -6677,27 +6731,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3193, col: 1, offset: 100090},
+			pos:  position{line: 3247, col: 1, offset: 102173},
 			expr: &choiceExpr{
-				pos: position{line: 3193, col: 20, offset: 100109},
+				pos: position{line: 3247, col: 20, offset: 102192},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3193, col: 20, offset: 100109},
+						pos: position{line: 3247, col: 20, offset: 102192},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3193, col: 20, offset: 100109},
+							pos: position{line: 3247, col: 20, offset: 102192},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3193, col: 20, offset: 100109},
+									pos:        position{line: 3247, col: 20, offset: 102192},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3193, col: 28, offset: 100117},
+									pos: position{line: 3247, col: 28, offset: 102200},
 									expr: &charClassMatcher{
-										pos:        position{line: 3193, col: 28, offset: 100117},
+										pos:        position{line: 3247, col: 28, offset: 102200},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6706,9 +6760,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3193, col: 42, offset: 100131},
+									pos: position{line: 3247, col: 42, offset: 102214},
 									expr: &litMatcher{
-										pos:        position{line: 3193, col: 44, offset: 100133},
+										pos:        position{line: 3247, col: 44, offset: 102216},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6718,27 +6772,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3196, col: 3, offset: 100175},
+						pos: position{line: 3250, col: 3, offset: 102258},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3196, col: 3, offset: 100175},
+							pos: position{line: 3250, col: 3, offset: 102258},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3196, col: 3, offset: 100175},
+									pos:        position{line: 3250, col: 3, offset: 102258},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3196, col: 7, offset: 100179},
+									pos:   position{line: 3250, col: 7, offset: 102262},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3196, col: 13, offset: 100185},
+										pos:  position{line: 3250, col: 13, offset: 102268},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3196, col: 23, offset: 100195},
+									pos:        position{line: 3250, col: 23, offset: 102278},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6751,26 +6805,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3201, col: 1, offset: 100263},
+			pos:  position{line: 3255, col: 1, offset: 102346},
 			expr: &actionExpr{
-				pos: position{line: 3201, col: 15, offset: 100277},
+				pos: position{line: 3255, col: 15, offset: 102360},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3201, col: 15, offset: 100277},
+					pos: position{line: 3255, col: 15, offset: 102360},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3201, col: 15, offset: 100277},
+							pos:  position{line: 3255, col: 15, offset: 102360},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3201, col: 20, offset: 100282},
+							pos:  position{line: 3255, col: 20, offset: 102365},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3201, col: 30, offset: 100292},
+							pos:   position{line: 3255, col: 30, offset: 102375},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3201, col: 40, offset: 100302},
+								pos:  position{line: 3255, col: 40, offset: 102385},
 								name: "BoolExpr",
 							},
 						},
@@ -6780,15 +6834,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3214, col: 1, offset: 100645},
+			pos:  position{line: 3268, col: 1, offset: 102728},
 			expr: &actionExpr{
-				pos: position{line: 3214, col: 13, offset: 100657},
+				pos: position{line: 3268, col: 13, offset: 102740},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3214, col: 13, offset: 100657},
+					pos:   position{line: 3268, col: 13, offset: 102740},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3214, col: 18, offset: 100662},
+						pos:  position{line: 3268, col: 18, offset: 102745},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6796,35 +6850,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3219, col: 1, offset: 100732},
+			pos:  position{line: 3273, col: 1, offset: 102815},
 			expr: &actionExpr{
-				pos: position{line: 3219, col: 19, offset: 100750},
+				pos: position{line: 3273, col: 19, offset: 102833},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3219, col: 19, offset: 100750},
+					pos: position{line: 3273, col: 19, offset: 102833},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3219, col: 19, offset: 100750},
+							pos:   position{line: 3273, col: 19, offset: 102833},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3219, col: 25, offset: 100756},
+								pos:  position{line: 3273, col: 25, offset: 102839},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3219, col: 40, offset: 100771},
+							pos:   position{line: 3273, col: 40, offset: 102854},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3219, col: 45, offset: 100776},
+								pos: position{line: 3273, col: 45, offset: 102859},
 								expr: &seqExpr{
-									pos: position{line: 3219, col: 46, offset: 100777},
+									pos: position{line: 3273, col: 46, offset: 102860},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3219, col: 46, offset: 100777},
+											pos:  position{line: 3273, col: 46, offset: 102860},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3219, col: 49, offset: 100780},
+											pos:  position{line: 3273, col: 49, offset: 102863},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6837,35 +6891,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3239, col: 1, offset: 101218},
+			pos:  position{line: 3293, col: 1, offset: 103301},
 			expr: &actionExpr{
-				pos: position{line: 3239, col: 19, offset: 101236},
+				pos: position{line: 3293, col: 19, offset: 103319},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3239, col: 19, offset: 101236},
+					pos: position{line: 3293, col: 19, offset: 103319},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3239, col: 19, offset: 101236},
+							pos:   position{line: 3293, col: 19, offset: 103319},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3239, col: 25, offset: 101242},
+								pos:  position{line: 3293, col: 25, offset: 103325},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3239, col: 40, offset: 101257},
+							pos:   position{line: 3293, col: 40, offset: 103340},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3239, col: 45, offset: 101262},
+								pos: position{line: 3293, col: 45, offset: 103345},
 								expr: &seqExpr{
-									pos: position{line: 3239, col: 46, offset: 101263},
+									pos: position{line: 3293, col: 46, offset: 103346},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3239, col: 46, offset: 101263},
+											pos:  position{line: 3293, col: 46, offset: 103346},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3239, col: 50, offset: 101267},
+											pos:  position{line: 3293, col: 50, offset: 103350},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6878,47 +6932,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3259, col: 1, offset: 101706},
+			pos:  position{line: 3313, col: 1, offset: 103789},
 			expr: &choiceExpr{
-				pos: position{line: 3259, col: 19, offset: 101724},
+				pos: position{line: 3313, col: 19, offset: 103807},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3259, col: 19, offset: 101724},
+						pos: position{line: 3313, col: 19, offset: 103807},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3259, col: 19, offset: 101724},
+							pos: position{line: 3313, col: 19, offset: 103807},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3259, col: 19, offset: 101724},
+									pos:  position{line: 3313, col: 19, offset: 103807},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3259, col: 23, offset: 101728},
+									pos:  position{line: 3313, col: 23, offset: 103811},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3259, col: 31, offset: 101736},
+									pos:   position{line: 3313, col: 31, offset: 103819},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3259, col: 37, offset: 101742},
+										pos:  position{line: 3313, col: 37, offset: 103825},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3259, col: 52, offset: 101757},
+									pos:  position{line: 3313, col: 52, offset: 103840},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3269, col: 3, offset: 101960},
+						pos: position{line: 3323, col: 3, offset: 104043},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3269, col: 3, offset: 101960},
+							pos:   position{line: 3323, col: 3, offset: 104043},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3269, col: 9, offset: 101966},
+								pos:  position{line: 3323, col: 9, offset: 104049},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6928,50 +6982,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3274, col: 1, offset: 102037},
+			pos:  position{line: 3328, col: 1, offset: 104120},
 			expr: &choiceExpr{
-				pos: position{line: 3274, col: 19, offset: 102055},
+				pos: position{line: 3328, col: 19, offset: 104138},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3274, col: 19, offset: 102055},
+						pos: position{line: 3328, col: 19, offset: 104138},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3274, col: 19, offset: 102055},
+							pos: position{line: 3328, col: 19, offset: 104138},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3274, col: 19, offset: 102055},
+									pos:  position{line: 3328, col: 19, offset: 104138},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3274, col: 27, offset: 102063},
+									pos:   position{line: 3328, col: 27, offset: 104146},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3274, col: 33, offset: 102069},
+										pos:  position{line: 3328, col: 33, offset: 104152},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3274, col: 48, offset: 102084},
+									pos:  position{line: 3328, col: 48, offset: 104167},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3277, col: 3, offset: 102120},
+						pos: position{line: 3331, col: 3, offset: 104203},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3277, col: 3, offset: 102120},
+							pos:   position{line: 3331, col: 3, offset: 104203},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3277, col: 10, offset: 102127},
+								pos: position{line: 3331, col: 10, offset: 104210},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3277, col: 10, offset: 102127},
+										pos:  position{line: 3331, col: 10, offset: 104210},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3277, col: 31, offset: 102148},
+										pos:  position{line: 3331, col: 31, offset: 104231},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6983,72 +7037,72 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3282, col: 1, offset: 102268},
+			pos:  position{line: 3336, col: 1, offset: 104351},
 			expr: &choiceExpr{
-				pos: position{line: 3282, col: 23, offset: 102290},
+				pos: position{line: 3336, col: 23, offset: 104373},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3282, col: 23, offset: 102290},
+						pos: position{line: 3336, col: 23, offset: 104373},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3282, col: 24, offset: 102291},
+							pos: position{line: 3336, col: 24, offset: 104374},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3282, col: 24, offset: 102291},
+									pos:   position{line: 3336, col: 24, offset: 104374},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3282, col: 28, offset: 102295},
+										pos: position{line: 3336, col: 28, offset: 104378},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3282, col: 28, offset: 102295},
+												pos:        position{line: 3336, col: 28, offset: 104378},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 39, offset: 102306},
+												pos:        position{line: 3336, col: 39, offset: 104389},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 49, offset: 102316},
+												pos:        position{line: 3336, col: 49, offset: 104399},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 59, offset: 102326},
+												pos:        position{line: 3336, col: 59, offset: 104409},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 70, offset: 102337},
+												pos:        position{line: 3336, col: 70, offset: 104420},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 84, offset: 102351},
+												pos:        position{line: 3336, col: 84, offset: 104434},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 94, offset: 102361},
+												pos:        position{line: 3336, col: 94, offset: 104444},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 110, offset: 102377},
+												pos:        position{line: 3336, col: 110, offset: 104460},
 												val:        "ismv",
 												ignoreCase: false,
 												want:       "\"ismv\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3282, col: 119, offset: 102386},
+												pos:        position{line: 3336, col: 119, offset: 104469},
 												val:        "isobject",
 												ignoreCase: false,
 												want:       "\"isobject\"",
@@ -7057,56 +7111,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3282, col: 131, offset: 102398},
+									pos:  position{line: 3336, col: 131, offset: 104481},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3282, col: 139, offset: 102406},
+									pos:   position{line: 3336, col: 139, offset: 104489},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3282, col: 145, offset: 102412},
+										pos:  position{line: 3336, col: 145, offset: 104495},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3282, col: 155, offset: 102422},
+									pos:  position{line: 3336, col: 155, offset: 104505},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3312, col: 3, offset: 103293},
+						pos: position{line: 3366, col: 3, offset: 105376},
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3312, col: 3, offset: 103293},
+							pos: position{line: 3366, col: 3, offset: 105376},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3312, col: 3, offset: 103293},
+									pos:   position{line: 3366, col: 3, offset: 105376},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3312, col: 11, offset: 103301},
+										pos: position{line: 3366, col: 11, offset: 105384},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3312, col: 11, offset: 103301},
+												pos:        position{line: 3366, col: 11, offset: 105384},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3312, col: 20, offset: 103310},
+												pos:        position{line: 3366, col: 20, offset: 105393},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3312, col: 29, offset: 103319},
+												pos:        position{line: 3366, col: 29, offset: 105402},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3312, col: 39, offset: 103329},
+												pos:        position{line: 3366, col: 39, offset: 105412},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -7115,86 +7169,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3312, col: 52, offset: 103342},
+									pos:  position{line: 3366, col: 52, offset: 105425},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3312, col: 60, offset: 103350},
+									pos:   position{line: 3366, col: 60, offset: 105433},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3312, col: 70, offset: 103360},
+										pos:  position{line: 3366, col: 70, offset: 105443},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3312, col: 80, offset: 103370},
+									pos:  position{line: 3366, col: 80, offset: 105453},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3312, col: 86, offset: 103376},
+									pos:   position{line: 3366, col: 86, offset: 105459},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3312, col: 97, offset: 103387},
+										pos:  position{line: 3366, col: 97, offset: 105470},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3312, col: 107, offset: 103397},
+									pos:  position{line: 3366, col: 107, offset: 105480},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3325, col: 3, offset: 103767},
+						pos: position{line: 3379, col: 3, offset: 105850},
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
-							pos: position{line: 3325, col: 3, offset: 103767},
+							pos: position{line: 3379, col: 3, offset: 105850},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3325, col: 3, offset: 103767},
+									pos:   position{line: 3379, col: 3, offset: 105850},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3325, col: 8, offset: 103772},
+										pos:  position{line: 3379, col: 8, offset: 105855},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3325, col: 18, offset: 103782},
+									pos:  position{line: 3379, col: 18, offset: 105865},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3325, col: 24, offset: 103788},
+									pos:        position{line: 3379, col: 24, offset: 105871},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3325, col: 29, offset: 103793},
+									pos:  position{line: 3379, col: 29, offset: 105876},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3325, col: 37, offset: 103801},
+									pos:   position{line: 3379, col: 37, offset: 105884},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3325, col: 50, offset: 103814},
+										pos:  position{line: 3379, col: 50, offset: 105897},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3325, col: 60, offset: 103824},
+									pos:   position{line: 3379, col: 60, offset: 105907},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3325, col: 65, offset: 103829},
+										pos: position{line: 3379, col: 65, offset: 105912},
 										expr: &seqExpr{
-											pos: position{line: 3325, col: 66, offset: 103830},
+											pos: position{line: 3379, col: 66, offset: 105913},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3325, col: 66, offset: 103830},
+													pos:  position{line: 3379, col: 66, offset: 105913},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3325, col: 72, offset: 103836},
+													pos:  position{line: 3379, col: 72, offset: 105919},
 													name: "ValueExpr",
 												},
 											},
@@ -7202,50 +7256,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3325, col: 84, offset: 103848},
+									pos:  position{line: 3379, col: 84, offset: 105931},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3344, col: 3, offset: 104399},
+						pos: position{line: 3398, col: 3, offset: 106482},
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
-							pos: position{line: 3344, col: 3, offset: 104399},
+							pos: position{line: 3398, col: 3, offset: 106482},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3344, col: 3, offset: 104399},
+									pos:        position{line: 3398, col: 3, offset: 106482},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3344, col: 8, offset: 104404},
+									pos:  position{line: 3398, col: 8, offset: 106487},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3344, col: 16, offset: 104412},
+									pos:   position{line: 3398, col: 16, offset: 106495},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3344, col: 29, offset: 104425},
+										pos:  position{line: 3398, col: 29, offset: 106508},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3344, col: 39, offset: 104435},
+									pos:   position{line: 3398, col: 39, offset: 106518},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3344, col: 44, offset: 104440},
+										pos: position{line: 3398, col: 44, offset: 106523},
 										expr: &seqExpr{
-											pos: position{line: 3344, col: 45, offset: 104441},
+											pos: position{line: 3398, col: 45, offset: 106524},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3344, col: 45, offset: 104441},
+													pos:  position{line: 3398, col: 45, offset: 106524},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3344, col: 51, offset: 104447},
+													pos:  position{line: 3398, col: 51, offset: 106530},
 													name: "ValueExpr",
 												},
 											},
@@ -7253,7 +7307,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3344, col: 63, offset: 104459},
+									pos:  position{line: 3398, col: 63, offset: 106542},
 									name: "R_PAREN",
 								},
 							},
@@ -7264,34 +7318,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3362, col: 1, offset: 104880},
+			pos:  position{line: 3416, col: 1, offset: 106963},
 			expr: &actionExpr{
-				pos: position{line: 3362, col: 23, offset: 104902},
+				pos: position{line: 3416, col: 23, offset: 106985},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3362, col: 23, offset: 104902},
+					pos: position{line: 3416, col: 23, offset: 106985},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3362, col: 23, offset: 104902},
+							pos:   position{line: 3416, col: 23, offset: 106985},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3362, col: 28, offset: 104907},
+								pos:  position{line: 3416, col: 28, offset: 106990},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3362, col: 38, offset: 104917},
+							pos:   position{line: 3416, col: 38, offset: 107000},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3362, col: 41, offset: 104920},
+								pos:  position{line: 3416, col: 41, offset: 107003},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3362, col: 62, offset: 104941},
+							pos:   position{line: 3416, col: 62, offset: 107024},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3362, col: 68, offset: 104947},
+								pos:  position{line: 3416, col: 68, offset: 107030},
 								name: "ValueExpr",
 							},
 						},
@@ -7301,141 +7355,141 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3380, col: 1, offset: 105541},
+			pos:  position{line: 3434, col: 1, offset: 107624},
 			expr: &choiceExpr{
-				pos: position{line: 3380, col: 14, offset: 105554},
+				pos: position{line: 3434, col: 14, offset: 107637},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3380, col: 14, offset: 105554},
+						pos: position{line: 3434, col: 14, offset: 107637},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3380, col: 14, offset: 105554},
+							pos:   position{line: 3434, col: 14, offset: 107637},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3380, col: 24, offset: 105564},
+								pos:  position{line: 3434, col: 24, offset: 107647},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3389, col: 3, offset: 105754},
+						pos: position{line: 3443, col: 3, offset: 107837},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3389, col: 3, offset: 105754},
+							pos: position{line: 3443, col: 3, offset: 107837},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3389, col: 3, offset: 105754},
+									pos:  position{line: 3443, col: 3, offset: 107837},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3389, col: 12, offset: 105763},
+									pos:   position{line: 3443, col: 12, offset: 107846},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3389, col: 22, offset: 105773},
+										pos:  position{line: 3443, col: 22, offset: 107856},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3389, col: 37, offset: 105788},
+									pos:  position{line: 3443, col: 37, offset: 107871},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3398, col: 3, offset: 105972},
+						pos: position{line: 3452, col: 3, offset: 108055},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3398, col: 3, offset: 105972},
+							pos:   position{line: 3452, col: 3, offset: 108055},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3398, col: 11, offset: 105980},
+								pos:  position{line: 3452, col: 11, offset: 108063},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3407, col: 3, offset: 106160},
+						pos: position{line: 3461, col: 3, offset: 108243},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3407, col: 3, offset: 106160},
+							pos:   position{line: 3461, col: 3, offset: 108243},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3407, col: 7, offset: 106164},
+								pos:  position{line: 3461, col: 7, offset: 108247},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3416, col: 3, offset: 106336},
+						pos: position{line: 3470, col: 3, offset: 108419},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3416, col: 3, offset: 106336},
+							pos: position{line: 3470, col: 3, offset: 108419},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 3, offset: 106336},
+									pos:  position{line: 3470, col: 3, offset: 108419},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3416, col: 12, offset: 106345},
+									pos:   position{line: 3470, col: 12, offset: 108428},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3416, col: 16, offset: 106349},
+										pos:  position{line: 3470, col: 16, offset: 108432},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3416, col: 28, offset: 106361},
+									pos:  position{line: 3470, col: 28, offset: 108444},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3425, col: 3, offset: 106530},
+						pos: position{line: 3479, col: 3, offset: 108613},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3425, col: 3, offset: 106530},
+							pos: position{line: 3479, col: 3, offset: 108613},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3425, col: 3, offset: 106530},
+									pos:  position{line: 3479, col: 3, offset: 108613},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3425, col: 11, offset: 106538},
+									pos:   position{line: 3479, col: 11, offset: 108621},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3425, col: 19, offset: 106546},
+										pos:  position{line: 3479, col: 19, offset: 108629},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3425, col: 28, offset: 106555},
+									pos:  position{line: 3479, col: 28, offset: 108638},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3434, col: 3, offset: 106727},
+						pos: position{line: 3488, col: 3, offset: 108810},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3434, col: 3, offset: 106727},
+							pos:   position{line: 3488, col: 3, offset: 108810},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3434, col: 18, offset: 106742},
+								pos:  position{line: 3488, col: 18, offset: 108825},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3443, col: 3, offset: 106940},
+						pos: position{line: 3497, col: 3, offset: 109023},
 						run: (*parser).callonValueExpr32,
 						expr: &labeledExpr{
-							pos:   position{line: 3443, col: 3, offset: 106940},
+							pos:   position{line: 3497, col: 3, offset: 109023},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3443, col: 12, offset: 106949},
+								pos:  position{line: 3497, col: 12, offset: 109032},
 								name: "JsonExpr",
 							},
 						},
@@ -7445,28 +7499,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3452, col: 1, offset: 107116},
+			pos:  position{line: 3506, col: 1, offset: 109199},
 			expr: &choiceExpr{
-				pos: position{line: 3452, col: 15, offset: 107130},
+				pos: position{line: 3506, col: 15, offset: 109213},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3452, col: 15, offset: 107130},
+						pos: position{line: 3506, col: 15, offset: 109213},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3452, col: 15, offset: 107130},
+							pos: position{line: 3506, col: 15, offset: 109213},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3452, col: 15, offset: 107130},
+									pos:   position{line: 3506, col: 15, offset: 109213},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3452, col: 20, offset: 107135},
+										pos:  position{line: 3506, col: 20, offset: 109218},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3452, col: 29, offset: 107144},
+									pos: position{line: 3506, col: 29, offset: 109227},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3452, col: 31, offset: 107146},
+										pos:  position{line: 3506, col: 31, offset: 109229},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7474,23 +7528,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3460, col: 3, offset: 107316},
+						pos: position{line: 3514, col: 3, offset: 109399},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3460, col: 3, offset: 107316},
+							pos: position{line: 3514, col: 3, offset: 109399},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3460, col: 3, offset: 107316},
+									pos:   position{line: 3514, col: 3, offset: 109399},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3460, col: 7, offset: 107320},
+										pos:  position{line: 3514, col: 7, offset: 109403},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3460, col: 20, offset: 107333},
+									pos: position{line: 3514, col: 20, offset: 109416},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3460, col: 22, offset: 107335},
+										pos:  position{line: 3514, col: 22, offset: 109418},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7498,50 +7552,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3468, col: 3, offset: 107500},
+						pos: position{line: 3522, col: 3, offset: 109583},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3468, col: 3, offset: 107500},
+							pos: position{line: 3522, col: 3, offset: 109583},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3468, col: 3, offset: 107500},
+									pos:   position{line: 3522, col: 3, offset: 109583},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3468, col: 9, offset: 107506},
+										pos:  position{line: 3522, col: 9, offset: 109589},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3468, col: 25, offset: 107522},
+									pos: position{line: 3522, col: 25, offset: 109605},
 									expr: &choiceExpr{
-										pos: position{line: 3468, col: 27, offset: 107524},
+										pos: position{line: 3522, col: 27, offset: 109607},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 27, offset: 107524},
+												pos:  position{line: 3522, col: 27, offset: 109607},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 36, offset: 107533},
+												pos:  position{line: 3522, col: 36, offset: 109616},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 46, offset: 107543},
+												pos:  position{line: 3522, col: 46, offset: 109626},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 54, offset: 107551},
+												pos:  position{line: 3522, col: 54, offset: 109634},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 62, offset: 107559},
+												pos:  position{line: 3522, col: 62, offset: 109642},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3468, col: 70, offset: 107567},
+												pos:  position{line: 3522, col: 70, offset: 109650},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3468, col: 84, offset: 107581},
+												pos:        position{line: 3522, col: 84, offset: 109664},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7553,13 +7607,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3476, col: 3, offset: 107731},
+						pos: position{line: 3530, col: 3, offset: 109814},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3476, col: 3, offset: 107731},
+							pos:   position{line: 3530, col: 3, offset: 109814},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3476, col: 10, offset: 107738},
+								pos:  position{line: 3530, col: 10, offset: 109821},
 								name: "ConcatExpr",
 							},
 						},
@@ -7569,35 +7623,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3486, col: 1, offset: 107944},
+			pos:  position{line: 3540, col: 1, offset: 110027},
 			expr: &actionExpr{
-				pos: position{line: 3486, col: 15, offset: 107958},
+				pos: position{line: 3540, col: 15, offset: 110041},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3486, col: 15, offset: 107958},
+					pos: position{line: 3540, col: 15, offset: 110041},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3486, col: 15, offset: 107958},
+							pos:   position{line: 3540, col: 15, offset: 110041},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3486, col: 21, offset: 107964},
+								pos:  position{line: 3540, col: 21, offset: 110047},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3486, col: 32, offset: 107975},
+							pos:   position{line: 3540, col: 32, offset: 110058},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3486, col: 37, offset: 107980},
+								pos: position{line: 3540, col: 37, offset: 110063},
 								expr: &seqExpr{
-									pos: position{line: 3486, col: 38, offset: 107981},
+									pos: position{line: 3540, col: 38, offset: 110064},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3486, col: 38, offset: 107981},
+											pos:  position{line: 3540, col: 38, offset: 110064},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3486, col: 50, offset: 107993},
+											pos:  position{line: 3540, col: 50, offset: 110076},
 											name: "ConcatAtom",
 										},
 									},
@@ -7605,28 +7659,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3486, col: 63, offset: 108006},
+							pos: position{line: 3540, col: 63, offset: 110089},
 							expr: &choiceExpr{
-								pos: position{line: 3486, col: 65, offset: 108008},
+								pos: position{line: 3540, col: 65, offset: 110091},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3486, col: 65, offset: 108008},
+										pos:  position{line: 3540, col: 65, offset: 110091},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3486, col: 74, offset: 108017},
+										pos:  position{line: 3540, col: 74, offset: 110100},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3486, col: 84, offset: 108027},
+										pos:  position{line: 3540, col: 84, offset: 110110},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3486, col: 92, offset: 108035},
+										pos:  position{line: 3540, col: 92, offset: 110118},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3486, col: 100, offset: 108043},
+										pos:        position{line: 3540, col: 100, offset: 110126},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7640,54 +7694,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3504, col: 1, offset: 108449},
+			pos:  position{line: 3558, col: 1, offset: 110532},
 			expr: &choiceExpr{
-				pos: position{line: 3504, col: 15, offset: 108463},
+				pos: position{line: 3558, col: 15, offset: 110546},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3504, col: 15, offset: 108463},
+						pos: position{line: 3558, col: 15, offset: 110546},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3504, col: 15, offset: 108463},
+							pos:   position{line: 3558, col: 15, offset: 110546},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3504, col: 20, offset: 108468},
+								pos:  position{line: 3558, col: 20, offset: 110551},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3513, col: 3, offset: 108632},
+						pos: position{line: 3567, col: 3, offset: 110715},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3513, col: 3, offset: 108632},
+							pos:   position{line: 3567, col: 3, offset: 110715},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3513, col: 7, offset: 108636},
+								pos:  position{line: 3567, col: 7, offset: 110719},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3521, col: 3, offset: 108775},
+						pos: position{line: 3575, col: 3, offset: 110858},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3521, col: 3, offset: 108775},
+							pos:   position{line: 3575, col: 3, offset: 110858},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3521, col: 10, offset: 108782},
+								pos:  position{line: 3575, col: 10, offset: 110865},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3529, col: 3, offset: 108921},
+						pos: position{line: 3583, col: 3, offset: 111004},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3529, col: 3, offset: 108921},
+							pos:   position{line: 3583, col: 3, offset: 111004},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3529, col: 9, offset: 108927},
+								pos:  position{line: 3583, col: 9, offset: 111010},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7697,32 +7751,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3539, col: 1, offset: 109096},
+			pos:  position{line: 3593, col: 1, offset: 111179},
 			expr: &actionExpr{
-				pos: position{line: 3539, col: 16, offset: 109111},
+				pos: position{line: 3593, col: 16, offset: 111194},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3539, col: 16, offset: 109111},
+					pos: position{line: 3593, col: 16, offset: 111194},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3539, col: 16, offset: 109111},
+							pos:   position{line: 3593, col: 16, offset: 111194},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3539, col: 21, offset: 109116},
+								pos:  position{line: 3593, col: 21, offset: 111199},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3539, col: 39, offset: 109134},
+							pos: position{line: 3593, col: 39, offset: 111217},
 							expr: &choiceExpr{
-								pos: position{line: 3539, col: 41, offset: 109136},
+								pos: position{line: 3593, col: 41, offset: 111219},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3539, col: 41, offset: 109136},
+										pos:  position{line: 3593, col: 41, offset: 111219},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3539, col: 55, offset: 109150},
+										pos:        position{line: 3593, col: 55, offset: 111233},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7736,44 +7790,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3544, col: 1, offset: 109215},
+			pos:  position{line: 3598, col: 1, offset: 111298},
 			expr: &actionExpr{
-				pos: position{line: 3544, col: 22, offset: 109236},
+				pos: position{line: 3598, col: 22, offset: 111319},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3544, col: 22, offset: 109236},
+					pos: position{line: 3598, col: 22, offset: 111319},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3544, col: 22, offset: 109236},
+							pos:   position{line: 3598, col: 22, offset: 111319},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3544, col: 28, offset: 109242},
+								pos:  position{line: 3598, col: 28, offset: 111325},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3544, col: 46, offset: 109260},
+							pos:   position{line: 3598, col: 46, offset: 111343},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3544, col: 51, offset: 109265},
+								pos: position{line: 3598, col: 51, offset: 111348},
 								expr: &seqExpr{
-									pos: position{line: 3544, col: 52, offset: 109266},
+									pos: position{line: 3598, col: 52, offset: 111349},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3544, col: 53, offset: 109267},
+											pos: position{line: 3598, col: 53, offset: 111350},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3544, col: 53, offset: 109267},
+													pos:  position{line: 3598, col: 53, offset: 111350},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3544, col: 62, offset: 109276},
+													pos:  position{line: 3598, col: 62, offset: 111359},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3544, col: 71, offset: 109285},
+											pos:  position{line: 3598, col: 71, offset: 111368},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7786,48 +7840,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3565, col: 1, offset: 109786},
+			pos:  position{line: 3619, col: 1, offset: 111869},
 			expr: &actionExpr{
-				pos: position{line: 3565, col: 22, offset: 109807},
+				pos: position{line: 3619, col: 22, offset: 111890},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3565, col: 22, offset: 109807},
+					pos: position{line: 3619, col: 22, offset: 111890},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3565, col: 22, offset: 109807},
+							pos:   position{line: 3619, col: 22, offset: 111890},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3565, col: 28, offset: 109813},
+								pos:  position{line: 3619, col: 28, offset: 111896},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3565, col: 46, offset: 109831},
+							pos:   position{line: 3619, col: 46, offset: 111914},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3565, col: 51, offset: 109836},
+								pos: position{line: 3619, col: 51, offset: 111919},
 								expr: &seqExpr{
-									pos: position{line: 3565, col: 52, offset: 109837},
+									pos: position{line: 3619, col: 52, offset: 111920},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3565, col: 53, offset: 109838},
+											pos: position{line: 3619, col: 53, offset: 111921},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3565, col: 53, offset: 109838},
+													pos:  position{line: 3619, col: 53, offset: 111921},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3565, col: 61, offset: 109846},
+													pos:  position{line: 3619, col: 61, offset: 111929},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3565, col: 69, offset: 109854},
+													pos:  position{line: 3619, col: 69, offset: 111937},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3565, col: 76, offset: 109861},
+											pos:  position{line: 3619, col: 76, offset: 111944},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7840,22 +7894,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3585, col: 1, offset: 110330},
+			pos:  position{line: 3639, col: 1, offset: 112413},
 			expr: &actionExpr{
-				pos: position{line: 3585, col: 21, offset: 110350},
+				pos: position{line: 3639, col: 21, offset: 112433},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3585, col: 21, offset: 110350},
+					pos: position{line: 3639, col: 21, offset: 112433},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3585, col: 21, offset: 110350},
+							pos:  position{line: 3639, col: 21, offset: 112433},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3585, col: 27, offset: 110356},
+							pos:   position{line: 3639, col: 27, offset: 112439},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3585, col: 32, offset: 110361},
+								pos:  position{line: 3639, col: 32, offset: 112444},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7865,67 +7919,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3595, col: 1, offset: 110605},
+			pos:  position{line: 3649, col: 1, offset: 112688},
 			expr: &choiceExpr{
-				pos: position{line: 3595, col: 22, offset: 110626},
+				pos: position{line: 3649, col: 22, offset: 112709},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3595, col: 22, offset: 110626},
+						pos: position{line: 3649, col: 22, offset: 112709},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3595, col: 22, offset: 110626},
+							pos: position{line: 3649, col: 22, offset: 112709},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3595, col: 22, offset: 110626},
+									pos:  position{line: 3649, col: 22, offset: 112709},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3595, col: 30, offset: 110634},
+									pos:   position{line: 3649, col: 30, offset: 112717},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3595, col: 35, offset: 110639},
+										pos:  position{line: 3649, col: 35, offset: 112722},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3595, col: 53, offset: 110657},
+									pos:  position{line: 3649, col: 53, offset: 112740},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3598, col: 3, offset: 110692},
+						pos: position{line: 3652, col: 3, offset: 112775},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3598, col: 3, offset: 110692},
+							pos:   position{line: 3652, col: 3, offset: 112775},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3598, col: 20, offset: 110709},
+								pos:  position{line: 3652, col: 20, offset: 112792},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3601, col: 3, offset: 110763},
+						pos: position{line: 3655, col: 3, offset: 112846},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3601, col: 3, offset: 110763},
+							pos:   position{line: 3655, col: 3, offset: 112846},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3601, col: 9, offset: 110769},
+								pos:  position{line: 3655, col: 9, offset: 112852},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3611, col: 3, offset: 110988},
+						pos: position{line: 3665, col: 3, offset: 113071},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3611, col: 3, offset: 110988},
+							pos:   position{line: 3665, col: 3, offset: 113071},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3611, col: 10, offset: 110995},
+								pos:  position{line: 3665, col: 10, offset: 113078},
 								name: "NumberAsString",
 							},
 						},
@@ -7935,144 +7989,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3624, col: 1, offset: 111373},
+			pos:  position{line: 3678, col: 1, offset: 113456},
 			expr: &choiceExpr{
-				pos: position{line: 3624, col: 20, offset: 111392},
+				pos: position{line: 3678, col: 20, offset: 113475},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3624, col: 20, offset: 111392},
+						pos: position{line: 3678, col: 20, offset: 113475},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3624, col: 21, offset: 111393},
+							pos: position{line: 3678, col: 21, offset: 113476},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3624, col: 21, offset: 111393},
+									pos:   position{line: 3678, col: 21, offset: 113476},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3624, col: 29, offset: 111401},
+										pos: position{line: 3678, col: 29, offset: 113484},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3624, col: 29, offset: 111401},
+												pos:        position{line: 3678, col: 29, offset: 113484},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 37, offset: 111409},
+												pos:        position{line: 3678, col: 37, offset: 113492},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 46, offset: 111418},
+												pos:        position{line: 3678, col: 46, offset: 113501},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 58, offset: 111430},
+												pos:        position{line: 3678, col: 58, offset: 113513},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 67, offset: 111439},
+												pos:        position{line: 3678, col: 67, offset: 113522},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 77, offset: 111449},
+												pos:        position{line: 3678, col: 77, offset: 113532},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 85, offset: 111457},
+												pos:        position{line: 3678, col: 85, offset: 113540},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 95, offset: 111467},
+												pos:        position{line: 3678, col: 95, offset: 113550},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 102, offset: 111474},
+												pos:        position{line: 3678, col: 102, offset: 113557},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 113, offset: 111485},
+												pos:        position{line: 3678, col: 113, offset: 113568},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 123, offset: 111495},
+												pos:        position{line: 3678, col: 123, offset: 113578},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 132, offset: 111504},
+												pos:        position{line: 3678, col: 132, offset: 113587},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 142, offset: 111514},
+												pos:        position{line: 3678, col: 142, offset: 113597},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 151, offset: 111523},
+												pos:        position{line: 3678, col: 151, offset: 113606},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 161, offset: 111533},
+												pos:        position{line: 3678, col: 161, offset: 113616},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 170, offset: 111542},
+												pos:        position{line: 3678, col: 170, offset: 113625},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 179, offset: 111551},
+												pos:        position{line: 3678, col: 179, offset: 113634},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 187, offset: 111559},
+												pos:        position{line: 3678, col: 187, offset: 113642},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 196, offset: 111568},
+												pos:        position{line: 3678, col: 196, offset: 113651},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 204, offset: 111576},
+												pos:        position{line: 3678, col: 204, offset: 113659},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3624, col: 213, offset: 111585},
+												pos:        position{line: 3678, col: 213, offset: 113668},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -8081,102 +8135,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3624, col: 220, offset: 111592},
+									pos:  position{line: 3678, col: 220, offset: 113675},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3624, col: 228, offset: 111600},
+									pos:   position{line: 3678, col: 228, offset: 113683},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3624, col: 234, offset: 111606},
+										pos:  position{line: 3678, col: 234, offset: 113689},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3624, col: 253, offset: 111625},
+									pos:  position{line: 3678, col: 253, offset: 113708},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3644, col: 3, offset: 112137},
+						pos: position{line: 3698, col: 3, offset: 114220},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3644, col: 3, offset: 112137},
+							pos: position{line: 3698, col: 3, offset: 114220},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3644, col: 3, offset: 112137},
+									pos:   position{line: 3698, col: 3, offset: 114220},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3644, col: 13, offset: 112147},
+										pos:        position{line: 3698, col: 13, offset: 114230},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3644, col: 21, offset: 112155},
+									pos:  position{line: 3698, col: 21, offset: 114238},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3644, col: 29, offset: 112163},
+									pos:   position{line: 3698, col: 29, offset: 114246},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3644, col: 35, offset: 112169},
+										pos:  position{line: 3698, col: 35, offset: 114252},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3644, col: 54, offset: 112188},
+									pos:   position{line: 3698, col: 54, offset: 114271},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3644, col: 69, offset: 112203},
+										pos: position{line: 3698, col: 69, offset: 114286},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3644, col: 70, offset: 112204},
+											pos:  position{line: 3698, col: 70, offset: 114287},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3644, col: 89, offset: 112223},
+									pos:  position{line: 3698, col: 89, offset: 114306},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3665, col: 3, offset: 112841},
+						pos: position{line: 3719, col: 3, offset: 114924},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3665, col: 4, offset: 112842},
+							pos: position{line: 3719, col: 4, offset: 114925},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3665, col: 4, offset: 112842},
+									pos:   position{line: 3719, col: 4, offset: 114925},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3665, col: 12, offset: 112850},
+										pos: position{line: 3719, col: 12, offset: 114933},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3665, col: 12, offset: 112850},
+												pos:        position{line: 3719, col: 12, offset: 114933},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3665, col: 20, offset: 112858},
+												pos:        position{line: 3719, col: 20, offset: 114941},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3665, col: 27, offset: 112865},
+												pos:        position{line: 3719, col: 27, offset: 114948},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3665, col: 38, offset: 112876},
+												pos:        position{line: 3719, col: 38, offset: 114959},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -8185,54 +8239,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3665, col: 46, offset: 112884},
+									pos:  position{line: 3719, col: 46, offset: 114967},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3665, col: 54, offset: 112892},
+									pos:  position{line: 3719, col: 54, offset: 114975},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3678, col: 3, offset: 113178},
+						pos: position{line: 3732, col: 3, offset: 115261},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3678, col: 3, offset: 113178},
+							pos: position{line: 3732, col: 3, offset: 115261},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3678, col: 3, offset: 113178},
+									pos:        position{line: 3732, col: 3, offset: 115261},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3678, col: 14, offset: 113189},
+									pos:  position{line: 3732, col: 14, offset: 115272},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3678, col: 22, offset: 113197},
+									pos:   position{line: 3732, col: 22, offset: 115280},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3678, col: 33, offset: 113208},
+										pos:  position{line: 3732, col: 33, offset: 115291},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3678, col: 44, offset: 113219},
+									pos:   position{line: 3732, col: 44, offset: 115302},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3678, col: 53, offset: 113228},
+										pos: position{line: 3732, col: 53, offset: 115311},
 										expr: &seqExpr{
-											pos: position{line: 3678, col: 54, offset: 113229},
+											pos: position{line: 3732, col: 54, offset: 115312},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3678, col: 54, offset: 113229},
+													pos:  position{line: 3732, col: 54, offset: 115312},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3678, col: 60, offset: 113235},
+													pos:  position{line: 3732, col: 60, offset: 115318},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8240,38 +8294,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3678, col: 80, offset: 113255},
+									pos:  position{line: 3732, col: 80, offset: 115338},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3706, col: 3, offset: 114098},
+						pos: position{line: 3760, col: 3, offset: 116181},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3706, col: 4, offset: 114099},
+							pos: position{line: 3760, col: 4, offset: 116182},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3706, col: 4, offset: 114099},
+									pos:   position{line: 3760, col: 4, offset: 116182},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3706, col: 12, offset: 114107},
+										pos: position{line: 3760, col: 12, offset: 116190},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3706, col: 12, offset: 114107},
+												pos:        position{line: 3760, col: 12, offset: 116190},
 												val:        "bit_and",
 												ignoreCase: false,
 												want:       "\"bit_and\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3706, col: 24, offset: 114119},
+												pos:        position{line: 3760, col: 24, offset: 116202},
 												val:        "bit_or",
 												ignoreCase: false,
 												want:       "\"bit_or\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3706, col: 35, offset: 114130},
+												pos:        position{line: 3760, col: 35, offset: 116213},
 												val:        "bit_xor",
 												ignoreCase: false,
 												want:       "\"bit_xor\"",
@@ -8280,43 +8334,43 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3706, col: 46, offset: 114141},
+									pos:  position{line: 3760, col: 46, offset: 116224},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3706, col: 54, offset: 114149},
+									pos:   position{line: 3760, col: 54, offset: 116232},
 									label: "firstArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3706, col: 63, offset: 114158},
+										pos:  position{line: 3760, col: 63, offset: 116241},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3706, col: 81, offset: 114176},
+									pos:  position{line: 3760, col: 81, offset: 116259},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3706, col: 87, offset: 114182},
+									pos:   position{line: 3760, col: 87, offset: 116265},
 									label: "secondArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3706, col: 97, offset: 114192},
+										pos:  position{line: 3760, col: 97, offset: 116275},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3706, col: 115, offset: 114210},
+									pos:   position{line: 3760, col: 115, offset: 116293},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3706, col: 120, offset: 114215},
+										pos: position{line: 3760, col: 120, offset: 116298},
 										expr: &seqExpr{
-											pos: position{line: 3706, col: 121, offset: 114216},
+											pos: position{line: 3760, col: 121, offset: 116299},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3706, col: 121, offset: 114216},
+													pos:  position{line: 3760, col: 121, offset: 116299},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3706, col: 127, offset: 114222},
+													pos:  position{line: 3760, col: 127, offset: 116305},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8324,38 +8378,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3706, col: 147, offset: 114242},
+									pos:  position{line: 3760, col: 147, offset: 116325},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3742, col: 3, offset: 115339},
+						pos: position{line: 3796, col: 3, offset: 117422},
 						run: (*parser).callonNumericEvalExpr83,
 						expr: &seqExpr{
-							pos: position{line: 3742, col: 4, offset: 115340},
+							pos: position{line: 3796, col: 4, offset: 117423},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3742, col: 4, offset: 115340},
+									pos:   position{line: 3796, col: 4, offset: 117423},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3742, col: 12, offset: 115348},
+										pos: position{line: 3796, col: 12, offset: 117431},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3742, col: 12, offset: 115348},
+												pos:        position{line: 3796, col: 12, offset: 117431},
 												val:        "bit_not",
 												ignoreCase: false,
 												want:       "\"bit_not\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3742, col: 24, offset: 115360},
+												pos:        position{line: 3796, col: 24, offset: 117443},
 												val:        "bit_shift_left",
 												ignoreCase: false,
 												want:       "\"bit_shift_left\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3742, col: 43, offset: 115379},
+												pos:        position{line: 3796, col: 43, offset: 117462},
 												val:        "bit_shift_right",
 												ignoreCase: false,
 												want:       "\"bit_shift_right\"",
@@ -8364,31 +8418,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3742, col: 62, offset: 115398},
+									pos:  position{line: 3796, col: 62, offset: 117481},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3742, col: 70, offset: 115406},
+									pos:   position{line: 3796, col: 70, offset: 117489},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3742, col: 75, offset: 115411},
+										pos:  position{line: 3796, col: 75, offset: 117494},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3742, col: 93, offset: 115429},
+									pos:   position{line: 3796, col: 93, offset: 117512},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3742, col: 99, offset: 115435},
+										pos: position{line: 3796, col: 99, offset: 117518},
 										expr: &seqExpr{
-											pos: position{line: 3742, col: 100, offset: 115436},
+											pos: position{line: 3796, col: 100, offset: 117519},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3742, col: 100, offset: 115436},
+													pos:  position{line: 3796, col: 100, offset: 117519},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3742, col: 106, offset: 115442},
+													pos:  position{line: 3796, col: 106, offset: 117525},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8396,73 +8450,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3742, col: 126, offset: 115462},
+									pos:  position{line: 3796, col: 126, offset: 117545},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3769, col: 3, offset: 116386},
+						pos: position{line: 3823, col: 3, offset: 118469},
 						run: (*parser).callonNumericEvalExpr99,
 						expr: &seqExpr{
-							pos: position{line: 3769, col: 3, offset: 116386},
+							pos: position{line: 3823, col: 3, offset: 118469},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3769, col: 3, offset: 116386},
+									pos:   position{line: 3823, col: 3, offset: 118469},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3769, col: 12, offset: 116395},
+										pos:        position{line: 3823, col: 12, offset: 118478},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3769, col: 18, offset: 116401},
+									pos:  position{line: 3823, col: 18, offset: 118484},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3769, col: 26, offset: 116409},
+									pos:   position{line: 3823, col: 26, offset: 118492},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3769, col: 31, offset: 116414},
+										pos:  position{line: 3823, col: 31, offset: 118497},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3769, col: 39, offset: 116422},
+									pos:  position{line: 3823, col: 39, offset: 118505},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3772, col: 3, offset: 116457},
+						pos: position{line: 3826, col: 3, offset: 118540},
 						run: (*parser).callonNumericEvalExpr107,
 						expr: &seqExpr{
-							pos: position{line: 3772, col: 4, offset: 116458},
+							pos: position{line: 3826, col: 4, offset: 118541},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3772, col: 4, offset: 116458},
+									pos:   position{line: 3826, col: 4, offset: 118541},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3772, col: 12, offset: 116466},
+										pos: position{line: 3826, col: 12, offset: 118549},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3772, col: 12, offset: 116466},
+												pos:        position{line: 3826, col: 12, offset: 118549},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3772, col: 20, offset: 116474},
+												pos:        position{line: 3826, col: 20, offset: 118557},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3772, col: 30, offset: 116484},
+												pos:        position{line: 3826, col: 30, offset: 118567},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8471,128 +8525,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3772, col: 39, offset: 116493},
+									pos:  position{line: 3826, col: 39, offset: 118576},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3772, col: 47, offset: 116501},
+									pos:   position{line: 3826, col: 47, offset: 118584},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3772, col: 53, offset: 116507},
+										pos:  position{line: 3826, col: 53, offset: 118590},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3772, col: 72, offset: 116526},
+									pos:   position{line: 3826, col: 72, offset: 118609},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3772, col: 79, offset: 116533},
+										pos:  position{line: 3826, col: 79, offset: 118616},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3772, col: 97, offset: 116551},
+									pos:  position{line: 3826, col: 97, offset: 118634},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3802, col: 3, offset: 117390},
+						pos: position{line: 3856, col: 3, offset: 119473},
 						run: (*parser).callonNumericEvalExpr120,
 						expr: &seqExpr{
-							pos: position{line: 3802, col: 4, offset: 117391},
+							pos: position{line: 3856, col: 4, offset: 119474},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3802, col: 4, offset: 117391},
+									pos:   position{line: 3856, col: 4, offset: 119474},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3802, col: 11, offset: 117398},
+										pos:        position{line: 3856, col: 11, offset: 119481},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3802, col: 17, offset: 117404},
+									pos:  position{line: 3856, col: 17, offset: 119487},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3802, col: 25, offset: 117412},
+									pos:   position{line: 3856, col: 25, offset: 119495},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3802, col: 31, offset: 117418},
+										pos:  position{line: 3856, col: 31, offset: 119501},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3802, col: 50, offset: 117437},
+									pos:   position{line: 3856, col: 50, offset: 119520},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3802, col: 56, offset: 117443},
+										pos: position{line: 3856, col: 56, offset: 119526},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3802, col: 57, offset: 117444},
+											pos:  position{line: 3856, col: 57, offset: 119527},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3802, col: 76, offset: 117463},
+									pos:  position{line: 3856, col: 76, offset: 119546},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3831, col: 3, offset: 118236},
+						pos: position{line: 3885, col: 3, offset: 120319},
 						run: (*parser).callonNumericEvalExpr131,
 						expr: &seqExpr{
-							pos: position{line: 3831, col: 3, offset: 118236},
+							pos: position{line: 3885, col: 3, offset: 120319},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3831, col: 3, offset: 118236},
+									pos:   position{line: 3885, col: 3, offset: 120319},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3831, col: 11, offset: 118244},
+										pos:        position{line: 3885, col: 11, offset: 120327},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3831, col: 28, offset: 118261},
+									pos:  position{line: 3885, col: 28, offset: 120344},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3831, col: 36, offset: 118269},
+									pos:   position{line: 3885, col: 36, offset: 120352},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3831, col: 42, offset: 118275},
+										pos:  position{line: 3885, col: 42, offset: 120358},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3831, col: 61, offset: 118294},
+									pos:  position{line: 3885, col: 61, offset: 120377},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3831, col: 67, offset: 118300},
+									pos:  position{line: 3885, col: 67, offset: 120383},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3831, col: 73, offset: 118306},
+									pos:   position{line: 3885, col: 73, offset: 120389},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3831, col: 84, offset: 118317},
+										pos:  position{line: 3885, col: 84, offset: 120400},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3831, col: 120, offset: 118353},
+									pos:  position{line: 3885, col: 120, offset: 120436},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3831, col: 126, offset: 118359},
+									pos:  position{line: 3885, col: 126, offset: 120442},
 									name: "R_PAREN",
 								},
 							},
@@ -8603,103 +8657,103 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExprLevel1",
-			pos:  position{line: 3848, col: 1, offset: 118889},
+			pos:  position{line: 3902, col: 1, offset: 120972},
 			expr: &choiceExpr{
-				pos: position{line: 3848, col: 19, offset: 118907},
+				pos: position{line: 3902, col: 19, offset: 120990},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3848, col: 19, offset: 118907},
+						pos: position{line: 3902, col: 19, offset: 120990},
 						run: (*parser).callonJsonExprLevel12,
 						expr: &labeledExpr{
-							pos:   position{line: 3848, col: 19, offset: 118907},
+							pos:   position{line: 3902, col: 19, offset: 120990},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3848, col: 28, offset: 118916},
+								pos:  position{line: 3902, col: 28, offset: 120999},
 								name: "JsonExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3851, col: 3, offset: 118956},
+						pos: position{line: 3905, col: 3, offset: 121039},
 						run: (*parser).callonJsonExprLevel15,
 						expr: &labeledExpr{
-							pos:   position{line: 3851, col: 3, offset: 118956},
+							pos:   position{line: 3905, col: 3, offset: 121039},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3851, col: 9, offset: 118962},
+								pos:  position{line: 3905, col: 9, offset: 121045},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3865, col: 3, offset: 119308},
+						pos: position{line: 3919, col: 3, offset: 121391},
 						run: (*parser).callonJsonExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3865, col: 3, offset: 119308},
+							pos:   position{line: 3919, col: 3, offset: 121391},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3865, col: 9, offset: 119314},
+								pos:  position{line: 3919, col: 9, offset: 121397},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3879, col: 3, offset: 119678},
+						pos: position{line: 3933, col: 3, offset: 121761},
 						run: (*parser).callonJsonExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3879, col: 3, offset: 119678},
+							pos:   position{line: 3933, col: 3, offset: 121761},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3879, col: 9, offset: 119684},
+								pos:  position{line: 3933, col: 9, offset: 121767},
 								name: "NumericExprLevel3",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3893, col: 3, offset: 120050},
+						pos: position{line: 3947, col: 3, offset: 122133},
 						run: (*parser).callonJsonExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3893, col: 3, offset: 120050},
+							pos:   position{line: 3947, col: 3, offset: 122133},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3893, col: 9, offset: 120056},
+								pos:  position{line: 3947, col: 9, offset: 122139},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3907, col: 3, offset: 120433},
+						pos: position{line: 3961, col: 3, offset: 122516},
 						run: (*parser).callonJsonExprLevel117,
 						expr: &labeledExpr{
-							pos:   position{line: 3907, col: 3, offset: 120433},
+							pos:   position{line: 3961, col: 3, offset: 122516},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3907, col: 9, offset: 120439},
+								pos:  position{line: 3961, col: 9, offset: 122522},
 								name: "BoolExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3921, col: 3, offset: 120794},
+						pos: position{line: 3975, col: 3, offset: 122877},
 						run: (*parser).callonJsonExprLevel120,
 						expr: &labeledExpr{
-							pos:   position{line: 3921, col: 3, offset: 120794},
+							pos:   position{line: 3975, col: 3, offset: 122877},
 							label: "value",
 							expr: &seqExpr{
-								pos: position{line: 3921, col: 10, offset: 120801},
+								pos: position{line: 3975, col: 10, offset: 122884},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 3921, col: 10, offset: 120801},
+										pos:        position{line: 3975, col: 10, offset: 122884},
 										val:        "null",
 										ignoreCase: false,
 										want:       "\"null\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3921, col: 17, offset: 120808},
+										pos:  position{line: 3975, col: 17, offset: 122891},
 										name: "L_PAREN",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3921, col: 25, offset: 120816},
+										pos:  position{line: 3975, col: 25, offset: 122899},
 										name: "R_PAREN",
 									},
 								},
@@ -8707,13 +8761,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3931, col: 3, offset: 121011},
+						pos: position{line: 3985, col: 3, offset: 123094},
 						run: (*parser).callonJsonExprLevel126,
 						expr: &labeledExpr{
-							pos:   position{line: 3931, col: 3, offset: 121011},
+							pos:   position{line: 3985, col: 3, offset: 123094},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3931, col: 9, offset: 121017},
+								pos:  position{line: 3985, col: 9, offset: 123100},
 								name: "StringExpr",
 							},
 						},
@@ -8723,68 +8777,68 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExpr",
-			pos:  position{line: 3946, col: 1, offset: 121380},
+			pos:  position{line: 4000, col: 1, offset: 123463},
 			expr: &choiceExpr{
-				pos: position{line: 3946, col: 13, offset: 121392},
+				pos: position{line: 4000, col: 13, offset: 123475},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3946, col: 13, offset: 121392},
+						pos: position{line: 4000, col: 13, offset: 123475},
 						run: (*parser).callonJsonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3946, col: 13, offset: 121392},
+							pos: position{line: 4000, col: 13, offset: 123475},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3946, col: 13, offset: 121392},
+									pos:        position{line: 4000, col: 13, offset: 123475},
 									val:        "json_object",
 									ignoreCase: false,
 									want:       "\"json_object\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3946, col: 27, offset: 121406},
+									pos:  position{line: 4000, col: 27, offset: 123489},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3946, col: 35, offset: 121414},
+									pos:   position{line: 4000, col: 35, offset: 123497},
 									label: "firstKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3946, col: 45, offset: 121424},
+										pos:  position{line: 4000, col: 45, offset: 123507},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3946, col: 61, offset: 121440},
+									pos:  position{line: 4000, col: 61, offset: 123523},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3946, col: 67, offset: 121446},
+									pos:   position{line: 4000, col: 67, offset: 123529},
 									label: "firstValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3946, col: 79, offset: 121458},
+										pos:  position{line: 4000, col: 79, offset: 123541},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3946, col: 95, offset: 121474},
+									pos:   position{line: 4000, col: 95, offset: 123557},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3946, col: 100, offset: 121479},
+										pos: position{line: 4000, col: 100, offset: 123562},
 										expr: &seqExpr{
-											pos: position{line: 3946, col: 101, offset: 121480},
+											pos: position{line: 4000, col: 101, offset: 123563},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3946, col: 101, offset: 121480},
+													pos:  position{line: 4000, col: 101, offset: 123563},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3946, col: 107, offset: 121486},
+													pos:  position{line: 4000, col: 107, offset: 123569},
 													name: "JsonExprLevel1",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3946, col: 122, offset: 121501},
+													pos:  position{line: 4000, col: 122, offset: 123584},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3946, col: 128, offset: 121507},
+													pos:  position{line: 4000, col: 128, offset: 123590},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -8792,121 +8846,167 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3946, col: 145, offset: 121524},
+									pos:  position{line: 4000, col: 145, offset: 123607},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3954, col: 3, offset: 121704},
+						pos: position{line: 4008, col: 3, offset: 123787},
 						run: (*parser).callonJsonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3954, col: 3, offset: 121704},
+							pos: position{line: 4008, col: 3, offset: 123787},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3954, col: 3, offset: 121704},
+									pos:   position{line: 4008, col: 3, offset: 123787},
 									label: "opName",
-									expr: &litMatcher{
-										pos:        position{line: 3954, col: 10, offset: 121711},
-										val:        "json",
-										ignoreCase: false,
-										want:       "\"json\"",
+									expr: &choiceExpr{
+										pos: position{line: 4008, col: 11, offset: 123795},
+										alternatives: []any{
+											&litMatcher{
+												pos:        position{line: 4008, col: 11, offset: 123795},
+												val:        "json",
+												ignoreCase: false,
+												want:       "\"json\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4008, col: 20, offset: 123804},
+												val:        "json_entries",
+												ignoreCase: false,
+												want:       "\"json_entries\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4008, col: 37, offset: 123821},
+												val:        "json_keys",
+												ignoreCase: false,
+												want:       "\"json_keys\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4008, col: 51, offset: 123835},
+												val:        "json_valid",
+												ignoreCase: false,
+												want:       "\"json_valid\"",
+											},
+										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3954, col: 17, offset: 121718},
+									pos:  position{line: 4008, col: 65, offset: 123849},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3954, col: 25, offset: 121726},
+									pos:   position{line: 4008, col: 73, offset: 123857},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3954, col: 31, offset: 121732},
+										pos:  position{line: 4008, col: 79, offset: 123863},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3954, col: 46, offset: 121747},
+									pos:  position{line: 4008, col: 94, offset: 123878},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3972, col: 3, offset: 122236},
-						run: (*parser).callonJsonExpr27,
+						pos: position{line: 4034, col: 3, offset: 125088},
+						run: (*parser).callonJsonExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3972, col: 3, offset: 122236},
+							pos: position{line: 4034, col: 3, offset: 125088},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3972, col: 3, offset: 122236},
+									pos:   position{line: 4034, col: 3, offset: 125088},
 									label: "opName",
-									expr: &litMatcher{
-										pos:        position{line: 3972, col: 10, offset: 122243},
-										val:        "json_append",
-										ignoreCase: false,
-										want:       "\"json_append\"",
+									expr: &choiceExpr{
+										pos: position{line: 4034, col: 11, offset: 125096},
+										alternatives: []any{
+											&litMatcher{
+												pos:        position{line: 4034, col: 11, offset: 125096},
+												val:        "json_append",
+												ignoreCase: false,
+												want:       "\"json_append\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4034, col: 27, offset: 125112},
+												val:        "json_extend",
+												ignoreCase: false,
+												want:       "\"json_extend\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4034, col: 43, offset: 125128},
+												val:        "json_set",
+												ignoreCase: false,
+												want:       "\"json_set\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4034, col: 56, offset: 125141},
+												val:        "json_set_exact",
+												ignoreCase: false,
+												want:       "\"json_set_exact\"",
+											},
+										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 24, offset: 122257},
+									pos:  position{line: 4034, col: 74, offset: 125159},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 32, offset: 122265},
+									pos:   position{line: 4034, col: 82, offset: 125167},
 									label: "json",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 37, offset: 122270},
+										pos:  position{line: 4034, col: 87, offset: 125172},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 52, offset: 122285},
+									pos:  position{line: 4034, col: 102, offset: 125187},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 58, offset: 122291},
+									pos:   position{line: 4034, col: 108, offset: 125193},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 63, offset: 122296},
+										pos:  position{line: 4034, col: 113, offset: 125198},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 78, offset: 122311},
+									pos:  position{line: 4034, col: 128, offset: 125213},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 84, offset: 122317},
+									pos:   position{line: 4034, col: 134, offset: 125219},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3972, col: 90, offset: 122323},
+										pos:  position{line: 4034, col: 140, offset: 125225},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3972, col: 105, offset: 122338},
+									pos:   position{line: 4034, col: 155, offset: 125240},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3972, col: 110, offset: 122343},
+										pos: position{line: 4034, col: 160, offset: 125245},
 										expr: &seqExpr{
-											pos: position{line: 3972, col: 111, offset: 122344},
+											pos: position{line: 4034, col: 161, offset: 125246},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3972, col: 111, offset: 122344},
+													pos:  position{line: 4034, col: 161, offset: 125246},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3972, col: 117, offset: 122350},
+													pos:  position{line: 4034, col: 167, offset: 125252},
 													name: "JsonExprLevel1",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3972, col: 132, offset: 122365},
+													pos:  position{line: 4034, col: 182, offset: 125267},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3972, col: 138, offset: 122371},
+													pos:  position{line: 4034, col: 188, offset: 125273},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -8914,50 +9014,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3972, col: 155, offset: 122388},
+									pos:  position{line: 4034, col: 205, offset: 125290},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4000, col: 3, offset: 123477},
-						run: (*parser).callonJsonExpr48,
+						pos: position{line: 4073, col: 3, offset: 126917},
+						run: (*parser).callonJsonExpr56,
 						expr: &seqExpr{
-							pos: position{line: 4000, col: 3, offset: 123477},
+							pos: position{line: 4073, col: 3, offset: 126917},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4000, col: 3, offset: 123477},
+									pos:        position{line: 4073, col: 3, offset: 126917},
 									val:        "json_array",
 									ignoreCase: false,
 									want:       "\"json_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4000, col: 16, offset: 123490},
+									pos:  position{line: 4073, col: 16, offset: 126930},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4000, col: 24, offset: 123498},
+									pos:   position{line: 4073, col: 24, offset: 126938},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4000, col: 30, offset: 123504},
+										pos:  position{line: 4073, col: 30, offset: 126944},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4000, col: 45, offset: 123519},
+									pos:   position{line: 4073, col: 45, offset: 126959},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4000, col: 50, offset: 123524},
+										pos: position{line: 4073, col: 50, offset: 126964},
 										expr: &seqExpr{
-											pos: position{line: 4000, col: 51, offset: 123525},
+											pos: position{line: 4073, col: 51, offset: 126965},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 51, offset: 123525},
+													pos:  position{line: 4073, col: 51, offset: 126965},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 57, offset: 123531},
+													pos:  position{line: 4073, col: 57, offset: 126971},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -8965,7 +9065,201 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4000, col: 74, offset: 123548},
+									pos:  position{line: 4073, col: 74, offset: 126988},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 4081, col: 3, offset: 127143},
+						run: (*parser).callonJsonExpr68,
+						expr: &seqExpr{
+							pos: position{line: 4081, col: 3, offset: 127143},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 4081, col: 3, offset: 127143},
+									val:        "json_delete",
+									ignoreCase: false,
+									want:       "\"json_delete\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4081, col: 17, offset: 127157},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 4081, col: 25, offset: 127165},
+									label: "object",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4081, col: 32, offset: 127172},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4081, col: 47, offset: 127187},
+									name: "COMMA",
+								},
+								&litMatcher{
+									pos:        position{line: 4081, col: 53, offset: 127193},
+									val:        "[",
+									ignoreCase: false,
+									want:       "\"[\"",
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 4081, col: 57, offset: 127197},
+									expr: &ruleRefExpr{
+										pos:  position{line: 4081, col: 57, offset: 127197},
+										name: "SPACE",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 4081, col: 64, offset: 127204},
+									label: "firstKey",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4081, col: 73, offset: 127213},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 4081, col: 88, offset: 127228},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 4081, col: 93, offset: 127233},
+										expr: &seqExpr{
+											pos: position{line: 4081, col: 94, offset: 127234},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 4081, col: 94, offset: 127234},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 4081, col: 100, offset: 127240},
+													name: "JsonExprLevel1",
+												},
+											},
+										},
+									},
+								},
+								&zeroOrOneExpr{
+									pos: position{line: 4081, col: 117, offset: 127257},
+									expr: &ruleRefExpr{
+										pos:  position{line: 4081, col: 117, offset: 127257},
+										name: "SPACE",
+									},
+								},
+								&litMatcher{
+									pos:        position{line: 4081, col: 124, offset: 127264},
+									val:        "]",
+									ignoreCase: false,
+									want:       "\"]\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4081, col: 128, offset: 127268},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 4099, col: 3, offset: 127742},
+						run: (*parser).callonJsonExpr89,
+						expr: &seqExpr{
+							pos: position{line: 4099, col: 3, offset: 127742},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 4099, col: 3, offset: 127742},
+									label: "opName",
+									expr: &choiceExpr{
+										pos: position{line: 4099, col: 11, offset: 127750},
+										alternatives: []any{
+											&litMatcher{
+												pos:        position{line: 4099, col: 11, offset: 127750},
+												val:        "json_extract",
+												ignoreCase: false,
+												want:       "\"json_extract\"",
+											},
+											&litMatcher{
+												pos:        position{line: 4099, col: 28, offset: 127767},
+												val:        "json_extract_exact",
+												ignoreCase: false,
+												want:       "\"json_extract_exact\"",
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4099, col: 50, offset: 127789},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 4099, col: 58, offset: 127797},
+									label: "json",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4099, col: 63, offset: 127802},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 4099, col: 78, offset: 127817},
+									label: "paths",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 4099, col: 84, offset: 127823},
+										expr: &seqExpr{
+											pos: position{line: 4099, col: 85, offset: 127824},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 4099, col: 85, offset: 127824},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 4099, col: 91, offset: 127830},
+													name: "JsonExprLevel1",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4099, col: 108, offset: 127847},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 4134, col: 3, offset: 129023},
+						run: (*parser).callonJsonExpr104,
+						expr: &seqExpr{
+							pos: position{line: 4134, col: 3, offset: 129023},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 4134, col: 3, offset: 129023},
+									val:        "json_has_key_exact",
+									ignoreCase: false,
+									want:       "\"json_has_key_exact\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4134, col: 24, offset: 129044},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 4134, col: 32, offset: 129052},
+									label: "object",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4134, col: 39, offset: 129059},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 4134, col: 54, offset: 129074},
+									label: "key",
+									expr: &ruleRefExpr{
+										pos:  position{line: 4134, col: 58, offset: 129078},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 4134, col: 73, offset: 129093},
 									name: "R_PAREN",
 								},
 							},
@@ -8976,28 +9270,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 4040, col: 1, offset: 124706},
+			pos:  position{line: 4163, col: 1, offset: 130093},
 			expr: &choiceExpr{
-				pos: position{line: 4040, col: 12, offset: 124717},
+				pos: position{line: 4163, col: 12, offset: 130104},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4040, col: 12, offset: 124717},
+						pos: position{line: 4163, col: 12, offset: 130104},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 4040, col: 12, offset: 124717},
+							pos: position{line: 4163, col: 12, offset: 130104},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4040, col: 12, offset: 124717},
+									pos:   position{line: 4163, col: 12, offset: 130104},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4040, col: 16, offset: 124721},
+										pos:  position{line: 4163, col: 16, offset: 130108},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4040, col: 29, offset: 124734},
+									pos: position{line: 4163, col: 29, offset: 130121},
 									expr: &ruleRefExpr{
-										pos:  position{line: 4040, col: 31, offset: 124736},
+										pos:  position{line: 4163, col: 31, offset: 130123},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -9005,50 +9299,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4056, col: 3, offset: 125111},
+						pos: position{line: 4179, col: 3, offset: 130498},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 4056, col: 3, offset: 125111},
+							pos: position{line: 4179, col: 3, offset: 130498},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4056, col: 3, offset: 125111},
+									pos:   position{line: 4179, col: 3, offset: 130498},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4056, col: 9, offset: 125117},
+										pos:  position{line: 4179, col: 9, offset: 130504},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4056, col: 25, offset: 125133},
+									pos: position{line: 4179, col: 25, offset: 130520},
 									expr: &choiceExpr{
-										pos: position{line: 4056, col: 27, offset: 125135},
+										pos: position{line: 4179, col: 27, offset: 130522},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 27, offset: 125135},
+												pos:  position{line: 4179, col: 27, offset: 130522},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 36, offset: 125144},
+												pos:  position{line: 4179, col: 36, offset: 130531},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 46, offset: 125154},
+												pos:  position{line: 4179, col: 46, offset: 130541},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 54, offset: 125162},
+												pos:  position{line: 4179, col: 54, offset: 130549},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 62, offset: 125170},
+												pos:  position{line: 4179, col: 62, offset: 130557},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4056, col: 70, offset: 125178},
+												pos:  position{line: 4179, col: 70, offset: 130565},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 4056, col: 84, offset: 125192},
+												pos:        position{line: 4179, col: 84, offset: 130579},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -9064,28 +9358,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 4073, col: 1, offset: 125543},
+			pos:  position{line: 4196, col: 1, offset: 130930},
 			expr: &actionExpr{
-				pos: position{line: 4073, col: 19, offset: 125561},
+				pos: position{line: 4196, col: 19, offset: 130948},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 4073, col: 19, offset: 125561},
+					pos: position{line: 4196, col: 19, offset: 130948},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4073, col: 19, offset: 125561},
+							pos:        position{line: 4196, col: 19, offset: 130948},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4073, col: 26, offset: 125568},
+							pos:  position{line: 4196, col: 26, offset: 130955},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4073, col: 32, offset: 125574},
+							pos:   position{line: 4196, col: 32, offset: 130961},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4073, col: 40, offset: 125582},
+								pos:  position{line: 4196, col: 40, offset: 130969},
 								name: "Boolean",
 							},
 						},
@@ -9095,28 +9389,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 4084, col: 1, offset: 125771},
+			pos:  position{line: 4207, col: 1, offset: 131158},
 			expr: &actionExpr{
-				pos: position{line: 4084, col: 23, offset: 125793},
+				pos: position{line: 4207, col: 23, offset: 131180},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 4084, col: 23, offset: 125793},
+					pos: position{line: 4207, col: 23, offset: 131180},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4084, col: 23, offset: 125793},
+							pos:        position{line: 4207, col: 23, offset: 131180},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4084, col: 34, offset: 125804},
+							pos:  position{line: 4207, col: 34, offset: 131191},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4084, col: 40, offset: 125810},
+							pos:   position{line: 4207, col: 40, offset: 131197},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4084, col: 48, offset: 125818},
+								pos:  position{line: 4207, col: 48, offset: 131205},
 								name: "Boolean",
 							},
 						},
@@ -9126,28 +9420,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 4095, col: 1, offset: 126015},
+			pos:  position{line: 4218, col: 1, offset: 131402},
 			expr: &actionExpr{
-				pos: position{line: 4095, col: 20, offset: 126034},
+				pos: position{line: 4218, col: 20, offset: 131421},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4095, col: 20, offset: 126034},
+					pos: position{line: 4218, col: 20, offset: 131421},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4095, col: 20, offset: 126034},
+							pos:        position{line: 4218, col: 20, offset: 131421},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4095, col: 28, offset: 126042},
+							pos:  position{line: 4218, col: 28, offset: 131429},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4095, col: 34, offset: 126048},
+							pos:   position{line: 4218, col: 34, offset: 131435},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4095, col: 43, offset: 126057},
+								pos:  position{line: 4218, col: 43, offset: 131444},
 								name: "IntegerAsString",
 							},
 						},
@@ -9157,15 +9451,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 4110, col: 1, offset: 126419},
+			pos:  position{line: 4233, col: 1, offset: 131806},
 			expr: &actionExpr{
-				pos: position{line: 4110, col: 19, offset: 126437},
+				pos: position{line: 4233, col: 19, offset: 131824},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 4110, col: 19, offset: 126437},
+					pos:   position{line: 4233, col: 19, offset: 131824},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4110, col: 28, offset: 126446},
+						pos:  position{line: 4233, col: 28, offset: 131833},
 						name: "BoolExpr",
 					},
 				},
@@ -9173,30 +9467,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 4121, col: 1, offset: 126658},
+			pos:  position{line: 4244, col: 1, offset: 132045},
 			expr: &actionExpr{
-				pos: position{line: 4121, col: 15, offset: 126672},
+				pos: position{line: 4244, col: 15, offset: 132059},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4121, col: 15, offset: 126672},
+					pos:   position{line: 4244, col: 15, offset: 132059},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4121, col: 23, offset: 126680},
+						pos: position{line: 4244, col: 23, offset: 132067},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4121, col: 23, offset: 126680},
+								pos:  position{line: 4244, col: 23, offset: 132067},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4121, col: 44, offset: 126701},
+								pos:  position{line: 4244, col: 44, offset: 132088},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4121, col: 61, offset: 126718},
+								pos:  position{line: 4244, col: 61, offset: 132105},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4121, col: 79, offset: 126736},
+								pos:  position{line: 4244, col: 79, offset: 132123},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -9206,35 +9500,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 4125, col: 1, offset: 126780},
+			pos:  position{line: 4248, col: 1, offset: 132167},
 			expr: &actionExpr{
-				pos: position{line: 4125, col: 19, offset: 126798},
+				pos: position{line: 4248, col: 19, offset: 132185},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4125, col: 19, offset: 126798},
+					pos: position{line: 4248, col: 19, offset: 132185},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4125, col: 19, offset: 126798},
+							pos:   position{line: 4248, col: 19, offset: 132185},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4125, col: 26, offset: 126805},
+								pos:  position{line: 4248, col: 26, offset: 132192},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4125, col: 37, offset: 126816},
+							pos:   position{line: 4248, col: 37, offset: 132203},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4125, col: 43, offset: 126822},
+								pos: position{line: 4248, col: 43, offset: 132209},
 								expr: &seqExpr{
-									pos: position{line: 4125, col: 44, offset: 126823},
+									pos: position{line: 4248, col: 44, offset: 132210},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4125, col: 44, offset: 126823},
+											pos:  position{line: 4248, col: 44, offset: 132210},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4125, col: 50, offset: 126829},
+											pos:  position{line: 4248, col: 50, offset: 132216},
 											name: "HeadOption",
 										},
 									},
@@ -9247,29 +9541,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4182, col: 1, offset: 128629},
+			pos:  position{line: 4305, col: 1, offset: 134016},
 			expr: &choiceExpr{
-				pos: position{line: 4182, col: 14, offset: 128642},
+				pos: position{line: 4305, col: 14, offset: 134029},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4182, col: 14, offset: 128642},
+						pos: position{line: 4305, col: 14, offset: 134029},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4182, col: 14, offset: 128642},
+							pos: position{line: 4305, col: 14, offset: 134029},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4182, col: 14, offset: 128642},
+									pos:  position{line: 4305, col: 14, offset: 134029},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4182, col: 19, offset: 128647},
+									pos:  position{line: 4305, col: 19, offset: 134034},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4182, col: 28, offset: 128656},
+									pos:   position{line: 4305, col: 28, offset: 134043},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4182, col: 37, offset: 128665},
+										pos:  position{line: 4305, col: 37, offset: 134052},
 										name: "HeadOptionList",
 									},
 								},
@@ -9277,24 +9571,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4193, col: 3, offset: 128984},
+						pos: position{line: 4316, col: 3, offset: 134371},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4193, col: 3, offset: 128984},
+							pos: position{line: 4316, col: 3, offset: 134371},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4193, col: 3, offset: 128984},
+									pos:  position{line: 4316, col: 3, offset: 134371},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4193, col: 8, offset: 128989},
+									pos:  position{line: 4316, col: 8, offset: 134376},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4193, col: 17, offset: 128998},
+									pos:   position{line: 4316, col: 17, offset: 134385},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4193, col: 26, offset: 129007},
+										pos:  position{line: 4316, col: 26, offset: 134394},
 										name: "IntegerAsString",
 									},
 								},
@@ -9302,17 +9596,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4213, col: 3, offset: 129524},
+						pos: position{line: 4336, col: 3, offset: 134911},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4213, col: 3, offset: 129524},
+							pos: position{line: 4336, col: 3, offset: 134911},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4213, col: 3, offset: 129524},
+									pos:  position{line: 4336, col: 3, offset: 134911},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4213, col: 8, offset: 129529},
+									pos:  position{line: 4336, col: 8, offset: 134916},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9323,29 +9617,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4231, col: 1, offset: 129999},
+			pos:  position{line: 4354, col: 1, offset: 135386},
 			expr: &choiceExpr{
-				pos: position{line: 4231, col: 14, offset: 130012},
+				pos: position{line: 4354, col: 14, offset: 135399},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4231, col: 14, offset: 130012},
+						pos: position{line: 4354, col: 14, offset: 135399},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4231, col: 14, offset: 130012},
+							pos: position{line: 4354, col: 14, offset: 135399},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4231, col: 14, offset: 130012},
+									pos:  position{line: 4354, col: 14, offset: 135399},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4231, col: 19, offset: 130017},
+									pos:  position{line: 4354, col: 19, offset: 135404},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4231, col: 28, offset: 130026},
+									pos:   position{line: 4354, col: 28, offset: 135413},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4231, col: 37, offset: 130035},
+										pos:  position{line: 4354, col: 37, offset: 135422},
 										name: "IntegerAsString",
 									},
 								},
@@ -9353,17 +9647,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4252, col: 3, offset: 130609},
+						pos: position{line: 4375, col: 3, offset: 135996},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4252, col: 3, offset: 130609},
+							pos: position{line: 4375, col: 3, offset: 135996},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4252, col: 3, offset: 130609},
+									pos:  position{line: 4375, col: 3, offset: 135996},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4252, col: 8, offset: 130614},
+									pos:  position{line: 4375, col: 8, offset: 136001},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9374,44 +9668,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4273, col: 1, offset: 131232},
+			pos:  position{line: 4396, col: 1, offset: 136619},
 			expr: &actionExpr{
-				pos: position{line: 4273, col: 20, offset: 131251},
+				pos: position{line: 4396, col: 20, offset: 136638},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4273, col: 20, offset: 131251},
+					pos: position{line: 4396, col: 20, offset: 136638},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4273, col: 20, offset: 131251},
+							pos:   position{line: 4396, col: 20, offset: 136638},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4273, col: 26, offset: 131257},
+								pos:  position{line: 4396, col: 26, offset: 136644},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4273, col: 37, offset: 131268},
+							pos:   position{line: 4396, col: 37, offset: 136655},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4273, col: 42, offset: 131273},
+								pos: position{line: 4396, col: 42, offset: 136660},
 								expr: &seqExpr{
-									pos: position{line: 4273, col: 43, offset: 131274},
+									pos: position{line: 4396, col: 43, offset: 136661},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4273, col: 44, offset: 131275},
+											pos: position{line: 4396, col: 44, offset: 136662},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4273, col: 44, offset: 131275},
+													pos:  position{line: 4396, col: 44, offset: 136662},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4273, col: 52, offset: 131283},
+													pos:  position{line: 4396, col: 52, offset: 136670},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4273, col: 59, offset: 131290},
+											pos:  position{line: 4396, col: 59, offset: 136677},
 											name: "Aggregator",
 										},
 									},
@@ -9424,28 +9718,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4290, col: 1, offset: 131793},
+			pos:  position{line: 4413, col: 1, offset: 137180},
 			expr: &actionExpr{
-				pos: position{line: 4290, col: 15, offset: 131807},
+				pos: position{line: 4413, col: 15, offset: 137194},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4290, col: 15, offset: 131807},
+					pos: position{line: 4413, col: 15, offset: 137194},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4290, col: 15, offset: 131807},
+							pos:   position{line: 4413, col: 15, offset: 137194},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4290, col: 23, offset: 131815},
+								pos:  position{line: 4413, col: 23, offset: 137202},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4290, col: 35, offset: 131827},
+							pos:   position{line: 4413, col: 35, offset: 137214},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4290, col: 43, offset: 131835},
+								pos: position{line: 4413, col: 43, offset: 137222},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4290, col: 43, offset: 131835},
+									pos:  position{line: 4413, col: 43, offset: 137222},
 									name: "AsField",
 								},
 							},
@@ -9456,26 +9750,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4306, col: 1, offset: 132676},
+			pos:  position{line: 4429, col: 1, offset: 138063},
 			expr: &actionExpr{
-				pos: position{line: 4306, col: 16, offset: 132691},
+				pos: position{line: 4429, col: 16, offset: 138078},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4306, col: 16, offset: 132691},
+					pos:   position{line: 4429, col: 16, offset: 138078},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4306, col: 21, offset: 132696},
+						pos: position{line: 4429, col: 21, offset: 138083},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4306, col: 21, offset: 132696},
+								pos:  position{line: 4429, col: 21, offset: 138083},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4306, col: 32, offset: 132707},
+								pos:  position{line: 4429, col: 32, offset: 138094},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4306, col: 48, offset: 132723},
+								pos:  position{line: 4429, col: 48, offset: 138110},
 								name: "AggCommon",
 							},
 						},
@@ -9485,165 +9779,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4311, col: 1, offset: 132891},
+			pos:  position{line: 4434, col: 1, offset: 138278},
 			expr: &actionExpr{
-				pos: position{line: 4311, col: 18, offset: 132908},
+				pos: position{line: 4434, col: 18, offset: 138295},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4311, col: 19, offset: 132909},
+					pos: position{line: 4434, col: 19, offset: 138296},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4311, col: 19, offset: 132909},
+							pos:        position{line: 4434, col: 19, offset: 138296},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 30, offset: 132920},
+							pos:        position{line: 4434, col: 30, offset: 138307},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 39, offset: 132929},
+							pos:        position{line: 4434, col: 39, offset: 138316},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 47, offset: 132937},
+							pos:        position{line: 4434, col: 47, offset: 138324},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 57, offset: 132947},
+							pos:        position{line: 4434, col: 57, offset: 138334},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 65, offset: 132955},
+							pos:        position{line: 4434, col: 65, offset: 138342},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 76, offset: 132966},
+							pos:        position{line: 4434, col: 76, offset: 138353},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 86, offset: 132976},
+							pos:        position{line: 4434, col: 86, offset: 138363},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 95, offset: 132985},
+							pos:        position{line: 4434, col: 95, offset: 138372},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 105, offset: 132995},
+							pos:        position{line: 4434, col: 105, offset: 138382},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 114, offset: 133004},
+							pos:        position{line: 4434, col: 114, offset: 138391},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 122, offset: 133012},
+							pos:        position{line: 4434, col: 122, offset: 138399},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 133, offset: 133023},
+							pos:        position{line: 4434, col: 133, offset: 138410},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4311, col: 142, offset: 133032},
+							pos:        position{line: 4434, col: 142, offset: 138419},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 1, offset: 133041},
+							pos:        position{line: 4435, col: 1, offset: 138428},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 10, offset: 133050},
+							pos:        position{line: 4435, col: 10, offset: 138437},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 26, offset: 133066},
+							pos:        position{line: 4435, col: 26, offset: 138453},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 37, offset: 133077},
+							pos:        position{line: 4435, col: 37, offset: 138464},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 46, offset: 133086},
+							pos:        position{line: 4435, col: 46, offset: 138473},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 56, offset: 133096},
+							pos:        position{line: 4435, col: 56, offset: 138483},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 72, offset: 133112},
+							pos:        position{line: 4435, col: 72, offset: 138499},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 82, offset: 133122},
+							pos:        position{line: 4435, col: 82, offset: 138509},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 100, offset: 133140},
+							pos:        position{line: 4435, col: 100, offset: 138527},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 113, offset: 133153},
+							pos:        position{line: 4435, col: 113, offset: 138540},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 132, offset: 133172},
+							pos:        position{line: 4435, col: 132, offset: 138559},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4312, col: 139, offset: 133179},
+							pos:        position{line: 4435, col: 139, offset: 138566},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9654,33 +9948,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4316, col: 1, offset: 133222},
+			pos:  position{line: 4439, col: 1, offset: 138609},
 			expr: &actionExpr{
-				pos: position{line: 4316, col: 22, offset: 133243},
+				pos: position{line: 4439, col: 22, offset: 138630},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4316, col: 23, offset: 133244},
+					pos: position{line: 4439, col: 23, offset: 138631},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4316, col: 23, offset: 133244},
+							pos:        position{line: 4439, col: 23, offset: 138631},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4316, col: 37, offset: 133258},
+							pos:        position{line: 4439, col: 37, offset: 138645},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4316, col: 51, offset: 133272},
+							pos:        position{line: 4439, col: 51, offset: 138659},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4316, col: 60, offset: 133281},
+							pos:        position{line: 4439, col: 60, offset: 138668},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9691,29 +9985,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4320, col: 1, offset: 133322},
+			pos:  position{line: 4443, col: 1, offset: 138709},
 			expr: &actionExpr{
-				pos: position{line: 4320, col: 12, offset: 133333},
+				pos: position{line: 4443, col: 12, offset: 138720},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4320, col: 12, offset: 133333},
+					pos: position{line: 4443, col: 12, offset: 138720},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4320, col: 12, offset: 133333},
+							pos:  position{line: 4443, col: 12, offset: 138720},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4320, col: 15, offset: 133336},
+							pos:   position{line: 4443, col: 15, offset: 138723},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4320, col: 23, offset: 133344},
+								pos: position{line: 4443, col: 23, offset: 138731},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4320, col: 23, offset: 133344},
+										pos:  position{line: 4443, col: 23, offset: 138731},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4320, col: 35, offset: 133356},
+										pos:  position{line: 4443, col: 35, offset: 138743},
 										name: "String",
 									},
 								},
@@ -9725,27 +10019,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4334, col: 1, offset: 133685},
+			pos:  position{line: 4457, col: 1, offset: 139072},
 			expr: &choiceExpr{
-				pos: position{line: 4334, col: 13, offset: 133697},
+				pos: position{line: 4457, col: 13, offset: 139084},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4334, col: 13, offset: 133697},
+						pos: position{line: 4457, col: 13, offset: 139084},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4334, col: 13, offset: 133697},
+							pos: position{line: 4457, col: 13, offset: 139084},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4334, col: 14, offset: 133698},
+									pos: position{line: 4457, col: 14, offset: 139085},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4334, col: 14, offset: 133698},
+											pos:        position{line: 4457, col: 14, offset: 139085},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4334, col: 24, offset: 133708},
+											pos:        position{line: 4457, col: 24, offset: 139095},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9753,47 +10047,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4334, col: 29, offset: 133713},
+									pos:  position{line: 4457, col: 29, offset: 139100},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4334, col: 37, offset: 133721},
+									pos:        position{line: 4457, col: 37, offset: 139108},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4334, col: 44, offset: 133728},
+									pos:   position{line: 4457, col: 44, offset: 139115},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4334, col: 54, offset: 133738},
+										pos:  position{line: 4457, col: 54, offset: 139125},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4334, col: 64, offset: 133748},
+									pos:  position{line: 4457, col: 64, offset: 139135},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4344, col: 3, offset: 133977},
+						pos: position{line: 4467, col: 3, offset: 139364},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4344, col: 3, offset: 133977},
+							pos: position{line: 4467, col: 3, offset: 139364},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4344, col: 4, offset: 133978},
+									pos: position{line: 4467, col: 4, offset: 139365},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4344, col: 4, offset: 133978},
+											pos:        position{line: 4467, col: 4, offset: 139365},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4344, col: 14, offset: 133988},
+											pos:        position{line: 4467, col: 14, offset: 139375},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9801,38 +10095,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4344, col: 19, offset: 133993},
+									pos:  position{line: 4467, col: 19, offset: 139380},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4344, col: 27, offset: 134001},
+									pos:   position{line: 4467, col: 27, offset: 139388},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4344, col: 33, offset: 134007},
+										pos:  position{line: 4467, col: 33, offset: 139394},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4344, col: 43, offset: 134017},
+									pos:  position{line: 4467, col: 43, offset: 139404},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4351, col: 5, offset: 134169},
+						pos: position{line: 4474, col: 5, offset: 139556},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4351, col: 6, offset: 134170},
+							pos: position{line: 4474, col: 6, offset: 139557},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4351, col: 6, offset: 134170},
+									pos:        position{line: 4474, col: 6, offset: 139557},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4351, col: 16, offset: 134180},
+									pos:        position{line: 4474, col: 16, offset: 139567},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9845,77 +10139,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4360, col: 1, offset: 134317},
+			pos:  position{line: 4483, col: 1, offset: 139704},
 			expr: &choiceExpr{
-				pos: position{line: 4360, col: 14, offset: 134330},
+				pos: position{line: 4483, col: 14, offset: 139717},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4360, col: 14, offset: 134330},
+						pos: position{line: 4483, col: 14, offset: 139717},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4360, col: 14, offset: 134330},
+							pos: position{line: 4483, col: 14, offset: 139717},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4360, col: 14, offset: 134330},
+									pos:   position{line: 4483, col: 14, offset: 139717},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4360, col: 22, offset: 134338},
+										pos:  position{line: 4483, col: 22, offset: 139725},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4360, col: 36, offset: 134352},
+									pos:  position{line: 4483, col: 36, offset: 139739},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4360, col: 44, offset: 134360},
+									pos:        position{line: 4483, col: 44, offset: 139747},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4360, col: 51, offset: 134367},
+									pos:   position{line: 4483, col: 51, offset: 139754},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4360, col: 61, offset: 134377},
+										pos:  position{line: 4483, col: 61, offset: 139764},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4360, col: 71, offset: 134387},
+									pos:  position{line: 4483, col: 71, offset: 139774},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4375, col: 3, offset: 134798},
+						pos: position{line: 4498, col: 3, offset: 140185},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4375, col: 3, offset: 134798},
+							pos: position{line: 4498, col: 3, offset: 140185},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4375, col: 3, offset: 134798},
+									pos:   position{line: 4498, col: 3, offset: 140185},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4375, col: 11, offset: 134806},
+										pos:  position{line: 4498, col: 11, offset: 140193},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4375, col: 25, offset: 134820},
+									pos:  position{line: 4498, col: 25, offset: 140207},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4375, col: 33, offset: 134828},
+									pos:   position{line: 4498, col: 33, offset: 140215},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4375, col: 39, offset: 134834},
+										pos:  position{line: 4498, col: 39, offset: 140221},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4375, col: 49, offset: 134844},
+									pos:  position{line: 4498, col: 49, offset: 140231},
 									name: "R_PAREN",
 								},
 							},
@@ -9926,22 +10220,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4405, col: 1, offset: 135825},
+			pos:  position{line: 4528, col: 1, offset: 141212},
 			expr: &actionExpr{
-				pos: position{line: 4405, col: 18, offset: 135842},
+				pos: position{line: 4528, col: 18, offset: 141229},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4405, col: 18, offset: 135842},
+					pos:   position{line: 4528, col: 18, offset: 141229},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4405, col: 26, offset: 135850},
+						pos: position{line: 4528, col: 26, offset: 141237},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4405, col: 26, offset: 135850},
+								pos:  position{line: 4528, col: 26, offset: 141237},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4405, col: 42, offset: 135866},
+								pos:  position{line: 4528, col: 42, offset: 141253},
 								name: "IntegerAsString",
 							},
 						},
@@ -9951,161 +10245,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4417, col: 1, offset: 136233},
+			pos:  position{line: 4540, col: 1, offset: 141620},
 			expr: &choiceExpr{
-				pos: position{line: 4417, col: 18, offset: 136250},
+				pos: position{line: 4540, col: 18, offset: 141637},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4417, col: 18, offset: 136250},
+						pos: position{line: 4540, col: 18, offset: 141637},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4417, col: 18, offset: 136250},
+							pos: position{line: 4540, col: 18, offset: 141637},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4417, col: 18, offset: 136250},
+									pos:   position{line: 4540, col: 18, offset: 141637},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4417, col: 26, offset: 136258},
+										pos:  position{line: 4540, col: 26, offset: 141645},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4417, col: 44, offset: 136276},
+									pos:   position{line: 4540, col: 44, offset: 141663},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4417, col: 58, offset: 136290},
+										pos:  position{line: 4540, col: 58, offset: 141677},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4417, col: 72, offset: 136304},
+									pos:  position{line: 4540, col: 72, offset: 141691},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4417, col: 80, offset: 136312},
+									pos:        position{line: 4540, col: 80, offset: 141699},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4417, col: 87, offset: 136319},
+									pos:   position{line: 4540, col: 87, offset: 141706},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4417, col: 97, offset: 136329},
+										pos:  position{line: 4540, col: 97, offset: 141716},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4417, col: 107, offset: 136339},
+									pos:  position{line: 4540, col: 107, offset: 141726},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4433, col: 3, offset: 136863},
+						pos: position{line: 4556, col: 3, offset: 142250},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4433, col: 3, offset: 136863},
+							pos: position{line: 4556, col: 3, offset: 142250},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4433, col: 3, offset: 136863},
+									pos:   position{line: 4556, col: 3, offset: 142250},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4433, col: 11, offset: 136871},
+										pos:  position{line: 4556, col: 11, offset: 142258},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4433, col: 29, offset: 136889},
+									pos:   position{line: 4556, col: 29, offset: 142276},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4433, col: 43, offset: 136903},
+										pos:  position{line: 4556, col: 43, offset: 142290},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4433, col: 57, offset: 136917},
+									pos:  position{line: 4556, col: 57, offset: 142304},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4433, col: 65, offset: 136925},
+									pos:   position{line: 4556, col: 65, offset: 142312},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4433, col: 71, offset: 136931},
+										pos:  position{line: 4556, col: 71, offset: 142318},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4433, col: 81, offset: 136941},
+									pos:  position{line: 4556, col: 81, offset: 142328},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4448, col: 3, offset: 137421},
+						pos: position{line: 4571, col: 3, offset: 142808},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4448, col: 3, offset: 137421},
+							pos: position{line: 4571, col: 3, offset: 142808},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4448, col: 4, offset: 137422},
+									pos:        position{line: 4571, col: 4, offset: 142809},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4448, col: 14, offset: 137432},
+									pos:  position{line: 4571, col: 14, offset: 142819},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4448, col: 22, offset: 137440},
+									pos:   position{line: 4571, col: 22, offset: 142827},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4448, col: 28, offset: 137446},
+										pos:  position{line: 4571, col: 28, offset: 142833},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4448, col: 38, offset: 137456},
+									pos:  position{line: 4571, col: 38, offset: 142843},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4463, col: 3, offset: 137843},
+						pos: position{line: 4586, col: 3, offset: 143230},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4463, col: 3, offset: 137843},
+							pos: position{line: 4586, col: 3, offset: 143230},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4463, col: 4, offset: 137844},
+									pos:        position{line: 4586, col: 4, offset: 143231},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4463, col: 14, offset: 137854},
+									pos:  position{line: 4586, col: 14, offset: 143241},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4463, col: 22, offset: 137862},
+									pos:        position{line: 4586, col: 22, offset: 143249},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4463, col: 29, offset: 137869},
+									pos:   position{line: 4586, col: 29, offset: 143256},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4463, col: 39, offset: 137879},
+										pos:  position{line: 4586, col: 39, offset: 143266},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4463, col: 49, offset: 137889},
+									pos:  position{line: 4586, col: 49, offset: 143276},
 									name: "R_PAREN",
 								},
 							},
@@ -10116,22 +10410,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4481, col: 1, offset: 138320},
+			pos:  position{line: 4604, col: 1, offset: 143707},
 			expr: &actionExpr{
-				pos: position{line: 4481, col: 25, offset: 138344},
+				pos: position{line: 4604, col: 25, offset: 143731},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4481, col: 25, offset: 138344},
+					pos:   position{line: 4604, col: 25, offset: 143731},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4481, col: 39, offset: 138358},
+						pos: position{line: 4604, col: 39, offset: 143745},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4481, col: 39, offset: 138358},
+								pos:  position{line: 4604, col: 39, offset: 143745},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4481, col: 67, offset: 138386},
+								pos:  position{line: 4604, col: 67, offset: 143773},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -10141,43 +10435,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4485, col: 1, offset: 138449},
+			pos:  position{line: 4608, col: 1, offset: 143836},
 			expr: &actionExpr{
-				pos: position{line: 4485, col: 30, offset: 138478},
+				pos: position{line: 4608, col: 30, offset: 143865},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4485, col: 30, offset: 138478},
+					pos: position{line: 4608, col: 30, offset: 143865},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4485, col: 30, offset: 138478},
+							pos:   position{line: 4608, col: 30, offset: 143865},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4485, col: 34, offset: 138482},
+								pos:  position{line: 4608, col: 34, offset: 143869},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4485, col: 44, offset: 138492},
+							pos:   position{line: 4608, col: 44, offset: 143879},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4485, col: 48, offset: 138496},
+								pos: position{line: 4608, col: 48, offset: 143883},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4485, col: 48, offset: 138496},
+										pos:  position{line: 4608, col: 48, offset: 143883},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4485, col: 67, offset: 138515},
+										pos:  position{line: 4608, col: 67, offset: 143902},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4485, col: 87, offset: 138535},
+							pos:   position{line: 4608, col: 87, offset: 143922},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4485, col: 93, offset: 138541},
+								pos:  position{line: 4608, col: 93, offset: 143928},
 								name: "Number",
 							},
 						},
@@ -10187,15 +10481,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4498, col: 1, offset: 138775},
+			pos:  position{line: 4621, col: 1, offset: 144162},
 			expr: &actionExpr{
-				pos: position{line: 4498, col: 32, offset: 138806},
+				pos: position{line: 4621, col: 32, offset: 144193},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4498, col: 32, offset: 138806},
+					pos:   position{line: 4621, col: 32, offset: 144193},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4498, col: 38, offset: 138812},
+						pos:  position{line: 4621, col: 38, offset: 144199},
 						name: "Number",
 					},
 				},
@@ -10203,34 +10497,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4511, col: 1, offset: 139029},
+			pos:  position{line: 4634, col: 1, offset: 144416},
 			expr: &actionExpr{
-				pos: position{line: 4511, col: 26, offset: 139054},
+				pos: position{line: 4634, col: 26, offset: 144441},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4511, col: 26, offset: 139054},
+					pos: position{line: 4634, col: 26, offset: 144441},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4511, col: 26, offset: 139054},
+							pos:   position{line: 4634, col: 26, offset: 144441},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4511, col: 30, offset: 139058},
+								pos:  position{line: 4634, col: 30, offset: 144445},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4511, col: 40, offset: 139068},
+							pos:   position{line: 4634, col: 40, offset: 144455},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4511, col: 43, offset: 139071},
+								pos:  position{line: 4634, col: 43, offset: 144458},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4511, col: 60, offset: 139088},
+							pos:   position{line: 4634, col: 60, offset: 144475},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4511, col: 66, offset: 139094},
+								pos:  position{line: 4634, col: 66, offset: 144481},
 								name: "Boolean",
 							},
 						},
@@ -10240,22 +10534,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4524, col: 1, offset: 139329},
+			pos:  position{line: 4647, col: 1, offset: 144716},
 			expr: &actionExpr{
-				pos: position{line: 4524, col: 25, offset: 139353},
+				pos: position{line: 4647, col: 25, offset: 144740},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4524, col: 25, offset: 139353},
+					pos:   position{line: 4647, col: 25, offset: 144740},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4524, col: 39, offset: 139367},
+						pos: position{line: 4647, col: 39, offset: 144754},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4524, col: 39, offset: 139367},
+								pos:  position{line: 4647, col: 39, offset: 144754},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4524, col: 67, offset: 139395},
+								pos:  position{line: 4647, col: 67, offset: 144782},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -10265,41 +10559,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4528, col: 1, offset: 139458},
+			pos:  position{line: 4651, col: 1, offset: 144845},
 			expr: &actionExpr{
-				pos: position{line: 4528, col: 30, offset: 139487},
+				pos: position{line: 4651, col: 30, offset: 144874},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4528, col: 30, offset: 139487},
+					pos: position{line: 4651, col: 30, offset: 144874},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4528, col: 30, offset: 139487},
+							pos:   position{line: 4651, col: 30, offset: 144874},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4528, col: 34, offset: 139491},
+								pos:  position{line: 4651, col: 34, offset: 144878},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4528, col: 44, offset: 139501},
+							pos:   position{line: 4651, col: 44, offset: 144888},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4528, col: 47, offset: 139504},
+								pos:  position{line: 4651, col: 47, offset: 144891},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4528, col: 64, offset: 139521},
+							pos:   position{line: 4651, col: 64, offset: 144908},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4528, col: 81, offset: 139538},
+								pos: position{line: 4651, col: 81, offset: 144925},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4528, col: 81, offset: 139538},
+										pos:  position{line: 4651, col: 81, offset: 144925},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4528, col: 103, offset: 139560},
+										pos:  position{line: 4651, col: 103, offset: 144947},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10311,22 +10605,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4544, col: 1, offset: 139992},
+			pos:  position{line: 4667, col: 1, offset: 145379},
 			expr: &actionExpr{
-				pos: position{line: 4544, col: 32, offset: 140023},
+				pos: position{line: 4667, col: 32, offset: 145410},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4544, col: 32, offset: 140023},
+					pos:   position{line: 4667, col: 32, offset: 145410},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4544, col: 49, offset: 140040},
+						pos: position{line: 4667, col: 49, offset: 145427},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4544, col: 49, offset: 140040},
+								pos:  position{line: 4667, col: 49, offset: 145427},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4544, col: 71, offset: 140062},
+								pos:  position{line: 4667, col: 71, offset: 145449},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10336,33 +10630,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4561, col: 1, offset: 140573},
+			pos:  position{line: 4684, col: 1, offset: 145960},
 			expr: &actionExpr{
-				pos: position{line: 4561, col: 24, offset: 140596},
+				pos: position{line: 4684, col: 24, offset: 145983},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4561, col: 24, offset: 140596},
+					pos: position{line: 4684, col: 24, offset: 145983},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4561, col: 24, offset: 140596},
+							pos:        position{line: 4684, col: 24, offset: 145983},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4561, col: 31, offset: 140603},
+							pos:  position{line: 4684, col: 31, offset: 145990},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4561, col: 39, offset: 140611},
+							pos:   position{line: 4684, col: 39, offset: 145998},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4561, col: 45, offset: 140617},
+								pos:  position{line: 4684, col: 45, offset: 146004},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4561, col: 52, offset: 140624},
+							pos:  position{line: 4684, col: 52, offset: 146011},
 							name: "R_PAREN",
 						},
 					},
@@ -10371,49 +10665,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4570, col: 1, offset: 140861},
+			pos:  position{line: 4693, col: 1, offset: 146248},
 			expr: &choiceExpr{
-				pos: position{line: 4570, col: 26, offset: 140886},
+				pos: position{line: 4693, col: 26, offset: 146273},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4570, col: 26, offset: 140886},
+						pos: position{line: 4693, col: 26, offset: 146273},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4570, col: 26, offset: 140886},
+							pos: position{line: 4693, col: 26, offset: 146273},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4570, col: 26, offset: 140886},
+									pos:        position{line: 4693, col: 26, offset: 146273},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4570, col: 33, offset: 140893},
+									pos:  position{line: 4693, col: 33, offset: 146280},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4570, col: 41, offset: 140901},
+									pos:   position{line: 4693, col: 41, offset: 146288},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4570, col: 47, offset: 140907},
+										pos:  position{line: 4693, col: 47, offset: 146294},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4570, col: 54, offset: 140914},
+									pos:  position{line: 4693, col: 54, offset: 146301},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4579, col: 3, offset: 141104},
+						pos: position{line: 4702, col: 3, offset: 146491},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4579, col: 3, offset: 141104},
+							pos:   position{line: 4702, col: 3, offset: 146491},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4579, col: 9, offset: 141110},
+								pos:  position{line: 4702, col: 9, offset: 146497},
 								name: "String",
 							},
 						},
@@ -10423,35 +10717,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4589, col: 1, offset: 141390},
+			pos:  position{line: 4712, col: 1, offset: 146777},
 			expr: &actionExpr{
-				pos: position{line: 4589, col: 18, offset: 141407},
+				pos: position{line: 4712, col: 18, offset: 146794},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4589, col: 18, offset: 141407},
+					pos: position{line: 4712, col: 18, offset: 146794},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4589, col: 18, offset: 141407},
+							pos:   position{line: 4712, col: 18, offset: 146794},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4589, col: 24, offset: 141413},
+								pos:  position{line: 4712, col: 24, offset: 146800},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4589, col: 34, offset: 141423},
+							pos:   position{line: 4712, col: 34, offset: 146810},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4589, col: 39, offset: 141428},
+								pos: position{line: 4712, col: 39, offset: 146815},
 								expr: &seqExpr{
-									pos: position{line: 4589, col: 40, offset: 141429},
+									pos: position{line: 4712, col: 40, offset: 146816},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4589, col: 40, offset: 141429},
+											pos:  position{line: 4712, col: 40, offset: 146816},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4589, col: 46, offset: 141435},
+											pos:  position{line: 4712, col: 46, offset: 146822},
 											name: "FieldName",
 										},
 									},
@@ -10464,16 +10758,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4606, col: 1, offset: 141930},
+			pos:  position{line: 4729, col: 1, offset: 147317},
 			expr: &choiceExpr{
-				pos: position{line: 4606, col: 18, offset: 141947},
+				pos: position{line: 4729, col: 18, offset: 147334},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4606, col: 18, offset: 141947},
+						pos:  position{line: 4729, col: 18, offset: 147334},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4606, col: 38, offset: 141967},
+						pos:  position{line: 4729, col: 38, offset: 147354},
 						name: "EarliestOnly",
 					},
 				},
@@ -10481,62 +10775,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4608, col: 1, offset: 141981},
+			pos:  position{line: 4731, col: 1, offset: 147368},
 			expr: &actionExpr{
-				pos: position{line: 4608, col: 22, offset: 142002},
+				pos: position{line: 4731, col: 22, offset: 147389},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4608, col: 22, offset: 142002},
+					pos: position{line: 4731, col: 22, offset: 147389},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4608, col: 22, offset: 142002},
+							pos:  position{line: 4731, col: 22, offset: 147389},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4608, col: 35, offset: 142015},
+							pos:  position{line: 4731, col: 35, offset: 147402},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4608, col: 41, offset: 142021},
+							pos:   position{line: 4731, col: 41, offset: 147408},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4608, col: 55, offset: 142035},
+								pos: position{line: 4731, col: 55, offset: 147422},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 55, offset: 142035},
+										pos:  position{line: 4731, col: 55, offset: 147422},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 75, offset: 142055},
+										pos:  position{line: 4731, col: 75, offset: 147442},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4608, col: 94, offset: 142074},
+							pos:  position{line: 4731, col: 94, offset: 147461},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4608, col: 100, offset: 142080},
+							pos:  position{line: 4731, col: 100, offset: 147467},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4608, col: 111, offset: 142091},
+							pos:  position{line: 4731, col: 111, offset: 147478},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4608, col: 117, offset: 142097},
+							pos:   position{line: 4731, col: 117, offset: 147484},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4608, col: 129, offset: 142109},
+								pos: position{line: 4731, col: 129, offset: 147496},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 129, offset: 142109},
+										pos:  position{line: 4731, col: 129, offset: 147496},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 149, offset: 142129},
+										pos:  position{line: 4731, col: 149, offset: 147516},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10548,33 +10842,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4649, col: 1, offset: 143268},
+			pos:  position{line: 4772, col: 1, offset: 148655},
 			expr: &actionExpr{
-				pos: position{line: 4649, col: 17, offset: 143284},
+				pos: position{line: 4772, col: 17, offset: 148671},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4649, col: 17, offset: 143284},
+					pos: position{line: 4772, col: 17, offset: 148671},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4649, col: 17, offset: 143284},
+							pos:  position{line: 4772, col: 17, offset: 148671},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4649, col: 30, offset: 143297},
+							pos:  position{line: 4772, col: 30, offset: 148684},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4649, col: 36, offset: 143303},
+							pos:   position{line: 4772, col: 36, offset: 148690},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4649, col: 50, offset: 143317},
+								pos: position{line: 4772, col: 50, offset: 148704},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4649, col: 50, offset: 143317},
+										pos:  position{line: 4772, col: 50, offset: 148704},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4649, col: 70, offset: 143337},
+										pos:  position{line: 4772, col: 70, offset: 148724},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10586,24 +10880,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4677, col: 1, offset: 144045},
+			pos:  position{line: 4800, col: 1, offset: 149432},
 			expr: &actionExpr{
-				pos: position{line: 4677, col: 23, offset: 144067},
+				pos: position{line: 4800, col: 23, offset: 149454},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4677, col: 23, offset: 144067},
+					pos: position{line: 4800, col: 23, offset: 149454},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4677, col: 23, offset: 144067},
+							pos:        position{line: 4800, col: 23, offset: 149454},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4677, col: 27, offset: 144071},
+							pos: position{line: 4800, col: 27, offset: 149458},
 							expr: &charClassMatcher{
-								pos:        position{line: 4677, col: 27, offset: 144071},
+								pos:        position{line: 4800, col: 27, offset: 149458},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10616,21 +10910,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4681, col: 1, offset: 144114},
+			pos:  position{line: 4804, col: 1, offset: 149501},
 			expr: &actionExpr{
-				pos: position{line: 4681, col: 13, offset: 144126},
+				pos: position{line: 4804, col: 13, offset: 149513},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4681, col: 14, offset: 144127},
+					pos: position{line: 4804, col: 14, offset: 149514},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4681, col: 14, offset: 144127},
+							pos:        position{line: 4804, col: 14, offset: 149514},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4681, col: 17, offset: 144130},
+							pos:        position{line: 4804, col: 17, offset: 149517},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10642,15 +10936,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4685, col: 1, offset: 144173},
+			pos:  position{line: 4808, col: 1, offset: 149560},
 			expr: &actionExpr{
-				pos: position{line: 4685, col: 16, offset: 144188},
+				pos: position{line: 4808, col: 16, offset: 149575},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4685, col: 16, offset: 144188},
+					pos:   position{line: 4808, col: 16, offset: 149575},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4685, col: 26, offset: 144198},
+						pos:  position{line: 4808, col: 26, offset: 149585},
 						name: "AllTimeScale",
 					},
 				},
@@ -10658,31 +10952,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4692, col: 1, offset: 144425},
+			pos:  position{line: 4815, col: 1, offset: 149812},
 			expr: &actionExpr{
-				pos: position{line: 4692, col: 9, offset: 144433},
+				pos: position{line: 4815, col: 9, offset: 149820},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4692, col: 9, offset: 144433},
+					pos: position{line: 4815, col: 9, offset: 149820},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4692, col: 9, offset: 144433},
+							pos:        position{line: 4815, col: 9, offset: 149820},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4692, col: 13, offset: 144437},
+							pos:   position{line: 4815, col: 13, offset: 149824},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4692, col: 19, offset: 144443},
+								pos: position{line: 4815, col: 19, offset: 149830},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4692, col: 19, offset: 144443},
+										pos:  position{line: 4815, col: 19, offset: 149830},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4692, col: 30, offset: 144454},
+										pos:  position{line: 4815, col: 30, offset: 149841},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10694,26 +10988,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4696, col: 1, offset: 144502},
+			pos:  position{line: 4819, col: 1, offset: 149889},
 			expr: &actionExpr{
-				pos: position{line: 4696, col: 11, offset: 144512},
+				pos: position{line: 4819, col: 11, offset: 149899},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4696, col: 11, offset: 144512},
+					pos: position{line: 4819, col: 11, offset: 149899},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4696, col: 11, offset: 144512},
+							pos:   position{line: 4819, col: 11, offset: 149899},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4696, col: 16, offset: 144517},
+								pos:  position{line: 4819, col: 16, offset: 149904},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4696, col: 36, offset: 144537},
+							pos:   position{line: 4819, col: 36, offset: 149924},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4696, col: 43, offset: 144544},
+								pos:  position{line: 4819, col: 43, offset: 149931},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10723,44 +11017,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4724, col: 1, offset: 145283},
+			pos:  position{line: 4847, col: 1, offset: 150670},
 			expr: &actionExpr{
-				pos: position{line: 4724, col: 29, offset: 145311},
+				pos: position{line: 4847, col: 29, offset: 150698},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4724, col: 29, offset: 145311},
+					pos: position{line: 4847, col: 29, offset: 150698},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4724, col: 29, offset: 145311},
+							pos:   position{line: 4847, col: 29, offset: 150698},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4724, col: 36, offset: 145318},
+								pos: position{line: 4847, col: 36, offset: 150705},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4724, col: 36, offset: 145318},
+										pos:  position{line: 4847, col: 36, offset: 150705},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4724, col: 45, offset: 145327},
+										pos:  position{line: 4847, col: 45, offset: 150714},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4724, col: 51, offset: 145333},
+							pos:   position{line: 4847, col: 51, offset: 150720},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4724, col: 57, offset: 145339},
+								pos: position{line: 4847, col: 57, offset: 150726},
 								expr: &choiceExpr{
-									pos: position{line: 4724, col: 58, offset: 145340},
+									pos: position{line: 4847, col: 58, offset: 150727},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4724, col: 58, offset: 145340},
+											pos:  position{line: 4847, col: 58, offset: 150727},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4724, col: 67, offset: 145349},
+											pos:  position{line: 4847, col: 67, offset: 150736},
 											name: "Snap",
 										},
 									},
@@ -10773,29 +11067,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4771, col: 1, offset: 146781},
+			pos:  position{line: 4894, col: 1, offset: 152168},
 			expr: &actionExpr{
-				pos: position{line: 4771, col: 22, offset: 146802},
+				pos: position{line: 4894, col: 22, offset: 152189},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4771, col: 22, offset: 146802},
+					pos: position{line: 4894, col: 22, offset: 152189},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4771, col: 22, offset: 146802},
+							pos:   position{line: 4894, col: 22, offset: 152189},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4771, col: 34, offset: 146814},
+								pos: position{line: 4894, col: 34, offset: 152201},
 								expr: &choiceExpr{
-									pos: position{line: 4771, col: 35, offset: 146815},
+									pos: position{line: 4894, col: 35, offset: 152202},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4771, col: 35, offset: 146815},
+											pos:        position{line: 4894, col: 35, offset: 152202},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4771, col: 43, offset: 146823},
+											pos:        position{line: 4894, col: 43, offset: 152210},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10805,12 +11099,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4771, col: 49, offset: 146829},
+							pos:   position{line: 4894, col: 49, offset: 152216},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4771, col: 57, offset: 146837},
+								pos: position{line: 4894, col: 57, offset: 152224},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4771, col: 58, offset: 146838},
+									pos:  position{line: 4894, col: 58, offset: 152225},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10821,31 +11115,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4796, col: 1, offset: 147521},
+			pos:  position{line: 4919, col: 1, offset: 152908},
 			expr: &actionExpr{
-				pos: position{line: 4796, col: 39, offset: 147559},
+				pos: position{line: 4919, col: 39, offset: 152946},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4796, col: 39, offset: 147559},
+					pos: position{line: 4919, col: 39, offset: 152946},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4796, col: 39, offset: 147559},
+							pos:   position{line: 4919, col: 39, offset: 152946},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4796, col: 46, offset: 147566},
+								pos: position{line: 4919, col: 46, offset: 152953},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4796, col: 47, offset: 147567},
+									pos:  position{line: 4919, col: 47, offset: 152954},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4796, col: 56, offset: 147576},
+							pos:   position{line: 4919, col: 56, offset: 152963},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4796, col: 66, offset: 147586},
+								pos: position{line: 4919, col: 66, offset: 152973},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4796, col: 67, offset: 147587},
+									pos:  position{line: 4919, col: 67, offset: 152974},
 									name: "Snap",
 								},
 							},
@@ -10856,136 +11150,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4823, col: 1, offset: 148217},
+			pos:  position{line: 4946, col: 1, offset: 153604},
 			expr: &actionExpr{
-				pos: position{line: 4823, col: 18, offset: 148234},
+				pos: position{line: 4946, col: 18, offset: 153621},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4823, col: 18, offset: 148234},
+					pos: position{line: 4946, col: 18, offset: 153621},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 18, offset: 148234},
+							pos:        position{line: 4946, col: 18, offset: 153621},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 23, offset: 148239},
+							pos:        position{line: 4946, col: 23, offset: 153626},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 29, offset: 148245},
+							pos:        position{line: 4946, col: 29, offset: 153632},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 33, offset: 148249},
+							pos:        position{line: 4946, col: 33, offset: 153636},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 38, offset: 148254},
+							pos:        position{line: 4946, col: 38, offset: 153641},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 44, offset: 148260},
+							pos:        position{line: 4946, col: 44, offset: 153647},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 48, offset: 148264},
+							pos:        position{line: 4946, col: 48, offset: 153651},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 53, offset: 148269},
+							pos:        position{line: 4946, col: 53, offset: 153656},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 58, offset: 148274},
+							pos:        position{line: 4946, col: 58, offset: 153661},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 63, offset: 148279},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4823, col: 69, offset: 148285},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4823, col: 73, offset: 148289},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4823, col: 78, offset: 148294},
+							pos:        position{line: 4946, col: 63, offset: 153666},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 84, offset: 148300},
+							pos:        position{line: 4946, col: 69, offset: 153672},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 88, offset: 148304},
+							pos:        position{line: 4946, col: 73, offset: 153676},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 93, offset: 148309},
+							pos:        position{line: 4946, col: 78, offset: 153681},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4823, col: 99, offset: 148315},
+							pos:        position{line: 4946, col: 84, offset: 153687},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 103, offset: 148319},
+							pos:        position{line: 4946, col: 88, offset: 153691},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4823, col: 108, offset: 148324},
+							pos:        position{line: 4946, col: 93, offset: 153696},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4946, col: 99, offset: 153702},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4946, col: 103, offset: 153706},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4946, col: 108, offset: 153711},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10997,15 +11291,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4827, col: 1, offset: 148366},
+			pos:  position{line: 4950, col: 1, offset: 153753},
 			expr: &actionExpr{
-				pos: position{line: 4827, col: 22, offset: 148387},
+				pos: position{line: 4950, col: 22, offset: 153774},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4827, col: 22, offset: 148387},
+					pos:   position{line: 4950, col: 22, offset: 153774},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4827, col: 32, offset: 148397},
+						pos:  position{line: 4950, col: 32, offset: 153784},
 						name: "FullTimeStamp",
 					},
 				},
@@ -11013,18 +11307,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4838, col: 1, offset: 148840},
+			pos:  position{line: 4961, col: 1, offset: 154227},
 			expr: &choiceExpr{
-				pos: position{line: 4838, col: 14, offset: 148853},
+				pos: position{line: 4961, col: 14, offset: 154240},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4838, col: 14, offset: 148853},
+						pos: position{line: 4961, col: 14, offset: 154240},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4838, col: 14, offset: 148853},
+							pos: position{line: 4961, col: 14, offset: 154240},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4838, col: 14, offset: 148853},
+									pos:        position{line: 4961, col: 14, offset: 154240},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11032,9 +11326,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4838, col: 29, offset: 148868},
+									pos: position{line: 4961, col: 29, offset: 154255},
 									expr: &charClassMatcher{
-										pos:        position{line: 4838, col: 29, offset: 148868},
+										pos:        position{line: 4961, col: 29, offset: 154255},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11046,10 +11340,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4841, col: 3, offset: 148924},
+						pos: position{line: 4964, col: 3, offset: 154311},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4841, col: 3, offset: 148924},
+							pos:  position{line: 4964, col: 3, offset: 154311},
 							name: "QuotedString",
 						},
 					},
@@ -11058,15 +11352,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4845, col: 1, offset: 148987},
+			pos:  position{line: 4968, col: 1, offset: 154374},
 			expr: &actionExpr{
-				pos: position{line: 4845, col: 24, offset: 149010},
+				pos: position{line: 4968, col: 24, offset: 154397},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4845, col: 24, offset: 149010},
+					pos: position{line: 4968, col: 24, offset: 154397},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4845, col: 24, offset: 149010},
+							pos:        position{line: 4968, col: 24, offset: 154397},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11074,9 +11368,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4845, col: 39, offset: 149025},
+							pos: position{line: 4968, col: 39, offset: 154412},
 							expr: &charClassMatcher{
-								pos:        position{line: 4845, col: 39, offset: 149025},
+								pos:        position{line: 4968, col: 39, offset: 154412},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11090,22 +11384,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4849, col: 1, offset: 149078},
+			pos:  position{line: 4972, col: 1, offset: 154465},
 			expr: &actionExpr{
-				pos: position{line: 4849, col: 11, offset: 149088},
+				pos: position{line: 4972, col: 11, offset: 154475},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4849, col: 11, offset: 149088},
+					pos:   position{line: 4972, col: 11, offset: 154475},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4849, col: 16, offset: 149093},
+						pos: position{line: 4972, col: 16, offset: 154480},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4849, col: 16, offset: 149093},
+								pos:  position{line: 4972, col: 16, offset: 154480},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4849, col: 31, offset: 149108},
+								pos:  position{line: 4972, col: 31, offset: 154495},
 								name: "UnquotedString",
 							},
 						},
@@ -11115,38 +11409,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4853, col: 1, offset: 149149},
+			pos:  position{line: 4976, col: 1, offset: 154536},
 			expr: &actionExpr{
-				pos: position{line: 4853, col: 17, offset: 149165},
+				pos: position{line: 4976, col: 17, offset: 154552},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4853, col: 17, offset: 149165},
+					pos: position{line: 4976, col: 17, offset: 154552},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4853, col: 17, offset: 149165},
+							pos:        position{line: 4976, col: 17, offset: 154552},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4853, col: 21, offset: 149169},
+							pos: position{line: 4976, col: 21, offset: 154556},
 							expr: &choiceExpr{
-								pos: position{line: 4853, col: 22, offset: 149170},
+								pos: position{line: 4976, col: 22, offset: 154557},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4853, col: 22, offset: 149170},
+										pos: position{line: 4976, col: 22, offset: 154557},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4853, col: 22, offset: 149170},
+												pos: position{line: 4976, col: 22, offset: 154557},
 												expr: &litMatcher{
-													pos:        position{line: 4853, col: 23, offset: 149171},
+													pos:        position{line: 4976, col: 23, offset: 154558},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4853, col: 28, offset: 149176},
+												pos:        position{line: 4976, col: 28, offset: 154563},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -11155,16 +11449,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4853, col: 35, offset: 149183},
+										pos: position{line: 4976, col: 35, offset: 154570},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4853, col: 35, offset: 149183},
+												pos:        position{line: 4976, col: 35, offset: 154570},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4853, col: 40, offset: 149188,
+												line: 4976, col: 40, offset: 154575,
 											},
 										},
 									},
@@ -11172,7 +11466,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4853, col: 44, offset: 149192},
+							pos:        position{line: 4976, col: 44, offset: 154579},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11183,48 +11477,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4858, col: 1, offset: 149303},
+			pos:  position{line: 4981, col: 1, offset: 154690},
 			expr: &actionExpr{
-				pos: position{line: 4858, col: 19, offset: 149321},
+				pos: position{line: 4981, col: 19, offset: 154708},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4858, col: 19, offset: 149321},
+					pos: position{line: 4981, col: 19, offset: 154708},
 					expr: &choiceExpr{
-						pos: position{line: 4858, col: 20, offset: 149322},
+						pos: position{line: 4981, col: 20, offset: 154709},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4858, col: 20, offset: 149322},
+								pos:        position{line: 4981, col: 20, offset: 154709},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4858, col: 27, offset: 149329},
+								pos: position{line: 4981, col: 27, offset: 154716},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4858, col: 27, offset: 149329},
+										pos: position{line: 4981, col: 27, offset: 154716},
 										expr: &choiceExpr{
-											pos: position{line: 4858, col: 29, offset: 149331},
+											pos: position{line: 4981, col: 29, offset: 154718},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4858, col: 29, offset: 149331},
+													pos:  position{line: 4981, col: 29, offset: 154718},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4858, col: 43, offset: 149345},
+													pos:        position{line: 4981, col: 43, offset: 154732},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4858, col: 49, offset: 149351},
+													pos:  position{line: 4981, col: 49, offset: 154738},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4858, col: 54, offset: 149356,
+										line: 4981, col: 54, offset: 154743,
 									},
 								},
 							},
@@ -11235,12 +11529,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4865, col: 1, offset: 149471},
+			pos:  position{line: 4988, col: 1, offset: 154858},
 			expr: &choiceExpr{
-				pos: position{line: 4865, col: 16, offset: 149486},
+				pos: position{line: 4988, col: 16, offset: 154873},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4865, col: 16, offset: 149486},
+						pos:        position{line: 4988, col: 16, offset: 154873},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11248,18 +11542,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4865, col: 37, offset: 149507},
+						pos: position{line: 4988, col: 37, offset: 154894},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4865, col: 37, offset: 149507},
+								pos:        position{line: 4988, col: 37, offset: 154894},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4865, col: 41, offset: 149511},
+								pos: position{line: 4988, col: 41, offset: 154898},
 								expr: &charClassMatcher{
-									pos:        position{line: 4865, col: 41, offset: 149511},
+									pos:        position{line: 4988, col: 41, offset: 154898},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -11267,7 +11561,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4865, col: 48, offset: 149518},
+								pos:        position{line: 4988, col: 48, offset: 154905},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -11279,46 +11573,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4867, col: 1, offset: 149524},
+			pos:  position{line: 4990, col: 1, offset: 154911},
 			expr: &actionExpr{
-				pos: position{line: 4867, col: 39, offset: 149562},
+				pos: position{line: 4990, col: 39, offset: 154949},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4867, col: 39, offset: 149562},
+					pos: position{line: 4990, col: 39, offset: 154949},
 					expr: &choiceExpr{
-						pos: position{line: 4867, col: 40, offset: 149563},
+						pos: position{line: 4990, col: 40, offset: 154950},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4867, col: 40, offset: 149563},
+								pos:  position{line: 4990, col: 40, offset: 154950},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4867, col: 54, offset: 149577},
+								pos: position{line: 4990, col: 54, offset: 154964},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4867, col: 54, offset: 149577},
+										pos: position{line: 4990, col: 54, offset: 154964},
 										expr: &choiceExpr{
-											pos: position{line: 4867, col: 56, offset: 149579},
+											pos: position{line: 4990, col: 56, offset: 154966},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4867, col: 56, offset: 149579},
+													pos:  position{line: 4990, col: 56, offset: 154966},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4867, col: 70, offset: 149593},
+													pos:        position{line: 4990, col: 70, offset: 154980},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4867, col: 76, offset: 149599},
+													pos:  position{line: 4990, col: 76, offset: 154986},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4867, col: 81, offset: 149604,
+										line: 4990, col: 81, offset: 154991,
 									},
 								},
 							},
@@ -11329,21 +11623,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4871, col: 1, offset: 149644},
+			pos:  position{line: 4994, col: 1, offset: 155031},
 			expr: &actionExpr{
-				pos: position{line: 4871, col: 12, offset: 149655},
+				pos: position{line: 4994, col: 12, offset: 155042},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4871, col: 13, offset: 149656},
+					pos: position{line: 4994, col: 13, offset: 155043},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4871, col: 13, offset: 149656},
+							pos:        position{line: 4994, col: 13, offset: 155043},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4871, col: 22, offset: 149665},
+							pos:        position{line: 4994, col: 22, offset: 155052},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11354,14 +11648,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4877, col: 1, offset: 149819},
+			pos:  position{line: 5000, col: 1, offset: 155206},
 			expr: &actionExpr{
-				pos: position{line: 4877, col: 18, offset: 149836},
+				pos: position{line: 5000, col: 18, offset: 155223},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4877, col: 18, offset: 149836},
+					pos: position{line: 5000, col: 18, offset: 155223},
 					expr: &charClassMatcher{
-						pos:        position{line: 4877, col: 18, offset: 149836},
+						pos:        position{line: 5000, col: 18, offset: 155223},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11373,15 +11667,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4881, col: 1, offset: 149887},
+			pos:  position{line: 5004, col: 1, offset: 155274},
 			expr: &actionExpr{
-				pos: position{line: 4881, col: 11, offset: 149897},
+				pos: position{line: 5004, col: 11, offset: 155284},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4881, col: 11, offset: 149897},
+					pos:   position{line: 5004, col: 11, offset: 155284},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4881, col: 18, offset: 149904},
+						pos:  position{line: 5004, col: 18, offset: 155291},
 						name: "NumberAsString",
 					},
 				},
@@ -11389,59 +11683,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4887, col: 1, offset: 150093},
+			pos:  position{line: 5010, col: 1, offset: 155480},
 			expr: &actionExpr{
-				pos: position{line: 4887, col: 19, offset: 150111},
+				pos: position{line: 5010, col: 19, offset: 155498},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4887, col: 19, offset: 150111},
+					pos: position{line: 5010, col: 19, offset: 155498},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4887, col: 19, offset: 150111},
+							pos:   position{line: 5010, col: 19, offset: 155498},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4887, col: 27, offset: 150119},
+								pos: position{line: 5010, col: 27, offset: 155506},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4887, col: 27, offset: 150119},
+										pos:  position{line: 5010, col: 27, offset: 155506},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4887, col: 43, offset: 150135},
+										pos:  position{line: 5010, col: 43, offset: 155522},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4887, col: 60, offset: 150152},
+							pos: position{line: 5010, col: 60, offset: 155539},
 							expr: &choiceExpr{
-								pos: position{line: 4887, col: 62, offset: 150154},
+								pos: position{line: 5010, col: 62, offset: 155541},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4887, col: 62, offset: 150154},
+										pos:  position{line: 5010, col: 62, offset: 155541},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4887, col: 70, offset: 150162},
+										pos:        position{line: 5010, col: 70, offset: 155549},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4887, col: 76, offset: 150168},
+										pos:        position{line: 5010, col: 76, offset: 155555},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4887, col: 82, offset: 150174},
+										pos:        position{line: 5010, col: 82, offset: 155561},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4887, col: 88, offset: 150180},
+										pos:  position{line: 5010, col: 88, offset: 155567},
 										name: "EOF",
 									},
 								},
@@ -11453,17 +11747,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4893, col: 1, offset: 150309},
+			pos:  position{line: 5016, col: 1, offset: 155696},
 			expr: &actionExpr{
-				pos: position{line: 4893, col: 18, offset: 150326},
+				pos: position{line: 5016, col: 18, offset: 155713},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4893, col: 18, offset: 150326},
+					pos: position{line: 5016, col: 18, offset: 155713},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4893, col: 18, offset: 150326},
+							pos: position{line: 5016, col: 18, offset: 155713},
 							expr: &charClassMatcher{
-								pos:        position{line: 4893, col: 18, offset: 150326},
+								pos:        position{line: 5016, col: 18, offset: 155713},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11471,9 +11765,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4893, col: 24, offset: 150332},
+							pos: position{line: 5016, col: 24, offset: 155719},
 							expr: &charClassMatcher{
-								pos:        position{line: 4893, col: 24, offset: 150332},
+								pos:        position{line: 5016, col: 24, offset: 155719},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11481,15 +11775,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4893, col: 31, offset: 150339},
+							pos:        position{line: 5016, col: 31, offset: 155726},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4893, col: 35, offset: 150343},
+							pos: position{line: 5016, col: 35, offset: 155730},
 							expr: &charClassMatcher{
-								pos:        position{line: 4893, col: 35, offset: 150343},
+								pos:        position{line: 5016, col: 35, offset: 155730},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11502,17 +11796,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4898, col: 1, offset: 150438},
+			pos:  position{line: 5021, col: 1, offset: 155825},
 			expr: &actionExpr{
-				pos: position{line: 4898, col: 20, offset: 150457},
+				pos: position{line: 5021, col: 20, offset: 155844},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4898, col: 20, offset: 150457},
+					pos: position{line: 5021, col: 20, offset: 155844},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4898, col: 20, offset: 150457},
+							pos: position{line: 5021, col: 20, offset: 155844},
 							expr: &charClassMatcher{
-								pos:        position{line: 4898, col: 20, offset: 150457},
+								pos:        position{line: 5021, col: 20, offset: 155844},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11520,9 +11814,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4898, col: 26, offset: 150463},
+							pos: position{line: 5021, col: 26, offset: 155850},
 							expr: &charClassMatcher{
-								pos:        position{line: 4898, col: 26, offset: 150463},
+								pos:        position{line: 5021, col: 26, offset: 155850},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11535,14 +11829,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4902, col: 1, offset: 150506},
+			pos:  position{line: 5025, col: 1, offset: 155893},
 			expr: &actionExpr{
-				pos: position{line: 4902, col: 28, offset: 150533},
+				pos: position{line: 5025, col: 28, offset: 155920},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4902, col: 28, offset: 150533},
+					pos: position{line: 5025, col: 28, offset: 155920},
 					expr: &charClassMatcher{
-						pos:        position{line: 4902, col: 28, offset: 150533},
+						pos:        position{line: 5025, col: 28, offset: 155920},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11553,15 +11847,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4906, col: 1, offset: 150576},
+			pos:  position{line: 5029, col: 1, offset: 155963},
 			expr: &actionExpr{
-				pos: position{line: 4906, col: 20, offset: 150595},
+				pos: position{line: 5029, col: 20, offset: 155982},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4906, col: 20, offset: 150595},
+					pos:   position{line: 5029, col: 20, offset: 155982},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4906, col: 27, offset: 150602},
+						pos:  position{line: 5029, col: 27, offset: 155989},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11569,37 +11863,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4914, col: 1, offset: 150849},
+			pos:  position{line: 5037, col: 1, offset: 156236},
 			expr: &actionExpr{
-				pos: position{line: 4914, col: 21, offset: 150869},
+				pos: position{line: 5037, col: 21, offset: 156256},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4914, col: 21, offset: 150869},
+					pos: position{line: 5037, col: 21, offset: 156256},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4914, col: 21, offset: 150869},
+							pos:  position{line: 5037, col: 21, offset: 156256},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4914, col: 36, offset: 150884},
+							pos:   position{line: 5037, col: 36, offset: 156271},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4914, col: 40, offset: 150888},
+								pos: position{line: 5037, col: 40, offset: 156275},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4914, col: 40, offset: 150888},
+										pos:        position{line: 5037, col: 40, offset: 156275},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4914, col: 47, offset: 150895},
+										pos:        position{line: 5037, col: 47, offset: 156282},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4914, col: 53, offset: 150901},
+										pos:        position{line: 5037, col: 53, offset: 156288},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11608,7 +11902,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4914, col: 59, offset: 150907},
+							pos:  position{line: 5037, col: 59, offset: 156294},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11617,43 +11911,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4925, col: 1, offset: 151137},
+			pos:  position{line: 5048, col: 1, offset: 156524},
 			expr: &actionExpr{
-				pos: position{line: 4925, col: 23, offset: 151159},
+				pos: position{line: 5048, col: 23, offset: 156546},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4925, col: 23, offset: 151159},
+					pos: position{line: 5048, col: 23, offset: 156546},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4925, col: 23, offset: 151159},
+							pos:  position{line: 5048, col: 23, offset: 156546},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4925, col: 38, offset: 151174},
+							pos:   position{line: 5048, col: 38, offset: 156561},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4925, col: 42, offset: 151178},
+								pos: position{line: 5048, col: 42, offset: 156565},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4925, col: 42, offset: 151178},
+										pos:        position{line: 5048, col: 42, offset: 156565},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4925, col: 49, offset: 151185},
+										pos:        position{line: 5048, col: 49, offset: 156572},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4925, col: 55, offset: 151191},
+										pos:        position{line: 5048, col: 55, offset: 156578},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4925, col: 62, offset: 151198},
+										pos:        position{line: 5048, col: 62, offset: 156585},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11662,7 +11956,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4925, col: 67, offset: 151203},
+							pos:  position{line: 5048, col: 67, offset: 156590},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11671,30 +11965,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4933, col: 1, offset: 151386},
+			pos:  position{line: 5056, col: 1, offset: 156773},
 			expr: &choiceExpr{
-				pos: position{line: 4933, col: 25, offset: 151410},
+				pos: position{line: 5056, col: 25, offset: 156797},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4933, col: 25, offset: 151410},
+						pos: position{line: 5056, col: 25, offset: 156797},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4933, col: 25, offset: 151410},
+							pos:   position{line: 5056, col: 25, offset: 156797},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4933, col: 28, offset: 151413},
+								pos:  position{line: 5056, col: 28, offset: 156800},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4936, col: 3, offset: 151455},
+						pos: position{line: 5059, col: 3, offset: 156842},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4936, col: 3, offset: 151455},
+							pos:   position{line: 5059, col: 3, offset: 156842},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4936, col: 6, offset: 151458},
+								pos:  position{line: 5059, col: 6, offset: 156845},
 								name: "InequalityOperator",
 							},
 						},
@@ -11704,25 +11998,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4940, col: 1, offset: 151501},
+			pos:  position{line: 5063, col: 1, offset: 156888},
 			expr: &actionExpr{
-				pos: position{line: 4940, col: 11, offset: 151511},
+				pos: position{line: 5063, col: 11, offset: 156898},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4940, col: 11, offset: 151511},
+					pos: position{line: 5063, col: 11, offset: 156898},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4940, col: 11, offset: 151511},
+							pos:  position{line: 5063, col: 11, offset: 156898},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4940, col: 26, offset: 151526},
+							pos:        position{line: 5063, col: 26, offset: 156913},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4940, col: 30, offset: 151530},
+							pos:  position{line: 5063, col: 30, offset: 156917},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11731,25 +12025,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4944, col: 1, offset: 151570},
+			pos:  position{line: 5067, col: 1, offset: 156957},
 			expr: &actionExpr{
-				pos: position{line: 4944, col: 12, offset: 151581},
+				pos: position{line: 5067, col: 12, offset: 156968},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4944, col: 12, offset: 151581},
+					pos: position{line: 5067, col: 12, offset: 156968},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4944, col: 12, offset: 151581},
+							pos:  position{line: 5067, col: 12, offset: 156968},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4944, col: 27, offset: 151596},
+							pos:        position{line: 5067, col: 27, offset: 156983},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4944, col: 31, offset: 151600},
+							pos:  position{line: 5067, col: 31, offset: 156987},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11758,25 +12052,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4948, col: 1, offset: 151640},
+			pos:  position{line: 5071, col: 1, offset: 157027},
 			expr: &actionExpr{
-				pos: position{line: 4948, col: 10, offset: 151649},
+				pos: position{line: 5071, col: 10, offset: 157036},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4948, col: 10, offset: 151649},
+					pos: position{line: 5071, col: 10, offset: 157036},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4948, col: 10, offset: 151649},
+							pos:  position{line: 5071, col: 10, offset: 157036},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4948, col: 25, offset: 151664},
+							pos:        position{line: 5071, col: 25, offset: 157051},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4948, col: 29, offset: 151668},
+							pos:  position{line: 5071, col: 29, offset: 157055},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11785,25 +12079,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4952, col: 1, offset: 151708},
+			pos:  position{line: 5075, col: 1, offset: 157095},
 			expr: &actionExpr{
-				pos: position{line: 4952, col: 10, offset: 151717},
+				pos: position{line: 5075, col: 10, offset: 157104},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4952, col: 10, offset: 151717},
+					pos: position{line: 5075, col: 10, offset: 157104},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4952, col: 10, offset: 151717},
+							pos:  position{line: 5075, col: 10, offset: 157104},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4952, col: 25, offset: 151732},
+							pos:        position{line: 5075, col: 25, offset: 157119},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4952, col: 29, offset: 151736},
+							pos:  position{line: 5075, col: 29, offset: 157123},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11812,25 +12106,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4956, col: 1, offset: 151776},
+			pos:  position{line: 5079, col: 1, offset: 157163},
 			expr: &actionExpr{
-				pos: position{line: 4956, col: 10, offset: 151785},
+				pos: position{line: 5079, col: 10, offset: 157172},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4956, col: 10, offset: 151785},
+					pos: position{line: 5079, col: 10, offset: 157172},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4956, col: 10, offset: 151785},
+							pos:  position{line: 5079, col: 10, offset: 157172},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4956, col: 25, offset: 151800},
+							pos:        position{line: 5079, col: 25, offset: 157187},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4956, col: 29, offset: 151804},
+							pos:  position{line: 5079, col: 29, offset: 157191},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11839,39 +12133,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4961, col: 1, offset: 151868},
+			pos:  position{line: 5084, col: 1, offset: 157255},
 			expr: &actionExpr{
-				pos: position{line: 4961, col: 11, offset: 151878},
+				pos: position{line: 5084, col: 11, offset: 157265},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4961, col: 12, offset: 151879},
+					pos: position{line: 5084, col: 12, offset: 157266},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4961, col: 12, offset: 151879},
+							pos:        position{line: 5084, col: 12, offset: 157266},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4961, col: 24, offset: 151891},
+							pos:        position{line: 5084, col: 24, offset: 157278},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4961, col: 35, offset: 151902},
+							pos:        position{line: 5084, col: 35, offset: 157289},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4961, col: 44, offset: 151911},
+							pos:        position{line: 5084, col: 44, offset: 157298},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4961, col: 52, offset: 151919},
+							pos:        position{line: 5084, col: 52, offset: 157306},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11882,39 +12176,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4965, col: 1, offset: 151961},
+			pos:  position{line: 5088, col: 1, offset: 157348},
 			expr: &actionExpr{
-				pos: position{line: 4965, col: 11, offset: 151971},
+				pos: position{line: 5088, col: 11, offset: 157358},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4965, col: 12, offset: 151972},
+					pos: position{line: 5088, col: 12, offset: 157359},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4965, col: 12, offset: 151972},
+							pos:        position{line: 5088, col: 12, offset: 157359},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4965, col: 24, offset: 151984},
+							pos:        position{line: 5088, col: 24, offset: 157371},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4965, col: 35, offset: 151995},
+							pos:        position{line: 5088, col: 35, offset: 157382},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4965, col: 44, offset: 152004},
+							pos:        position{line: 5088, col: 44, offset: 157391},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4965, col: 52, offset: 152012},
+							pos:        position{line: 5088, col: 52, offset: 157399},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11925,39 +12219,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4969, col: 1, offset: 152054},
+			pos:  position{line: 5092, col: 1, offset: 157441},
 			expr: &actionExpr{
-				pos: position{line: 4969, col: 9, offset: 152062},
+				pos: position{line: 5092, col: 9, offset: 157449},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4969, col: 10, offset: 152063},
+					pos: position{line: 5092, col: 10, offset: 157450},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4969, col: 10, offset: 152063},
+							pos:        position{line: 5092, col: 10, offset: 157450},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4969, col: 20, offset: 152073},
+							pos:        position{line: 5092, col: 20, offset: 157460},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4969, col: 29, offset: 152082},
+							pos:        position{line: 5092, col: 29, offset: 157469},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4969, col: 37, offset: 152090},
+							pos:        position{line: 5092, col: 37, offset: 157477},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4969, col: 44, offset: 152097},
+							pos:        position{line: 5092, col: 44, offset: 157484},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11968,27 +12262,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4973, col: 1, offset: 152137},
+			pos:  position{line: 5096, col: 1, offset: 157524},
 			expr: &actionExpr{
-				pos: position{line: 4973, col: 8, offset: 152144},
+				pos: position{line: 5096, col: 8, offset: 157531},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4973, col: 9, offset: 152145},
+					pos: position{line: 5096, col: 9, offset: 157532},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4973, col: 9, offset: 152145},
+							pos:        position{line: 5096, col: 9, offset: 157532},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4973, col: 18, offset: 152154},
+							pos:        position{line: 5096, col: 18, offset: 157541},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4973, col: 26, offset: 152162},
+							pos:        position{line: 5096, col: 26, offset: 157549},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11999,27 +12293,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4977, col: 1, offset: 152201},
+			pos:  position{line: 5100, col: 1, offset: 157588},
 			expr: &actionExpr{
-				pos: position{line: 4977, col: 9, offset: 152209},
+				pos: position{line: 5100, col: 9, offset: 157596},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4977, col: 10, offset: 152210},
+					pos: position{line: 5100, col: 10, offset: 157597},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4977, col: 10, offset: 152210},
+							pos:        position{line: 5100, col: 10, offset: 157597},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4977, col: 20, offset: 152220},
+							pos:        position{line: 5100, col: 20, offset: 157607},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4977, col: 29, offset: 152229},
+							pos:        position{line: 5100, col: 29, offset: 157616},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -12030,27 +12324,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4981, col: 1, offset: 152269},
+			pos:  position{line: 5104, col: 1, offset: 157656},
 			expr: &actionExpr{
-				pos: position{line: 4981, col: 10, offset: 152278},
+				pos: position{line: 5104, col: 10, offset: 157665},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4981, col: 11, offset: 152279},
+					pos: position{line: 5104, col: 11, offset: 157666},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4981, col: 11, offset: 152279},
+							pos:        position{line: 5104, col: 11, offset: 157666},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4981, col: 22, offset: 152290},
+							pos:        position{line: 5104, col: 22, offset: 157677},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4981, col: 32, offset: 152300},
+							pos:        position{line: 5104, col: 32, offset: 157687},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -12061,39 +12355,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4985, col: 1, offset: 152343},
+			pos:  position{line: 5108, col: 1, offset: 157730},
 			expr: &actionExpr{
-				pos: position{line: 4985, col: 12, offset: 152354},
+				pos: position{line: 5108, col: 12, offset: 157741},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4985, col: 13, offset: 152355},
+					pos: position{line: 5108, col: 13, offset: 157742},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4985, col: 13, offset: 152355},
+							pos:        position{line: 5108, col: 13, offset: 157742},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4985, col: 26, offset: 152368},
+							pos:        position{line: 5108, col: 26, offset: 157755},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4985, col: 38, offset: 152380},
+							pos:        position{line: 5108, col: 38, offset: 157767},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4985, col: 47, offset: 152389},
+							pos:        position{line: 5108, col: 47, offset: 157776},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4985, col: 55, offset: 152397},
+							pos:        position{line: 5108, col: 55, offset: 157784},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -12104,39 +12398,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4989, col: 1, offset: 152440},
+			pos:  position{line: 5112, col: 1, offset: 157827},
 			expr: &actionExpr{
-				pos: position{line: 4989, col: 9, offset: 152448},
+				pos: position{line: 5112, col: 9, offset: 157835},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4989, col: 10, offset: 152449},
+					pos: position{line: 5112, col: 10, offset: 157836},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4989, col: 10, offset: 152449},
+							pos:        position{line: 5112, col: 10, offset: 157836},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4989, col: 20, offset: 152459},
+							pos:        position{line: 5112, col: 20, offset: 157846},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4989, col: 29, offset: 152468},
+							pos:        position{line: 5112, col: 29, offset: 157855},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4989, col: 37, offset: 152476},
+							pos:        position{line: 5112, col: 37, offset: 157863},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4989, col: 44, offset: 152483},
+							pos:        position{line: 5112, col: 44, offset: 157870},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -12147,33 +12441,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4994, col: 1, offset: 152615},
+			pos:  position{line: 5117, col: 1, offset: 158002},
 			expr: &actionExpr{
-				pos: position{line: 4994, col: 15, offset: 152629},
+				pos: position{line: 5117, col: 15, offset: 158016},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4994, col: 16, offset: 152630},
+					pos: position{line: 5117, col: 16, offset: 158017},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4994, col: 16, offset: 152630},
+							pos:        position{line: 5117, col: 16, offset: 158017},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4994, col: 23, offset: 152637},
+							pos:        position{line: 5117, col: 23, offset: 158024},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4994, col: 30, offset: 152644},
+							pos:        position{line: 5117, col: 30, offset: 158031},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4994, col: 37, offset: 152651},
+							pos:        position{line: 5117, col: 37, offset: 158038},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -12184,26 +12478,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 5003, col: 1, offset: 152875},
+			pos:  position{line: 5126, col: 1, offset: 158262},
 			expr: &actionExpr{
-				pos: position{line: 5003, col: 21, offset: 152895},
+				pos: position{line: 5126, col: 21, offset: 158282},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5003, col: 21, offset: 152895},
+					pos: position{line: 5126, col: 21, offset: 158282},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5003, col: 21, offset: 152895},
+							pos:  position{line: 5126, col: 21, offset: 158282},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5003, col: 26, offset: 152900},
+							pos:  position{line: 5126, col: 26, offset: 158287},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 5003, col: 42, offset: 152916},
+							pos:   position{line: 5126, col: 42, offset: 158303},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5003, col: 53, offset: 152927},
+								pos:  position{line: 5126, col: 53, offset: 158314},
 								name: "TransactionOptions",
 							},
 						},
@@ -12213,17 +12507,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 5013, col: 1, offset: 153302},
+			pos:  position{line: 5136, col: 1, offset: 158689},
 			expr: &actionExpr{
-				pos: position{line: 5013, col: 23, offset: 153324},
+				pos: position{line: 5136, col: 23, offset: 158711},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 5013, col: 23, offset: 153324},
+					pos:   position{line: 5136, col: 23, offset: 158711},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 5013, col: 34, offset: 153335},
+						pos: position{line: 5136, col: 34, offset: 158722},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5013, col: 34, offset: 153335},
+							pos:  position{line: 5136, col: 34, offset: 158722},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -12232,35 +12526,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 5028, col: 1, offset: 153726},
+			pos:  position{line: 5151, col: 1, offset: 159113},
 			expr: &actionExpr{
-				pos: position{line: 5028, col: 37, offset: 153762},
+				pos: position{line: 5151, col: 37, offset: 159149},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5028, col: 37, offset: 153762},
+					pos: position{line: 5151, col: 37, offset: 159149},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5028, col: 37, offset: 153762},
+							pos:   position{line: 5151, col: 37, offset: 159149},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5028, col: 43, offset: 153768},
+								pos:  position{line: 5151, col: 43, offset: 159155},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5028, col: 71, offset: 153796},
+							pos:   position{line: 5151, col: 71, offset: 159183},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5028, col: 76, offset: 153801},
+								pos: position{line: 5151, col: 76, offset: 159188},
 								expr: &seqExpr{
-									pos: position{line: 5028, col: 77, offset: 153802},
+									pos: position{line: 5151, col: 77, offset: 159189},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5028, col: 77, offset: 153802},
+											pos:  position{line: 5151, col: 77, offset: 159189},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5028, col: 83, offset: 153808},
+											pos:  position{line: 5151, col: 83, offset: 159195},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -12273,26 +12567,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 5063, col: 1, offset: 154797},
+			pos:  position{line: 5186, col: 1, offset: 160184},
 			expr: &actionExpr{
-				pos: position{line: 5063, col: 32, offset: 154828},
+				pos: position{line: 5186, col: 32, offset: 160215},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5063, col: 32, offset: 154828},
+					pos:   position{line: 5186, col: 32, offset: 160215},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5063, col: 40, offset: 154836},
+						pos: position{line: 5186, col: 40, offset: 160223},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5063, col: 40, offset: 154836},
+								pos:  position{line: 5186, col: 40, offset: 160223},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5063, col: 77, offset: 154873},
+								pos:  position{line: 5186, col: 77, offset: 160260},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5063, col: 96, offset: 154892},
+								pos:  position{line: 5186, col: 96, offset: 160279},
 								name: "EndsWithOption",
 							},
 						},
@@ -12302,15 +12596,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 5067, col: 1, offset: 154936},
+			pos:  position{line: 5190, col: 1, offset: 160323},
 			expr: &actionExpr{
-				pos: position{line: 5067, col: 39, offset: 154974},
+				pos: position{line: 5190, col: 39, offset: 160361},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 5067, col: 39, offset: 154974},
+					pos:   position{line: 5190, col: 39, offset: 160361},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5067, col: 46, offset: 154981},
+						pos:  position{line: 5190, col: 46, offset: 160368},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12318,28 +12612,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 5078, col: 1, offset: 155197},
+			pos:  position{line: 5201, col: 1, offset: 160584},
 			expr: &actionExpr{
-				pos: position{line: 5078, col: 21, offset: 155217},
+				pos: position{line: 5201, col: 21, offset: 160604},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5078, col: 21, offset: 155217},
+					pos: position{line: 5201, col: 21, offset: 160604},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5078, col: 21, offset: 155217},
+							pos:        position{line: 5201, col: 21, offset: 160604},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5078, col: 34, offset: 155230},
+							pos:  position{line: 5201, col: 34, offset: 160617},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5078, col: 40, offset: 155236},
+							pos:   position{line: 5201, col: 40, offset: 160623},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5078, col: 48, offset: 155244},
+								pos:  position{line: 5201, col: 48, offset: 160631},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12349,28 +12643,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 5088, col: 1, offset: 155482},
+			pos:  position{line: 5211, col: 1, offset: 160869},
 			expr: &actionExpr{
-				pos: position{line: 5088, col: 19, offset: 155500},
+				pos: position{line: 5211, col: 19, offset: 160887},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5088, col: 19, offset: 155500},
+					pos: position{line: 5211, col: 19, offset: 160887},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5088, col: 19, offset: 155500},
+							pos:        position{line: 5211, col: 19, offset: 160887},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5088, col: 30, offset: 155511},
+							pos:  position{line: 5211, col: 30, offset: 160898},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5088, col: 36, offset: 155517},
+							pos:   position{line: 5211, col: 36, offset: 160904},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5088, col: 44, offset: 155525},
+								pos:  position{line: 5211, col: 44, offset: 160912},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12380,26 +12674,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 5099, col: 1, offset: 155794},
+			pos:  position{line: 5222, col: 1, offset: 161181},
 			expr: &actionExpr{
-				pos: position{line: 5099, col: 28, offset: 155821},
+				pos: position{line: 5222, col: 28, offset: 161208},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5099, col: 28, offset: 155821},
+					pos:   position{line: 5222, col: 28, offset: 161208},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5099, col: 37, offset: 155830},
+						pos: position{line: 5222, col: 37, offset: 161217},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5099, col: 37, offset: 155830},
+								pos:  position{line: 5222, col: 37, offset: 161217},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5099, col: 63, offset: 155856},
+								pos:  position{line: 5222, col: 63, offset: 161243},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5099, col: 81, offset: 155874},
+								pos:  position{line: 5222, col: 81, offset: 161261},
 								name: "TransactionSearch",
 							},
 						},
@@ -12409,22 +12703,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 5103, col: 1, offset: 155922},
+			pos:  position{line: 5226, col: 1, offset: 161309},
 			expr: &actionExpr{
-				pos: position{line: 5103, col: 28, offset: 155949},
+				pos: position{line: 5226, col: 28, offset: 161336},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5103, col: 28, offset: 155949},
+					pos:   position{line: 5226, col: 28, offset: 161336},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 5103, col: 33, offset: 155954},
+						pos: position{line: 5226, col: 33, offset: 161341},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5103, col: 33, offset: 155954},
+								pos:  position{line: 5226, col: 33, offset: 161341},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5103, col: 64, offset: 155985},
+								pos:  position{line: 5226, col: 64, offset: 161372},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12434,29 +12728,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 5107, col: 1, offset: 156045},
+			pos:  position{line: 5230, col: 1, offset: 161432},
 			expr: &actionExpr{
-				pos: position{line: 5107, col: 38, offset: 156082},
+				pos: position{line: 5230, col: 38, offset: 161469},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 5107, col: 38, offset: 156082},
+					pos: position{line: 5230, col: 38, offset: 161469},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5107, col: 38, offset: 156082},
+							pos:        position{line: 5230, col: 38, offset: 161469},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 5107, col: 42, offset: 156086},
+							pos:   position{line: 5230, col: 42, offset: 161473},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5107, col: 55, offset: 156099},
+								pos:  position{line: 5230, col: 55, offset: 161486},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5107, col: 68, offset: 156112},
+							pos:        position{line: 5230, col: 68, offset: 161499},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12467,23 +12761,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 5115, col: 1, offset: 156251},
+			pos:  position{line: 5238, col: 1, offset: 161638},
 			expr: &actionExpr{
-				pos: position{line: 5115, col: 21, offset: 156271},
+				pos: position{line: 5238, col: 21, offset: 161658},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 5115, col: 21, offset: 156271},
+					pos: position{line: 5238, col: 21, offset: 161658},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5115, col: 21, offset: 156271},
+							pos:        position{line: 5238, col: 21, offset: 161658},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 5115, col: 25, offset: 156275},
+							pos: position{line: 5238, col: 25, offset: 161662},
 							expr: &charClassMatcher{
-								pos:        position{line: 5115, col: 25, offset: 156275},
+								pos:        position{line: 5238, col: 25, offset: 161662},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12491,7 +12785,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5115, col: 44, offset: 156294},
+							pos:        position{line: 5238, col: 44, offset: 161681},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12502,15 +12796,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 5120, col: 1, offset: 156405},
+			pos:  position{line: 5243, col: 1, offset: 161792},
 			expr: &actionExpr{
-				pos: position{line: 5120, col: 33, offset: 156437},
+				pos: position{line: 5243, col: 33, offset: 161824},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 5120, col: 33, offset: 156437},
+					pos:   position{line: 5243, col: 33, offset: 161824},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5120, col: 37, offset: 156441},
+						pos:  position{line: 5243, col: 37, offset: 161828},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12518,15 +12812,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 5128, col: 1, offset: 156596},
+			pos:  position{line: 5251, col: 1, offset: 161983},
 			expr: &actionExpr{
-				pos: position{line: 5128, col: 22, offset: 156617},
+				pos: position{line: 5251, col: 22, offset: 162004},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 5128, col: 22, offset: 156617},
+					pos:   position{line: 5251, col: 22, offset: 162004},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5128, col: 27, offset: 156622},
+						pos:  position{line: 5251, col: 27, offset: 162009},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12534,37 +12828,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 5138, col: 1, offset: 156794},
+			pos:  position{line: 5261, col: 1, offset: 162181},
 			expr: &actionExpr{
-				pos: position{line: 5138, col: 20, offset: 156813},
+				pos: position{line: 5261, col: 20, offset: 162200},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 5138, col: 20, offset: 156813},
+					pos: position{line: 5261, col: 20, offset: 162200},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5138, col: 20, offset: 156813},
+							pos:        position{line: 5261, col: 20, offset: 162200},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 27, offset: 156820},
+							pos:  position{line: 5261, col: 27, offset: 162207},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 42, offset: 156835},
+							pos:  position{line: 5261, col: 42, offset: 162222},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5138, col: 50, offset: 156843},
+							pos:   position{line: 5261, col: 50, offset: 162230},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5138, col: 60, offset: 156853},
+								pos:  position{line: 5261, col: 60, offset: 162240},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5138, col: 69, offset: 156862},
+							pos:  position{line: 5261, col: 69, offset: 162249},
 							name: "R_PAREN",
 						},
 					},
@@ -12573,22 +12867,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5148, col: 1, offset: 157165},
+			pos:  position{line: 5271, col: 1, offset: 162552},
 			expr: &actionExpr{
-				pos: position{line: 5148, col: 20, offset: 157184},
+				pos: position{line: 5271, col: 20, offset: 162571},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5148, col: 20, offset: 157184},
+					pos: position{line: 5271, col: 20, offset: 162571},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5148, col: 20, offset: 157184},
+							pos:  position{line: 5271, col: 20, offset: 162571},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5148, col: 25, offset: 157189},
+							pos:   position{line: 5271, col: 25, offset: 162576},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5148, col: 42, offset: 157206},
+								pos:  position{line: 5271, col: 42, offset: 162593},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12598,41 +12892,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5152, col: 1, offset: 157255},
+			pos:  position{line: 5275, col: 1, offset: 162642},
 			expr: &actionExpr{
-				pos: position{line: 5152, col: 16, offset: 157270},
+				pos: position{line: 5275, col: 16, offset: 162657},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5152, col: 16, offset: 157270},
+					pos: position{line: 5275, col: 16, offset: 162657},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5152, col: 16, offset: 157270},
+							pos:  position{line: 5275, col: 16, offset: 162657},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5152, col: 27, offset: 157281},
+							pos:  position{line: 5275, col: 27, offset: 162668},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5152, col: 33, offset: 157287},
+							pos:   position{line: 5275, col: 33, offset: 162674},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5152, col: 50, offset: 157304},
+								pos: position{line: 5275, col: 50, offset: 162691},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5152, col: 50, offset: 157304},
+									pos:  position{line: 5275, col: 50, offset: 162691},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5152, col: 70, offset: 157324},
+							pos:  position{line: 5275, col: 70, offset: 162711},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5152, col: 85, offset: 157339},
+							pos:   position{line: 5275, col: 85, offset: 162726},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5152, col: 91, offset: 157345},
+								pos:  position{line: 5275, col: 91, offset: 162732},
 								name: "FieldName",
 							},
 						},
@@ -12642,35 +12936,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5181, col: 1, offset: 158116},
+			pos:  position{line: 5304, col: 1, offset: 163503},
 			expr: &actionExpr{
-				pos: position{line: 5181, col: 23, offset: 158138},
+				pos: position{line: 5304, col: 23, offset: 163525},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5181, col: 23, offset: 158138},
+					pos: position{line: 5304, col: 23, offset: 163525},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5181, col: 23, offset: 158138},
+							pos:   position{line: 5304, col: 23, offset: 163525},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5181, col: 31, offset: 158146},
+								pos:  position{line: 5304, col: 31, offset: 163533},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5181, col: 46, offset: 158161},
+							pos:   position{line: 5304, col: 46, offset: 163548},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5181, col: 52, offset: 158167},
+								pos: position{line: 5304, col: 52, offset: 163554},
 								expr: &seqExpr{
-									pos: position{line: 5181, col: 53, offset: 158168},
+									pos: position{line: 5304, col: 53, offset: 163555},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5181, col: 53, offset: 158168},
+											pos:  position{line: 5304, col: 53, offset: 163555},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5181, col: 59, offset: 158174},
+											pos:  position{line: 5304, col: 59, offset: 163561},
 											name: "MVBlockOption",
 										},
 									},
@@ -12683,26 +12977,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5215, col: 1, offset: 159230},
+			pos:  position{line: 5338, col: 1, offset: 164617},
 			expr: &actionExpr{
-				pos: position{line: 5215, col: 18, offset: 159247},
+				pos: position{line: 5338, col: 18, offset: 164634},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5215, col: 18, offset: 159247},
+					pos:   position{line: 5338, col: 18, offset: 164634},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5215, col: 27, offset: 159256},
+						pos: position{line: 5338, col: 27, offset: 164643},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5215, col: 27, offset: 159256},
+								pos:  position{line: 5338, col: 27, offset: 164643},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5215, col: 41, offset: 159270},
+								pos:  position{line: 5338, col: 41, offset: 164657},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5215, col: 60, offset: 159289},
+								pos:  position{line: 5338, col: 60, offset: 164676},
 								name: "SetSvOption",
 							},
 						},
@@ -12712,22 +13006,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5219, col: 1, offset: 159330},
+			pos:  position{line: 5342, col: 1, offset: 164717},
 			expr: &actionExpr{
-				pos: position{line: 5219, col: 16, offset: 159345},
+				pos: position{line: 5342, col: 16, offset: 164732},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5219, col: 16, offset: 159345},
+					pos:   position{line: 5342, col: 16, offset: 164732},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5219, col: 28, offset: 159357},
+						pos: position{line: 5342, col: 28, offset: 164744},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5219, col: 28, offset: 159357},
+								pos:  position{line: 5342, col: 28, offset: 164744},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5219, col: 46, offset: 159375},
+								pos:  position{line: 5342, col: 46, offset: 164762},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12737,28 +13031,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5223, col: 1, offset: 159422},
+			pos:  position{line: 5346, col: 1, offset: 164809},
 			expr: &actionExpr{
-				pos: position{line: 5223, col: 20, offset: 159441},
+				pos: position{line: 5346, col: 20, offset: 164828},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5223, col: 20, offset: 159441},
+					pos: position{line: 5346, col: 20, offset: 164828},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5223, col: 20, offset: 159441},
+							pos:        position{line: 5346, col: 20, offset: 164828},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5223, col: 28, offset: 159449},
+							pos:  position{line: 5346, col: 28, offset: 164836},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5223, col: 34, offset: 159455},
+							pos:   position{line: 5346, col: 34, offset: 164842},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5223, col: 38, offset: 159459},
+								pos:  position{line: 5346, col: 38, offset: 164846},
 								name: "QuotedString",
 							},
 						},
@@ -12768,28 +13062,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5234, col: 1, offset: 159710},
+			pos:  position{line: 5357, col: 1, offset: 165097},
 			expr: &actionExpr{
-				pos: position{line: 5234, col: 19, offset: 159728},
+				pos: position{line: 5357, col: 19, offset: 165115},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5234, col: 19, offset: 159728},
+					pos: position{line: 5357, col: 19, offset: 165115},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5234, col: 19, offset: 159728},
+							pos:        position{line: 5357, col: 19, offset: 165115},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5234, col: 31, offset: 159740},
+							pos:  position{line: 5357, col: 31, offset: 165127},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5234, col: 37, offset: 159746},
+							pos:   position{line: 5357, col: 37, offset: 165133},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5234, col: 41, offset: 159750},
+								pos:  position{line: 5357, col: 41, offset: 165137},
 								name: "QuotedString",
 							},
 						},
@@ -12799,28 +13093,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5252, col: 1, offset: 160221},
+			pos:  position{line: 5375, col: 1, offset: 165608},
 			expr: &actionExpr{
-				pos: position{line: 5252, col: 21, offset: 160241},
+				pos: position{line: 5375, col: 21, offset: 165628},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5252, col: 21, offset: 160241},
+					pos: position{line: 5375, col: 21, offset: 165628},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5252, col: 21, offset: 160241},
+							pos:        position{line: 5375, col: 21, offset: 165628},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5252, col: 34, offset: 160254},
+							pos:  position{line: 5375, col: 34, offset: 165641},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5252, col: 40, offset: 160260},
+							pos:   position{line: 5375, col: 40, offset: 165647},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5252, col: 48, offset: 160268},
+								pos:  position{line: 5375, col: 48, offset: 165655},
 								name: "Boolean",
 							},
 						},
@@ -12830,28 +13124,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5264, col: 1, offset: 160508},
+			pos:  position{line: 5387, col: 1, offset: 165895},
 			expr: &actionExpr{
-				pos: position{line: 5264, col: 16, offset: 160523},
+				pos: position{line: 5387, col: 16, offset: 165910},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5264, col: 16, offset: 160523},
+					pos: position{line: 5387, col: 16, offset: 165910},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5264, col: 16, offset: 160523},
+							pos:        position{line: 5387, col: 16, offset: 165910},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5264, col: 24, offset: 160531},
+							pos:  position{line: 5387, col: 24, offset: 165918},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5264, col: 30, offset: 160537},
+							pos:   position{line: 5387, col: 30, offset: 165924},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5264, col: 38, offset: 160545},
+								pos:  position{line: 5387, col: 38, offset: 165932},
 								name: "Boolean",
 							},
 						},
@@ -12861,28 +13155,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5276, col: 1, offset: 160810},
+			pos:  position{line: 5399, col: 1, offset: 166197},
 			expr: &actionExpr{
-				pos: position{line: 5276, col: 15, offset: 160824},
+				pos: position{line: 5399, col: 15, offset: 166211},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5276, col: 15, offset: 160824},
+					pos: position{line: 5399, col: 15, offset: 166211},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5276, col: 15, offset: 160824},
+							pos:  position{line: 5399, col: 15, offset: 166211},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5276, col: 20, offset: 160829},
+							pos:  position{line: 5399, col: 20, offset: 166216},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5276, col: 30, offset: 160839},
+							pos:   position{line: 5399, col: 30, offset: 166226},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5276, col: 40, offset: 160849},
+								pos: position{line: 5399, col: 40, offset: 166236},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5276, col: 40, offset: 160849},
+									pos:  position{line: 5399, col: 40, offset: 166236},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12893,39 +13187,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5283, col: 1, offset: 160975},
+			pos:  position{line: 5406, col: 1, offset: 166362},
 			expr: &actionExpr{
-				pos: position{line: 5283, col: 23, offset: 160997},
+				pos: position{line: 5406, col: 23, offset: 166384},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5283, col: 23, offset: 160997},
+					pos: position{line: 5406, col: 23, offset: 166384},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5283, col: 23, offset: 160997},
+							pos:  position{line: 5406, col: 23, offset: 166384},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5283, col: 29, offset: 161003},
+							pos:   position{line: 5406, col: 29, offset: 166390},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5283, col: 35, offset: 161009},
+								pos:  position{line: 5406, col: 35, offset: 166396},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5283, col: 49, offset: 161023},
+							pos:   position{line: 5406, col: 49, offset: 166410},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5283, col: 54, offset: 161028},
+								pos: position{line: 5406, col: 54, offset: 166415},
 								expr: &seqExpr{
-									pos: position{line: 5283, col: 55, offset: 161029},
+									pos: position{line: 5406, col: 55, offset: 166416},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5283, col: 55, offset: 161029},
+											pos:  position{line: 5406, col: 55, offset: 166416},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5283, col: 61, offset: 161035},
+											pos:  position{line: 5406, col: 61, offset: 166422},
 											name: "SPathArgument",
 										},
 									},
@@ -12938,26 +13232,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5315, col: 1, offset: 161928},
+			pos:  position{line: 5438, col: 1, offset: 167315},
 			expr: &actionExpr{
-				pos: position{line: 5315, col: 18, offset: 161945},
+				pos: position{line: 5438, col: 18, offset: 167332},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5315, col: 18, offset: 161945},
+					pos:   position{line: 5438, col: 18, offset: 167332},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5315, col: 23, offset: 161950},
+						pos: position{line: 5438, col: 23, offset: 167337},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5315, col: 23, offset: 161950},
+								pos:  position{line: 5438, col: 23, offset: 167337},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5315, col: 36, offset: 161963},
+								pos:  position{line: 5438, col: 36, offset: 167350},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5315, col: 50, offset: 161977},
+								pos:  position{line: 5438, col: 50, offset: 167364},
 								name: "PathField",
 							},
 						},
@@ -12967,28 +13261,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5319, col: 1, offset: 162013},
+			pos:  position{line: 5442, col: 1, offset: 167400},
 			expr: &actionExpr{
-				pos: position{line: 5319, col: 15, offset: 162027},
+				pos: position{line: 5442, col: 15, offset: 167414},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5319, col: 15, offset: 162027},
+					pos: position{line: 5442, col: 15, offset: 167414},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5319, col: 15, offset: 162027},
+							pos:        position{line: 5442, col: 15, offset: 167414},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5319, col: 23, offset: 162035},
+							pos:  position{line: 5442, col: 23, offset: 167422},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5319, col: 29, offset: 162041},
+							pos:   position{line: 5442, col: 29, offset: 167428},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5319, col: 35, offset: 162047},
+								pos:  position{line: 5442, col: 35, offset: 167434},
 								name: "FieldName",
 							},
 						},
@@ -12998,28 +13292,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5322, col: 1, offset: 162103},
+			pos:  position{line: 5445, col: 1, offset: 167490},
 			expr: &actionExpr{
-				pos: position{line: 5322, col: 16, offset: 162118},
+				pos: position{line: 5445, col: 16, offset: 167505},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5322, col: 16, offset: 162118},
+					pos: position{line: 5445, col: 16, offset: 167505},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5322, col: 16, offset: 162118},
+							pos:        position{line: 5445, col: 16, offset: 167505},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5322, col: 25, offset: 162127},
+							pos:  position{line: 5445, col: 25, offset: 167514},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5322, col: 31, offset: 162133},
+							pos:   position{line: 5445, col: 31, offset: 167520},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5322, col: 37, offset: 162139},
+								pos:  position{line: 5445, col: 37, offset: 167526},
 								name: "FieldName",
 							},
 						},
@@ -13029,34 +13323,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5325, col: 1, offset: 162196},
+			pos:  position{line: 5448, col: 1, offset: 167583},
 			expr: &actionExpr{
-				pos: position{line: 5325, col: 14, offset: 162209},
+				pos: position{line: 5448, col: 14, offset: 167596},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5325, col: 15, offset: 162210},
+					pos: position{line: 5448, col: 15, offset: 167597},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5325, col: 15, offset: 162210},
+							pos: position{line: 5448, col: 15, offset: 167597},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5325, col: 15, offset: 162210},
+									pos:        position{line: 5448, col: 15, offset: 167597},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5325, col: 22, offset: 162217},
+									pos:  position{line: 5448, col: 22, offset: 167604},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5325, col: 28, offset: 162223},
+									pos:  position{line: 5448, col: 28, offset: 167610},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5325, col: 47, offset: 162242},
+							pos:  position{line: 5448, col: 47, offset: 167629},
 							name: "SPathFieldString",
 						},
 					},
@@ -13065,16 +13359,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5337, col: 1, offset: 162654},
+			pos:  position{line: 5460, col: 1, offset: 168041},
 			expr: &choiceExpr{
-				pos: position{line: 5337, col: 21, offset: 162674},
+				pos: position{line: 5460, col: 21, offset: 168061},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 21, offset: 162674},
+						pos:  position{line: 5460, col: 21, offset: 168061},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5337, col: 36, offset: 162689},
+						pos:  position{line: 5460, col: 36, offset: 168076},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -13082,28 +13376,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5340, col: 1, offset: 162762},
+			pos:  position{line: 5463, col: 1, offset: 168149},
 			expr: &actionExpr{
-				pos: position{line: 5340, col: 16, offset: 162777},
+				pos: position{line: 5463, col: 16, offset: 168164},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5340, col: 16, offset: 162777},
+					pos: position{line: 5463, col: 16, offset: 168164},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5340, col: 16, offset: 162777},
+							pos:  position{line: 5463, col: 16, offset: 168164},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5340, col: 21, offset: 162782},
+							pos:  position{line: 5463, col: 21, offset: 168169},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5340, col: 32, offset: 162793},
+							pos:   position{line: 5463, col: 32, offset: 168180},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5340, col: 46, offset: 162807},
+								pos: position{line: 5463, col: 46, offset: 168194},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5340, col: 46, offset: 162807},
+									pos:  position{line: 5463, col: 46, offset: 168194},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -13114,39 +13408,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5362, col: 1, offset: 163416},
+			pos:  position{line: 5485, col: 1, offset: 168803},
 			expr: &actionExpr{
-				pos: position{line: 5362, col: 24, offset: 163439},
+				pos: position{line: 5485, col: 24, offset: 168826},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5362, col: 24, offset: 163439},
+					pos: position{line: 5485, col: 24, offset: 168826},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5362, col: 24, offset: 163439},
+							pos:  position{line: 5485, col: 24, offset: 168826},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5362, col: 30, offset: 163445},
+							pos:   position{line: 5485, col: 30, offset: 168832},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5362, col: 37, offset: 163452},
+								pos:  position{line: 5485, col: 37, offset: 168839},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5362, col: 52, offset: 163467},
+							pos:   position{line: 5485, col: 52, offset: 168854},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5362, col: 57, offset: 163472},
+								pos: position{line: 5485, col: 57, offset: 168859},
 								expr: &seqExpr{
-									pos: position{line: 5362, col: 58, offset: 163473},
+									pos: position{line: 5485, col: 58, offset: 168860},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5362, col: 58, offset: 163473},
+											pos:  position{line: 5485, col: 58, offset: 168860},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5362, col: 64, offset: 163479},
+											pos:  position{line: 5485, col: 64, offset: 168866},
 											name: "FormatArgument",
 										},
 									},
@@ -13159,30 +13453,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5396, col: 1, offset: 164668},
+			pos:  position{line: 5519, col: 1, offset: 170055},
 			expr: &actionExpr{
-				pos: position{line: 5396, col: 19, offset: 164686},
+				pos: position{line: 5519, col: 19, offset: 170073},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5396, col: 19, offset: 164686},
+					pos:   position{line: 5519, col: 19, offset: 170073},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5396, col: 28, offset: 164695},
+						pos: position{line: 5519, col: 28, offset: 170082},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5396, col: 28, offset: 164695},
+								pos:  position{line: 5519, col: 28, offset: 170082},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5396, col: 46, offset: 164713},
+								pos:  position{line: 5519, col: 46, offset: 170100},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5396, col: 65, offset: 164732},
+								pos:  position{line: 5519, col: 65, offset: 170119},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5396, col: 82, offset: 164749},
+								pos:  position{line: 5519, col: 82, offset: 170136},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -13192,28 +13486,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5400, col: 1, offset: 164799},
+			pos:  position{line: 5523, col: 1, offset: 170186},
 			expr: &actionExpr{
-				pos: position{line: 5400, col: 20, offset: 164818},
+				pos: position{line: 5523, col: 20, offset: 170205},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5400, col: 20, offset: 164818},
+					pos: position{line: 5523, col: 20, offset: 170205},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5400, col: 20, offset: 164818},
+							pos:        position{line: 5523, col: 20, offset: 170205},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5400, col: 28, offset: 164826},
+							pos:  position{line: 5523, col: 28, offset: 170213},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5400, col: 34, offset: 164832},
+							pos:   position{line: 5523, col: 34, offset: 170219},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5400, col: 38, offset: 164836},
+								pos:  position{line: 5523, col: 38, offset: 170223},
 								name: "QuotedString",
 							},
 						},
@@ -13223,28 +13517,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5409, col: 1, offset: 165048},
+			pos:  position{line: 5532, col: 1, offset: 170435},
 			expr: &actionExpr{
-				pos: position{line: 5409, col: 21, offset: 165068},
+				pos: position{line: 5532, col: 21, offset: 170455},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5409, col: 21, offset: 165068},
+					pos: position{line: 5532, col: 21, offset: 170455},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5409, col: 21, offset: 165068},
+							pos:        position{line: 5532, col: 21, offset: 170455},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5409, col: 34, offset: 165081},
+							pos:  position{line: 5532, col: 34, offset: 170468},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5409, col: 40, offset: 165087},
+							pos:   position{line: 5532, col: 40, offset: 170474},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5409, col: 47, offset: 165094},
+								pos:  position{line: 5532, col: 47, offset: 170481},
 								name: "IntegerAsString",
 							},
 						},
@@ -13254,28 +13548,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5422, col: 1, offset: 165500},
+			pos:  position{line: 5545, col: 1, offset: 170887},
 			expr: &actionExpr{
-				pos: position{line: 5422, col: 19, offset: 165518},
+				pos: position{line: 5545, col: 19, offset: 170905},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5422, col: 19, offset: 165518},
+					pos: position{line: 5545, col: 19, offset: 170905},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5422, col: 19, offset: 165518},
+							pos:        position{line: 5545, col: 19, offset: 170905},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5422, col: 30, offset: 165529},
+							pos:  position{line: 5545, col: 30, offset: 170916},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5422, col: 36, offset: 165535},
+							pos:   position{line: 5545, col: 36, offset: 170922},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5422, col: 40, offset: 165539},
+								pos:  position{line: 5545, col: 40, offset: 170926},
 								name: "QuotedString",
 							},
 						},
@@ -13285,78 +13579,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5431, col: 1, offset: 165754},
+			pos:  position{line: 5554, col: 1, offset: 171141},
 			expr: &actionExpr{
-				pos: position{line: 5431, col: 24, offset: 165777},
+				pos: position{line: 5554, col: 24, offset: 171164},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5431, col: 24, offset: 165777},
+					pos: position{line: 5554, col: 24, offset: 171164},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5431, col: 24, offset: 165777},
+							pos:   position{line: 5554, col: 24, offset: 171164},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 34, offset: 165787},
+								pos:  position{line: 5554, col: 34, offset: 171174},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5431, col: 47, offset: 165800},
+							pos:  position{line: 5554, col: 47, offset: 171187},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5431, col: 53, offset: 165806},
+							pos:   position{line: 5554, col: 53, offset: 171193},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 63, offset: 165816},
+								pos:  position{line: 5554, col: 63, offset: 171203},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5431, col: 76, offset: 165829},
+							pos:  position{line: 5554, col: 76, offset: 171216},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5431, col: 82, offset: 165835},
+							pos:   position{line: 5554, col: 82, offset: 171222},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 95, offset: 165848},
+								pos:  position{line: 5554, col: 95, offset: 171235},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5431, col: 108, offset: 165861},
+							pos:  position{line: 5554, col: 108, offset: 171248},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5431, col: 114, offset: 165867},
+							pos:   position{line: 5554, col: 114, offset: 171254},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 121, offset: 165874},
+								pos:  position{line: 5554, col: 121, offset: 171261},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5431, col: 134, offset: 165887},
+							pos:  position{line: 5554, col: 134, offset: 171274},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5431, col: 140, offset: 165893},
+							pos:   position{line: 5554, col: 140, offset: 171280},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 153, offset: 165906},
+								pos:  position{line: 5554, col: 153, offset: 171293},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5431, col: 166, offset: 165919},
+							pos:  position{line: 5554, col: 166, offset: 171306},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5431, col: 172, offset: 165925},
+							pos:   position{line: 5554, col: 172, offset: 171312},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5431, col: 179, offset: 165932},
+								pos:  position{line: 5554, col: 179, offset: 171319},
 								name: "QuotedString",
 							},
 						},
@@ -13366,28 +13660,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5449, col: 1, offset: 166508},
+			pos:  position{line: 5572, col: 1, offset: 171895},
 			expr: &actionExpr{
-				pos: position{line: 5449, col: 20, offset: 166527},
+				pos: position{line: 5572, col: 20, offset: 171914},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5449, col: 20, offset: 166527},
+					pos: position{line: 5572, col: 20, offset: 171914},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5449, col: 20, offset: 166527},
+							pos:  position{line: 5572, col: 20, offset: 171914},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5449, col: 25, offset: 166532},
+							pos:  position{line: 5572, col: 25, offset: 171919},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5449, col: 40, offset: 166547},
+							pos:   position{line: 5572, col: 40, offset: 171934},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5449, col: 55, offset: 166562},
+								pos: position{line: 5572, col: 55, offset: 171949},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5449, col: 55, offset: 166562},
+									pos:  position{line: 5572, col: 55, offset: 171949},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13398,42 +13692,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5456, col: 1, offset: 166715},
+			pos:  position{line: 5579, col: 1, offset: 172102},
 			expr: &actionExpr{
-				pos: position{line: 5456, col: 28, offset: 166742},
+				pos: position{line: 5579, col: 28, offset: 172129},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5456, col: 28, offset: 166742},
+					pos: position{line: 5579, col: 28, offset: 172129},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5456, col: 28, offset: 166742},
+							pos:  position{line: 5579, col: 28, offset: 172129},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5456, col: 34, offset: 166748},
+							pos:   position{line: 5579, col: 34, offset: 172135},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5456, col: 40, offset: 166754},
+								pos: position{line: 5579, col: 40, offset: 172141},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5456, col: 40, offset: 166754},
+									pos:  position{line: 5579, col: 40, offset: 172141},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5456, col: 60, offset: 166774},
+							pos:   position{line: 5579, col: 60, offset: 172161},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5456, col: 65, offset: 166779},
+								pos: position{line: 5579, col: 65, offset: 172166},
 								expr: &seqExpr{
-									pos: position{line: 5456, col: 66, offset: 166780},
+									pos: position{line: 5579, col: 66, offset: 172167},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5456, col: 66, offset: 166780},
+											pos:  position{line: 5579, col: 66, offset: 172167},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5456, col: 72, offset: 166786},
+											pos:  position{line: 5579, col: 72, offset: 172173},
 											name: "EventCountArgument",
 										},
 									},
@@ -13446,30 +13740,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5512, col: 1, offset: 168663},
+			pos:  position{line: 5635, col: 1, offset: 174050},
 			expr: &actionExpr{
-				pos: position{line: 5512, col: 23, offset: 168685},
+				pos: position{line: 5635, col: 23, offset: 174072},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5512, col: 23, offset: 168685},
+					pos:   position{line: 5635, col: 23, offset: 174072},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5512, col: 28, offset: 168690},
+						pos: position{line: 5635, col: 28, offset: 174077},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5512, col: 28, offset: 168690},
+								pos:  position{line: 5635, col: 28, offset: 174077},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5512, col: 41, offset: 168703},
+								pos:  position{line: 5635, col: 41, offset: 174090},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5512, col: 58, offset: 168720},
+								pos:  position{line: 5635, col: 58, offset: 174107},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5512, col: 76, offset: 168738},
+								pos:  position{line: 5635, col: 76, offset: 174125},
 								name: "ListVixField",
 							},
 						},
@@ -13479,28 +13773,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5516, col: 1, offset: 168777},
+			pos:  position{line: 5639, col: 1, offset: 174164},
 			expr: &actionExpr{
-				pos: position{line: 5516, col: 15, offset: 168791},
+				pos: position{line: 5639, col: 15, offset: 174178},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5516, col: 15, offset: 168791},
+					pos: position{line: 5639, col: 15, offset: 174178},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5516, col: 15, offset: 168791},
+							pos:        position{line: 5639, col: 15, offset: 174178},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5516, col: 23, offset: 168799},
+							pos:  position{line: 5639, col: 23, offset: 174186},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5516, col: 29, offset: 168805},
+							pos:   position{line: 5639, col: 29, offset: 174192},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5516, col: 35, offset: 168811},
+								pos:  position{line: 5639, col: 35, offset: 174198},
 								name: "IndexName",
 							},
 						},
@@ -13510,28 +13804,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5519, col: 1, offset: 168867},
+			pos:  position{line: 5642, col: 1, offset: 174254},
 			expr: &actionExpr{
-				pos: position{line: 5519, col: 19, offset: 168885},
+				pos: position{line: 5642, col: 19, offset: 174272},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5519, col: 19, offset: 168885},
+					pos: position{line: 5642, col: 19, offset: 174272},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5519, col: 19, offset: 168885},
+							pos:        position{line: 5642, col: 19, offset: 174272},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5519, col: 31, offset: 168897},
+							pos:  position{line: 5642, col: 31, offset: 174284},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5519, col: 37, offset: 168903},
+							pos:   position{line: 5642, col: 37, offset: 174290},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5519, col: 43, offset: 168909},
+								pos:  position{line: 5642, col: 43, offset: 174296},
 								name: "Boolean",
 							},
 						},
@@ -13541,28 +13835,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5522, col: 1, offset: 168985},
+			pos:  position{line: 5645, col: 1, offset: 174372},
 			expr: &actionExpr{
-				pos: position{line: 5522, col: 20, offset: 169004},
+				pos: position{line: 5645, col: 20, offset: 174391},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5522, col: 20, offset: 169004},
+					pos: position{line: 5645, col: 20, offset: 174391},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5522, col: 20, offset: 169004},
+							pos:        position{line: 5645, col: 20, offset: 174391},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5522, col: 34, offset: 169018},
+							pos:  position{line: 5645, col: 34, offset: 174405},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5522, col: 40, offset: 169024},
+							pos:   position{line: 5645, col: 40, offset: 174411},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5522, col: 46, offset: 169030},
+								pos:  position{line: 5645, col: 46, offset: 174417},
 								name: "Boolean",
 							},
 						},
@@ -13572,28 +13866,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5525, col: 1, offset: 169108},
+			pos:  position{line: 5648, col: 1, offset: 174495},
 			expr: &actionExpr{
-				pos: position{line: 5525, col: 17, offset: 169124},
+				pos: position{line: 5648, col: 17, offset: 174511},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5525, col: 17, offset: 169124},
+					pos: position{line: 5648, col: 17, offset: 174511},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5525, col: 17, offset: 169124},
+							pos:        position{line: 5648, col: 17, offset: 174511},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5525, col: 28, offset: 169135},
+							pos:  position{line: 5648, col: 28, offset: 174522},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5525, col: 34, offset: 169141},
+							pos:   position{line: 5648, col: 34, offset: 174528},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5525, col: 40, offset: 169147},
+								pos:  position{line: 5648, col: 40, offset: 174534},
 								name: "Boolean",
 							},
 						},
@@ -13603,24 +13897,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5529, col: 1, offset: 169223},
+			pos:  position{line: 5652, col: 1, offset: 174610},
 			expr: &actionExpr{
-				pos: position{line: 5529, col: 14, offset: 169236},
+				pos: position{line: 5652, col: 14, offset: 174623},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5529, col: 14, offset: 169236},
+					pos: position{line: 5652, col: 14, offset: 174623},
 					expr: &seqExpr{
-						pos: position{line: 5529, col: 15, offset: 169237},
+						pos: position{line: 5652, col: 15, offset: 174624},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5529, col: 15, offset: 169237},
+								pos: position{line: 5652, col: 15, offset: 174624},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5529, col: 16, offset: 169238},
+									pos:  position{line: 5652, col: 16, offset: 174625},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5529, col: 22, offset: 169244,
+								line: 5652, col: 22, offset: 174631,
 							},
 						},
 					},
@@ -13629,39 +13923,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5534, col: 1, offset: 169317},
+			pos:  position{line: 5657, col: 1, offset: 174704},
 			expr: &actionExpr{
-				pos: position{line: 5534, col: 18, offset: 169334},
+				pos: position{line: 5657, col: 18, offset: 174721},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5534, col: 18, offset: 169334},
+					pos: position{line: 5657, col: 18, offset: 174721},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5534, col: 18, offset: 169334},
+							pos:  position{line: 5657, col: 18, offset: 174721},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5534, col: 23, offset: 169339},
+							pos:  position{line: 5657, col: 23, offset: 174726},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5534, col: 36, offset: 169352},
+							pos:   position{line: 5657, col: 36, offset: 174739},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5534, col: 49, offset: 169365},
+								pos: position{line: 5657, col: 49, offset: 174752},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5534, col: 49, offset: 169365},
+									pos:  position{line: 5657, col: 49, offset: 174752},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5534, col: 70, offset: 169386},
+							pos:   position{line: 5657, col: 70, offset: 174773},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5534, col: 77, offset: 169393},
+								pos: position{line: 5657, col: 77, offset: 174780},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5534, col: 77, offset: 169393},
+									pos:  position{line: 5657, col: 77, offset: 174780},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13672,32 +13966,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5564, col: 1, offset: 170156},
+			pos:  position{line: 5687, col: 1, offset: 175543},
 			expr: &actionExpr{
-				pos: position{line: 5564, col: 24, offset: 170179},
+				pos: position{line: 5687, col: 24, offset: 175566},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5564, col: 24, offset: 170179},
+					pos: position{line: 5687, col: 24, offset: 175566},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5564, col: 24, offset: 170179},
+							pos:  position{line: 5687, col: 24, offset: 175566},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5564, col: 30, offset: 170185},
+							pos:        position{line: 5687, col: 30, offset: 175572},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5564, col: 38, offset: 170193},
+							pos:  position{line: 5687, col: 38, offset: 175580},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5564, col: 44, offset: 170199},
+							pos:   position{line: 5687, col: 44, offset: 175586},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5564, col: 48, offset: 170203},
+								pos:  position{line: 5687, col: 48, offset: 175590},
 								name: "String",
 							},
 						},
@@ -13707,22 +14001,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5568, col: 1, offset: 170249},
+			pos:  position{line: 5691, col: 1, offset: 175636},
 			expr: &actionExpr{
-				pos: position{line: 5568, col: 22, offset: 170270},
+				pos: position{line: 5691, col: 22, offset: 175657},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5568, col: 22, offset: 170270},
+					pos: position{line: 5691, col: 22, offset: 175657},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5568, col: 22, offset: 170270},
+							pos:  position{line: 5691, col: 22, offset: 175657},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5568, col: 28, offset: 170276},
+							pos:   position{line: 5691, col: 28, offset: 175663},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5568, col: 38, offset: 170286},
+								pos:  position{line: 5691, col: 38, offset: 175673},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13732,36 +14026,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5572, col: 1, offset: 170345},
+			pos:  position{line: 5695, col: 1, offset: 175732},
 			expr: &actionExpr{
-				pos: position{line: 5572, col: 18, offset: 170362},
+				pos: position{line: 5695, col: 18, offset: 175749},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5572, col: 18, offset: 170362},
+					pos: position{line: 5695, col: 18, offset: 175749},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5572, col: 18, offset: 170362},
+							pos:  position{line: 5695, col: 18, offset: 175749},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5572, col: 23, offset: 170367},
+							pos:  position{line: 5695, col: 23, offset: 175754},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5572, col: 36, offset: 170380},
+							pos:   position{line: 5695, col: 36, offset: 175767},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5572, col: 42, offset: 170386},
+								pos:  position{line: 5695, col: 42, offset: 175773},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5572, col: 56, offset: 170400},
+							pos:   position{line: 5695, col: 56, offset: 175787},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5572, col: 65, offset: 170409},
+								pos: position{line: 5695, col: 65, offset: 175796},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5572, col: 65, offset: 170409},
+									pos:  position{line: 5695, col: 65, offset: 175796},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13772,22 +14066,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5601, col: 1, offset: 171185},
+			pos:  position{line: 5724, col: 1, offset: 176572},
 			expr: &actionExpr{
-				pos: position{line: 5601, col: 18, offset: 171202},
+				pos: position{line: 5724, col: 18, offset: 176589},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5601, col: 18, offset: 171202},
+					pos: position{line: 5724, col: 18, offset: 176589},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5601, col: 18, offset: 171202},
+							pos:  position{line: 5724, col: 18, offset: 176589},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5601, col: 24, offset: 171208},
+							pos:   position{line: 5724, col: 24, offset: 176595},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5601, col: 34, offset: 171218},
+								pos:  position{line: 5724, col: 34, offset: 176605},
 								name: "FieldName",
 							},
 						},
@@ -13797,32 +14091,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5605, col: 1, offset: 171259},
+			pos:  position{line: 5728, col: 1, offset: 176646},
 			expr: &actionExpr{
-				pos: position{line: 5605, col: 18, offset: 171276},
+				pos: position{line: 5728, col: 18, offset: 176663},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5605, col: 18, offset: 171276},
+					pos: position{line: 5728, col: 18, offset: 176663},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5605, col: 18, offset: 171276},
+							pos:  position{line: 5728, col: 18, offset: 176663},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5605, col: 24, offset: 171282},
+							pos:        position{line: 5728, col: 24, offset: 176669},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5605, col: 32, offset: 171290},
+							pos:  position{line: 5728, col: 32, offset: 176677},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5605, col: 38, offset: 171296},
+							pos:   position{line: 5728, col: 38, offset: 176683},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5605, col: 47, offset: 171305},
+								pos:  position{line: 5728, col: 47, offset: 176692},
 								name: "IntegerAsString",
 							},
 						},
@@ -13832,26 +14126,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5609, col: 1, offset: 171351},
+			pos:  position{line: 5732, col: 1, offset: 176738},
 			expr: &actionExpr{
-				pos: position{line: 5609, col: 16, offset: 171366},
+				pos: position{line: 5732, col: 16, offset: 176753},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5609, col: 16, offset: 171366},
+					pos: position{line: 5732, col: 16, offset: 176753},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5609, col: 16, offset: 171366},
+							pos:  position{line: 5732, col: 16, offset: 176753},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5609, col: 22, offset: 171372},
+							pos:  position{line: 5732, col: 22, offset: 176759},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5609, col: 32, offset: 171382},
+							pos:   position{line: 5732, col: 32, offset: 176769},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5609, col: 42, offset: 171392},
+								pos:  position{line: 5732, col: 42, offset: 176779},
 								name: "BoolExpr",
 							},
 						},
@@ -13861,28 +14155,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5613, col: 1, offset: 171452},
+			pos:  position{line: 5736, col: 1, offset: 176839},
 			expr: &actionExpr{
-				pos: position{line: 5613, col: 28, offset: 171479},
+				pos: position{line: 5736, col: 28, offset: 176866},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5613, col: 28, offset: 171479},
+					pos: position{line: 5736, col: 28, offset: 176866},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5613, col: 28, offset: 171479},
+							pos:        position{line: 5736, col: 28, offset: 176866},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5613, col: 37, offset: 171488},
+							pos:  position{line: 5736, col: 37, offset: 176875},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5613, col: 43, offset: 171494},
+							pos:   position{line: 5736, col: 43, offset: 176881},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5613, col: 51, offset: 171502},
+								pos:  position{line: 5736, col: 51, offset: 176889},
 								name: "Boolean",
 							},
 						},
@@ -13892,28 +14186,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5622, col: 1, offset: 171686},
+			pos:  position{line: 5745, col: 1, offset: 177073},
 			expr: &actionExpr{
-				pos: position{line: 5622, col: 28, offset: 171713},
+				pos: position{line: 5745, col: 28, offset: 177100},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5622, col: 28, offset: 171713},
+					pos: position{line: 5745, col: 28, offset: 177100},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5622, col: 28, offset: 171713},
+							pos:        position{line: 5745, col: 28, offset: 177100},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5622, col: 37, offset: 171722},
+							pos:  position{line: 5745, col: 37, offset: 177109},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5622, col: 43, offset: 171728},
+							pos:   position{line: 5745, col: 43, offset: 177115},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5622, col: 51, offset: 171736},
+								pos:  position{line: 5745, col: 51, offset: 177123},
 								name: "Boolean",
 							},
 						},
@@ -13923,28 +14217,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5631, col: 1, offset: 171920},
+			pos:  position{line: 5754, col: 1, offset: 177307},
 			expr: &actionExpr{
-				pos: position{line: 5631, col: 27, offset: 171946},
+				pos: position{line: 5754, col: 27, offset: 177333},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5631, col: 27, offset: 171946},
+					pos: position{line: 5754, col: 27, offset: 177333},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5631, col: 27, offset: 171946},
+							pos:        position{line: 5754, col: 27, offset: 177333},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5631, col: 35, offset: 171954},
+							pos:  position{line: 5754, col: 35, offset: 177341},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5631, col: 41, offset: 171960},
+							pos:   position{line: 5754, col: 41, offset: 177347},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5631, col: 48, offset: 171967},
+								pos:  position{line: 5754, col: 48, offset: 177354},
 								name: "PositiveInteger",
 							},
 						},
@@ -13954,28 +14248,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5640, col: 1, offset: 172158},
+			pos:  position{line: 5763, col: 1, offset: 177545},
 			expr: &actionExpr{
-				pos: position{line: 5640, col: 25, offset: 172182},
+				pos: position{line: 5763, col: 25, offset: 177569},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5640, col: 25, offset: 172182},
+					pos: position{line: 5763, col: 25, offset: 177569},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5640, col: 25, offset: 172182},
+							pos:        position{line: 5763, col: 25, offset: 177569},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5640, col: 31, offset: 172188},
+							pos:  position{line: 5763, col: 31, offset: 177575},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5640, col: 37, offset: 172194},
+							pos:   position{line: 5763, col: 37, offset: 177581},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5640, col: 44, offset: 172201},
+								pos:  position{line: 5763, col: 44, offset: 177588},
 								name: "PositiveInteger",
 							},
 						},
@@ -13985,30 +14279,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5649, col: 1, offset: 172388},
+			pos:  position{line: 5772, col: 1, offset: 177775},
 			expr: &actionExpr{
-				pos: position{line: 5649, col: 22, offset: 172409},
+				pos: position{line: 5772, col: 22, offset: 177796},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5649, col: 22, offset: 172409},
+					pos:   position{line: 5772, col: 22, offset: 177796},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5649, col: 41, offset: 172428},
+						pos: position{line: 5772, col: 41, offset: 177815},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5649, col: 41, offset: 172428},
+								pos:  position{line: 5772, col: 41, offset: 177815},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5649, col: 67, offset: 172454},
+								pos:  position{line: 5772, col: 67, offset: 177841},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5649, col: 93, offset: 172480},
+								pos:  position{line: 5772, col: 93, offset: 177867},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5649, col: 118, offset: 172505},
+								pos:  position{line: 5772, col: 118, offset: 177892},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -14018,35 +14312,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5653, col: 1, offset: 172566},
+			pos:  position{line: 5776, col: 1, offset: 177953},
 			expr: &actionExpr{
-				pos: position{line: 5653, col: 26, offset: 172591},
+				pos: position{line: 5776, col: 26, offset: 177978},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5653, col: 26, offset: 172591},
+					pos: position{line: 5776, col: 26, offset: 177978},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5653, col: 26, offset: 172591},
+							pos:   position{line: 5776, col: 26, offset: 177978},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5653, col: 34, offset: 172599},
+								pos:  position{line: 5776, col: 34, offset: 177986},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5653, col: 53, offset: 172618},
+							pos:   position{line: 5776, col: 53, offset: 178005},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5653, col: 58, offset: 172623},
+								pos: position{line: 5776, col: 58, offset: 178010},
 								expr: &seqExpr{
-									pos: position{line: 5653, col: 59, offset: 172624},
+									pos: position{line: 5776, col: 59, offset: 178011},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5653, col: 59, offset: 172624},
+											pos:  position{line: 5776, col: 59, offset: 178011},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5653, col: 65, offset: 172630},
+											pos:  position{line: 5776, col: 65, offset: 178017},
 											name: "InputLookupOption",
 										},
 									},
@@ -14059,35 +14353,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5695, col: 1, offset: 174076},
+			pos:  position{line: 5818, col: 1, offset: 179463},
 			expr: &actionExpr{
-				pos: position{line: 5695, col: 21, offset: 174096},
+				pos: position{line: 5818, col: 21, offset: 179483},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5695, col: 21, offset: 174096},
+					pos: position{line: 5818, col: 21, offset: 179483},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5695, col: 21, offset: 174096},
+							pos:  position{line: 5818, col: 21, offset: 179483},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5695, col: 26, offset: 174101},
+							pos:  position{line: 5818, col: 26, offset: 179488},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 42, offset: 174117},
+							pos:   position{line: 5818, col: 42, offset: 179504},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5695, col: 60, offset: 174135},
+								pos: position{line: 5818, col: 60, offset: 179522},
 								expr: &seqExpr{
-									pos: position{line: 5695, col: 61, offset: 174136},
+									pos: position{line: 5818, col: 61, offset: 179523},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5695, col: 61, offset: 174136},
+											pos:  position{line: 5818, col: 61, offset: 179523},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5695, col: 83, offset: 174158},
+											pos:  position{line: 5818, col: 83, offset: 179545},
 											name: "SPACE",
 										},
 									},
@@ -14095,20 +14389,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 91, offset: 174166},
+							pos:   position{line: 5818, col: 91, offset: 179553},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5695, col: 101, offset: 174176},
+								pos:  position{line: 5818, col: 101, offset: 179563},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 109, offset: 174184},
+							pos:   position{line: 5818, col: 109, offset: 179571},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5695, col: 121, offset: 174196},
+								pos: position{line: 5818, col: 121, offset: 179583},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5695, col: 122, offset: 174197},
+									pos:  position{line: 5818, col: 122, offset: 179584},
 									name: "WhereClause",
 								},
 							},
@@ -14119,15 +14413,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5718, col: 1, offset: 174885},
+			pos:  position{line: 5841, col: 1, offset: 180272},
 			expr: &actionExpr{
-				pos: position{line: 5718, col: 24, offset: 174908},
+				pos: position{line: 5841, col: 24, offset: 180295},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5718, col: 24, offset: 174908},
+					pos:   position{line: 5841, col: 24, offset: 180295},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5718, col: 41, offset: 174925},
+						pos:  position{line: 5841, col: 41, offset: 180312},
 						name: "InputLookupBlock",
 					},
 				},
@@ -14135,26 +14429,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5729, col: 1, offset: 175324},
+			pos:  position{line: 5852, col: 1, offset: 180711},
 			expr: &actionExpr{
-				pos: position{line: 5729, col: 20, offset: 175343},
+				pos: position{line: 5852, col: 20, offset: 180730},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5729, col: 20, offset: 175343},
+					pos:   position{line: 5852, col: 20, offset: 180730},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5729, col: 28, offset: 175351},
+						pos: position{line: 5852, col: 28, offset: 180738},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5729, col: 28, offset: 175351},
+								pos:  position{line: 5852, col: 28, offset: 180738},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5729, col: 52, offset: 175375},
+								pos:  position{line: 5852, col: 52, offset: 180762},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5729, col: 68, offset: 175391},
+								pos:  position{line: 5852, col: 68, offset: 180778},
 								name: "MaxOutOption",
 							},
 						},
@@ -14164,28 +14458,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5734, col: 1, offset: 175489},
+			pos:  position{line: 5857, col: 1, offset: 180876},
 			expr: &actionExpr{
-				pos: position{line: 5734, col: 26, offset: 175514},
+				pos: position{line: 5857, col: 26, offset: 180901},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5734, col: 26, offset: 175514},
+					pos: position{line: 5857, col: 26, offset: 180901},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5734, col: 26, offset: 175514},
+							pos:        position{line: 5857, col: 26, offset: 180901},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5734, col: 44, offset: 175532},
+							pos:  position{line: 5857, col: 44, offset: 180919},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5734, col: 50, offset: 175538},
+							pos:   position{line: 5857, col: 50, offset: 180925},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5734, col: 58, offset: 175546},
+								pos:  position{line: 5857, col: 58, offset: 180933},
 								name: "Boolean",
 							},
 						},
@@ -14195,28 +14489,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5741, col: 1, offset: 175685},
+			pos:  position{line: 5864, col: 1, offset: 181072},
 			expr: &actionExpr{
-				pos: position{line: 5741, col: 18, offset: 175702},
+				pos: position{line: 5864, col: 18, offset: 181089},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5741, col: 18, offset: 175702},
+					pos: position{line: 5864, col: 18, offset: 181089},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5741, col: 18, offset: 175702},
+							pos:        position{line: 5864, col: 18, offset: 181089},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5741, col: 28, offset: 175712},
+							pos:  position{line: 5864, col: 28, offset: 181099},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5741, col: 34, offset: 175718},
+							pos:   position{line: 5864, col: 34, offset: 181105},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5741, col: 39, offset: 175723},
+								pos:  position{line: 5864, col: 39, offset: 181110},
 								name: "IntegerAsString",
 							},
 						},
@@ -14226,28 +14520,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5752, col: 1, offset: 176024},
+			pos:  position{line: 5875, col: 1, offset: 181411},
 			expr: &actionExpr{
-				pos: position{line: 5752, col: 17, offset: 176040},
+				pos: position{line: 5875, col: 17, offset: 181427},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5752, col: 17, offset: 176040},
+					pos: position{line: 5875, col: 17, offset: 181427},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5752, col: 17, offset: 176040},
+							pos:        position{line: 5875, col: 17, offset: 181427},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5752, col: 26, offset: 176049},
+							pos:  position{line: 5875, col: 26, offset: 181436},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5752, col: 32, offset: 176055},
+							pos:   position{line: 5875, col: 32, offset: 181442},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5752, col: 36, offset: 176059},
+								pos:  position{line: 5875, col: 36, offset: 181446},
 								name: "IntegerAsString",
 							},
 						},
@@ -14257,43 +14551,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5764, col: 1, offset: 176414},
+			pos:  position{line: 5887, col: 1, offset: 181801},
 			expr: &actionExpr{
-				pos: position{line: 5764, col: 14, offset: 176427},
+				pos: position{line: 5887, col: 14, offset: 181814},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5764, col: 14, offset: 176427},
+					pos: position{line: 5887, col: 14, offset: 181814},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5764, col: 14, offset: 176427},
+							pos:        position{line: 5887, col: 14, offset: 181814},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5764, col: 18, offset: 176431},
+							pos: position{line: 5887, col: 18, offset: 181818},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5764, col: 18, offset: 176431},
+								pos:  position{line: 5887, col: 18, offset: 181818},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5764, col: 25, offset: 176438},
+							pos:   position{line: 5887, col: 25, offset: 181825},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5764, col: 32, offset: 176445},
+								pos:  position{line: 5887, col: 32, offset: 181832},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5764, col: 44, offset: 176457},
+							pos: position{line: 5887, col: 44, offset: 181844},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5764, col: 44, offset: 176457},
+								pos:  position{line: 5887, col: 44, offset: 181844},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5764, col: 51, offset: 176464},
+							pos:        position{line: 5887, col: 51, offset: 181851},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14304,35 +14598,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5769, col: 1, offset: 176553},
+			pos:  position{line: 5892, col: 1, offset: 181940},
 			expr: &actionExpr{
-				pos: position{line: 5769, col: 25, offset: 176577},
+				pos: position{line: 5892, col: 25, offset: 181964},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5769, col: 25, offset: 176577},
+					pos: position{line: 5892, col: 25, offset: 181964},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5769, col: 25, offset: 176577},
+							pos:   position{line: 5892, col: 25, offset: 181964},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5769, col: 31, offset: 176583},
+								pos:  position{line: 5892, col: 31, offset: 181970},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5769, col: 47, offset: 176599},
+							pos:   position{line: 5892, col: 47, offset: 181986},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5769, col: 52, offset: 176604},
+								pos: position{line: 5892, col: 52, offset: 181991},
 								expr: &seqExpr{
-									pos: position{line: 5769, col: 53, offset: 176605},
+									pos: position{line: 5892, col: 53, offset: 181992},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5769, col: 53, offset: 176605},
+											pos:  position{line: 5892, col: 53, offset: 181992},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5769, col: 59, offset: 176611},
+											pos:  position{line: 5892, col: 59, offset: 181998},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14345,37 +14639,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5796, col: 1, offset: 177421},
+			pos:  position{line: 5919, col: 1, offset: 182808},
 			expr: &actionExpr{
-				pos: position{line: 5796, col: 16, offset: 177436},
+				pos: position{line: 5919, col: 16, offset: 182823},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5796, col: 16, offset: 177436},
+					pos: position{line: 5919, col: 16, offset: 182823},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5796, col: 16, offset: 177436},
+							pos:  position{line: 5919, col: 16, offset: 182823},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5796, col: 21, offset: 177441},
+							pos:  position{line: 5919, col: 21, offset: 182828},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5796, col: 32, offset: 177452},
+							pos:   position{line: 5919, col: 32, offset: 182839},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5796, col: 40, offset: 177460},
+								pos: position{line: 5919, col: 40, offset: 182847},
 								expr: &seqExpr{
-									pos: position{line: 5796, col: 41, offset: 177461},
+									pos: position{line: 5919, col: 41, offset: 182848},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5796, col: 41, offset: 177461},
+											pos:  position{line: 5919, col: 41, offset: 182848},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5796, col: 57, offset: 177477},
+											pos: position{line: 5919, col: 57, offset: 182864},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5796, col: 57, offset: 177477},
+												pos:  position{line: 5919, col: 57, offset: 182864},
 												name: "SPACE",
 											},
 										},
@@ -14384,10 +14678,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5796, col: 66, offset: 177486},
+							pos:   position{line: 5919, col: 66, offset: 182873},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5796, col: 76, offset: 177496},
+								pos:  position{line: 5919, col: 76, offset: 182883},
 								name: "Subsearch",
 							},
 						},
@@ -14397,45 +14691,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5838, col: 1, offset: 179033},
+			pos:  position{line: 5961, col: 1, offset: 184420},
 			expr: &actionExpr{
-				pos: position{line: 5838, col: 17, offset: 179049},
+				pos: position{line: 5961, col: 17, offset: 184436},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5838, col: 17, offset: 179049},
+					pos: position{line: 5961, col: 17, offset: 184436},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5838, col: 17, offset: 179049},
+							pos:  position{line: 5961, col: 17, offset: 184436},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5838, col: 23, offset: 179055},
+							pos:   position{line: 5961, col: 23, offset: 184442},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5838, col: 31, offset: 179063},
+								pos: position{line: 5961, col: 31, offset: 184450},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 31, offset: 179063},
+										pos:  position{line: 5961, col: 31, offset: 184450},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 54, offset: 179086},
+										pos:  position{line: 5961, col: 54, offset: 184473},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 74, offset: 179106},
+										pos:  position{line: 5961, col: 74, offset: 184493},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 91, offset: 179123},
+										pos:  position{line: 5961, col: 91, offset: 184510},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 115, offset: 179147},
+										pos:  position{line: 5961, col: 115, offset: 184534},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5838, col: 135, offset: 179167},
+										pos:  position{line: 5961, col: 135, offset: 184554},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14447,51 +14741,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5842, col: 1, offset: 179222},
+			pos:  position{line: 5965, col: 1, offset: 184609},
 			expr: &actionExpr{
-				pos: position{line: 5842, col: 25, offset: 179246},
+				pos: position{line: 5965, col: 25, offset: 184633},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5842, col: 26, offset: 179247},
+					pos: position{line: 5965, col: 26, offset: 184634},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5842, col: 26, offset: 179247},
+							pos:   position{line: 5965, col: 26, offset: 184634},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5842, col: 33, offset: 179254},
+								pos: position{line: 5965, col: 33, offset: 184641},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5842, col: 33, offset: 179254},
+										pos:        position{line: 5965, col: 33, offset: 184641},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5842, col: 42, offset: 179263},
+										pos:        position{line: 5965, col: 42, offset: 184650},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5842, col: 51, offset: 179272},
+										pos:        position{line: 5965, col: 51, offset: 184659},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5842, col: 60, offset: 179281},
+										pos:        position{line: 5965, col: 60, offset: 184668},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5842, col: 68, offset: 179289},
+										pos:        position{line: 5965, col: 68, offset: 184676},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5842, col: 76, offset: 179297},
+										pos:        position{line: 5965, col: 76, offset: 184684},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14500,19 +14794,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5842, col: 84, offset: 179305},
+							pos:  position{line: 5965, col: 84, offset: 184692},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5842, col: 92, offset: 179313},
+							pos:   position{line: 5965, col: 92, offset: 184700},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5842, col: 105, offset: 179326},
+								pos:  position{line: 5965, col: 105, offset: 184713},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5842, col: 116, offset: 179337},
+							pos:  position{line: 5965, col: 116, offset: 184724},
 							name: "R_PAREN",
 						},
 					},
@@ -14521,15 +14815,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5868, col: 1, offset: 180095},
+			pos:  position{line: 5991, col: 1, offset: 185482},
 			expr: &actionExpr{
-				pos: position{line: 5868, col: 30, offset: 180124},
+				pos: position{line: 5991, col: 30, offset: 185511},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5868, col: 30, offset: 180124},
+					pos:   position{line: 5991, col: 30, offset: 185511},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5868, col: 43, offset: 180137},
+						pos:  position{line: 5991, col: 43, offset: 185524},
 						name: "StringExpr",
 					},
 				},
@@ -14537,61 +14831,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5893, col: 1, offset: 180845},
+			pos:  position{line: 6016, col: 1, offset: 186232},
 			expr: &actionExpr{
-				pos: position{line: 5893, col: 22, offset: 180866},
+				pos: position{line: 6016, col: 22, offset: 186253},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5893, col: 22, offset: 180866},
+					pos: position{line: 6016, col: 22, offset: 186253},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5893, col: 22, offset: 180866},
+							pos:        position{line: 6016, col: 22, offset: 186253},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5893, col: 37, offset: 180881},
+							pos:  position{line: 6016, col: 37, offset: 186268},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5893, col: 43, offset: 180887},
+							pos:   position{line: 6016, col: 43, offset: 186274},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5893, col: 50, offset: 180894},
+								pos: position{line: 6016, col: 50, offset: 186281},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5893, col: 50, offset: 180894},
+										pos:        position{line: 6016, col: 50, offset: 186281},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5893, col: 59, offset: 180903},
+										pos:        position{line: 6016, col: 59, offset: 186290},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5893, col: 68, offset: 180912},
+										pos:        position{line: 6016, col: 68, offset: 186299},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5893, col: 77, offset: 180921},
+										pos:        position{line: 6016, col: 77, offset: 186308},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5893, col: 85, offset: 180929},
+										pos:        position{line: 6016, col: 85, offset: 186316},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5893, col: 93, offset: 180937},
+										pos:        position{line: 6016, col: 93, offset: 186324},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14605,28 +14899,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5906, col: 1, offset: 181266},
+			pos:  position{line: 6029, col: 1, offset: 186653},
 			expr: &actionExpr{
-				pos: position{line: 5906, col: 19, offset: 181284},
+				pos: position{line: 6029, col: 19, offset: 186671},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5906, col: 19, offset: 181284},
+					pos: position{line: 6029, col: 19, offset: 186671},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5906, col: 19, offset: 181284},
+							pos:        position{line: 6029, col: 19, offset: 186671},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5906, col: 31, offset: 181296},
+							pos:  position{line: 6029, col: 31, offset: 186683},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5906, col: 37, offset: 181302},
+							pos:   position{line: 6029, col: 37, offset: 186689},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5906, col: 45, offset: 181310},
+								pos:  position{line: 6029, col: 45, offset: 186697},
 								name: "Boolean",
 							},
 						},
@@ -14636,28 +14930,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5913, col: 1, offset: 181433},
+			pos:  position{line: 6036, col: 1, offset: 186820},
 			expr: &actionExpr{
-				pos: position{line: 5913, col: 26, offset: 181458},
+				pos: position{line: 6036, col: 26, offset: 186845},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5913, col: 26, offset: 181458},
+					pos: position{line: 6036, col: 26, offset: 186845},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5913, col: 26, offset: 181458},
+							pos:        position{line: 6036, col: 26, offset: 186845},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5913, col: 45, offset: 181477},
+							pos:  position{line: 6036, col: 45, offset: 186864},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5913, col: 51, offset: 181483},
+							pos:   position{line: 6036, col: 51, offset: 186870},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5913, col: 59, offset: 181491},
+								pos:  position{line: 6036, col: 59, offset: 186878},
 								name: "Boolean",
 							},
 						},
@@ -14667,28 +14961,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5920, col: 1, offset: 181621},
+			pos:  position{line: 6043, col: 1, offset: 187008},
 			expr: &actionExpr{
-				pos: position{line: 5920, col: 22, offset: 181642},
+				pos: position{line: 6043, col: 22, offset: 187029},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5920, col: 22, offset: 181642},
+					pos: position{line: 6043, col: 22, offset: 187029},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5920, col: 22, offset: 181642},
+							pos:        position{line: 6043, col: 22, offset: 187029},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5920, col: 37, offset: 181657},
+							pos:  position{line: 6043, col: 37, offset: 187044},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5920, col: 43, offset: 181663},
+							pos:   position{line: 6043, col: 43, offset: 187050},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5920, col: 50, offset: 181670},
+								pos:  position{line: 6043, col: 50, offset: 187057},
 								name: "String",
 							},
 						},
@@ -14698,28 +14992,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5927, col: 1, offset: 181796},
+			pos:  position{line: 6050, col: 1, offset: 187183},
 			expr: &actionExpr{
-				pos: position{line: 5927, col: 16, offset: 181811},
+				pos: position{line: 6050, col: 16, offset: 187198},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5927, col: 16, offset: 181811},
+					pos: position{line: 6050, col: 16, offset: 187198},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5927, col: 16, offset: 181811},
+							pos:  position{line: 6050, col: 16, offset: 187198},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5927, col: 21, offset: 181816},
+							pos:  position{line: 6050, col: 21, offset: 187203},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5927, col: 32, offset: 181827},
+							pos:   position{line: 6050, col: 32, offset: 187214},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5927, col: 40, offset: 181835},
+								pos: position{line: 6050, col: 40, offset: 187222},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5927, col: 41, offset: 181836},
+									pos:  position{line: 6050, col: 41, offset: 187223},
 									name: "ToJsonOption",
 								},
 							},
@@ -14730,132 +15024,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5980, col: 1, offset: 183918},
+			pos:  position{line: 6103, col: 1, offset: 189305},
 			expr: &choiceExpr{
-				pos: position{line: 5980, col: 12, offset: 183929},
+				pos: position{line: 6103, col: 12, offset: 189316},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 12, offset: 183929},
+						pos:  position{line: 6103, col: 12, offset: 189316},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 24, offset: 183941},
+						pos:  position{line: 6103, col: 24, offset: 189328},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 36, offset: 183953},
+						pos:  position{line: 6103, col: 36, offset: 189340},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 49, offset: 183966},
+						pos:  position{line: 6103, col: 49, offset: 189353},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 61, offset: 183978},
+						pos:  position{line: 6103, col: 61, offset: 189365},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 81, offset: 183998},
+						pos:  position{line: 6103, col: 81, offset: 189385},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 92, offset: 184009},
+						pos:  position{line: 6103, col: 92, offset: 189396},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 112, offset: 184029},
+						pos:  position{line: 6103, col: 112, offset: 189416},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 123, offset: 184040},
+						pos:  position{line: 6103, col: 123, offset: 189427},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 134, offset: 184051},
+						pos:  position{line: 6103, col: 134, offset: 189438},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 144, offset: 184061},
+						pos:  position{line: 6103, col: 144, offset: 189448},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 154, offset: 184071},
+						pos:  position{line: 6103, col: 154, offset: 189458},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 165, offset: 184082},
+						pos:  position{line: 6103, col: 165, offset: 189469},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 178, offset: 184095},
+						pos:  position{line: 6103, col: 178, offset: 189482},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 194, offset: 184111},
+						pos:  position{line: 6103, col: 194, offset: 189498},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 212, offset: 184129},
+						pos:  position{line: 6103, col: 212, offset: 189516},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 224, offset: 184141},
+						pos:  position{line: 6103, col: 224, offset: 189528},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 235, offset: 184152},
+						pos:  position{line: 6103, col: 235, offset: 189539},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 248, offset: 184165},
+						pos:  position{line: 6103, col: 248, offset: 189552},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 260, offset: 184177},
+						pos:  position{line: 6103, col: 260, offset: 189564},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 273, offset: 184190},
+						pos:  position{line: 6103, col: 273, offset: 189577},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 288, offset: 184205},
+						pos:  position{line: 6103, col: 288, offset: 189592},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 301, offset: 184218},
+						pos:  position{line: 6103, col: 301, offset: 189605},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 318, offset: 184235},
+						pos:  position{line: 6103, col: 318, offset: 189622},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 328, offset: 184245},
+						pos:  position{line: 6103, col: 328, offset: 189632},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 346, offset: 184263},
+						pos:  position{line: 6103, col: 346, offset: 189650},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 361, offset: 184278},
+						pos:  position{line: 6103, col: 361, offset: 189665},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 376, offset: 184293},
+						pos:  position{line: 6103, col: 376, offset: 189680},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 391, offset: 184308},
+						pos:  position{line: 6103, col: 391, offset: 189695},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 409, offset: 184326},
+						pos:  position{line: 6103, col: 409, offset: 189713},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5980, col: 422, offset: 184339},
+						pos:  position{line: 6103, col: 422, offset: 189726},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14863,18 +15157,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5981, col: 1, offset: 184351},
+			pos:  position{line: 6104, col: 1, offset: 189738},
 			expr: &seqExpr{
-				pos: position{line: 5981, col: 15, offset: 184365},
+				pos: position{line: 6104, col: 15, offset: 189752},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5981, col: 15, offset: 184365},
+						pos:        position{line: 6104, col: 15, offset: 189752},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5981, col: 24, offset: 184374},
+						pos:  position{line: 6104, col: 24, offset: 189761},
 						name: "SPACE",
 					},
 				},
@@ -14882,18 +15176,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5982, col: 1, offset: 184380},
+			pos:  position{line: 6105, col: 1, offset: 189767},
 			expr: &seqExpr{
-				pos: position{line: 5982, col: 14, offset: 184393},
+				pos: position{line: 6105, col: 14, offset: 189780},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5982, col: 14, offset: 184393},
+						pos:        position{line: 6105, col: 14, offset: 189780},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5982, col: 22, offset: 184401},
+						pos:  position{line: 6105, col: 22, offset: 189788},
 						name: "SPACE",
 					},
 				},
@@ -14901,18 +15195,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5983, col: 1, offset: 184407},
+			pos:  position{line: 6106, col: 1, offset: 189794},
 			expr: &seqExpr{
-				pos: position{line: 5983, col: 14, offset: 184420},
+				pos: position{line: 6106, col: 14, offset: 189807},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5983, col: 14, offset: 184420},
+						pos:        position{line: 6106, col: 14, offset: 189807},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5983, col: 22, offset: 184428},
+						pos:  position{line: 6106, col: 22, offset: 189815},
 						name: "SPACE",
 					},
 				},
@@ -14920,18 +15214,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5984, col: 1, offset: 184434},
+			pos:  position{line: 6107, col: 1, offset: 189821},
 			expr: &seqExpr{
-				pos: position{line: 5984, col: 20, offset: 184453},
+				pos: position{line: 6107, col: 20, offset: 189840},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5984, col: 20, offset: 184453},
+						pos:        position{line: 6107, col: 20, offset: 189840},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5984, col: 34, offset: 184467},
+						pos:  position{line: 6107, col: 34, offset: 189854},
 						name: "SPACE",
 					},
 				},
@@ -14939,18 +15233,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5985, col: 1, offset: 184473},
+			pos:  position{line: 6108, col: 1, offset: 189860},
 			expr: &seqExpr{
-				pos: position{line: 5985, col: 15, offset: 184487},
+				pos: position{line: 6108, col: 15, offset: 189874},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5985, col: 15, offset: 184487},
+						pos:        position{line: 6108, col: 15, offset: 189874},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5985, col: 24, offset: 184496},
+						pos:  position{line: 6108, col: 24, offset: 189883},
 						name: "SPACE",
 					},
 				},
@@ -14958,18 +15252,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5986, col: 1, offset: 184502},
+			pos:  position{line: 6109, col: 1, offset: 189889},
 			expr: &seqExpr{
-				pos: position{line: 5986, col: 14, offset: 184515},
+				pos: position{line: 6109, col: 14, offset: 189902},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5986, col: 14, offset: 184515},
+						pos:        position{line: 6109, col: 14, offset: 189902},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5986, col: 22, offset: 184523},
+						pos:  position{line: 6109, col: 22, offset: 189910},
 						name: "SPACE",
 					},
 				},
@@ -14977,9 +15271,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5987, col: 1, offset: 184529},
+			pos:  position{line: 6110, col: 1, offset: 189916},
 			expr: &litMatcher{
-				pos:        position{line: 5987, col: 22, offset: 184550},
+				pos:        position{line: 6110, col: 22, offset: 189937},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14987,16 +15281,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5988, col: 1, offset: 184557},
+			pos:  position{line: 6111, col: 1, offset: 189944},
 			expr: &seqExpr{
-				pos: position{line: 5988, col: 13, offset: 184569},
+				pos: position{line: 6111, col: 13, offset: 189956},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5988, col: 13, offset: 184569},
+						pos:  position{line: 6111, col: 13, offset: 189956},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5988, col: 31, offset: 184587},
+						pos:  position{line: 6111, col: 31, offset: 189974},
 						name: "SPACE",
 					},
 				},
@@ -15004,9 +15298,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5989, col: 1, offset: 184593},
+			pos:  position{line: 6112, col: 1, offset: 189980},
 			expr: &litMatcher{
-				pos:        position{line: 5989, col: 22, offset: 184614},
+				pos:        position{line: 6112, col: 22, offset: 190001},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -15014,16 +15308,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5990, col: 1, offset: 184621},
+			pos:  position{line: 6113, col: 1, offset: 190008},
 			expr: &seqExpr{
-				pos: position{line: 5990, col: 13, offset: 184633},
+				pos: position{line: 6113, col: 13, offset: 190020},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5990, col: 13, offset: 184633},
+						pos:  position{line: 6113, col: 13, offset: 190020},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5990, col: 31, offset: 184651},
+						pos:  position{line: 6113, col: 31, offset: 190038},
 						name: "SPACE",
 					},
 				},
@@ -15031,18 +15325,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5991, col: 1, offset: 184657},
+			pos:  position{line: 6114, col: 1, offset: 190044},
 			expr: &seqExpr{
-				pos: position{line: 5991, col: 13, offset: 184669},
+				pos: position{line: 6114, col: 13, offset: 190056},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5991, col: 13, offset: 184669},
+						pos:        position{line: 6114, col: 13, offset: 190056},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5991, col: 20, offset: 184676},
+						pos:  position{line: 6114, col: 20, offset: 190063},
 						name: "SPACE",
 					},
 				},
@@ -15050,18 +15344,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5992, col: 1, offset: 184682},
+			pos:  position{line: 6115, col: 1, offset: 190069},
 			expr: &seqExpr{
-				pos: position{line: 5992, col: 12, offset: 184693},
+				pos: position{line: 6115, col: 12, offset: 190080},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5992, col: 12, offset: 184693},
+						pos:        position{line: 6115, col: 12, offset: 190080},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5992, col: 18, offset: 184699},
+						pos:  position{line: 6115, col: 18, offset: 190086},
 						name: "SPACE",
 					},
 				},
@@ -15069,18 +15363,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5993, col: 1, offset: 184705},
+			pos:  position{line: 6116, col: 1, offset: 190092},
 			expr: &seqExpr{
-				pos: position{line: 5993, col: 13, offset: 184717},
+				pos: position{line: 6116, col: 13, offset: 190104},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5993, col: 13, offset: 184717},
+						pos:        position{line: 6116, col: 13, offset: 190104},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5993, col: 20, offset: 184724},
+						pos:  position{line: 6116, col: 20, offset: 190111},
 						name: "SPACE",
 					},
 				},
@@ -15088,9 +15382,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5994, col: 1, offset: 184730},
+			pos:  position{line: 6117, col: 1, offset: 190117},
 			expr: &litMatcher{
-				pos:        position{line: 5994, col: 12, offset: 184741},
+				pos:        position{line: 6117, col: 12, offset: 190128},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -15098,9 +15392,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5995, col: 1, offset: 184747},
+			pos:  position{line: 6118, col: 1, offset: 190134},
 			expr: &litMatcher{
-				pos:        position{line: 5995, col: 13, offset: 184759},
+				pos:        position{line: 6118, col: 13, offset: 190146},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -15108,18 +15402,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5996, col: 1, offset: 184766},
+			pos:  position{line: 6119, col: 1, offset: 190153},
 			expr: &seqExpr{
-				pos: position{line: 5996, col: 15, offset: 184780},
+				pos: position{line: 6119, col: 15, offset: 190167},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5996, col: 15, offset: 184780},
+						pos:        position{line: 6119, col: 15, offset: 190167},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5996, col: 24, offset: 184789},
+						pos:  position{line: 6119, col: 24, offset: 190176},
 						name: "SPACE",
 					},
 				},
@@ -15127,18 +15421,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5997, col: 1, offset: 184795},
+			pos:  position{line: 6120, col: 1, offset: 190182},
 			expr: &seqExpr{
-				pos: position{line: 5997, col: 18, offset: 184812},
+				pos: position{line: 6120, col: 18, offset: 190199},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5997, col: 18, offset: 184812},
+						pos:        position{line: 6120, col: 18, offset: 190199},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5997, col: 30, offset: 184824},
+						pos:  position{line: 6120, col: 30, offset: 190211},
 						name: "SPACE",
 					},
 				},
@@ -15146,18 +15440,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5998, col: 1, offset: 184830},
+			pos:  position{line: 6121, col: 1, offset: 190217},
 			expr: &seqExpr{
-				pos: position{line: 5998, col: 12, offset: 184841},
+				pos: position{line: 6121, col: 12, offset: 190228},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5998, col: 12, offset: 184841},
+						pos:        position{line: 6121, col: 12, offset: 190228},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5998, col: 18, offset: 184847},
+						pos:  position{line: 6121, col: 18, offset: 190234},
 						name: "SPACE",
 					},
 				},
@@ -15165,9 +15459,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5999, col: 1, offset: 184853},
+			pos:  position{line: 6122, col: 1, offset: 190240},
 			expr: &litMatcher{
-				pos:        position{line: 5999, col: 13, offset: 184865},
+				pos:        position{line: 6122, col: 13, offset: 190252},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -15175,18 +15469,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 6000, col: 1, offset: 184872},
+			pos:  position{line: 6123, col: 1, offset: 190259},
 			expr: &seqExpr{
-				pos: position{line: 6000, col: 20, offset: 184891},
+				pos: position{line: 6123, col: 20, offset: 190278},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6000, col: 20, offset: 184891},
+						pos:        position{line: 6123, col: 20, offset: 190278},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6000, col: 34, offset: 184905},
+						pos:  position{line: 6123, col: 34, offset: 190292},
 						name: "SPACE",
 					},
 				},
@@ -15194,9 +15488,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 6001, col: 1, offset: 184911},
+			pos:  position{line: 6124, col: 1, offset: 190298},
 			expr: &litMatcher{
-				pos:        position{line: 6001, col: 14, offset: 184924},
+				pos:        position{line: 6124, col: 14, offset: 190311},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -15204,22 +15498,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 6002, col: 1, offset: 184932},
+			pos:  position{line: 6125, col: 1, offset: 190319},
 			expr: &seqExpr{
-				pos: position{line: 6002, col: 21, offset: 184952},
+				pos: position{line: 6125, col: 21, offset: 190339},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6002, col: 21, offset: 184952},
+						pos:  position{line: 6125, col: 21, offset: 190339},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6002, col: 27, offset: 184958},
+						pos:        position{line: 6125, col: 27, offset: 190345},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6002, col: 36, offset: 184967},
+						pos:  position{line: 6125, col: 36, offset: 190354},
 						name: "SPACE",
 					},
 				},
@@ -15227,9 +15521,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 6003, col: 1, offset: 184973},
+			pos:  position{line: 6126, col: 1, offset: 190360},
 			expr: &litMatcher{
-				pos:        position{line: 6003, col: 15, offset: 184987},
+				pos:        position{line: 6126, col: 15, offset: 190374},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -15237,9 +15531,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 6004, col: 1, offset: 184996},
+			pos:  position{line: 6127, col: 1, offset: 190383},
 			expr: &litMatcher{
-				pos:        position{line: 6004, col: 14, offset: 185009},
+				pos:        position{line: 6127, col: 14, offset: 190396},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -15247,9 +15541,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 6005, col: 1, offset: 185017},
+			pos:  position{line: 6128, col: 1, offset: 190404},
 			expr: &litMatcher{
-				pos:        position{line: 6005, col: 15, offset: 185031},
+				pos:        position{line: 6128, col: 15, offset: 190418},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -15257,9 +15551,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 6006, col: 1, offset: 185040},
+			pos:  position{line: 6129, col: 1, offset: 190427},
 			expr: &litMatcher{
-				pos:        position{line: 6006, col: 17, offset: 185056},
+				pos:        position{line: 6129, col: 17, offset: 190443},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -15267,9 +15561,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 6007, col: 1, offset: 185067},
+			pos:  position{line: 6130, col: 1, offset: 190454},
 			expr: &litMatcher{
-				pos:        position{line: 6007, col: 15, offset: 185081},
+				pos:        position{line: 6130, col: 15, offset: 190468},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -15277,9 +15571,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 6008, col: 1, offset: 185090},
+			pos:  position{line: 6131, col: 1, offset: 190477},
 			expr: &litMatcher{
-				pos:        position{line: 6008, col: 19, offset: 185108},
+				pos:        position{line: 6131, col: 19, offset: 190495},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -15287,9 +15581,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 6009, col: 1, offset: 185121},
+			pos:  position{line: 6132, col: 1, offset: 190508},
 			expr: &litMatcher{
-				pos:        position{line: 6009, col: 17, offset: 185137},
+				pos:        position{line: 6132, col: 17, offset: 190524},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -15297,9 +15591,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 6010, col: 1, offset: 185148},
+			pos:  position{line: 6133, col: 1, offset: 190535},
 			expr: &litMatcher{
-				pos:        position{line: 6010, col: 17, offset: 185164},
+				pos:        position{line: 6133, col: 17, offset: 190551},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15307,18 +15601,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 6011, col: 1, offset: 185175},
+			pos:  position{line: 6134, col: 1, offset: 190562},
 			expr: &seqExpr{
-				pos: position{line: 6011, col: 20, offset: 185194},
+				pos: position{line: 6134, col: 20, offset: 190581},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6011, col: 20, offset: 185194},
+						pos:        position{line: 6134, col: 20, offset: 190581},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6011, col: 34, offset: 185208},
+						pos:  position{line: 6134, col: 34, offset: 190595},
 						name: "SPACE",
 					},
 				},
@@ -15326,28 +15620,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 6012, col: 1, offset: 185214},
+			pos:  position{line: 6135, col: 1, offset: 190601},
 			expr: &seqExpr{
-				pos: position{line: 6012, col: 16, offset: 185229},
+				pos: position{line: 6135, col: 16, offset: 190616},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 6012, col: 16, offset: 185229},
+						pos: position{line: 6135, col: 16, offset: 190616},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6012, col: 16, offset: 185229},
+							pos:  position{line: 6135, col: 16, offset: 190616},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 6012, col: 24, offset: 185237},
+						pos: position{line: 6135, col: 24, offset: 190624},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 6012, col: 24, offset: 185237},
+								pos:        position{line: 6135, col: 24, offset: 190624},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 6012, col: 30, offset: 185243},
+								pos:        position{line: 6135, col: 30, offset: 190630},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15355,9 +15649,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 6012, col: 35, offset: 185248},
+						pos: position{line: 6135, col: 35, offset: 190635},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6012, col: 35, offset: 185248},
+							pos:  position{line: 6135, col: 35, offset: 190635},
 							name: "SPACE",
 						},
 					},
@@ -15366,9 +15660,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 6013, col: 1, offset: 185255},
+			pos:  position{line: 6136, col: 1, offset: 190642},
 			expr: &litMatcher{
-				pos:        position{line: 6013, col: 17, offset: 185271},
+				pos:        position{line: 6136, col: 17, offset: 190658},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15376,18 +15670,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 6014, col: 1, offset: 185282},
+			pos:  position{line: 6137, col: 1, offset: 190669},
 			expr: &seqExpr{
-				pos: position{line: 6014, col: 15, offset: 185296},
+				pos: position{line: 6137, col: 15, offset: 190683},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6014, col: 15, offset: 185296},
+						pos:        position{line: 6137, col: 15, offset: 190683},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6014, col: 24, offset: 185305},
+						pos:  position{line: 6137, col: 24, offset: 190692},
 						name: "SPACE",
 					},
 				},
@@ -15395,9 +15689,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 6015, col: 1, offset: 185311},
+			pos:  position{line: 6138, col: 1, offset: 190698},
 			expr: &litMatcher{
-				pos:        position{line: 6015, col: 15, offset: 185325},
+				pos:        position{line: 6138, col: 15, offset: 190712},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15405,115 +15699,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 6018, col: 1, offset: 185438},
+			pos:  position{line: 6141, col: 1, offset: 190825},
 			expr: &choiceExpr{
-				pos: position{line: 6018, col: 16, offset: 185453},
+				pos: position{line: 6141, col: 16, offset: 190840},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 6018, col: 16, offset: 185453},
+						pos:        position{line: 6141, col: 16, offset: 190840},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 6018, col: 47, offset: 185484},
+						pos:        position{line: 6141, col: 47, offset: 190871},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6018, col: 55, offset: 185492},
+						pos:        position{line: 6141, col: 55, offset: 190879},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 16, offset: 185515},
+						pos:        position{line: 6142, col: 16, offset: 190902},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 26, offset: 185525},
+						pos:        position{line: 6142, col: 26, offset: 190912},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 34, offset: 185533},
+						pos:        position{line: 6142, col: 34, offset: 190920},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 42, offset: 185541},
+						pos:        position{line: 6142, col: 42, offset: 190928},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 50, offset: 185549},
+						pos:        position{line: 6142, col: 50, offset: 190936},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 58, offset: 185557},
+						pos:        position{line: 6142, col: 58, offset: 190944},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6019, col: 66, offset: 185565},
+						pos:        position{line: 6142, col: 66, offset: 190952},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 16, offset: 185587},
+						pos:        position{line: 6143, col: 16, offset: 190974},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 26, offset: 185597},
+						pos:        position{line: 6143, col: 26, offset: 190984},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 34, offset: 185605},
+						pos:        position{line: 6143, col: 34, offset: 190992},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 42, offset: 185613},
+						pos:        position{line: 6143, col: 42, offset: 191000},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 50, offset: 185621},
+						pos:        position{line: 6143, col: 50, offset: 191008},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 58, offset: 185629},
+						pos:        position{line: 6143, col: 58, offset: 191016},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 66, offset: 185637},
+						pos:        position{line: 6143, col: 66, offset: 191024},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6020, col: 74, offset: 185645},
+						pos:        position{line: 6143, col: 74, offset: 191032},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15523,25 +15817,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 6021, col: 1, offset: 185651},
+			pos:  position{line: 6144, col: 1, offset: 191038},
 			expr: &choiceExpr{
-				pos: position{line: 6021, col: 16, offset: 185666},
+				pos: position{line: 6144, col: 16, offset: 191053},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 6021, col: 16, offset: 185666},
+						pos:        position{line: 6144, col: 16, offset: 191053},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 6021, col: 30, offset: 185680},
+						pos:        position{line: 6144, col: 30, offset: 191067},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6021, col: 36, offset: 185686},
+						pos:        position{line: 6144, col: 36, offset: 191073},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15551,18 +15845,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 6025, col: 1, offset: 185842},
+			pos:  position{line: 6148, col: 1, offset: 191229},
 			expr: &seqExpr{
-				pos: position{line: 6025, col: 8, offset: 185849},
+				pos: position{line: 6148, col: 8, offset: 191236},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6025, col: 8, offset: 185849},
+						pos:        position{line: 6148, col: 8, offset: 191236},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6025, col: 14, offset: 185855},
+						pos:  position{line: 6148, col: 14, offset: 191242},
 						name: "SPACE",
 					},
 				},
@@ -15570,22 +15864,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 6026, col: 1, offset: 185861},
+			pos:  position{line: 6149, col: 1, offset: 191248},
 			expr: &seqExpr{
-				pos: position{line: 6026, col: 7, offset: 185867},
+				pos: position{line: 6149, col: 7, offset: 191254},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6026, col: 7, offset: 185867},
+						pos:  position{line: 6149, col: 7, offset: 191254},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6026, col: 13, offset: 185873},
+						pos:        position{line: 6149, col: 13, offset: 191260},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6026, col: 18, offset: 185878},
+						pos:  position{line: 6149, col: 18, offset: 191265},
 						name: "SPACE",
 					},
 				},
@@ -15593,22 +15887,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 6027, col: 1, offset: 185884},
+			pos:  position{line: 6150, col: 1, offset: 191271},
 			expr: &seqExpr{
-				pos: position{line: 6027, col: 8, offset: 185891},
+				pos: position{line: 6150, col: 8, offset: 191278},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6027, col: 8, offset: 185891},
+						pos:  position{line: 6150, col: 8, offset: 191278},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6027, col: 14, offset: 185897},
+						pos:        position{line: 6150, col: 14, offset: 191284},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6027, col: 20, offset: 185903},
+						pos:  position{line: 6150, col: 20, offset: 191290},
 						name: "SPACE",
 					},
 				},
@@ -15616,22 +15910,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 6028, col: 1, offset: 185909},
+			pos:  position{line: 6151, col: 1, offset: 191296},
 			expr: &seqExpr{
-				pos: position{line: 6028, col: 9, offset: 185917},
+				pos: position{line: 6151, col: 9, offset: 191304},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6028, col: 9, offset: 185917},
+						pos:  position{line: 6151, col: 9, offset: 191304},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6028, col: 24, offset: 185932},
+						pos:        position{line: 6151, col: 24, offset: 191319},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6028, col: 28, offset: 185936},
+						pos:  position{line: 6151, col: 28, offset: 191323},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15639,22 +15933,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 6029, col: 1, offset: 185951},
+			pos:  position{line: 6152, col: 1, offset: 191338},
 			expr: &seqExpr{
-				pos: position{line: 6029, col: 7, offset: 185957},
+				pos: position{line: 6152, col: 7, offset: 191344},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6029, col: 7, offset: 185957},
+						pos:  position{line: 6152, col: 7, offset: 191344},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6029, col: 13, offset: 185963},
+						pos:        position{line: 6152, col: 13, offset: 191350},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6029, col: 19, offset: 185969},
+						pos:  position{line: 6152, col: 19, offset: 191356},
 						name: "SPACE",
 					},
 				},
@@ -15662,22 +15956,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 6030, col: 1, offset: 185995},
+			pos:  position{line: 6153, col: 1, offset: 191382},
 			expr: &seqExpr{
-				pos: position{line: 6030, col: 7, offset: 186001},
+				pos: position{line: 6153, col: 7, offset: 191388},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6030, col: 7, offset: 186001},
+						pos:  position{line: 6153, col: 7, offset: 191388},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6030, col: 13, offset: 186007},
+						pos:        position{line: 6153, col: 13, offset: 191394},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6030, col: 19, offset: 186013},
+						pos:  position{line: 6153, col: 19, offset: 191400},
 						name: "SPACE",
 					},
 				},
@@ -15685,22 +15979,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 6032, col: 1, offset: 186040},
+			pos:  position{line: 6155, col: 1, offset: 191427},
 			expr: &seqExpr{
-				pos: position{line: 6032, col: 10, offset: 186049},
+				pos: position{line: 6155, col: 10, offset: 191436},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6032, col: 10, offset: 186049},
+						pos:  position{line: 6155, col: 10, offset: 191436},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6032, col: 25, offset: 186064},
+						pos:        position{line: 6155, col: 25, offset: 191451},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6032, col: 29, offset: 186068},
+						pos:  position{line: 6155, col: 29, offset: 191455},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15708,22 +16002,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 6033, col: 1, offset: 186083},
+			pos:  position{line: 6156, col: 1, offset: 191470},
 			expr: &seqExpr{
-				pos: position{line: 6033, col: 10, offset: 186092},
+				pos: position{line: 6156, col: 10, offset: 191479},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6033, col: 10, offset: 186092},
+						pos:  position{line: 6156, col: 10, offset: 191479},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6033, col: 25, offset: 186107},
+						pos:        position{line: 6156, col: 25, offset: 191494},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6033, col: 29, offset: 186111},
+						pos:  position{line: 6156, col: 29, offset: 191498},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15731,9 +16025,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 6034, col: 1, offset: 186126},
+			pos:  position{line: 6157, col: 1, offset: 191513},
 			expr: &litMatcher{
-				pos:        position{line: 6034, col: 10, offset: 186135},
+				pos:        position{line: 6157, col: 10, offset: 191522},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15741,18 +16035,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 6035, col: 1, offset: 186139},
+			pos:  position{line: 6158, col: 1, offset: 191526},
 			expr: &seqExpr{
-				pos: position{line: 6035, col: 12, offset: 186150},
+				pos: position{line: 6158, col: 12, offset: 191537},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6035, col: 12, offset: 186150},
+						pos:        position{line: 6158, col: 12, offset: 191537},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6035, col: 16, offset: 186154},
+						pos:  position{line: 6158, col: 16, offset: 191541},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15760,16 +16054,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 6036, col: 1, offset: 186169},
+			pos:  position{line: 6159, col: 1, offset: 191556},
 			expr: &seqExpr{
-				pos: position{line: 6036, col: 12, offset: 186180},
+				pos: position{line: 6159, col: 12, offset: 191567},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6036, col: 12, offset: 186180},
+						pos:  position{line: 6159, col: 12, offset: 191567},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6036, col: 27, offset: 186195},
+						pos:        position{line: 6159, col: 27, offset: 191582},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15779,40 +16073,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 6038, col: 1, offset: 186200},
+			pos:  position{line: 6161, col: 1, offset: 191587},
 			expr: &notExpr{
-				pos: position{line: 6038, col: 8, offset: 186207},
+				pos: position{line: 6161, col: 8, offset: 191594},
 				expr: &anyMatcher{
-					line: 6038, col: 9, offset: 186208,
+					line: 6161, col: 9, offset: 191595,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 6039, col: 1, offset: 186210},
+			pos:  position{line: 6162, col: 1, offset: 191597},
 			expr: &choiceExpr{
-				pos: position{line: 6039, col: 15, offset: 186224},
+				pos: position{line: 6162, col: 15, offset: 191611},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 6039, col: 15, offset: 186224},
+						pos:        position{line: 6162, col: 15, offset: 191611},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 6039, col: 21, offset: 186230},
+						pos:        position{line: 6162, col: 21, offset: 191617},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6039, col: 28, offset: 186237},
+						pos:        position{line: 6162, col: 28, offset: 191624},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6039, col: 35, offset: 186244},
+						pos:        position{line: 6162, col: 35, offset: 191631},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15822,37 +16116,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 6040, col: 1, offset: 186249},
+			pos:  position{line: 6163, col: 1, offset: 191636},
 			expr: &choiceExpr{
-				pos: position{line: 6040, col: 10, offset: 186258},
+				pos: position{line: 6163, col: 10, offset: 191645},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 6040, col: 11, offset: 186259},
+						pos: position{line: 6163, col: 11, offset: 191646},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 6040, col: 11, offset: 186259},
+								pos: position{line: 6163, col: 11, offset: 191646},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6040, col: 11, offset: 186259},
+									pos:  position{line: 6163, col: 11, offset: 191646},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 6040, col: 23, offset: 186271},
+								pos:  position{line: 6163, col: 23, offset: 191658},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 6040, col: 31, offset: 186279},
+								pos: position{line: 6163, col: 31, offset: 191666},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6040, col: 31, offset: 186279},
+									pos:  position{line: 6163, col: 31, offset: 191666},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 6040, col: 46, offset: 186294},
+						pos: position{line: 6163, col: 46, offset: 191681},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6040, col: 46, offset: 186294},
+							pos:  position{line: 6163, col: 46, offset: 191681},
 							name: "WHITESPACE",
 						},
 					},
@@ -15861,38 +16155,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 6041, col: 1, offset: 186306},
+			pos:  position{line: 6164, col: 1, offset: 191693},
 			expr: &seqExpr{
-				pos: position{line: 6041, col: 12, offset: 186317},
+				pos: position{line: 6164, col: 12, offset: 191704},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6041, col: 12, offset: 186317},
+						pos:        position{line: 6164, col: 12, offset: 191704},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 6041, col: 18, offset: 186323},
+						pos: position{line: 6164, col: 18, offset: 191710},
 						expr: &seqExpr{
-							pos: position{line: 6041, col: 19, offset: 186324},
+							pos: position{line: 6164, col: 19, offset: 191711},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 6041, col: 19, offset: 186324},
+									pos: position{line: 6164, col: 19, offset: 191711},
 									expr: &litMatcher{
-										pos:        position{line: 6041, col: 21, offset: 186326},
+										pos:        position{line: 6164, col: 21, offset: 191713},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 6041, col: 28, offset: 186333,
+									line: 6164, col: 28, offset: 191720,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 6041, col: 32, offset: 186337},
+						pos:        position{line: 6164, col: 32, offset: 191724},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15902,16 +16196,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 6042, col: 1, offset: 186343},
+			pos:  position{line: 6165, col: 1, offset: 191730},
 			expr: &choiceExpr{
-				pos: position{line: 6042, col: 20, offset: 186362},
+				pos: position{line: 6165, col: 20, offset: 191749},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6042, col: 20, offset: 186362},
+						pos:  position{line: 6165, col: 20, offset: 191749},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6042, col: 28, offset: 186370},
+						pos:        position{line: 6165, col: 28, offset: 191757},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15921,16 +16215,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 6043, col: 1, offset: 186373},
+			pos:  position{line: 6166, col: 1, offset: 191760},
 			expr: &choiceExpr{
-				pos: position{line: 6043, col: 19, offset: 186391},
+				pos: position{line: 6166, col: 19, offset: 191778},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6043, col: 19, offset: 186391},
+						pos:  position{line: 6166, col: 19, offset: 191778},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6043, col: 27, offset: 186399},
+						pos:  position{line: 6166, col: 27, offset: 191786},
 						name: "SPACE",
 					},
 				},
@@ -20468,10 +20762,18 @@ func (c *current) onJsonExpr19(opName, value any) (any, error) {
 
 	leftJsonExpr, ok := value.(*structs.JsonExpr)
 	if !ok {
-		return nil, fmt.Errorf("failed to assert expr as *structs.JsonExpr")
+		return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr; Check the argument of the function")
 	}
 
-	node, err := createJsonExprAst(opNameStr, leftJsonExpr, nil, structs.JEMExpr)
+	if opNameStr == "json_entries" || opNameStr == "json_keys" {
+		if leftJsonExpr.JsonExprMode != structs.JEMString || leftJsonExpr.JsonExprMode != structs.JEMField {
+			// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/evaluation-functions/json-functions#e1d0bff6_e301_4880_8e8d_daf710234e07__json_delete.28.26lt.3Bobject.26gt.3B.2C.26lt.3Bkeys.26gt.3B.29
+			// text from documentation - The <value> argument can be a valid JSON object or the name of a field that contains a valid JSON object.
+			return nil, fmt.Errorf("spl peg: value argument can only take a json string or a field")
+		}
+	}
+
+	node, err := createJsonExprSingleNodeAst("json", leftJsonExpr, nil, structs.JEMExpr)
 	if err != nil {
 		return nil, err
 	}
@@ -20485,28 +20787,39 @@ func (p *parser) callonJsonExpr19() (any, error) {
 	return p.cur.onJsonExpr19(stack["opName"], stack["value"])
 }
 
-func (c *current) onJsonExpr27(opName, json, path, value, rest any) (any, error) {
+func (c *current) onJsonExpr31(opName, json, path, value, rest any) (any, error) {
 	// json can only be a field that references a json object
 	// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title4
 	// words from documentation - <json> (the name of a valid JSON document such as a JSON object)
 
+	opNameStr, err := transferUint8ToString(opName)
+	if err != nil {
+		return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+	}
+
 	castedJson, ok := json.(*structs.JsonExpr)
 	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr")
+		return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr; Check the json argument of the function")
 	}
 
 	// change this condition to allow other dtypes if splunk allows them since it is not stated in the documentation
 	if castedJson.JsonExprMode != structs.JEMField {
-		return nil, fmt.Errorf("spl peg: json field can only be a field")
+		if opNameStr == "json_append" {
+			return nil, fmt.Errorf("spl peg: json argument can only be a field")
+			// not explicitly stated for json_extend/json_set/json_set_exact
+		} else if castedJson.JsonExprMode != structs.JEMString {
+			return nil, fmt.Errorf("spl peg: json argument can only be a field or a json string")
+		}
 	}
 
-	result, err := createJsonExprKeyValueAst("json_append", path, value, rest)
+	var result *structs.JsonExpr
+	result, err = createJsonExprKeyValueAst(opNameStr, path, value, rest)
 	if err != nil {
 		return nil, err
 	}
 
 	// JsonExpr.Right will contain the field that may be pointing to a json object
-	result, err = createJsonExprAst("json_append", result, castedJson, structs.JEMExpr)
+	result, err = createJsonExprSingleNodeAst(opNameStr, result, castedJson, structs.JEMExpr)
 	if err != nil {
 		return nil, err
 	}
@@ -20514,56 +20827,127 @@ func (c *current) onJsonExpr27(opName, json, path, value, rest any) (any, error)
 	return result, nil
 }
 
-func (p *parser) callonJsonExpr27() (any, error) {
+func (p *parser) callonJsonExpr31() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExpr27(stack["opName"], stack["json"], stack["path"], stack["value"], stack["rest"])
+	return p.cur.onJsonExpr31(stack["opName"], stack["json"], stack["path"], stack["value"], stack["rest"])
 }
 
-func (c *current) onJsonExpr48(value, rest any) (any, error) {
-	castedValue, ok := value.(*structs.JsonExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
-	}
-
-	args := make([]*structs.JsonExpr, 1, 5)
-	args[0] = castedValue
-
-	if rest != nil {
-		var restValue *structs.JsonExpr
-		for idx, arg := range rest.([]any) {
-			restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
-			if !ok {
-				return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
-			}
-			args = append(args, restValue)
-		}
-	}
-
-	var result *structs.JsonExpr
-	var err error
-	if len(args) == 1 {
-		result, err = createJsonExprAst("json_array", args[0], nil, structs.JEMExpr)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		result = args[0]
-		for i := 1; i < len(args); i++ {
-			result, err = createJsonExprAst("json_array", result, args[i], structs.JEMExpr)
-			if err != nil {
-				return nil, err
-			}
-		}
+func (c *current) onJsonExpr56(value, rest any) (any, error) {
+	result, err := createJsonExprAst("json_array", value, rest, 0)
+	if err != nil {
+		return nil, err
 	}
 
 	return result, nil
 }
 
-func (p *parser) callonJsonExpr48() (any, error) {
+func (p *parser) callonJsonExpr56() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExpr48(stack["value"], stack["rest"])
+	return p.cur.onJsonExpr56(stack["value"], stack["rest"])
+}
+
+func (c *current) onJsonExpr68(object, firstKey, rest any) (any, error) {
+	castedJson, ok := object.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert object argument as *structs.JsonExpr")
+	}
+
+	result, err := createJsonExprAst("json_delete", firstKey, rest, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err = createJsonExprSingleNodeAst("json_delete", result, castedJson, structs.JEMExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr68() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr68(stack["object"], stack["firstKey"], stack["rest"])
+}
+
+func (c *current) onJsonExpr89(opName, json, paths any) (any, error) {
+	opNameStr, err := transferUint8ToString(opName)
+	if err != nil {
+		return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+	}
+
+	castedJson, ok := json.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert json argument as *structs.JsonExpr")
+	}
+
+	var result *structs.JsonExpr
+	if paths != nil {
+		// paths structure - [",", pathValue]
+		// if length is greater than 2 that means there are more than one paths
+		if len(paths.([]any)) > 2 {
+			// firstValue = first path value (i.e. value at index 1)
+			// rest of the values including commas are from index 2
+			result, err = createJsonExprAst(opNameStr, paths.([]any)[1], paths.([]any)[2:], 1)
+		} else {
+			// rest is nil here
+			result, err = createJsonExprAst(opNameStr, paths.([]any)[1], nil, 1)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result, err = createJsonExprSingleNodeAst(opNameStr, result, castedJson, structs.JEMExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr89() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr89(stack["opName"], stack["json"], stack["paths"])
+}
+
+func (c *current) onJsonExpr104(object, key any) (any, error) {
+	isValid := func(value *structs.JsonExpr) bool {
+		return value.JsonExprMode == structs.JEMField || value.JsonExprMode == structs.JEMString
+	}
+
+	castedObject, ok := object.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert object argument to *structs.JsonExpr")
+	}
+	if !isValid(castedObject) {
+		return nil, fmt.Errorf("spl peg: object argument of json_has_key_exact can only accept a field or a json string")
+	}
+
+	castedKey, ok := object.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert key argument to *structs.JsonExpr")
+	}
+	if !isValid(castedKey) {
+		return nil, fmt.Errorf("spl peg: key argument of json_has_key_exact can onlyy accept a field or a json string")
+	}
+
+	result, err := createJsonExprSingleNodeAst("json_has_key_exact", castedKey, castedObject, structs.JEMExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr104() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr104(stack["object"], stack["key"])
 }
 
 func (c *current) onLenExpr2(str any) (any, error) {

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -8654,14 +8654,14 @@ var g = &grammar{
 										},
 										&ruleRefExpr{
 											pos:  position{line: 3826, col: 107, offset: 117715},
-											name: "String",
+											name: "JsonExprLevel1",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 114, offset: 117722},
+											pos:  position{line: 3826, col: 122, offset: 117730},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3826, col: 120, offset: 117728},
+											pos:  position{line: 3826, col: 128, offset: 117736},
 											name: "JsonExprLevel1",
 										},
 									},
@@ -8669,7 +8669,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3826, col: 137, offset: 117745},
+							pos:  position{line: 3826, col: 145, offset: 117753},
 							name: "R_PAREN",
 						},
 					},
@@ -8678,28 +8678,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3900, col: 1, offset: 120200},
+			pos:  position{line: 3902, col: 1, offset: 120272},
 			expr: &choiceExpr{
-				pos: position{line: 3900, col: 12, offset: 120211},
+				pos: position{line: 3902, col: 12, offset: 120283},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3900, col: 12, offset: 120211},
+						pos: position{line: 3902, col: 12, offset: 120283},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3900, col: 12, offset: 120211},
+							pos: position{line: 3902, col: 12, offset: 120283},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3900, col: 12, offset: 120211},
+									pos:   position{line: 3902, col: 12, offset: 120283},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3900, col: 16, offset: 120215},
+										pos:  position{line: 3902, col: 16, offset: 120287},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3900, col: 29, offset: 120228},
+									pos: position{line: 3902, col: 29, offset: 120300},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3900, col: 31, offset: 120230},
+										pos:  position{line: 3902, col: 31, offset: 120302},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8707,50 +8707,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3916, col: 3, offset: 120605},
+						pos: position{line: 3918, col: 3, offset: 120677},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3916, col: 3, offset: 120605},
+							pos: position{line: 3918, col: 3, offset: 120677},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3916, col: 3, offset: 120605},
+									pos:   position{line: 3918, col: 3, offset: 120677},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3916, col: 9, offset: 120611},
+										pos:  position{line: 3918, col: 9, offset: 120683},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3916, col: 25, offset: 120627},
+									pos: position{line: 3918, col: 25, offset: 120699},
 									expr: &choiceExpr{
-										pos: position{line: 3916, col: 27, offset: 120629},
+										pos: position{line: 3918, col: 27, offset: 120701},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 27, offset: 120629},
+												pos:  position{line: 3918, col: 27, offset: 120701},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 36, offset: 120638},
+												pos:  position{line: 3918, col: 36, offset: 120710},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 46, offset: 120648},
+												pos:  position{line: 3918, col: 46, offset: 120720},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 54, offset: 120656},
+												pos:  position{line: 3918, col: 54, offset: 120728},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 62, offset: 120664},
+												pos:  position{line: 3918, col: 62, offset: 120736},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3916, col: 70, offset: 120672},
+												pos:  position{line: 3918, col: 70, offset: 120744},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3916, col: 84, offset: 120686},
+												pos:        position{line: 3918, col: 84, offset: 120758},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8766,28 +8766,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3933, col: 1, offset: 121037},
+			pos:  position{line: 3935, col: 1, offset: 121109},
 			expr: &actionExpr{
-				pos: position{line: 3933, col: 19, offset: 121055},
+				pos: position{line: 3935, col: 19, offset: 121127},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3933, col: 19, offset: 121055},
+					pos: position{line: 3935, col: 19, offset: 121127},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3933, col: 19, offset: 121055},
+							pos:        position{line: 3935, col: 19, offset: 121127},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3933, col: 26, offset: 121062},
+							pos:  position{line: 3935, col: 26, offset: 121134},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3933, col: 32, offset: 121068},
+							pos:   position{line: 3935, col: 32, offset: 121140},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3933, col: 40, offset: 121076},
+								pos:  position{line: 3935, col: 40, offset: 121148},
 								name: "Boolean",
 							},
 						},
@@ -8797,28 +8797,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3944, col: 1, offset: 121265},
+			pos:  position{line: 3946, col: 1, offset: 121337},
 			expr: &actionExpr{
-				pos: position{line: 3944, col: 23, offset: 121287},
+				pos: position{line: 3946, col: 23, offset: 121359},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3944, col: 23, offset: 121287},
+					pos: position{line: 3946, col: 23, offset: 121359},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3944, col: 23, offset: 121287},
+							pos:        position{line: 3946, col: 23, offset: 121359},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3944, col: 34, offset: 121298},
+							pos:  position{line: 3946, col: 34, offset: 121370},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3944, col: 40, offset: 121304},
+							pos:   position{line: 3946, col: 40, offset: 121376},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3944, col: 48, offset: 121312},
+								pos:  position{line: 3946, col: 48, offset: 121384},
 								name: "Boolean",
 							},
 						},
@@ -8828,28 +8828,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3955, col: 1, offset: 121509},
+			pos:  position{line: 3957, col: 1, offset: 121581},
 			expr: &actionExpr{
-				pos: position{line: 3955, col: 20, offset: 121528},
+				pos: position{line: 3957, col: 20, offset: 121600},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3955, col: 20, offset: 121528},
+					pos: position{line: 3957, col: 20, offset: 121600},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3955, col: 20, offset: 121528},
+							pos:        position{line: 3957, col: 20, offset: 121600},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3955, col: 28, offset: 121536},
+							pos:  position{line: 3957, col: 28, offset: 121608},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3955, col: 34, offset: 121542},
+							pos:   position{line: 3957, col: 34, offset: 121614},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3955, col: 43, offset: 121551},
+								pos:  position{line: 3957, col: 43, offset: 121623},
 								name: "IntegerAsString",
 							},
 						},
@@ -8859,15 +8859,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3970, col: 1, offset: 121913},
+			pos:  position{line: 3972, col: 1, offset: 121985},
 			expr: &actionExpr{
-				pos: position{line: 3970, col: 19, offset: 121931},
+				pos: position{line: 3972, col: 19, offset: 122003},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3970, col: 19, offset: 121931},
+					pos:   position{line: 3972, col: 19, offset: 122003},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3970, col: 28, offset: 121940},
+						pos:  position{line: 3972, col: 28, offset: 122012},
 						name: "BoolExpr",
 					},
 				},
@@ -8875,30 +8875,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 3981, col: 1, offset: 122152},
+			pos:  position{line: 3983, col: 1, offset: 122224},
 			expr: &actionExpr{
-				pos: position{line: 3981, col: 15, offset: 122166},
+				pos: position{line: 3983, col: 15, offset: 122238},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 3981, col: 15, offset: 122166},
+					pos:   position{line: 3983, col: 15, offset: 122238},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 3981, col: 23, offset: 122174},
+						pos: position{line: 3983, col: 23, offset: 122246},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 3981, col: 23, offset: 122174},
+								pos:  position{line: 3983, col: 23, offset: 122246},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3981, col: 44, offset: 122195},
+								pos:  position{line: 3983, col: 44, offset: 122267},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3981, col: 61, offset: 122212},
+								pos:  position{line: 3983, col: 61, offset: 122284},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 3981, col: 79, offset: 122230},
+								pos:  position{line: 3983, col: 79, offset: 122302},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8908,35 +8908,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 3985, col: 1, offset: 122274},
+			pos:  position{line: 3987, col: 1, offset: 122346},
 			expr: &actionExpr{
-				pos: position{line: 3985, col: 19, offset: 122292},
+				pos: position{line: 3987, col: 19, offset: 122364},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 3985, col: 19, offset: 122292},
+					pos: position{line: 3987, col: 19, offset: 122364},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3985, col: 19, offset: 122292},
+							pos:   position{line: 3987, col: 19, offset: 122364},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3985, col: 26, offset: 122299},
+								pos:  position{line: 3987, col: 26, offset: 122371},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3985, col: 37, offset: 122310},
+							pos:   position{line: 3987, col: 37, offset: 122382},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3985, col: 43, offset: 122316},
+								pos: position{line: 3987, col: 43, offset: 122388},
 								expr: &seqExpr{
-									pos: position{line: 3985, col: 44, offset: 122317},
+									pos: position{line: 3987, col: 44, offset: 122389},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3985, col: 44, offset: 122317},
+											pos:  position{line: 3987, col: 44, offset: 122389},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3985, col: 50, offset: 122323},
+											pos:  position{line: 3987, col: 50, offset: 122395},
 											name: "HeadOption",
 										},
 									},
@@ -8949,29 +8949,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4042, col: 1, offset: 124123},
+			pos:  position{line: 4044, col: 1, offset: 124195},
 			expr: &choiceExpr{
-				pos: position{line: 4042, col: 14, offset: 124136},
+				pos: position{line: 4044, col: 14, offset: 124208},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4042, col: 14, offset: 124136},
+						pos: position{line: 4044, col: 14, offset: 124208},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4042, col: 14, offset: 124136},
+							pos: position{line: 4044, col: 14, offset: 124208},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4042, col: 14, offset: 124136},
+									pos:  position{line: 4044, col: 14, offset: 124208},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4042, col: 19, offset: 124141},
+									pos:  position{line: 4044, col: 19, offset: 124213},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4042, col: 28, offset: 124150},
+									pos:   position{line: 4044, col: 28, offset: 124222},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4042, col: 37, offset: 124159},
+										pos:  position{line: 4044, col: 37, offset: 124231},
 										name: "HeadOptionList",
 									},
 								},
@@ -8979,24 +8979,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4053, col: 3, offset: 124478},
+						pos: position{line: 4055, col: 3, offset: 124550},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4053, col: 3, offset: 124478},
+							pos: position{line: 4055, col: 3, offset: 124550},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4053, col: 3, offset: 124478},
+									pos:  position{line: 4055, col: 3, offset: 124550},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4053, col: 8, offset: 124483},
+									pos:  position{line: 4055, col: 8, offset: 124555},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4053, col: 17, offset: 124492},
+									pos:   position{line: 4055, col: 17, offset: 124564},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4053, col: 26, offset: 124501},
+										pos:  position{line: 4055, col: 26, offset: 124573},
 										name: "IntegerAsString",
 									},
 								},
@@ -9004,17 +9004,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4073, col: 3, offset: 125018},
+						pos: position{line: 4075, col: 3, offset: 125090},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4073, col: 3, offset: 125018},
+							pos: position{line: 4075, col: 3, offset: 125090},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4073, col: 3, offset: 125018},
+									pos:  position{line: 4075, col: 3, offset: 125090},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4073, col: 8, offset: 125023},
+									pos:  position{line: 4075, col: 8, offset: 125095},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9025,29 +9025,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4091, col: 1, offset: 125493},
+			pos:  position{line: 4093, col: 1, offset: 125565},
 			expr: &choiceExpr{
-				pos: position{line: 4091, col: 14, offset: 125506},
+				pos: position{line: 4093, col: 14, offset: 125578},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4091, col: 14, offset: 125506},
+						pos: position{line: 4093, col: 14, offset: 125578},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4091, col: 14, offset: 125506},
+							pos: position{line: 4093, col: 14, offset: 125578},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4091, col: 14, offset: 125506},
+									pos:  position{line: 4093, col: 14, offset: 125578},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4091, col: 19, offset: 125511},
+									pos:  position{line: 4093, col: 19, offset: 125583},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4091, col: 28, offset: 125520},
+									pos:   position{line: 4093, col: 28, offset: 125592},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4091, col: 37, offset: 125529},
+										pos:  position{line: 4093, col: 37, offset: 125601},
 										name: "IntegerAsString",
 									},
 								},
@@ -9055,17 +9055,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4112, col: 3, offset: 126103},
+						pos: position{line: 4114, col: 3, offset: 126175},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4112, col: 3, offset: 126103},
+							pos: position{line: 4114, col: 3, offset: 126175},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4112, col: 3, offset: 126103},
+									pos:  position{line: 4114, col: 3, offset: 126175},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4112, col: 8, offset: 126108},
+									pos:  position{line: 4114, col: 8, offset: 126180},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9076,44 +9076,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4133, col: 1, offset: 126726},
+			pos:  position{line: 4135, col: 1, offset: 126798},
 			expr: &actionExpr{
-				pos: position{line: 4133, col: 20, offset: 126745},
+				pos: position{line: 4135, col: 20, offset: 126817},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4133, col: 20, offset: 126745},
+					pos: position{line: 4135, col: 20, offset: 126817},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4133, col: 20, offset: 126745},
+							pos:   position{line: 4135, col: 20, offset: 126817},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4133, col: 26, offset: 126751},
+								pos:  position{line: 4135, col: 26, offset: 126823},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4133, col: 37, offset: 126762},
+							pos:   position{line: 4135, col: 37, offset: 126834},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4133, col: 42, offset: 126767},
+								pos: position{line: 4135, col: 42, offset: 126839},
 								expr: &seqExpr{
-									pos: position{line: 4133, col: 43, offset: 126768},
+									pos: position{line: 4135, col: 43, offset: 126840},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4133, col: 44, offset: 126769},
+											pos: position{line: 4135, col: 44, offset: 126841},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4133, col: 44, offset: 126769},
+													pos:  position{line: 4135, col: 44, offset: 126841},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4133, col: 52, offset: 126777},
+													pos:  position{line: 4135, col: 52, offset: 126849},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4133, col: 59, offset: 126784},
+											pos:  position{line: 4135, col: 59, offset: 126856},
 											name: "Aggregator",
 										},
 									},
@@ -9126,28 +9126,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4150, col: 1, offset: 127287},
+			pos:  position{line: 4152, col: 1, offset: 127359},
 			expr: &actionExpr{
-				pos: position{line: 4150, col: 15, offset: 127301},
+				pos: position{line: 4152, col: 15, offset: 127373},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4150, col: 15, offset: 127301},
+					pos: position{line: 4152, col: 15, offset: 127373},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4150, col: 15, offset: 127301},
+							pos:   position{line: 4152, col: 15, offset: 127373},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4150, col: 23, offset: 127309},
+								pos:  position{line: 4152, col: 23, offset: 127381},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4150, col: 35, offset: 127321},
+							pos:   position{line: 4152, col: 35, offset: 127393},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4150, col: 43, offset: 127329},
+								pos: position{line: 4152, col: 43, offset: 127401},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4150, col: 43, offset: 127329},
+									pos:  position{line: 4152, col: 43, offset: 127401},
 									name: "AsField",
 								},
 							},
@@ -9158,26 +9158,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4166, col: 1, offset: 128170},
+			pos:  position{line: 4168, col: 1, offset: 128242},
 			expr: &actionExpr{
-				pos: position{line: 4166, col: 16, offset: 128185},
+				pos: position{line: 4168, col: 16, offset: 128257},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4166, col: 16, offset: 128185},
+					pos:   position{line: 4168, col: 16, offset: 128257},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4166, col: 21, offset: 128190},
+						pos: position{line: 4168, col: 21, offset: 128262},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4166, col: 21, offset: 128190},
+								pos:  position{line: 4168, col: 21, offset: 128262},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4166, col: 32, offset: 128201},
+								pos:  position{line: 4168, col: 32, offset: 128273},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4166, col: 48, offset: 128217},
+								pos:  position{line: 4168, col: 48, offset: 128289},
 								name: "AggCommon",
 							},
 						},
@@ -9187,165 +9187,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4171, col: 1, offset: 128385},
+			pos:  position{line: 4173, col: 1, offset: 128457},
 			expr: &actionExpr{
-				pos: position{line: 4171, col: 18, offset: 128402},
+				pos: position{line: 4173, col: 18, offset: 128474},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4171, col: 19, offset: 128403},
+					pos: position{line: 4173, col: 19, offset: 128475},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4171, col: 19, offset: 128403},
+							pos:        position{line: 4173, col: 19, offset: 128475},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 30, offset: 128414},
+							pos:        position{line: 4173, col: 30, offset: 128486},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 39, offset: 128423},
+							pos:        position{line: 4173, col: 39, offset: 128495},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 47, offset: 128431},
+							pos:        position{line: 4173, col: 47, offset: 128503},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 57, offset: 128441},
+							pos:        position{line: 4173, col: 57, offset: 128513},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 65, offset: 128449},
+							pos:        position{line: 4173, col: 65, offset: 128521},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 76, offset: 128460},
+							pos:        position{line: 4173, col: 76, offset: 128532},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 86, offset: 128470},
+							pos:        position{line: 4173, col: 86, offset: 128542},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 95, offset: 128479},
+							pos:        position{line: 4173, col: 95, offset: 128551},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 105, offset: 128489},
+							pos:        position{line: 4173, col: 105, offset: 128561},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 114, offset: 128498},
+							pos:        position{line: 4173, col: 114, offset: 128570},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 122, offset: 128506},
+							pos:        position{line: 4173, col: 122, offset: 128578},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 133, offset: 128517},
+							pos:        position{line: 4173, col: 133, offset: 128589},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4171, col: 142, offset: 128526},
+							pos:        position{line: 4173, col: 142, offset: 128598},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 1, offset: 128535},
+							pos:        position{line: 4174, col: 1, offset: 128607},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 10, offset: 128544},
+							pos:        position{line: 4174, col: 10, offset: 128616},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 26, offset: 128560},
+							pos:        position{line: 4174, col: 26, offset: 128632},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 37, offset: 128571},
+							pos:        position{line: 4174, col: 37, offset: 128643},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 46, offset: 128580},
+							pos:        position{line: 4174, col: 46, offset: 128652},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 56, offset: 128590},
+							pos:        position{line: 4174, col: 56, offset: 128662},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 72, offset: 128606},
+							pos:        position{line: 4174, col: 72, offset: 128678},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 82, offset: 128616},
+							pos:        position{line: 4174, col: 82, offset: 128688},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 100, offset: 128634},
+							pos:        position{line: 4174, col: 100, offset: 128706},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 113, offset: 128647},
+							pos:        position{line: 4174, col: 113, offset: 128719},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 132, offset: 128666},
+							pos:        position{line: 4174, col: 132, offset: 128738},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4172, col: 139, offset: 128673},
+							pos:        position{line: 4174, col: 139, offset: 128745},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9356,33 +9356,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4176, col: 1, offset: 128716},
+			pos:  position{line: 4178, col: 1, offset: 128788},
 			expr: &actionExpr{
-				pos: position{line: 4176, col: 22, offset: 128737},
+				pos: position{line: 4178, col: 22, offset: 128809},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4176, col: 23, offset: 128738},
+					pos: position{line: 4178, col: 23, offset: 128810},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4176, col: 23, offset: 128738},
+							pos:        position{line: 4178, col: 23, offset: 128810},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4176, col: 37, offset: 128752},
+							pos:        position{line: 4178, col: 37, offset: 128824},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4176, col: 51, offset: 128766},
+							pos:        position{line: 4178, col: 51, offset: 128838},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4176, col: 60, offset: 128775},
+							pos:        position{line: 4178, col: 60, offset: 128847},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9393,29 +9393,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4180, col: 1, offset: 128816},
+			pos:  position{line: 4182, col: 1, offset: 128888},
 			expr: &actionExpr{
-				pos: position{line: 4180, col: 12, offset: 128827},
+				pos: position{line: 4182, col: 12, offset: 128899},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4180, col: 12, offset: 128827},
+					pos: position{line: 4182, col: 12, offset: 128899},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4180, col: 12, offset: 128827},
+							pos:  position{line: 4182, col: 12, offset: 128899},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4180, col: 15, offset: 128830},
+							pos:   position{line: 4182, col: 15, offset: 128902},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4180, col: 23, offset: 128838},
+								pos: position{line: 4182, col: 23, offset: 128910},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4180, col: 23, offset: 128838},
+										pos:  position{line: 4182, col: 23, offset: 128910},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4180, col: 35, offset: 128850},
+										pos:  position{line: 4182, col: 35, offset: 128922},
 										name: "String",
 									},
 								},
@@ -9427,27 +9427,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4194, col: 1, offset: 129179},
+			pos:  position{line: 4196, col: 1, offset: 129251},
 			expr: &choiceExpr{
-				pos: position{line: 4194, col: 13, offset: 129191},
+				pos: position{line: 4196, col: 13, offset: 129263},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4194, col: 13, offset: 129191},
+						pos: position{line: 4196, col: 13, offset: 129263},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4194, col: 13, offset: 129191},
+							pos: position{line: 4196, col: 13, offset: 129263},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4194, col: 14, offset: 129192},
+									pos: position{line: 4196, col: 14, offset: 129264},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4194, col: 14, offset: 129192},
+											pos:        position{line: 4196, col: 14, offset: 129264},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4194, col: 24, offset: 129202},
+											pos:        position{line: 4196, col: 24, offset: 129274},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9455,47 +9455,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4194, col: 29, offset: 129207},
+									pos:  position{line: 4196, col: 29, offset: 129279},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4194, col: 37, offset: 129215},
+									pos:        position{line: 4196, col: 37, offset: 129287},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4194, col: 44, offset: 129222},
+									pos:   position{line: 4196, col: 44, offset: 129294},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4194, col: 54, offset: 129232},
+										pos:  position{line: 4196, col: 54, offset: 129304},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4194, col: 64, offset: 129242},
+									pos:  position{line: 4196, col: 64, offset: 129314},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4204, col: 3, offset: 129471},
+						pos: position{line: 4206, col: 3, offset: 129543},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4204, col: 3, offset: 129471},
+							pos: position{line: 4206, col: 3, offset: 129543},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4204, col: 4, offset: 129472},
+									pos: position{line: 4206, col: 4, offset: 129544},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4204, col: 4, offset: 129472},
+											pos:        position{line: 4206, col: 4, offset: 129544},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4204, col: 14, offset: 129482},
+											pos:        position{line: 4206, col: 14, offset: 129554},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9503,38 +9503,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4204, col: 19, offset: 129487},
+									pos:  position{line: 4206, col: 19, offset: 129559},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4204, col: 27, offset: 129495},
+									pos:   position{line: 4206, col: 27, offset: 129567},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4204, col: 33, offset: 129501},
+										pos:  position{line: 4206, col: 33, offset: 129573},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4204, col: 43, offset: 129511},
+									pos:  position{line: 4206, col: 43, offset: 129583},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4211, col: 5, offset: 129663},
+						pos: position{line: 4213, col: 5, offset: 129735},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4211, col: 6, offset: 129664},
+							pos: position{line: 4213, col: 6, offset: 129736},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4211, col: 6, offset: 129664},
+									pos:        position{line: 4213, col: 6, offset: 129736},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4211, col: 16, offset: 129674},
+									pos:        position{line: 4213, col: 16, offset: 129746},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9547,77 +9547,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4220, col: 1, offset: 129811},
+			pos:  position{line: 4222, col: 1, offset: 129883},
 			expr: &choiceExpr{
-				pos: position{line: 4220, col: 14, offset: 129824},
+				pos: position{line: 4222, col: 14, offset: 129896},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4220, col: 14, offset: 129824},
+						pos: position{line: 4222, col: 14, offset: 129896},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4220, col: 14, offset: 129824},
+							pos: position{line: 4222, col: 14, offset: 129896},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4220, col: 14, offset: 129824},
+									pos:   position{line: 4222, col: 14, offset: 129896},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4220, col: 22, offset: 129832},
+										pos:  position{line: 4222, col: 22, offset: 129904},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4220, col: 36, offset: 129846},
+									pos:  position{line: 4222, col: 36, offset: 129918},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4220, col: 44, offset: 129854},
+									pos:        position{line: 4222, col: 44, offset: 129926},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4220, col: 51, offset: 129861},
+									pos:   position{line: 4222, col: 51, offset: 129933},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4220, col: 61, offset: 129871},
+										pos:  position{line: 4222, col: 61, offset: 129943},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4220, col: 71, offset: 129881},
+									pos:  position{line: 4222, col: 71, offset: 129953},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4235, col: 3, offset: 130292},
+						pos: position{line: 4237, col: 3, offset: 130364},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4235, col: 3, offset: 130292},
+							pos: position{line: 4237, col: 3, offset: 130364},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4235, col: 3, offset: 130292},
+									pos:   position{line: 4237, col: 3, offset: 130364},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4235, col: 11, offset: 130300},
+										pos:  position{line: 4237, col: 11, offset: 130372},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4235, col: 25, offset: 130314},
+									pos:  position{line: 4237, col: 25, offset: 130386},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4235, col: 33, offset: 130322},
+									pos:   position{line: 4237, col: 33, offset: 130394},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4235, col: 39, offset: 130328},
+										pos:  position{line: 4237, col: 39, offset: 130400},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4235, col: 49, offset: 130338},
+									pos:  position{line: 4237, col: 49, offset: 130410},
 									name: "R_PAREN",
 								},
 							},
@@ -9628,22 +9628,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4265, col: 1, offset: 131319},
+			pos:  position{line: 4267, col: 1, offset: 131391},
 			expr: &actionExpr{
-				pos: position{line: 4265, col: 18, offset: 131336},
+				pos: position{line: 4267, col: 18, offset: 131408},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4265, col: 18, offset: 131336},
+					pos:   position{line: 4267, col: 18, offset: 131408},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4265, col: 26, offset: 131344},
+						pos: position{line: 4267, col: 26, offset: 131416},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4265, col: 26, offset: 131344},
+								pos:  position{line: 4267, col: 26, offset: 131416},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4265, col: 42, offset: 131360},
+								pos:  position{line: 4267, col: 42, offset: 131432},
 								name: "IntegerAsString",
 							},
 						},
@@ -9653,161 +9653,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4277, col: 1, offset: 131727},
+			pos:  position{line: 4279, col: 1, offset: 131799},
 			expr: &choiceExpr{
-				pos: position{line: 4277, col: 18, offset: 131744},
+				pos: position{line: 4279, col: 18, offset: 131816},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4277, col: 18, offset: 131744},
+						pos: position{line: 4279, col: 18, offset: 131816},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4277, col: 18, offset: 131744},
+							pos: position{line: 4279, col: 18, offset: 131816},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4277, col: 18, offset: 131744},
+									pos:   position{line: 4279, col: 18, offset: 131816},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4277, col: 26, offset: 131752},
+										pos:  position{line: 4279, col: 26, offset: 131824},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4277, col: 44, offset: 131770},
+									pos:   position{line: 4279, col: 44, offset: 131842},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4277, col: 58, offset: 131784},
+										pos:  position{line: 4279, col: 58, offset: 131856},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4277, col: 72, offset: 131798},
+									pos:  position{line: 4279, col: 72, offset: 131870},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4277, col: 80, offset: 131806},
+									pos:        position{line: 4279, col: 80, offset: 131878},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4277, col: 87, offset: 131813},
+									pos:   position{line: 4279, col: 87, offset: 131885},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4277, col: 97, offset: 131823},
+										pos:  position{line: 4279, col: 97, offset: 131895},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4277, col: 107, offset: 131833},
+									pos:  position{line: 4279, col: 107, offset: 131905},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4293, col: 3, offset: 132357},
+						pos: position{line: 4295, col: 3, offset: 132429},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4293, col: 3, offset: 132357},
+							pos: position{line: 4295, col: 3, offset: 132429},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4293, col: 3, offset: 132357},
+									pos:   position{line: 4295, col: 3, offset: 132429},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4293, col: 11, offset: 132365},
+										pos:  position{line: 4295, col: 11, offset: 132437},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4293, col: 29, offset: 132383},
+									pos:   position{line: 4295, col: 29, offset: 132455},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4293, col: 43, offset: 132397},
+										pos:  position{line: 4295, col: 43, offset: 132469},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4293, col: 57, offset: 132411},
+									pos:  position{line: 4295, col: 57, offset: 132483},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4293, col: 65, offset: 132419},
+									pos:   position{line: 4295, col: 65, offset: 132491},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4293, col: 71, offset: 132425},
+										pos:  position{line: 4295, col: 71, offset: 132497},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4293, col: 81, offset: 132435},
+									pos:  position{line: 4295, col: 81, offset: 132507},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4308, col: 3, offset: 132915},
+						pos: position{line: 4310, col: 3, offset: 132987},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4308, col: 3, offset: 132915},
+							pos: position{line: 4310, col: 3, offset: 132987},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4308, col: 4, offset: 132916},
+									pos:        position{line: 4310, col: 4, offset: 132988},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4308, col: 14, offset: 132926},
+									pos:  position{line: 4310, col: 14, offset: 132998},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4308, col: 22, offset: 132934},
+									pos:   position{line: 4310, col: 22, offset: 133006},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4308, col: 28, offset: 132940},
+										pos:  position{line: 4310, col: 28, offset: 133012},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4308, col: 38, offset: 132950},
+									pos:  position{line: 4310, col: 38, offset: 133022},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4323, col: 3, offset: 133337},
+						pos: position{line: 4325, col: 3, offset: 133409},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4323, col: 3, offset: 133337},
+							pos: position{line: 4325, col: 3, offset: 133409},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4323, col: 4, offset: 133338},
+									pos:        position{line: 4325, col: 4, offset: 133410},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4323, col: 14, offset: 133348},
+									pos:  position{line: 4325, col: 14, offset: 133420},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4323, col: 22, offset: 133356},
+									pos:        position{line: 4325, col: 22, offset: 133428},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4323, col: 29, offset: 133363},
+									pos:   position{line: 4325, col: 29, offset: 133435},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4323, col: 39, offset: 133373},
+										pos:  position{line: 4325, col: 39, offset: 133445},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4323, col: 49, offset: 133383},
+									pos:  position{line: 4325, col: 49, offset: 133455},
 									name: "R_PAREN",
 								},
 							},
@@ -9818,22 +9818,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4341, col: 1, offset: 133814},
+			pos:  position{line: 4343, col: 1, offset: 133886},
 			expr: &actionExpr{
-				pos: position{line: 4341, col: 25, offset: 133838},
+				pos: position{line: 4343, col: 25, offset: 133910},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4341, col: 25, offset: 133838},
+					pos:   position{line: 4343, col: 25, offset: 133910},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4341, col: 39, offset: 133852},
+						pos: position{line: 4343, col: 39, offset: 133924},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4341, col: 39, offset: 133852},
+								pos:  position{line: 4343, col: 39, offset: 133924},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4341, col: 67, offset: 133880},
+								pos:  position{line: 4343, col: 67, offset: 133952},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9843,43 +9843,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4345, col: 1, offset: 133943},
+			pos:  position{line: 4347, col: 1, offset: 134015},
 			expr: &actionExpr{
-				pos: position{line: 4345, col: 30, offset: 133972},
+				pos: position{line: 4347, col: 30, offset: 134044},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4345, col: 30, offset: 133972},
+					pos: position{line: 4347, col: 30, offset: 134044},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4345, col: 30, offset: 133972},
+							pos:   position{line: 4347, col: 30, offset: 134044},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4345, col: 34, offset: 133976},
+								pos:  position{line: 4347, col: 34, offset: 134048},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4345, col: 44, offset: 133986},
+							pos:   position{line: 4347, col: 44, offset: 134058},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4345, col: 48, offset: 133990},
+								pos: position{line: 4347, col: 48, offset: 134062},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4345, col: 48, offset: 133990},
+										pos:  position{line: 4347, col: 48, offset: 134062},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4345, col: 67, offset: 134009},
+										pos:  position{line: 4347, col: 67, offset: 134081},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4345, col: 87, offset: 134029},
+							pos:   position{line: 4347, col: 87, offset: 134101},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4345, col: 93, offset: 134035},
+								pos:  position{line: 4347, col: 93, offset: 134107},
 								name: "Number",
 							},
 						},
@@ -9889,15 +9889,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4358, col: 1, offset: 134269},
+			pos:  position{line: 4360, col: 1, offset: 134341},
 			expr: &actionExpr{
-				pos: position{line: 4358, col: 32, offset: 134300},
+				pos: position{line: 4360, col: 32, offset: 134372},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4358, col: 32, offset: 134300},
+					pos:   position{line: 4360, col: 32, offset: 134372},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4358, col: 38, offset: 134306},
+						pos:  position{line: 4360, col: 38, offset: 134378},
 						name: "Number",
 					},
 				},
@@ -9905,34 +9905,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4371, col: 1, offset: 134523},
+			pos:  position{line: 4373, col: 1, offset: 134595},
 			expr: &actionExpr{
-				pos: position{line: 4371, col: 26, offset: 134548},
+				pos: position{line: 4373, col: 26, offset: 134620},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4371, col: 26, offset: 134548},
+					pos: position{line: 4373, col: 26, offset: 134620},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4371, col: 26, offset: 134548},
+							pos:   position{line: 4373, col: 26, offset: 134620},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4371, col: 30, offset: 134552},
+								pos:  position{line: 4373, col: 30, offset: 134624},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4371, col: 40, offset: 134562},
+							pos:   position{line: 4373, col: 40, offset: 134634},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4371, col: 43, offset: 134565},
+								pos:  position{line: 4373, col: 43, offset: 134637},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4371, col: 60, offset: 134582},
+							pos:   position{line: 4373, col: 60, offset: 134654},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4371, col: 66, offset: 134588},
+								pos:  position{line: 4373, col: 66, offset: 134660},
 								name: "Boolean",
 							},
 						},
@@ -9942,22 +9942,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4384, col: 1, offset: 134823},
+			pos:  position{line: 4386, col: 1, offset: 134895},
 			expr: &actionExpr{
-				pos: position{line: 4384, col: 25, offset: 134847},
+				pos: position{line: 4386, col: 25, offset: 134919},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4384, col: 25, offset: 134847},
+					pos:   position{line: 4386, col: 25, offset: 134919},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4384, col: 39, offset: 134861},
+						pos: position{line: 4386, col: 39, offset: 134933},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4384, col: 39, offset: 134861},
+								pos:  position{line: 4386, col: 39, offset: 134933},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4384, col: 67, offset: 134889},
+								pos:  position{line: 4386, col: 67, offset: 134961},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9967,41 +9967,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4388, col: 1, offset: 134952},
+			pos:  position{line: 4390, col: 1, offset: 135024},
 			expr: &actionExpr{
-				pos: position{line: 4388, col: 30, offset: 134981},
+				pos: position{line: 4390, col: 30, offset: 135053},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4388, col: 30, offset: 134981},
+					pos: position{line: 4390, col: 30, offset: 135053},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4388, col: 30, offset: 134981},
+							pos:   position{line: 4390, col: 30, offset: 135053},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4388, col: 34, offset: 134985},
+								pos:  position{line: 4390, col: 34, offset: 135057},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4388, col: 44, offset: 134995},
+							pos:   position{line: 4390, col: 44, offset: 135067},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4388, col: 47, offset: 134998},
+								pos:  position{line: 4390, col: 47, offset: 135070},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4388, col: 64, offset: 135015},
+							pos:   position{line: 4390, col: 64, offset: 135087},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4388, col: 81, offset: 135032},
+								pos: position{line: 4390, col: 81, offset: 135104},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4388, col: 81, offset: 135032},
+										pos:  position{line: 4390, col: 81, offset: 135104},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4388, col: 103, offset: 135054},
+										pos:  position{line: 4390, col: 103, offset: 135126},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10013,22 +10013,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4404, col: 1, offset: 135486},
+			pos:  position{line: 4406, col: 1, offset: 135558},
 			expr: &actionExpr{
-				pos: position{line: 4404, col: 32, offset: 135517},
+				pos: position{line: 4406, col: 32, offset: 135589},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4404, col: 32, offset: 135517},
+					pos:   position{line: 4406, col: 32, offset: 135589},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4404, col: 49, offset: 135534},
+						pos: position{line: 4406, col: 49, offset: 135606},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4404, col: 49, offset: 135534},
+								pos:  position{line: 4406, col: 49, offset: 135606},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4404, col: 71, offset: 135556},
+								pos:  position{line: 4406, col: 71, offset: 135628},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10038,33 +10038,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4421, col: 1, offset: 136067},
+			pos:  position{line: 4423, col: 1, offset: 136139},
 			expr: &actionExpr{
-				pos: position{line: 4421, col: 24, offset: 136090},
+				pos: position{line: 4423, col: 24, offset: 136162},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4421, col: 24, offset: 136090},
+					pos: position{line: 4423, col: 24, offset: 136162},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4421, col: 24, offset: 136090},
+							pos:        position{line: 4423, col: 24, offset: 136162},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4421, col: 31, offset: 136097},
+							pos:  position{line: 4423, col: 31, offset: 136169},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4421, col: 39, offset: 136105},
+							pos:   position{line: 4423, col: 39, offset: 136177},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4421, col: 45, offset: 136111},
+								pos:  position{line: 4423, col: 45, offset: 136183},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4421, col: 52, offset: 136118},
+							pos:  position{line: 4423, col: 52, offset: 136190},
 							name: "R_PAREN",
 						},
 					},
@@ -10073,49 +10073,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4430, col: 1, offset: 136355},
+			pos:  position{line: 4432, col: 1, offset: 136427},
 			expr: &choiceExpr{
-				pos: position{line: 4430, col: 26, offset: 136380},
+				pos: position{line: 4432, col: 26, offset: 136452},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4430, col: 26, offset: 136380},
+						pos: position{line: 4432, col: 26, offset: 136452},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4430, col: 26, offset: 136380},
+							pos: position{line: 4432, col: 26, offset: 136452},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4430, col: 26, offset: 136380},
+									pos:        position{line: 4432, col: 26, offset: 136452},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4430, col: 33, offset: 136387},
+									pos:  position{line: 4432, col: 33, offset: 136459},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4430, col: 41, offset: 136395},
+									pos:   position{line: 4432, col: 41, offset: 136467},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4430, col: 47, offset: 136401},
+										pos:  position{line: 4432, col: 47, offset: 136473},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4430, col: 54, offset: 136408},
+									pos:  position{line: 4432, col: 54, offset: 136480},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4439, col: 3, offset: 136598},
+						pos: position{line: 4441, col: 3, offset: 136670},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4439, col: 3, offset: 136598},
+							pos:   position{line: 4441, col: 3, offset: 136670},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4439, col: 9, offset: 136604},
+								pos:  position{line: 4441, col: 9, offset: 136676},
 								name: "String",
 							},
 						},
@@ -10125,35 +10125,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4449, col: 1, offset: 136884},
+			pos:  position{line: 4451, col: 1, offset: 136956},
 			expr: &actionExpr{
-				pos: position{line: 4449, col: 18, offset: 136901},
+				pos: position{line: 4451, col: 18, offset: 136973},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4449, col: 18, offset: 136901},
+					pos: position{line: 4451, col: 18, offset: 136973},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4449, col: 18, offset: 136901},
+							pos:   position{line: 4451, col: 18, offset: 136973},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4449, col: 24, offset: 136907},
+								pos:  position{line: 4451, col: 24, offset: 136979},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4449, col: 34, offset: 136917},
+							pos:   position{line: 4451, col: 34, offset: 136989},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4449, col: 39, offset: 136922},
+								pos: position{line: 4451, col: 39, offset: 136994},
 								expr: &seqExpr{
-									pos: position{line: 4449, col: 40, offset: 136923},
+									pos: position{line: 4451, col: 40, offset: 136995},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4449, col: 40, offset: 136923},
+											pos:  position{line: 4451, col: 40, offset: 136995},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4449, col: 46, offset: 136929},
+											pos:  position{line: 4451, col: 46, offset: 137001},
 											name: "FieldName",
 										},
 									},
@@ -10166,16 +10166,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4466, col: 1, offset: 137424},
+			pos:  position{line: 4468, col: 1, offset: 137496},
 			expr: &choiceExpr{
-				pos: position{line: 4466, col: 18, offset: 137441},
+				pos: position{line: 4468, col: 18, offset: 137513},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4466, col: 18, offset: 137441},
+						pos:  position{line: 4468, col: 18, offset: 137513},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4466, col: 38, offset: 137461},
+						pos:  position{line: 4468, col: 38, offset: 137533},
 						name: "EarliestOnly",
 					},
 				},
@@ -10183,62 +10183,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4468, col: 1, offset: 137475},
+			pos:  position{line: 4470, col: 1, offset: 137547},
 			expr: &actionExpr{
-				pos: position{line: 4468, col: 22, offset: 137496},
+				pos: position{line: 4470, col: 22, offset: 137568},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4468, col: 22, offset: 137496},
+					pos: position{line: 4470, col: 22, offset: 137568},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 22, offset: 137496},
+							pos:  position{line: 4470, col: 22, offset: 137568},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 35, offset: 137509},
+							pos:  position{line: 4470, col: 35, offset: 137581},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4468, col: 41, offset: 137515},
+							pos:   position{line: 4470, col: 41, offset: 137587},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4468, col: 55, offset: 137529},
+								pos: position{line: 4470, col: 55, offset: 137601},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4468, col: 55, offset: 137529},
+										pos:  position{line: 4470, col: 55, offset: 137601},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4468, col: 75, offset: 137549},
+										pos:  position{line: 4470, col: 75, offset: 137621},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 94, offset: 137568},
+							pos:  position{line: 4470, col: 94, offset: 137640},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 100, offset: 137574},
+							pos:  position{line: 4470, col: 100, offset: 137646},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4468, col: 111, offset: 137585},
+							pos:  position{line: 4470, col: 111, offset: 137657},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4468, col: 117, offset: 137591},
+							pos:   position{line: 4470, col: 117, offset: 137663},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4468, col: 129, offset: 137603},
+								pos: position{line: 4470, col: 129, offset: 137675},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4468, col: 129, offset: 137603},
+										pos:  position{line: 4470, col: 129, offset: 137675},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4468, col: 149, offset: 137623},
+										pos:  position{line: 4470, col: 149, offset: 137695},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10250,33 +10250,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4509, col: 1, offset: 138762},
+			pos:  position{line: 4511, col: 1, offset: 138834},
 			expr: &actionExpr{
-				pos: position{line: 4509, col: 17, offset: 138778},
+				pos: position{line: 4511, col: 17, offset: 138850},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4509, col: 17, offset: 138778},
+					pos: position{line: 4511, col: 17, offset: 138850},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4509, col: 17, offset: 138778},
+							pos:  position{line: 4511, col: 17, offset: 138850},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4509, col: 30, offset: 138791},
+							pos:  position{line: 4511, col: 30, offset: 138863},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4509, col: 36, offset: 138797},
+							pos:   position{line: 4511, col: 36, offset: 138869},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4509, col: 50, offset: 138811},
+								pos: position{line: 4511, col: 50, offset: 138883},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4509, col: 50, offset: 138811},
+										pos:  position{line: 4511, col: 50, offset: 138883},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4509, col: 70, offset: 138831},
+										pos:  position{line: 4511, col: 70, offset: 138903},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10288,24 +10288,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4537, col: 1, offset: 139539},
+			pos:  position{line: 4539, col: 1, offset: 139611},
 			expr: &actionExpr{
-				pos: position{line: 4537, col: 23, offset: 139561},
+				pos: position{line: 4539, col: 23, offset: 139633},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4537, col: 23, offset: 139561},
+					pos: position{line: 4539, col: 23, offset: 139633},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4537, col: 23, offset: 139561},
+							pos:        position{line: 4539, col: 23, offset: 139633},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4537, col: 27, offset: 139565},
+							pos: position{line: 4539, col: 27, offset: 139637},
 							expr: &charClassMatcher{
-								pos:        position{line: 4537, col: 27, offset: 139565},
+								pos:        position{line: 4539, col: 27, offset: 139637},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10318,21 +10318,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4541, col: 1, offset: 139608},
+			pos:  position{line: 4543, col: 1, offset: 139680},
 			expr: &actionExpr{
-				pos: position{line: 4541, col: 13, offset: 139620},
+				pos: position{line: 4543, col: 13, offset: 139692},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4541, col: 14, offset: 139621},
+					pos: position{line: 4543, col: 14, offset: 139693},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4541, col: 14, offset: 139621},
+							pos:        position{line: 4543, col: 14, offset: 139693},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4541, col: 17, offset: 139624},
+							pos:        position{line: 4543, col: 17, offset: 139696},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10344,15 +10344,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4545, col: 1, offset: 139667},
+			pos:  position{line: 4547, col: 1, offset: 139739},
 			expr: &actionExpr{
-				pos: position{line: 4545, col: 16, offset: 139682},
+				pos: position{line: 4547, col: 16, offset: 139754},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4545, col: 16, offset: 139682},
+					pos:   position{line: 4547, col: 16, offset: 139754},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4545, col: 26, offset: 139692},
+						pos:  position{line: 4547, col: 26, offset: 139764},
 						name: "AllTimeScale",
 					},
 				},
@@ -10360,31 +10360,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4552, col: 1, offset: 139919},
+			pos:  position{line: 4554, col: 1, offset: 139991},
 			expr: &actionExpr{
-				pos: position{line: 4552, col: 9, offset: 139927},
+				pos: position{line: 4554, col: 9, offset: 139999},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4552, col: 9, offset: 139927},
+					pos: position{line: 4554, col: 9, offset: 139999},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4552, col: 9, offset: 139927},
+							pos:        position{line: 4554, col: 9, offset: 139999},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4552, col: 13, offset: 139931},
+							pos:   position{line: 4554, col: 13, offset: 140003},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4552, col: 19, offset: 139937},
+								pos: position{line: 4554, col: 19, offset: 140009},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4552, col: 19, offset: 139937},
+										pos:  position{line: 4554, col: 19, offset: 140009},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4552, col: 30, offset: 139948},
+										pos:  position{line: 4554, col: 30, offset: 140020},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10396,26 +10396,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4556, col: 1, offset: 139996},
+			pos:  position{line: 4558, col: 1, offset: 140068},
 			expr: &actionExpr{
-				pos: position{line: 4556, col: 11, offset: 140006},
+				pos: position{line: 4558, col: 11, offset: 140078},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4556, col: 11, offset: 140006},
+					pos: position{line: 4558, col: 11, offset: 140078},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4556, col: 11, offset: 140006},
+							pos:   position{line: 4558, col: 11, offset: 140078},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4556, col: 16, offset: 140011},
+								pos:  position{line: 4558, col: 16, offset: 140083},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4556, col: 36, offset: 140031},
+							pos:   position{line: 4558, col: 36, offset: 140103},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4556, col: 43, offset: 140038},
+								pos:  position{line: 4558, col: 43, offset: 140110},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10425,44 +10425,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4584, col: 1, offset: 140777},
+			pos:  position{line: 4586, col: 1, offset: 140849},
 			expr: &actionExpr{
-				pos: position{line: 4584, col: 29, offset: 140805},
+				pos: position{line: 4586, col: 29, offset: 140877},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4584, col: 29, offset: 140805},
+					pos: position{line: 4586, col: 29, offset: 140877},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4584, col: 29, offset: 140805},
+							pos:   position{line: 4586, col: 29, offset: 140877},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4584, col: 36, offset: 140812},
+								pos: position{line: 4586, col: 36, offset: 140884},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4584, col: 36, offset: 140812},
+										pos:  position{line: 4586, col: 36, offset: 140884},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4584, col: 45, offset: 140821},
+										pos:  position{line: 4586, col: 45, offset: 140893},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4584, col: 51, offset: 140827},
+							pos:   position{line: 4586, col: 51, offset: 140899},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4584, col: 57, offset: 140833},
+								pos: position{line: 4586, col: 57, offset: 140905},
 								expr: &choiceExpr{
-									pos: position{line: 4584, col: 58, offset: 140834},
+									pos: position{line: 4586, col: 58, offset: 140906},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4584, col: 58, offset: 140834},
+											pos:  position{line: 4586, col: 58, offset: 140906},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4584, col: 67, offset: 140843},
+											pos:  position{line: 4586, col: 67, offset: 140915},
 											name: "Snap",
 										},
 									},
@@ -10475,29 +10475,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4631, col: 1, offset: 142275},
+			pos:  position{line: 4633, col: 1, offset: 142347},
 			expr: &actionExpr{
-				pos: position{line: 4631, col: 22, offset: 142296},
+				pos: position{line: 4633, col: 22, offset: 142368},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4631, col: 22, offset: 142296},
+					pos: position{line: 4633, col: 22, offset: 142368},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4631, col: 22, offset: 142296},
+							pos:   position{line: 4633, col: 22, offset: 142368},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4631, col: 34, offset: 142308},
+								pos: position{line: 4633, col: 34, offset: 142380},
 								expr: &choiceExpr{
-									pos: position{line: 4631, col: 35, offset: 142309},
+									pos: position{line: 4633, col: 35, offset: 142381},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4631, col: 35, offset: 142309},
+											pos:        position{line: 4633, col: 35, offset: 142381},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4631, col: 43, offset: 142317},
+											pos:        position{line: 4633, col: 43, offset: 142389},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10507,12 +10507,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4631, col: 49, offset: 142323},
+							pos:   position{line: 4633, col: 49, offset: 142395},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4631, col: 57, offset: 142331},
+								pos: position{line: 4633, col: 57, offset: 142403},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4631, col: 58, offset: 142332},
+									pos:  position{line: 4633, col: 58, offset: 142404},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10523,31 +10523,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4656, col: 1, offset: 143015},
+			pos:  position{line: 4658, col: 1, offset: 143087},
 			expr: &actionExpr{
-				pos: position{line: 4656, col: 39, offset: 143053},
+				pos: position{line: 4658, col: 39, offset: 143125},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4656, col: 39, offset: 143053},
+					pos: position{line: 4658, col: 39, offset: 143125},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4656, col: 39, offset: 143053},
+							pos:   position{line: 4658, col: 39, offset: 143125},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4656, col: 46, offset: 143060},
+								pos: position{line: 4658, col: 46, offset: 143132},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4656, col: 47, offset: 143061},
+									pos:  position{line: 4658, col: 47, offset: 143133},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4656, col: 56, offset: 143070},
+							pos:   position{line: 4658, col: 56, offset: 143142},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4656, col: 66, offset: 143080},
+								pos: position{line: 4658, col: 66, offset: 143152},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4656, col: 67, offset: 143081},
+									pos:  position{line: 4658, col: 67, offset: 143153},
 									name: "Snap",
 								},
 							},
@@ -10558,136 +10558,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4683, col: 1, offset: 143711},
+			pos:  position{line: 4685, col: 1, offset: 143783},
 			expr: &actionExpr{
-				pos: position{line: 4683, col: 18, offset: 143728},
+				pos: position{line: 4685, col: 18, offset: 143800},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4683, col: 18, offset: 143728},
+					pos: position{line: 4685, col: 18, offset: 143800},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 18, offset: 143728},
+							pos:        position{line: 4685, col: 18, offset: 143800},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 23, offset: 143733},
+							pos:        position{line: 4685, col: 23, offset: 143805},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4683, col: 29, offset: 143739},
+							pos:        position{line: 4685, col: 29, offset: 143811},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 33, offset: 143743},
+							pos:        position{line: 4685, col: 33, offset: 143815},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 38, offset: 143748},
+							pos:        position{line: 4685, col: 38, offset: 143820},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4683, col: 44, offset: 143754},
+							pos:        position{line: 4685, col: 44, offset: 143826},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 48, offset: 143758},
+							pos:        position{line: 4685, col: 48, offset: 143830},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 53, offset: 143763},
+							pos:        position{line: 4685, col: 53, offset: 143835},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 58, offset: 143768},
+							pos:        position{line: 4685, col: 58, offset: 143840},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 63, offset: 143773},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4683, col: 69, offset: 143779},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4683, col: 73, offset: 143783},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4683, col: 78, offset: 143788},
+							pos:        position{line: 4685, col: 63, offset: 143845},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4683, col: 84, offset: 143794},
+							pos:        position{line: 4685, col: 69, offset: 143851},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 88, offset: 143798},
+							pos:        position{line: 4685, col: 73, offset: 143855},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 93, offset: 143803},
+							pos:        position{line: 4685, col: 78, offset: 143860},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4683, col: 99, offset: 143809},
+							pos:        position{line: 4685, col: 84, offset: 143866},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 103, offset: 143813},
+							pos:        position{line: 4685, col: 88, offset: 143870},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4683, col: 108, offset: 143818},
+							pos:        position{line: 4685, col: 93, offset: 143875},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4685, col: 99, offset: 143881},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4685, col: 103, offset: 143885},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4685, col: 108, offset: 143890},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10699,15 +10699,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4687, col: 1, offset: 143860},
+			pos:  position{line: 4689, col: 1, offset: 143932},
 			expr: &actionExpr{
-				pos: position{line: 4687, col: 22, offset: 143881},
+				pos: position{line: 4689, col: 22, offset: 143953},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4687, col: 22, offset: 143881},
+					pos:   position{line: 4689, col: 22, offset: 143953},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4687, col: 32, offset: 143891},
+						pos:  position{line: 4689, col: 32, offset: 143963},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10715,18 +10715,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4698, col: 1, offset: 144334},
+			pos:  position{line: 4700, col: 1, offset: 144406},
 			expr: &choiceExpr{
-				pos: position{line: 4698, col: 14, offset: 144347},
+				pos: position{line: 4700, col: 14, offset: 144419},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4698, col: 14, offset: 144347},
+						pos: position{line: 4700, col: 14, offset: 144419},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4698, col: 14, offset: 144347},
+							pos: position{line: 4700, col: 14, offset: 144419},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4698, col: 14, offset: 144347},
+									pos:        position{line: 4700, col: 14, offset: 144419},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10734,9 +10734,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4698, col: 29, offset: 144362},
+									pos: position{line: 4700, col: 29, offset: 144434},
 									expr: &charClassMatcher{
-										pos:        position{line: 4698, col: 29, offset: 144362},
+										pos:        position{line: 4700, col: 29, offset: 144434},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10748,10 +10748,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4701, col: 3, offset: 144418},
+						pos: position{line: 4703, col: 3, offset: 144490},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4701, col: 3, offset: 144418},
+							pos:  position{line: 4703, col: 3, offset: 144490},
 							name: "QuotedString",
 						},
 					},
@@ -10760,15 +10760,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4705, col: 1, offset: 144481},
+			pos:  position{line: 4707, col: 1, offset: 144553},
 			expr: &actionExpr{
-				pos: position{line: 4705, col: 24, offset: 144504},
+				pos: position{line: 4707, col: 24, offset: 144576},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4705, col: 24, offset: 144504},
+					pos: position{line: 4707, col: 24, offset: 144576},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4705, col: 24, offset: 144504},
+							pos:        position{line: 4707, col: 24, offset: 144576},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10776,9 +10776,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4705, col: 39, offset: 144519},
+							pos: position{line: 4707, col: 39, offset: 144591},
 							expr: &charClassMatcher{
-								pos:        position{line: 4705, col: 39, offset: 144519},
+								pos:        position{line: 4707, col: 39, offset: 144591},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10792,22 +10792,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4709, col: 1, offset: 144572},
+			pos:  position{line: 4711, col: 1, offset: 144644},
 			expr: &actionExpr{
-				pos: position{line: 4709, col: 11, offset: 144582},
+				pos: position{line: 4711, col: 11, offset: 144654},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4709, col: 11, offset: 144582},
+					pos:   position{line: 4711, col: 11, offset: 144654},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4709, col: 16, offset: 144587},
+						pos: position{line: 4711, col: 16, offset: 144659},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4709, col: 16, offset: 144587},
+								pos:  position{line: 4711, col: 16, offset: 144659},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4709, col: 31, offset: 144602},
+								pos:  position{line: 4711, col: 31, offset: 144674},
 								name: "UnquotedString",
 							},
 						},
@@ -10817,38 +10817,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4713, col: 1, offset: 144643},
+			pos:  position{line: 4715, col: 1, offset: 144715},
 			expr: &actionExpr{
-				pos: position{line: 4713, col: 17, offset: 144659},
+				pos: position{line: 4715, col: 17, offset: 144731},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4713, col: 17, offset: 144659},
+					pos: position{line: 4715, col: 17, offset: 144731},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4713, col: 17, offset: 144659},
+							pos:        position{line: 4715, col: 17, offset: 144731},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4713, col: 21, offset: 144663},
+							pos: position{line: 4715, col: 21, offset: 144735},
 							expr: &choiceExpr{
-								pos: position{line: 4713, col: 22, offset: 144664},
+								pos: position{line: 4715, col: 22, offset: 144736},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4713, col: 22, offset: 144664},
+										pos: position{line: 4715, col: 22, offset: 144736},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4713, col: 22, offset: 144664},
+												pos: position{line: 4715, col: 22, offset: 144736},
 												expr: &litMatcher{
-													pos:        position{line: 4713, col: 23, offset: 144665},
+													pos:        position{line: 4715, col: 23, offset: 144737},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4713, col: 28, offset: 144670},
+												pos:        position{line: 4715, col: 28, offset: 144742},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -10857,16 +10857,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4713, col: 35, offset: 144677},
+										pos: position{line: 4715, col: 35, offset: 144749},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4713, col: 35, offset: 144677},
+												pos:        position{line: 4715, col: 35, offset: 144749},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4713, col: 40, offset: 144682,
+												line: 4715, col: 40, offset: 144754,
 											},
 										},
 									},
@@ -10874,7 +10874,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4713, col: 44, offset: 144686},
+							pos:        position{line: 4715, col: 44, offset: 144758},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10885,48 +10885,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4718, col: 1, offset: 144797},
+			pos:  position{line: 4720, col: 1, offset: 144869},
 			expr: &actionExpr{
-				pos: position{line: 4718, col: 19, offset: 144815},
+				pos: position{line: 4720, col: 19, offset: 144887},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4718, col: 19, offset: 144815},
+					pos: position{line: 4720, col: 19, offset: 144887},
 					expr: &choiceExpr{
-						pos: position{line: 4718, col: 20, offset: 144816},
+						pos: position{line: 4720, col: 20, offset: 144888},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4718, col: 20, offset: 144816},
+								pos:        position{line: 4720, col: 20, offset: 144888},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4718, col: 27, offset: 144823},
+								pos: position{line: 4720, col: 27, offset: 144895},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4718, col: 27, offset: 144823},
+										pos: position{line: 4720, col: 27, offset: 144895},
 										expr: &choiceExpr{
-											pos: position{line: 4718, col: 29, offset: 144825},
+											pos: position{line: 4720, col: 29, offset: 144897},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4718, col: 29, offset: 144825},
+													pos:  position{line: 4720, col: 29, offset: 144897},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4718, col: 43, offset: 144839},
+													pos:        position{line: 4720, col: 43, offset: 144911},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4718, col: 49, offset: 144845},
+													pos:  position{line: 4720, col: 49, offset: 144917},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4718, col: 54, offset: 144850,
+										line: 4720, col: 54, offset: 144922,
 									},
 								},
 							},
@@ -10937,12 +10937,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4725, col: 1, offset: 144965},
+			pos:  position{line: 4727, col: 1, offset: 145037},
 			expr: &choiceExpr{
-				pos: position{line: 4725, col: 16, offset: 144980},
+				pos: position{line: 4727, col: 16, offset: 145052},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4725, col: 16, offset: 144980},
+						pos:        position{line: 4727, col: 16, offset: 145052},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10950,18 +10950,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4725, col: 37, offset: 145001},
+						pos: position{line: 4727, col: 37, offset: 145073},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4725, col: 37, offset: 145001},
+								pos:        position{line: 4727, col: 37, offset: 145073},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4725, col: 41, offset: 145005},
+								pos: position{line: 4727, col: 41, offset: 145077},
 								expr: &charClassMatcher{
-									pos:        position{line: 4725, col: 41, offset: 145005},
+									pos:        position{line: 4727, col: 41, offset: 145077},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10969,7 +10969,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4725, col: 48, offset: 145012},
+								pos:        position{line: 4727, col: 48, offset: 145084},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10981,46 +10981,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4727, col: 1, offset: 145018},
+			pos:  position{line: 4729, col: 1, offset: 145090},
 			expr: &actionExpr{
-				pos: position{line: 4727, col: 39, offset: 145056},
+				pos: position{line: 4729, col: 39, offset: 145128},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4727, col: 39, offset: 145056},
+					pos: position{line: 4729, col: 39, offset: 145128},
 					expr: &choiceExpr{
-						pos: position{line: 4727, col: 40, offset: 145057},
+						pos: position{line: 4729, col: 40, offset: 145129},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4727, col: 40, offset: 145057},
+								pos:  position{line: 4729, col: 40, offset: 145129},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4727, col: 54, offset: 145071},
+								pos: position{line: 4729, col: 54, offset: 145143},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4727, col: 54, offset: 145071},
+										pos: position{line: 4729, col: 54, offset: 145143},
 										expr: &choiceExpr{
-											pos: position{line: 4727, col: 56, offset: 145073},
+											pos: position{line: 4729, col: 56, offset: 145145},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4727, col: 56, offset: 145073},
+													pos:  position{line: 4729, col: 56, offset: 145145},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4727, col: 70, offset: 145087},
+													pos:        position{line: 4729, col: 70, offset: 145159},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4727, col: 76, offset: 145093},
+													pos:  position{line: 4729, col: 76, offset: 145165},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4727, col: 81, offset: 145098,
+										line: 4729, col: 81, offset: 145170,
 									},
 								},
 							},
@@ -11031,21 +11031,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4731, col: 1, offset: 145138},
+			pos:  position{line: 4733, col: 1, offset: 145210},
 			expr: &actionExpr{
-				pos: position{line: 4731, col: 12, offset: 145149},
+				pos: position{line: 4733, col: 12, offset: 145221},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4731, col: 13, offset: 145150},
+					pos: position{line: 4733, col: 13, offset: 145222},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4731, col: 13, offset: 145150},
+							pos:        position{line: 4733, col: 13, offset: 145222},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4731, col: 22, offset: 145159},
+							pos:        position{line: 4733, col: 22, offset: 145231},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11056,14 +11056,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4737, col: 1, offset: 145313},
+			pos:  position{line: 4739, col: 1, offset: 145385},
 			expr: &actionExpr{
-				pos: position{line: 4737, col: 18, offset: 145330},
+				pos: position{line: 4739, col: 18, offset: 145402},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4737, col: 18, offset: 145330},
+					pos: position{line: 4739, col: 18, offset: 145402},
 					expr: &charClassMatcher{
-						pos:        position{line: 4737, col: 18, offset: 145330},
+						pos:        position{line: 4739, col: 18, offset: 145402},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11075,15 +11075,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4741, col: 1, offset: 145381},
+			pos:  position{line: 4743, col: 1, offset: 145453},
 			expr: &actionExpr{
-				pos: position{line: 4741, col: 11, offset: 145391},
+				pos: position{line: 4743, col: 11, offset: 145463},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4741, col: 11, offset: 145391},
+					pos:   position{line: 4743, col: 11, offset: 145463},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4741, col: 18, offset: 145398},
+						pos:  position{line: 4743, col: 18, offset: 145470},
 						name: "NumberAsString",
 					},
 				},
@@ -11091,59 +11091,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4747, col: 1, offset: 145587},
+			pos:  position{line: 4749, col: 1, offset: 145659},
 			expr: &actionExpr{
-				pos: position{line: 4747, col: 19, offset: 145605},
+				pos: position{line: 4749, col: 19, offset: 145677},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4747, col: 19, offset: 145605},
+					pos: position{line: 4749, col: 19, offset: 145677},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4747, col: 19, offset: 145605},
+							pos:   position{line: 4749, col: 19, offset: 145677},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4747, col: 27, offset: 145613},
+								pos: position{line: 4749, col: 27, offset: 145685},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4747, col: 27, offset: 145613},
+										pos:  position{line: 4749, col: 27, offset: 145685},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4747, col: 43, offset: 145629},
+										pos:  position{line: 4749, col: 43, offset: 145701},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4747, col: 60, offset: 145646},
+							pos: position{line: 4749, col: 60, offset: 145718},
 							expr: &choiceExpr{
-								pos: position{line: 4747, col: 62, offset: 145648},
+								pos: position{line: 4749, col: 62, offset: 145720},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4747, col: 62, offset: 145648},
+										pos:  position{line: 4749, col: 62, offset: 145720},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4747, col: 70, offset: 145656},
+										pos:        position{line: 4749, col: 70, offset: 145728},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4747, col: 76, offset: 145662},
+										pos:        position{line: 4749, col: 76, offset: 145734},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4747, col: 82, offset: 145668},
+										pos:        position{line: 4749, col: 82, offset: 145740},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4747, col: 88, offset: 145674},
+										pos:  position{line: 4749, col: 88, offset: 145746},
 										name: "EOF",
 									},
 								},
@@ -11155,17 +11155,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4753, col: 1, offset: 145803},
+			pos:  position{line: 4755, col: 1, offset: 145875},
 			expr: &actionExpr{
-				pos: position{line: 4753, col: 18, offset: 145820},
+				pos: position{line: 4755, col: 18, offset: 145892},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4753, col: 18, offset: 145820},
+					pos: position{line: 4755, col: 18, offset: 145892},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4753, col: 18, offset: 145820},
+							pos: position{line: 4755, col: 18, offset: 145892},
 							expr: &charClassMatcher{
-								pos:        position{line: 4753, col: 18, offset: 145820},
+								pos:        position{line: 4755, col: 18, offset: 145892},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11173,9 +11173,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4753, col: 24, offset: 145826},
+							pos: position{line: 4755, col: 24, offset: 145898},
 							expr: &charClassMatcher{
-								pos:        position{line: 4753, col: 24, offset: 145826},
+								pos:        position{line: 4755, col: 24, offset: 145898},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11183,15 +11183,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4753, col: 31, offset: 145833},
+							pos:        position{line: 4755, col: 31, offset: 145905},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4753, col: 35, offset: 145837},
+							pos: position{line: 4755, col: 35, offset: 145909},
 							expr: &charClassMatcher{
-								pos:        position{line: 4753, col: 35, offset: 145837},
+								pos:        position{line: 4755, col: 35, offset: 145909},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11204,17 +11204,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4758, col: 1, offset: 145932},
+			pos:  position{line: 4760, col: 1, offset: 146004},
 			expr: &actionExpr{
-				pos: position{line: 4758, col: 20, offset: 145951},
+				pos: position{line: 4760, col: 20, offset: 146023},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4758, col: 20, offset: 145951},
+					pos: position{line: 4760, col: 20, offset: 146023},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4758, col: 20, offset: 145951},
+							pos: position{line: 4760, col: 20, offset: 146023},
 							expr: &charClassMatcher{
-								pos:        position{line: 4758, col: 20, offset: 145951},
+								pos:        position{line: 4760, col: 20, offset: 146023},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11222,9 +11222,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4758, col: 26, offset: 145957},
+							pos: position{line: 4760, col: 26, offset: 146029},
 							expr: &charClassMatcher{
-								pos:        position{line: 4758, col: 26, offset: 145957},
+								pos:        position{line: 4760, col: 26, offset: 146029},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11237,14 +11237,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4762, col: 1, offset: 146000},
+			pos:  position{line: 4764, col: 1, offset: 146072},
 			expr: &actionExpr{
-				pos: position{line: 4762, col: 28, offset: 146027},
+				pos: position{line: 4764, col: 28, offset: 146099},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4762, col: 28, offset: 146027},
+					pos: position{line: 4764, col: 28, offset: 146099},
 					expr: &charClassMatcher{
-						pos:        position{line: 4762, col: 28, offset: 146027},
+						pos:        position{line: 4764, col: 28, offset: 146099},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11255,15 +11255,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4766, col: 1, offset: 146070},
+			pos:  position{line: 4768, col: 1, offset: 146142},
 			expr: &actionExpr{
-				pos: position{line: 4766, col: 20, offset: 146089},
+				pos: position{line: 4768, col: 20, offset: 146161},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4766, col: 20, offset: 146089},
+					pos:   position{line: 4768, col: 20, offset: 146161},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4766, col: 27, offset: 146096},
+						pos:  position{line: 4768, col: 27, offset: 146168},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11271,37 +11271,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4774, col: 1, offset: 146343},
+			pos:  position{line: 4776, col: 1, offset: 146415},
 			expr: &actionExpr{
-				pos: position{line: 4774, col: 21, offset: 146363},
+				pos: position{line: 4776, col: 21, offset: 146435},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4774, col: 21, offset: 146363},
+					pos: position{line: 4776, col: 21, offset: 146435},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4774, col: 21, offset: 146363},
+							pos:  position{line: 4776, col: 21, offset: 146435},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4774, col: 36, offset: 146378},
+							pos:   position{line: 4776, col: 36, offset: 146450},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4774, col: 40, offset: 146382},
+								pos: position{line: 4776, col: 40, offset: 146454},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4774, col: 40, offset: 146382},
+										pos:        position{line: 4776, col: 40, offset: 146454},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4774, col: 47, offset: 146389},
+										pos:        position{line: 4776, col: 47, offset: 146461},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4774, col: 53, offset: 146395},
+										pos:        position{line: 4776, col: 53, offset: 146467},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11310,7 +11310,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4774, col: 59, offset: 146401},
+							pos:  position{line: 4776, col: 59, offset: 146473},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11319,43 +11319,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4785, col: 1, offset: 146631},
+			pos:  position{line: 4787, col: 1, offset: 146703},
 			expr: &actionExpr{
-				pos: position{line: 4785, col: 23, offset: 146653},
+				pos: position{line: 4787, col: 23, offset: 146725},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4785, col: 23, offset: 146653},
+					pos: position{line: 4787, col: 23, offset: 146725},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4785, col: 23, offset: 146653},
+							pos:  position{line: 4787, col: 23, offset: 146725},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4785, col: 38, offset: 146668},
+							pos:   position{line: 4787, col: 38, offset: 146740},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4785, col: 42, offset: 146672},
+								pos: position{line: 4787, col: 42, offset: 146744},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4785, col: 42, offset: 146672},
+										pos:        position{line: 4787, col: 42, offset: 146744},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4785, col: 49, offset: 146679},
+										pos:        position{line: 4787, col: 49, offset: 146751},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4785, col: 55, offset: 146685},
+										pos:        position{line: 4787, col: 55, offset: 146757},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4785, col: 62, offset: 146692},
+										pos:        position{line: 4787, col: 62, offset: 146764},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11364,7 +11364,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4785, col: 67, offset: 146697},
+							pos:  position{line: 4787, col: 67, offset: 146769},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11373,30 +11373,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4793, col: 1, offset: 146880},
+			pos:  position{line: 4795, col: 1, offset: 146952},
 			expr: &choiceExpr{
-				pos: position{line: 4793, col: 25, offset: 146904},
+				pos: position{line: 4795, col: 25, offset: 146976},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4793, col: 25, offset: 146904},
+						pos: position{line: 4795, col: 25, offset: 146976},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4793, col: 25, offset: 146904},
+							pos:   position{line: 4795, col: 25, offset: 146976},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4793, col: 28, offset: 146907},
+								pos:  position{line: 4795, col: 28, offset: 146979},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4796, col: 3, offset: 146949},
+						pos: position{line: 4798, col: 3, offset: 147021},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4796, col: 3, offset: 146949},
+							pos:   position{line: 4798, col: 3, offset: 147021},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4796, col: 6, offset: 146952},
+								pos:  position{line: 4798, col: 6, offset: 147024},
 								name: "InequalityOperator",
 							},
 						},
@@ -11406,25 +11406,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4800, col: 1, offset: 146995},
+			pos:  position{line: 4802, col: 1, offset: 147067},
 			expr: &actionExpr{
-				pos: position{line: 4800, col: 11, offset: 147005},
+				pos: position{line: 4802, col: 11, offset: 147077},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4800, col: 11, offset: 147005},
+					pos: position{line: 4802, col: 11, offset: 147077},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 11, offset: 147005},
+							pos:  position{line: 4802, col: 11, offset: 147077},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4800, col: 26, offset: 147020},
+							pos:        position{line: 4802, col: 26, offset: 147092},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4800, col: 30, offset: 147024},
+							pos:  position{line: 4802, col: 30, offset: 147096},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11433,25 +11433,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4804, col: 1, offset: 147064},
+			pos:  position{line: 4806, col: 1, offset: 147136},
 			expr: &actionExpr{
-				pos: position{line: 4804, col: 12, offset: 147075},
+				pos: position{line: 4806, col: 12, offset: 147147},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4804, col: 12, offset: 147075},
+					pos: position{line: 4806, col: 12, offset: 147147},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4804, col: 12, offset: 147075},
+							pos:  position{line: 4806, col: 12, offset: 147147},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4804, col: 27, offset: 147090},
+							pos:        position{line: 4806, col: 27, offset: 147162},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4804, col: 31, offset: 147094},
+							pos:  position{line: 4806, col: 31, offset: 147166},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11460,25 +11460,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4808, col: 1, offset: 147134},
+			pos:  position{line: 4810, col: 1, offset: 147206},
 			expr: &actionExpr{
-				pos: position{line: 4808, col: 10, offset: 147143},
+				pos: position{line: 4810, col: 10, offset: 147215},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4808, col: 10, offset: 147143},
+					pos: position{line: 4810, col: 10, offset: 147215},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4808, col: 10, offset: 147143},
+							pos:  position{line: 4810, col: 10, offset: 147215},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4808, col: 25, offset: 147158},
+							pos:        position{line: 4810, col: 25, offset: 147230},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4808, col: 29, offset: 147162},
+							pos:  position{line: 4810, col: 29, offset: 147234},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11487,25 +11487,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4812, col: 1, offset: 147202},
+			pos:  position{line: 4814, col: 1, offset: 147274},
 			expr: &actionExpr{
-				pos: position{line: 4812, col: 10, offset: 147211},
+				pos: position{line: 4814, col: 10, offset: 147283},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4812, col: 10, offset: 147211},
+					pos: position{line: 4814, col: 10, offset: 147283},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4812, col: 10, offset: 147211},
+							pos:  position{line: 4814, col: 10, offset: 147283},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4812, col: 25, offset: 147226},
+							pos:        position{line: 4814, col: 25, offset: 147298},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4812, col: 29, offset: 147230},
+							pos:  position{line: 4814, col: 29, offset: 147302},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11514,25 +11514,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4816, col: 1, offset: 147270},
+			pos:  position{line: 4818, col: 1, offset: 147342},
 			expr: &actionExpr{
-				pos: position{line: 4816, col: 10, offset: 147279},
+				pos: position{line: 4818, col: 10, offset: 147351},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4816, col: 10, offset: 147279},
+					pos: position{line: 4818, col: 10, offset: 147351},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4816, col: 10, offset: 147279},
+							pos:  position{line: 4818, col: 10, offset: 147351},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4816, col: 25, offset: 147294},
+							pos:        position{line: 4818, col: 25, offset: 147366},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4816, col: 29, offset: 147298},
+							pos:  position{line: 4818, col: 29, offset: 147370},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11541,39 +11541,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4821, col: 1, offset: 147362},
+			pos:  position{line: 4823, col: 1, offset: 147434},
 			expr: &actionExpr{
-				pos: position{line: 4821, col: 11, offset: 147372},
+				pos: position{line: 4823, col: 11, offset: 147444},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4821, col: 12, offset: 147373},
+					pos: position{line: 4823, col: 12, offset: 147445},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4821, col: 12, offset: 147373},
+							pos:        position{line: 4823, col: 12, offset: 147445},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4821, col: 24, offset: 147385},
+							pos:        position{line: 4823, col: 24, offset: 147457},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4821, col: 35, offset: 147396},
+							pos:        position{line: 4823, col: 35, offset: 147468},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4821, col: 44, offset: 147405},
+							pos:        position{line: 4823, col: 44, offset: 147477},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4821, col: 52, offset: 147413},
+							pos:        position{line: 4823, col: 52, offset: 147485},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11584,39 +11584,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4825, col: 1, offset: 147455},
+			pos:  position{line: 4827, col: 1, offset: 147527},
 			expr: &actionExpr{
-				pos: position{line: 4825, col: 11, offset: 147465},
+				pos: position{line: 4827, col: 11, offset: 147537},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4825, col: 12, offset: 147466},
+					pos: position{line: 4827, col: 12, offset: 147538},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4825, col: 12, offset: 147466},
+							pos:        position{line: 4827, col: 12, offset: 147538},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4825, col: 24, offset: 147478},
+							pos:        position{line: 4827, col: 24, offset: 147550},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4825, col: 35, offset: 147489},
+							pos:        position{line: 4827, col: 35, offset: 147561},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4825, col: 44, offset: 147498},
+							pos:        position{line: 4827, col: 44, offset: 147570},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4825, col: 52, offset: 147506},
+							pos:        position{line: 4827, col: 52, offset: 147578},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11627,39 +11627,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4829, col: 1, offset: 147548},
+			pos:  position{line: 4831, col: 1, offset: 147620},
 			expr: &actionExpr{
-				pos: position{line: 4829, col: 9, offset: 147556},
+				pos: position{line: 4831, col: 9, offset: 147628},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4829, col: 10, offset: 147557},
+					pos: position{line: 4831, col: 10, offset: 147629},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4829, col: 10, offset: 147557},
+							pos:        position{line: 4831, col: 10, offset: 147629},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4829, col: 20, offset: 147567},
+							pos:        position{line: 4831, col: 20, offset: 147639},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4829, col: 29, offset: 147576},
+							pos:        position{line: 4831, col: 29, offset: 147648},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4829, col: 37, offset: 147584},
+							pos:        position{line: 4831, col: 37, offset: 147656},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4829, col: 44, offset: 147591},
+							pos:        position{line: 4831, col: 44, offset: 147663},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11670,27 +11670,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4833, col: 1, offset: 147631},
+			pos:  position{line: 4835, col: 1, offset: 147703},
 			expr: &actionExpr{
-				pos: position{line: 4833, col: 8, offset: 147638},
+				pos: position{line: 4835, col: 8, offset: 147710},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4833, col: 9, offset: 147639},
+					pos: position{line: 4835, col: 9, offset: 147711},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4833, col: 9, offset: 147639},
+							pos:        position{line: 4835, col: 9, offset: 147711},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4833, col: 18, offset: 147648},
+							pos:        position{line: 4835, col: 18, offset: 147720},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4833, col: 26, offset: 147656},
+							pos:        position{line: 4835, col: 26, offset: 147728},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11701,27 +11701,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4837, col: 1, offset: 147695},
+			pos:  position{line: 4839, col: 1, offset: 147767},
 			expr: &actionExpr{
-				pos: position{line: 4837, col: 9, offset: 147703},
+				pos: position{line: 4839, col: 9, offset: 147775},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4837, col: 10, offset: 147704},
+					pos: position{line: 4839, col: 10, offset: 147776},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4837, col: 10, offset: 147704},
+							pos:        position{line: 4839, col: 10, offset: 147776},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4837, col: 20, offset: 147714},
+							pos:        position{line: 4839, col: 20, offset: 147786},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4837, col: 29, offset: 147723},
+							pos:        position{line: 4839, col: 29, offset: 147795},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11732,27 +11732,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4841, col: 1, offset: 147763},
+			pos:  position{line: 4843, col: 1, offset: 147835},
 			expr: &actionExpr{
-				pos: position{line: 4841, col: 10, offset: 147772},
+				pos: position{line: 4843, col: 10, offset: 147844},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4841, col: 11, offset: 147773},
+					pos: position{line: 4843, col: 11, offset: 147845},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4841, col: 11, offset: 147773},
+							pos:        position{line: 4843, col: 11, offset: 147845},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4841, col: 22, offset: 147784},
+							pos:        position{line: 4843, col: 22, offset: 147856},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4841, col: 32, offset: 147794},
+							pos:        position{line: 4843, col: 32, offset: 147866},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11763,39 +11763,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4845, col: 1, offset: 147837},
+			pos:  position{line: 4847, col: 1, offset: 147909},
 			expr: &actionExpr{
-				pos: position{line: 4845, col: 12, offset: 147848},
+				pos: position{line: 4847, col: 12, offset: 147920},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4845, col: 13, offset: 147849},
+					pos: position{line: 4847, col: 13, offset: 147921},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4845, col: 13, offset: 147849},
+							pos:        position{line: 4847, col: 13, offset: 147921},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4845, col: 26, offset: 147862},
+							pos:        position{line: 4847, col: 26, offset: 147934},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4845, col: 38, offset: 147874},
+							pos:        position{line: 4847, col: 38, offset: 147946},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4845, col: 47, offset: 147883},
+							pos:        position{line: 4847, col: 47, offset: 147955},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4845, col: 55, offset: 147891},
+							pos:        position{line: 4847, col: 55, offset: 147963},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11806,39 +11806,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4849, col: 1, offset: 147934},
+			pos:  position{line: 4851, col: 1, offset: 148006},
 			expr: &actionExpr{
-				pos: position{line: 4849, col: 9, offset: 147942},
+				pos: position{line: 4851, col: 9, offset: 148014},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4849, col: 10, offset: 147943},
+					pos: position{line: 4851, col: 10, offset: 148015},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4849, col: 10, offset: 147943},
+							pos:        position{line: 4851, col: 10, offset: 148015},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4849, col: 20, offset: 147953},
+							pos:        position{line: 4851, col: 20, offset: 148025},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4849, col: 29, offset: 147962},
+							pos:        position{line: 4851, col: 29, offset: 148034},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4849, col: 37, offset: 147970},
+							pos:        position{line: 4851, col: 37, offset: 148042},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4849, col: 44, offset: 147977},
+							pos:        position{line: 4851, col: 44, offset: 148049},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11849,33 +11849,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4854, col: 1, offset: 148109},
+			pos:  position{line: 4856, col: 1, offset: 148181},
 			expr: &actionExpr{
-				pos: position{line: 4854, col: 15, offset: 148123},
+				pos: position{line: 4856, col: 15, offset: 148195},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4854, col: 16, offset: 148124},
+					pos: position{line: 4856, col: 16, offset: 148196},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4854, col: 16, offset: 148124},
+							pos:        position{line: 4856, col: 16, offset: 148196},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4854, col: 23, offset: 148131},
+							pos:        position{line: 4856, col: 23, offset: 148203},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4854, col: 30, offset: 148138},
+							pos:        position{line: 4856, col: 30, offset: 148210},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4854, col: 37, offset: 148145},
+							pos:        position{line: 4856, col: 37, offset: 148217},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11886,26 +11886,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4863, col: 1, offset: 148369},
+			pos:  position{line: 4865, col: 1, offset: 148441},
 			expr: &actionExpr{
-				pos: position{line: 4863, col: 21, offset: 148389},
+				pos: position{line: 4865, col: 21, offset: 148461},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4863, col: 21, offset: 148389},
+					pos: position{line: 4865, col: 21, offset: 148461},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4863, col: 21, offset: 148389},
+							pos:  position{line: 4865, col: 21, offset: 148461},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4863, col: 26, offset: 148394},
+							pos:  position{line: 4865, col: 26, offset: 148466},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4863, col: 42, offset: 148410},
+							pos:   position{line: 4865, col: 42, offset: 148482},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4863, col: 53, offset: 148421},
+								pos:  position{line: 4865, col: 53, offset: 148493},
 								name: "TransactionOptions",
 							},
 						},
@@ -11915,17 +11915,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4873, col: 1, offset: 148796},
+			pos:  position{line: 4875, col: 1, offset: 148868},
 			expr: &actionExpr{
-				pos: position{line: 4873, col: 23, offset: 148818},
+				pos: position{line: 4875, col: 23, offset: 148890},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4873, col: 23, offset: 148818},
+					pos:   position{line: 4875, col: 23, offset: 148890},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4873, col: 34, offset: 148829},
+						pos: position{line: 4875, col: 34, offset: 148901},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4873, col: 34, offset: 148829},
+							pos:  position{line: 4875, col: 34, offset: 148901},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11934,35 +11934,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4888, col: 1, offset: 149220},
+			pos:  position{line: 4890, col: 1, offset: 149292},
 			expr: &actionExpr{
-				pos: position{line: 4888, col: 37, offset: 149256},
+				pos: position{line: 4890, col: 37, offset: 149328},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4888, col: 37, offset: 149256},
+					pos: position{line: 4890, col: 37, offset: 149328},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4888, col: 37, offset: 149256},
+							pos:   position{line: 4890, col: 37, offset: 149328},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4888, col: 43, offset: 149262},
+								pos:  position{line: 4890, col: 43, offset: 149334},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4888, col: 71, offset: 149290},
+							pos:   position{line: 4890, col: 71, offset: 149362},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4888, col: 76, offset: 149295},
+								pos: position{line: 4890, col: 76, offset: 149367},
 								expr: &seqExpr{
-									pos: position{line: 4888, col: 77, offset: 149296},
+									pos: position{line: 4890, col: 77, offset: 149368},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4888, col: 77, offset: 149296},
+											pos:  position{line: 4890, col: 77, offset: 149368},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4888, col: 83, offset: 149302},
+											pos:  position{line: 4890, col: 83, offset: 149374},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11975,26 +11975,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4923, col: 1, offset: 150291},
+			pos:  position{line: 4925, col: 1, offset: 150363},
 			expr: &actionExpr{
-				pos: position{line: 4923, col: 32, offset: 150322},
+				pos: position{line: 4925, col: 32, offset: 150394},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4923, col: 32, offset: 150322},
+					pos:   position{line: 4925, col: 32, offset: 150394},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4923, col: 40, offset: 150330},
+						pos: position{line: 4925, col: 40, offset: 150402},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4923, col: 40, offset: 150330},
+								pos:  position{line: 4925, col: 40, offset: 150402},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4923, col: 77, offset: 150367},
+								pos:  position{line: 4925, col: 77, offset: 150439},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4923, col: 96, offset: 150386},
+								pos:  position{line: 4925, col: 96, offset: 150458},
 								name: "EndsWithOption",
 							},
 						},
@@ -12004,15 +12004,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4927, col: 1, offset: 150430},
+			pos:  position{line: 4929, col: 1, offset: 150502},
 			expr: &actionExpr{
-				pos: position{line: 4927, col: 39, offset: 150468},
+				pos: position{line: 4929, col: 39, offset: 150540},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4927, col: 39, offset: 150468},
+					pos:   position{line: 4929, col: 39, offset: 150540},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4927, col: 46, offset: 150475},
+						pos:  position{line: 4929, col: 46, offset: 150547},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12020,28 +12020,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4938, col: 1, offset: 150691},
+			pos:  position{line: 4940, col: 1, offset: 150763},
 			expr: &actionExpr{
-				pos: position{line: 4938, col: 21, offset: 150711},
+				pos: position{line: 4940, col: 21, offset: 150783},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4938, col: 21, offset: 150711},
+					pos: position{line: 4940, col: 21, offset: 150783},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4938, col: 21, offset: 150711},
+							pos:        position{line: 4940, col: 21, offset: 150783},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4938, col: 34, offset: 150724},
+							pos:  position{line: 4940, col: 34, offset: 150796},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4938, col: 40, offset: 150730},
+							pos:   position{line: 4940, col: 40, offset: 150802},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4938, col: 48, offset: 150738},
+								pos:  position{line: 4940, col: 48, offset: 150810},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12051,28 +12051,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4948, col: 1, offset: 150976},
+			pos:  position{line: 4950, col: 1, offset: 151048},
 			expr: &actionExpr{
-				pos: position{line: 4948, col: 19, offset: 150994},
+				pos: position{line: 4950, col: 19, offset: 151066},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4948, col: 19, offset: 150994},
+					pos: position{line: 4950, col: 19, offset: 151066},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4948, col: 19, offset: 150994},
+							pos:        position{line: 4950, col: 19, offset: 151066},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4948, col: 30, offset: 151005},
+							pos:  position{line: 4950, col: 30, offset: 151077},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4948, col: 36, offset: 151011},
+							pos:   position{line: 4950, col: 36, offset: 151083},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4948, col: 44, offset: 151019},
+								pos:  position{line: 4950, col: 44, offset: 151091},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12082,26 +12082,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4959, col: 1, offset: 151288},
+			pos:  position{line: 4961, col: 1, offset: 151360},
 			expr: &actionExpr{
-				pos: position{line: 4959, col: 28, offset: 151315},
+				pos: position{line: 4961, col: 28, offset: 151387},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4959, col: 28, offset: 151315},
+					pos:   position{line: 4961, col: 28, offset: 151387},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4959, col: 37, offset: 151324},
+						pos: position{line: 4961, col: 37, offset: 151396},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4959, col: 37, offset: 151324},
+								pos:  position{line: 4961, col: 37, offset: 151396},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4959, col: 63, offset: 151350},
+								pos:  position{line: 4961, col: 63, offset: 151422},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4959, col: 81, offset: 151368},
+								pos:  position{line: 4961, col: 81, offset: 151440},
 								name: "TransactionSearch",
 							},
 						},
@@ -12111,22 +12111,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4963, col: 1, offset: 151416},
+			pos:  position{line: 4965, col: 1, offset: 151488},
 			expr: &actionExpr{
-				pos: position{line: 4963, col: 28, offset: 151443},
+				pos: position{line: 4965, col: 28, offset: 151515},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4963, col: 28, offset: 151443},
+					pos:   position{line: 4965, col: 28, offset: 151515},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4963, col: 33, offset: 151448},
+						pos: position{line: 4965, col: 33, offset: 151520},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 33, offset: 151448},
+								pos:  position{line: 4965, col: 33, offset: 151520},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4963, col: 64, offset: 151479},
+								pos:  position{line: 4965, col: 64, offset: 151551},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12136,29 +12136,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4967, col: 1, offset: 151539},
+			pos:  position{line: 4969, col: 1, offset: 151611},
 			expr: &actionExpr{
-				pos: position{line: 4967, col: 38, offset: 151576},
+				pos: position{line: 4969, col: 38, offset: 151648},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4967, col: 38, offset: 151576},
+					pos: position{line: 4969, col: 38, offset: 151648},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4967, col: 38, offset: 151576},
+							pos:        position{line: 4969, col: 38, offset: 151648},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4967, col: 42, offset: 151580},
+							pos:   position{line: 4969, col: 42, offset: 151652},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4967, col: 55, offset: 151593},
+								pos:  position{line: 4969, col: 55, offset: 151665},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4967, col: 68, offset: 151606},
+							pos:        position{line: 4969, col: 68, offset: 151678},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12169,23 +12169,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 4975, col: 1, offset: 151745},
+			pos:  position{line: 4977, col: 1, offset: 151817},
 			expr: &actionExpr{
-				pos: position{line: 4975, col: 21, offset: 151765},
+				pos: position{line: 4977, col: 21, offset: 151837},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 4975, col: 21, offset: 151765},
+					pos: position{line: 4977, col: 21, offset: 151837},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4975, col: 21, offset: 151765},
+							pos:        position{line: 4977, col: 21, offset: 151837},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4975, col: 25, offset: 151769},
+							pos: position{line: 4977, col: 25, offset: 151841},
 							expr: &charClassMatcher{
-								pos:        position{line: 4975, col: 25, offset: 151769},
+								pos:        position{line: 4977, col: 25, offset: 151841},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12193,7 +12193,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4975, col: 44, offset: 151788},
+							pos:        position{line: 4977, col: 44, offset: 151860},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12204,15 +12204,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 4980, col: 1, offset: 151899},
+			pos:  position{line: 4982, col: 1, offset: 151971},
 			expr: &actionExpr{
-				pos: position{line: 4980, col: 33, offset: 151931},
+				pos: position{line: 4982, col: 33, offset: 152003},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4980, col: 33, offset: 151931},
+					pos:   position{line: 4982, col: 33, offset: 152003},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4980, col: 37, offset: 151935},
+						pos:  position{line: 4982, col: 37, offset: 152007},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12220,15 +12220,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 4988, col: 1, offset: 152090},
+			pos:  position{line: 4990, col: 1, offset: 152162},
 			expr: &actionExpr{
-				pos: position{line: 4988, col: 22, offset: 152111},
+				pos: position{line: 4990, col: 22, offset: 152183},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 4988, col: 22, offset: 152111},
+					pos:   position{line: 4990, col: 22, offset: 152183},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4988, col: 27, offset: 152116},
+						pos:  position{line: 4990, col: 27, offset: 152188},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12236,37 +12236,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 4998, col: 1, offset: 152288},
+			pos:  position{line: 5000, col: 1, offset: 152360},
 			expr: &actionExpr{
-				pos: position{line: 4998, col: 20, offset: 152307},
+				pos: position{line: 5000, col: 20, offset: 152379},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 4998, col: 20, offset: 152307},
+					pos: position{line: 5000, col: 20, offset: 152379},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4998, col: 20, offset: 152307},
+							pos:        position{line: 5000, col: 20, offset: 152379},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4998, col: 27, offset: 152314},
+							pos:  position{line: 5000, col: 27, offset: 152386},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4998, col: 42, offset: 152329},
+							pos:  position{line: 5000, col: 42, offset: 152401},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4998, col: 50, offset: 152337},
+							pos:   position{line: 5000, col: 50, offset: 152409},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4998, col: 60, offset: 152347},
+								pos:  position{line: 5000, col: 60, offset: 152419},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4998, col: 69, offset: 152356},
+							pos:  position{line: 5000, col: 69, offset: 152428},
 							name: "R_PAREN",
 						},
 					},
@@ -12275,22 +12275,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5008, col: 1, offset: 152659},
+			pos:  position{line: 5010, col: 1, offset: 152731},
 			expr: &actionExpr{
-				pos: position{line: 5008, col: 20, offset: 152678},
+				pos: position{line: 5010, col: 20, offset: 152750},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5008, col: 20, offset: 152678},
+					pos: position{line: 5010, col: 20, offset: 152750},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5008, col: 20, offset: 152678},
+							pos:  position{line: 5010, col: 20, offset: 152750},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5008, col: 25, offset: 152683},
+							pos:   position{line: 5010, col: 25, offset: 152755},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5008, col: 42, offset: 152700},
+								pos:  position{line: 5010, col: 42, offset: 152772},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12300,41 +12300,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5012, col: 1, offset: 152749},
+			pos:  position{line: 5014, col: 1, offset: 152821},
 			expr: &actionExpr{
-				pos: position{line: 5012, col: 16, offset: 152764},
+				pos: position{line: 5014, col: 16, offset: 152836},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5012, col: 16, offset: 152764},
+					pos: position{line: 5014, col: 16, offset: 152836},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5012, col: 16, offset: 152764},
+							pos:  position{line: 5014, col: 16, offset: 152836},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5012, col: 27, offset: 152775},
+							pos:  position{line: 5014, col: 27, offset: 152847},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5012, col: 33, offset: 152781},
+							pos:   position{line: 5014, col: 33, offset: 152853},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5012, col: 50, offset: 152798},
+								pos: position{line: 5014, col: 50, offset: 152870},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5012, col: 50, offset: 152798},
+									pos:  position{line: 5014, col: 50, offset: 152870},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5012, col: 70, offset: 152818},
+							pos:  position{line: 5014, col: 70, offset: 152890},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5012, col: 85, offset: 152833},
+							pos:   position{line: 5014, col: 85, offset: 152905},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5012, col: 91, offset: 152839},
+								pos:  position{line: 5014, col: 91, offset: 152911},
 								name: "FieldName",
 							},
 						},
@@ -12344,35 +12344,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5041, col: 1, offset: 153610},
+			pos:  position{line: 5043, col: 1, offset: 153682},
 			expr: &actionExpr{
-				pos: position{line: 5041, col: 23, offset: 153632},
+				pos: position{line: 5043, col: 23, offset: 153704},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5041, col: 23, offset: 153632},
+					pos: position{line: 5043, col: 23, offset: 153704},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5041, col: 23, offset: 153632},
+							pos:   position{line: 5043, col: 23, offset: 153704},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5041, col: 31, offset: 153640},
+								pos:  position{line: 5043, col: 31, offset: 153712},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5041, col: 46, offset: 153655},
+							pos:   position{line: 5043, col: 46, offset: 153727},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5041, col: 52, offset: 153661},
+								pos: position{line: 5043, col: 52, offset: 153733},
 								expr: &seqExpr{
-									pos: position{line: 5041, col: 53, offset: 153662},
+									pos: position{line: 5043, col: 53, offset: 153734},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5041, col: 53, offset: 153662},
+											pos:  position{line: 5043, col: 53, offset: 153734},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5041, col: 59, offset: 153668},
+											pos:  position{line: 5043, col: 59, offset: 153740},
 											name: "MVBlockOption",
 										},
 									},
@@ -12385,26 +12385,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5075, col: 1, offset: 154724},
+			pos:  position{line: 5077, col: 1, offset: 154796},
 			expr: &actionExpr{
-				pos: position{line: 5075, col: 18, offset: 154741},
+				pos: position{line: 5077, col: 18, offset: 154813},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5075, col: 18, offset: 154741},
+					pos:   position{line: 5077, col: 18, offset: 154813},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5075, col: 27, offset: 154750},
+						pos: position{line: 5077, col: 27, offset: 154822},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5075, col: 27, offset: 154750},
+								pos:  position{line: 5077, col: 27, offset: 154822},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5075, col: 41, offset: 154764},
+								pos:  position{line: 5077, col: 41, offset: 154836},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5075, col: 60, offset: 154783},
+								pos:  position{line: 5077, col: 60, offset: 154855},
 								name: "SetSvOption",
 							},
 						},
@@ -12414,22 +12414,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5079, col: 1, offset: 154824},
+			pos:  position{line: 5081, col: 1, offset: 154896},
 			expr: &actionExpr{
-				pos: position{line: 5079, col: 16, offset: 154839},
+				pos: position{line: 5081, col: 16, offset: 154911},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5079, col: 16, offset: 154839},
+					pos:   position{line: 5081, col: 16, offset: 154911},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5079, col: 28, offset: 154851},
+						pos: position{line: 5081, col: 28, offset: 154923},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5079, col: 28, offset: 154851},
+								pos:  position{line: 5081, col: 28, offset: 154923},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5079, col: 46, offset: 154869},
+								pos:  position{line: 5081, col: 46, offset: 154941},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12439,28 +12439,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5083, col: 1, offset: 154916},
+			pos:  position{line: 5085, col: 1, offset: 154988},
 			expr: &actionExpr{
-				pos: position{line: 5083, col: 20, offset: 154935},
+				pos: position{line: 5085, col: 20, offset: 155007},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5083, col: 20, offset: 154935},
+					pos: position{line: 5085, col: 20, offset: 155007},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5083, col: 20, offset: 154935},
+							pos:        position{line: 5085, col: 20, offset: 155007},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5083, col: 28, offset: 154943},
+							pos:  position{line: 5085, col: 28, offset: 155015},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5083, col: 34, offset: 154949},
+							pos:   position{line: 5085, col: 34, offset: 155021},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5083, col: 38, offset: 154953},
+								pos:  position{line: 5085, col: 38, offset: 155025},
 								name: "QuotedString",
 							},
 						},
@@ -12470,28 +12470,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5094, col: 1, offset: 155204},
+			pos:  position{line: 5096, col: 1, offset: 155276},
 			expr: &actionExpr{
-				pos: position{line: 5094, col: 19, offset: 155222},
+				pos: position{line: 5096, col: 19, offset: 155294},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5094, col: 19, offset: 155222},
+					pos: position{line: 5096, col: 19, offset: 155294},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5094, col: 19, offset: 155222},
+							pos:        position{line: 5096, col: 19, offset: 155294},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5094, col: 31, offset: 155234},
+							pos:  position{line: 5096, col: 31, offset: 155306},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5094, col: 37, offset: 155240},
+							pos:   position{line: 5096, col: 37, offset: 155312},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5094, col: 41, offset: 155244},
+								pos:  position{line: 5096, col: 41, offset: 155316},
 								name: "QuotedString",
 							},
 						},
@@ -12501,28 +12501,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5112, col: 1, offset: 155715},
+			pos:  position{line: 5114, col: 1, offset: 155787},
 			expr: &actionExpr{
-				pos: position{line: 5112, col: 21, offset: 155735},
+				pos: position{line: 5114, col: 21, offset: 155807},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5112, col: 21, offset: 155735},
+					pos: position{line: 5114, col: 21, offset: 155807},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5112, col: 21, offset: 155735},
+							pos:        position{line: 5114, col: 21, offset: 155807},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5112, col: 34, offset: 155748},
+							pos:  position{line: 5114, col: 34, offset: 155820},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5112, col: 40, offset: 155754},
+							pos:   position{line: 5114, col: 40, offset: 155826},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5112, col: 48, offset: 155762},
+								pos:  position{line: 5114, col: 48, offset: 155834},
 								name: "Boolean",
 							},
 						},
@@ -12532,28 +12532,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5124, col: 1, offset: 156002},
+			pos:  position{line: 5126, col: 1, offset: 156074},
 			expr: &actionExpr{
-				pos: position{line: 5124, col: 16, offset: 156017},
+				pos: position{line: 5126, col: 16, offset: 156089},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5124, col: 16, offset: 156017},
+					pos: position{line: 5126, col: 16, offset: 156089},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5124, col: 16, offset: 156017},
+							pos:        position{line: 5126, col: 16, offset: 156089},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5124, col: 24, offset: 156025},
+							pos:  position{line: 5126, col: 24, offset: 156097},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5124, col: 30, offset: 156031},
+							pos:   position{line: 5126, col: 30, offset: 156103},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5124, col: 38, offset: 156039},
+								pos:  position{line: 5126, col: 38, offset: 156111},
 								name: "Boolean",
 							},
 						},
@@ -12563,28 +12563,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5136, col: 1, offset: 156304},
+			pos:  position{line: 5138, col: 1, offset: 156376},
 			expr: &actionExpr{
-				pos: position{line: 5136, col: 15, offset: 156318},
+				pos: position{line: 5138, col: 15, offset: 156390},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5136, col: 15, offset: 156318},
+					pos: position{line: 5138, col: 15, offset: 156390},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5136, col: 15, offset: 156318},
+							pos:  position{line: 5138, col: 15, offset: 156390},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5136, col: 20, offset: 156323},
+							pos:  position{line: 5138, col: 20, offset: 156395},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5136, col: 30, offset: 156333},
+							pos:   position{line: 5138, col: 30, offset: 156405},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5136, col: 40, offset: 156343},
+								pos: position{line: 5138, col: 40, offset: 156415},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5136, col: 40, offset: 156343},
+									pos:  position{line: 5138, col: 40, offset: 156415},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12595,39 +12595,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5143, col: 1, offset: 156469},
+			pos:  position{line: 5145, col: 1, offset: 156541},
 			expr: &actionExpr{
-				pos: position{line: 5143, col: 23, offset: 156491},
+				pos: position{line: 5145, col: 23, offset: 156563},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5143, col: 23, offset: 156491},
+					pos: position{line: 5145, col: 23, offset: 156563},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5143, col: 23, offset: 156491},
+							pos:  position{line: 5145, col: 23, offset: 156563},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5143, col: 29, offset: 156497},
+							pos:   position{line: 5145, col: 29, offset: 156569},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5143, col: 35, offset: 156503},
+								pos:  position{line: 5145, col: 35, offset: 156575},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5143, col: 49, offset: 156517},
+							pos:   position{line: 5145, col: 49, offset: 156589},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5143, col: 54, offset: 156522},
+								pos: position{line: 5145, col: 54, offset: 156594},
 								expr: &seqExpr{
-									pos: position{line: 5143, col: 55, offset: 156523},
+									pos: position{line: 5145, col: 55, offset: 156595},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5143, col: 55, offset: 156523},
+											pos:  position{line: 5145, col: 55, offset: 156595},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5143, col: 61, offset: 156529},
+											pos:  position{line: 5145, col: 61, offset: 156601},
 											name: "SPathArgument",
 										},
 									},
@@ -12640,26 +12640,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5175, col: 1, offset: 157422},
+			pos:  position{line: 5177, col: 1, offset: 157494},
 			expr: &actionExpr{
-				pos: position{line: 5175, col: 18, offset: 157439},
+				pos: position{line: 5177, col: 18, offset: 157511},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5175, col: 18, offset: 157439},
+					pos:   position{line: 5177, col: 18, offset: 157511},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5175, col: 23, offset: 157444},
+						pos: position{line: 5177, col: 23, offset: 157516},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5175, col: 23, offset: 157444},
+								pos:  position{line: 5177, col: 23, offset: 157516},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5175, col: 36, offset: 157457},
+								pos:  position{line: 5177, col: 36, offset: 157529},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5175, col: 50, offset: 157471},
+								pos:  position{line: 5177, col: 50, offset: 157543},
 								name: "PathField",
 							},
 						},
@@ -12669,28 +12669,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5179, col: 1, offset: 157507},
+			pos:  position{line: 5181, col: 1, offset: 157579},
 			expr: &actionExpr{
-				pos: position{line: 5179, col: 15, offset: 157521},
+				pos: position{line: 5181, col: 15, offset: 157593},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5179, col: 15, offset: 157521},
+					pos: position{line: 5181, col: 15, offset: 157593},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5179, col: 15, offset: 157521},
+							pos:        position{line: 5181, col: 15, offset: 157593},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5179, col: 23, offset: 157529},
+							pos:  position{line: 5181, col: 23, offset: 157601},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5179, col: 29, offset: 157535},
+							pos:   position{line: 5181, col: 29, offset: 157607},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5179, col: 35, offset: 157541},
+								pos:  position{line: 5181, col: 35, offset: 157613},
 								name: "FieldName",
 							},
 						},
@@ -12700,28 +12700,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5182, col: 1, offset: 157597},
+			pos:  position{line: 5184, col: 1, offset: 157669},
 			expr: &actionExpr{
-				pos: position{line: 5182, col: 16, offset: 157612},
+				pos: position{line: 5184, col: 16, offset: 157684},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5182, col: 16, offset: 157612},
+					pos: position{line: 5184, col: 16, offset: 157684},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5182, col: 16, offset: 157612},
+							pos:        position{line: 5184, col: 16, offset: 157684},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5182, col: 25, offset: 157621},
+							pos:  position{line: 5184, col: 25, offset: 157693},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5182, col: 31, offset: 157627},
+							pos:   position{line: 5184, col: 31, offset: 157699},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5182, col: 37, offset: 157633},
+								pos:  position{line: 5184, col: 37, offset: 157705},
 								name: "FieldName",
 							},
 						},
@@ -12731,34 +12731,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5185, col: 1, offset: 157690},
+			pos:  position{line: 5187, col: 1, offset: 157762},
 			expr: &actionExpr{
-				pos: position{line: 5185, col: 14, offset: 157703},
+				pos: position{line: 5187, col: 14, offset: 157775},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5185, col: 15, offset: 157704},
+					pos: position{line: 5187, col: 15, offset: 157776},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5185, col: 15, offset: 157704},
+							pos: position{line: 5187, col: 15, offset: 157776},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5185, col: 15, offset: 157704},
+									pos:        position{line: 5187, col: 15, offset: 157776},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5185, col: 22, offset: 157711},
+									pos:  position{line: 5187, col: 22, offset: 157783},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5185, col: 28, offset: 157717},
+									pos:  position{line: 5187, col: 28, offset: 157789},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5185, col: 47, offset: 157736},
+							pos:  position{line: 5187, col: 47, offset: 157808},
 							name: "SPathFieldString",
 						},
 					},
@@ -12767,16 +12767,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5197, col: 1, offset: 158148},
+			pos:  position{line: 5199, col: 1, offset: 158220},
 			expr: &choiceExpr{
-				pos: position{line: 5197, col: 21, offset: 158168},
+				pos: position{line: 5199, col: 21, offset: 158240},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5197, col: 21, offset: 158168},
+						pos:  position{line: 5199, col: 21, offset: 158240},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5197, col: 36, offset: 158183},
+						pos:  position{line: 5199, col: 36, offset: 158255},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12784,28 +12784,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5200, col: 1, offset: 158256},
+			pos:  position{line: 5202, col: 1, offset: 158328},
 			expr: &actionExpr{
-				pos: position{line: 5200, col: 16, offset: 158271},
+				pos: position{line: 5202, col: 16, offset: 158343},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5200, col: 16, offset: 158271},
+					pos: position{line: 5202, col: 16, offset: 158343},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5200, col: 16, offset: 158271},
+							pos:  position{line: 5202, col: 16, offset: 158343},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5200, col: 21, offset: 158276},
+							pos:  position{line: 5202, col: 21, offset: 158348},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5200, col: 32, offset: 158287},
+							pos:   position{line: 5202, col: 32, offset: 158359},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5200, col: 46, offset: 158301},
+								pos: position{line: 5202, col: 46, offset: 158373},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5200, col: 46, offset: 158301},
+									pos:  position{line: 5202, col: 46, offset: 158373},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12816,39 +12816,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5222, col: 1, offset: 158910},
+			pos:  position{line: 5224, col: 1, offset: 158982},
 			expr: &actionExpr{
-				pos: position{line: 5222, col: 24, offset: 158933},
+				pos: position{line: 5224, col: 24, offset: 159005},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5222, col: 24, offset: 158933},
+					pos: position{line: 5224, col: 24, offset: 159005},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5222, col: 24, offset: 158933},
+							pos:  position{line: 5224, col: 24, offset: 159005},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5222, col: 30, offset: 158939},
+							pos:   position{line: 5224, col: 30, offset: 159011},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5222, col: 37, offset: 158946},
+								pos:  position{line: 5224, col: 37, offset: 159018},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5222, col: 52, offset: 158961},
+							pos:   position{line: 5224, col: 52, offset: 159033},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5222, col: 57, offset: 158966},
+								pos: position{line: 5224, col: 57, offset: 159038},
 								expr: &seqExpr{
-									pos: position{line: 5222, col: 58, offset: 158967},
+									pos: position{line: 5224, col: 58, offset: 159039},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5222, col: 58, offset: 158967},
+											pos:  position{line: 5224, col: 58, offset: 159039},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5222, col: 64, offset: 158973},
+											pos:  position{line: 5224, col: 64, offset: 159045},
 											name: "FormatArgument",
 										},
 									},
@@ -12861,30 +12861,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5256, col: 1, offset: 160162},
+			pos:  position{line: 5258, col: 1, offset: 160234},
 			expr: &actionExpr{
-				pos: position{line: 5256, col: 19, offset: 160180},
+				pos: position{line: 5258, col: 19, offset: 160252},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5256, col: 19, offset: 160180},
+					pos:   position{line: 5258, col: 19, offset: 160252},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5256, col: 28, offset: 160189},
+						pos: position{line: 5258, col: 28, offset: 160261},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5256, col: 28, offset: 160189},
+								pos:  position{line: 5258, col: 28, offset: 160261},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5256, col: 46, offset: 160207},
+								pos:  position{line: 5258, col: 46, offset: 160279},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5256, col: 65, offset: 160226},
+								pos:  position{line: 5258, col: 65, offset: 160298},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5256, col: 82, offset: 160243},
+								pos:  position{line: 5258, col: 82, offset: 160315},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12894,28 +12894,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5260, col: 1, offset: 160293},
+			pos:  position{line: 5262, col: 1, offset: 160365},
 			expr: &actionExpr{
-				pos: position{line: 5260, col: 20, offset: 160312},
+				pos: position{line: 5262, col: 20, offset: 160384},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5260, col: 20, offset: 160312},
+					pos: position{line: 5262, col: 20, offset: 160384},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5260, col: 20, offset: 160312},
+							pos:        position{line: 5262, col: 20, offset: 160384},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5260, col: 28, offset: 160320},
+							pos:  position{line: 5262, col: 28, offset: 160392},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5260, col: 34, offset: 160326},
+							pos:   position{line: 5262, col: 34, offset: 160398},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5260, col: 38, offset: 160330},
+								pos:  position{line: 5262, col: 38, offset: 160402},
 								name: "QuotedString",
 							},
 						},
@@ -12925,28 +12925,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5269, col: 1, offset: 160542},
+			pos:  position{line: 5271, col: 1, offset: 160614},
 			expr: &actionExpr{
-				pos: position{line: 5269, col: 21, offset: 160562},
+				pos: position{line: 5271, col: 21, offset: 160634},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5269, col: 21, offset: 160562},
+					pos: position{line: 5271, col: 21, offset: 160634},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5269, col: 21, offset: 160562},
+							pos:        position{line: 5271, col: 21, offset: 160634},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5269, col: 34, offset: 160575},
+							pos:  position{line: 5271, col: 34, offset: 160647},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5269, col: 40, offset: 160581},
+							pos:   position{line: 5271, col: 40, offset: 160653},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5269, col: 47, offset: 160588},
+								pos:  position{line: 5271, col: 47, offset: 160660},
 								name: "IntegerAsString",
 							},
 						},
@@ -12956,28 +12956,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5282, col: 1, offset: 160994},
+			pos:  position{line: 5284, col: 1, offset: 161066},
 			expr: &actionExpr{
-				pos: position{line: 5282, col: 19, offset: 161012},
+				pos: position{line: 5284, col: 19, offset: 161084},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5282, col: 19, offset: 161012},
+					pos: position{line: 5284, col: 19, offset: 161084},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5282, col: 19, offset: 161012},
+							pos:        position{line: 5284, col: 19, offset: 161084},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5282, col: 30, offset: 161023},
+							pos:  position{line: 5284, col: 30, offset: 161095},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5282, col: 36, offset: 161029},
+							pos:   position{line: 5284, col: 36, offset: 161101},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5282, col: 40, offset: 161033},
+								pos:  position{line: 5284, col: 40, offset: 161105},
 								name: "QuotedString",
 							},
 						},
@@ -12987,78 +12987,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5291, col: 1, offset: 161248},
+			pos:  position{line: 5293, col: 1, offset: 161320},
 			expr: &actionExpr{
-				pos: position{line: 5291, col: 24, offset: 161271},
+				pos: position{line: 5293, col: 24, offset: 161343},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5291, col: 24, offset: 161271},
+					pos: position{line: 5293, col: 24, offset: 161343},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5291, col: 24, offset: 161271},
+							pos:   position{line: 5293, col: 24, offset: 161343},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 34, offset: 161281},
+								pos:  position{line: 5293, col: 34, offset: 161353},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 47, offset: 161294},
+							pos:  position{line: 5293, col: 47, offset: 161366},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 53, offset: 161300},
+							pos:   position{line: 5293, col: 53, offset: 161372},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 63, offset: 161310},
+								pos:  position{line: 5293, col: 63, offset: 161382},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 76, offset: 161323},
+							pos:  position{line: 5293, col: 76, offset: 161395},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 82, offset: 161329},
+							pos:   position{line: 5293, col: 82, offset: 161401},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 95, offset: 161342},
+								pos:  position{line: 5293, col: 95, offset: 161414},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 108, offset: 161355},
+							pos:  position{line: 5293, col: 108, offset: 161427},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 114, offset: 161361},
+							pos:   position{line: 5293, col: 114, offset: 161433},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 121, offset: 161368},
+								pos:  position{line: 5293, col: 121, offset: 161440},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 134, offset: 161381},
+							pos:  position{line: 5293, col: 134, offset: 161453},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 140, offset: 161387},
+							pos:   position{line: 5293, col: 140, offset: 161459},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 153, offset: 161400},
+								pos:  position{line: 5293, col: 153, offset: 161472},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5291, col: 166, offset: 161413},
+							pos:  position{line: 5293, col: 166, offset: 161485},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5291, col: 172, offset: 161419},
+							pos:   position{line: 5293, col: 172, offset: 161491},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5291, col: 179, offset: 161426},
+								pos:  position{line: 5293, col: 179, offset: 161498},
 								name: "QuotedString",
 							},
 						},
@@ -13068,28 +13068,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5309, col: 1, offset: 162002},
+			pos:  position{line: 5311, col: 1, offset: 162074},
 			expr: &actionExpr{
-				pos: position{line: 5309, col: 20, offset: 162021},
+				pos: position{line: 5311, col: 20, offset: 162093},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5309, col: 20, offset: 162021},
+					pos: position{line: 5311, col: 20, offset: 162093},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5309, col: 20, offset: 162021},
+							pos:  position{line: 5311, col: 20, offset: 162093},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5309, col: 25, offset: 162026},
+							pos:  position{line: 5311, col: 25, offset: 162098},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5309, col: 40, offset: 162041},
+							pos:   position{line: 5311, col: 40, offset: 162113},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5309, col: 55, offset: 162056},
+								pos: position{line: 5311, col: 55, offset: 162128},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5309, col: 55, offset: 162056},
+									pos:  position{line: 5311, col: 55, offset: 162128},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13100,42 +13100,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5316, col: 1, offset: 162209},
+			pos:  position{line: 5318, col: 1, offset: 162281},
 			expr: &actionExpr{
-				pos: position{line: 5316, col: 28, offset: 162236},
+				pos: position{line: 5318, col: 28, offset: 162308},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5316, col: 28, offset: 162236},
+					pos: position{line: 5318, col: 28, offset: 162308},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5316, col: 28, offset: 162236},
+							pos:  position{line: 5318, col: 28, offset: 162308},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5316, col: 34, offset: 162242},
+							pos:   position{line: 5318, col: 34, offset: 162314},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5316, col: 40, offset: 162248},
+								pos: position{line: 5318, col: 40, offset: 162320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5316, col: 40, offset: 162248},
+									pos:  position{line: 5318, col: 40, offset: 162320},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5316, col: 60, offset: 162268},
+							pos:   position{line: 5318, col: 60, offset: 162340},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5316, col: 65, offset: 162273},
+								pos: position{line: 5318, col: 65, offset: 162345},
 								expr: &seqExpr{
-									pos: position{line: 5316, col: 66, offset: 162274},
+									pos: position{line: 5318, col: 66, offset: 162346},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5316, col: 66, offset: 162274},
+											pos:  position{line: 5318, col: 66, offset: 162346},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5316, col: 72, offset: 162280},
+											pos:  position{line: 5318, col: 72, offset: 162352},
 											name: "EventCountArgument",
 										},
 									},
@@ -13148,30 +13148,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5372, col: 1, offset: 164157},
+			pos:  position{line: 5374, col: 1, offset: 164229},
 			expr: &actionExpr{
-				pos: position{line: 5372, col: 23, offset: 164179},
+				pos: position{line: 5374, col: 23, offset: 164251},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5372, col: 23, offset: 164179},
+					pos:   position{line: 5374, col: 23, offset: 164251},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5372, col: 28, offset: 164184},
+						pos: position{line: 5374, col: 28, offset: 164256},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5372, col: 28, offset: 164184},
+								pos:  position{line: 5374, col: 28, offset: 164256},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5372, col: 41, offset: 164197},
+								pos:  position{line: 5374, col: 41, offset: 164269},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5372, col: 58, offset: 164214},
+								pos:  position{line: 5374, col: 58, offset: 164286},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5372, col: 76, offset: 164232},
+								pos:  position{line: 5374, col: 76, offset: 164304},
 								name: "ListVixField",
 							},
 						},
@@ -13181,28 +13181,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5376, col: 1, offset: 164271},
+			pos:  position{line: 5378, col: 1, offset: 164343},
 			expr: &actionExpr{
-				pos: position{line: 5376, col: 15, offset: 164285},
+				pos: position{line: 5378, col: 15, offset: 164357},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5376, col: 15, offset: 164285},
+					pos: position{line: 5378, col: 15, offset: 164357},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5376, col: 15, offset: 164285},
+							pos:        position{line: 5378, col: 15, offset: 164357},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5376, col: 23, offset: 164293},
+							pos:  position{line: 5378, col: 23, offset: 164365},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5376, col: 29, offset: 164299},
+							pos:   position{line: 5378, col: 29, offset: 164371},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5376, col: 35, offset: 164305},
+								pos:  position{line: 5378, col: 35, offset: 164377},
 								name: "IndexName",
 							},
 						},
@@ -13212,28 +13212,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5379, col: 1, offset: 164361},
+			pos:  position{line: 5381, col: 1, offset: 164433},
 			expr: &actionExpr{
-				pos: position{line: 5379, col: 19, offset: 164379},
+				pos: position{line: 5381, col: 19, offset: 164451},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5379, col: 19, offset: 164379},
+					pos: position{line: 5381, col: 19, offset: 164451},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5379, col: 19, offset: 164379},
+							pos:        position{line: 5381, col: 19, offset: 164451},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5379, col: 31, offset: 164391},
+							pos:  position{line: 5381, col: 31, offset: 164463},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5379, col: 37, offset: 164397},
+							pos:   position{line: 5381, col: 37, offset: 164469},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5379, col: 43, offset: 164403},
+								pos:  position{line: 5381, col: 43, offset: 164475},
 								name: "Boolean",
 							},
 						},
@@ -13243,28 +13243,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5382, col: 1, offset: 164479},
+			pos:  position{line: 5384, col: 1, offset: 164551},
 			expr: &actionExpr{
-				pos: position{line: 5382, col: 20, offset: 164498},
+				pos: position{line: 5384, col: 20, offset: 164570},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5382, col: 20, offset: 164498},
+					pos: position{line: 5384, col: 20, offset: 164570},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5382, col: 20, offset: 164498},
+							pos:        position{line: 5384, col: 20, offset: 164570},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5382, col: 34, offset: 164512},
+							pos:  position{line: 5384, col: 34, offset: 164584},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5382, col: 40, offset: 164518},
+							pos:   position{line: 5384, col: 40, offset: 164590},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5382, col: 46, offset: 164524},
+								pos:  position{line: 5384, col: 46, offset: 164596},
 								name: "Boolean",
 							},
 						},
@@ -13274,28 +13274,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5385, col: 1, offset: 164602},
+			pos:  position{line: 5387, col: 1, offset: 164674},
 			expr: &actionExpr{
-				pos: position{line: 5385, col: 17, offset: 164618},
+				pos: position{line: 5387, col: 17, offset: 164690},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5385, col: 17, offset: 164618},
+					pos: position{line: 5387, col: 17, offset: 164690},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5385, col: 17, offset: 164618},
+							pos:        position{line: 5387, col: 17, offset: 164690},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5385, col: 28, offset: 164629},
+							pos:  position{line: 5387, col: 28, offset: 164701},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5385, col: 34, offset: 164635},
+							pos:   position{line: 5387, col: 34, offset: 164707},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5385, col: 40, offset: 164641},
+								pos:  position{line: 5387, col: 40, offset: 164713},
 								name: "Boolean",
 							},
 						},
@@ -13305,24 +13305,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5389, col: 1, offset: 164717},
+			pos:  position{line: 5391, col: 1, offset: 164789},
 			expr: &actionExpr{
-				pos: position{line: 5389, col: 14, offset: 164730},
+				pos: position{line: 5391, col: 14, offset: 164802},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5389, col: 14, offset: 164730},
+					pos: position{line: 5391, col: 14, offset: 164802},
 					expr: &seqExpr{
-						pos: position{line: 5389, col: 15, offset: 164731},
+						pos: position{line: 5391, col: 15, offset: 164803},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5389, col: 15, offset: 164731},
+								pos: position{line: 5391, col: 15, offset: 164803},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5389, col: 16, offset: 164732},
+									pos:  position{line: 5391, col: 16, offset: 164804},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5389, col: 22, offset: 164738,
+								line: 5391, col: 22, offset: 164810,
 							},
 						},
 					},
@@ -13331,39 +13331,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5394, col: 1, offset: 164811},
+			pos:  position{line: 5396, col: 1, offset: 164883},
 			expr: &actionExpr{
-				pos: position{line: 5394, col: 18, offset: 164828},
+				pos: position{line: 5396, col: 18, offset: 164900},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5394, col: 18, offset: 164828},
+					pos: position{line: 5396, col: 18, offset: 164900},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5394, col: 18, offset: 164828},
+							pos:  position{line: 5396, col: 18, offset: 164900},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5394, col: 23, offset: 164833},
+							pos:  position{line: 5396, col: 23, offset: 164905},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5394, col: 36, offset: 164846},
+							pos:   position{line: 5396, col: 36, offset: 164918},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5394, col: 49, offset: 164859},
+								pos: position{line: 5396, col: 49, offset: 164931},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5394, col: 49, offset: 164859},
+									pos:  position{line: 5396, col: 49, offset: 164931},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5394, col: 70, offset: 164880},
+							pos:   position{line: 5396, col: 70, offset: 164952},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5394, col: 77, offset: 164887},
+								pos: position{line: 5396, col: 77, offset: 164959},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5394, col: 77, offset: 164887},
+									pos:  position{line: 5396, col: 77, offset: 164959},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13374,32 +13374,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5424, col: 1, offset: 165650},
+			pos:  position{line: 5426, col: 1, offset: 165722},
 			expr: &actionExpr{
-				pos: position{line: 5424, col: 24, offset: 165673},
+				pos: position{line: 5426, col: 24, offset: 165745},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5424, col: 24, offset: 165673},
+					pos: position{line: 5426, col: 24, offset: 165745},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5424, col: 24, offset: 165673},
+							pos:  position{line: 5426, col: 24, offset: 165745},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5424, col: 30, offset: 165679},
+							pos:        position{line: 5426, col: 30, offset: 165751},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5424, col: 38, offset: 165687},
+							pos:  position{line: 5426, col: 38, offset: 165759},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5424, col: 44, offset: 165693},
+							pos:   position{line: 5426, col: 44, offset: 165765},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5424, col: 48, offset: 165697},
+								pos:  position{line: 5426, col: 48, offset: 165769},
 								name: "String",
 							},
 						},
@@ -13409,22 +13409,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5428, col: 1, offset: 165743},
+			pos:  position{line: 5430, col: 1, offset: 165815},
 			expr: &actionExpr{
-				pos: position{line: 5428, col: 22, offset: 165764},
+				pos: position{line: 5430, col: 22, offset: 165836},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5428, col: 22, offset: 165764},
+					pos: position{line: 5430, col: 22, offset: 165836},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5428, col: 22, offset: 165764},
+							pos:  position{line: 5430, col: 22, offset: 165836},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5428, col: 28, offset: 165770},
+							pos:   position{line: 5430, col: 28, offset: 165842},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5428, col: 38, offset: 165780},
+								pos:  position{line: 5430, col: 38, offset: 165852},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13434,36 +13434,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5432, col: 1, offset: 165839},
+			pos:  position{line: 5434, col: 1, offset: 165911},
 			expr: &actionExpr{
-				pos: position{line: 5432, col: 18, offset: 165856},
+				pos: position{line: 5434, col: 18, offset: 165928},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5432, col: 18, offset: 165856},
+					pos: position{line: 5434, col: 18, offset: 165928},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5432, col: 18, offset: 165856},
+							pos:  position{line: 5434, col: 18, offset: 165928},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5432, col: 23, offset: 165861},
+							pos:  position{line: 5434, col: 23, offset: 165933},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5432, col: 36, offset: 165874},
+							pos:   position{line: 5434, col: 36, offset: 165946},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5432, col: 42, offset: 165880},
+								pos:  position{line: 5434, col: 42, offset: 165952},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5432, col: 56, offset: 165894},
+							pos:   position{line: 5434, col: 56, offset: 165966},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5432, col: 65, offset: 165903},
+								pos: position{line: 5434, col: 65, offset: 165975},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5432, col: 65, offset: 165903},
+									pos:  position{line: 5434, col: 65, offset: 165975},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13474,22 +13474,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5461, col: 1, offset: 166679},
+			pos:  position{line: 5463, col: 1, offset: 166751},
 			expr: &actionExpr{
-				pos: position{line: 5461, col: 18, offset: 166696},
+				pos: position{line: 5463, col: 18, offset: 166768},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5461, col: 18, offset: 166696},
+					pos: position{line: 5463, col: 18, offset: 166768},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5461, col: 18, offset: 166696},
+							pos:  position{line: 5463, col: 18, offset: 166768},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5461, col: 24, offset: 166702},
+							pos:   position{line: 5463, col: 24, offset: 166774},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5461, col: 34, offset: 166712},
+								pos:  position{line: 5463, col: 34, offset: 166784},
 								name: "FieldName",
 							},
 						},
@@ -13499,32 +13499,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5465, col: 1, offset: 166753},
+			pos:  position{line: 5467, col: 1, offset: 166825},
 			expr: &actionExpr{
-				pos: position{line: 5465, col: 18, offset: 166770},
+				pos: position{line: 5467, col: 18, offset: 166842},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5465, col: 18, offset: 166770},
+					pos: position{line: 5467, col: 18, offset: 166842},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5465, col: 18, offset: 166770},
+							pos:  position{line: 5467, col: 18, offset: 166842},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5465, col: 24, offset: 166776},
+							pos:        position{line: 5467, col: 24, offset: 166848},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5465, col: 32, offset: 166784},
+							pos:  position{line: 5467, col: 32, offset: 166856},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5465, col: 38, offset: 166790},
+							pos:   position{line: 5467, col: 38, offset: 166862},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5465, col: 47, offset: 166799},
+								pos:  position{line: 5467, col: 47, offset: 166871},
 								name: "IntegerAsString",
 							},
 						},
@@ -13534,26 +13534,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5469, col: 1, offset: 166845},
+			pos:  position{line: 5471, col: 1, offset: 166917},
 			expr: &actionExpr{
-				pos: position{line: 5469, col: 16, offset: 166860},
+				pos: position{line: 5471, col: 16, offset: 166932},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5469, col: 16, offset: 166860},
+					pos: position{line: 5471, col: 16, offset: 166932},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5469, col: 16, offset: 166860},
+							pos:  position{line: 5471, col: 16, offset: 166932},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5469, col: 22, offset: 166866},
+							pos:  position{line: 5471, col: 22, offset: 166938},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5469, col: 32, offset: 166876},
+							pos:   position{line: 5471, col: 32, offset: 166948},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5469, col: 42, offset: 166886},
+								pos:  position{line: 5471, col: 42, offset: 166958},
 								name: "BoolExpr",
 							},
 						},
@@ -13563,28 +13563,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5473, col: 1, offset: 166946},
+			pos:  position{line: 5475, col: 1, offset: 167018},
 			expr: &actionExpr{
-				pos: position{line: 5473, col: 28, offset: 166973},
+				pos: position{line: 5475, col: 28, offset: 167045},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5473, col: 28, offset: 166973},
+					pos: position{line: 5475, col: 28, offset: 167045},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5473, col: 28, offset: 166973},
+							pos:        position{line: 5475, col: 28, offset: 167045},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5473, col: 37, offset: 166982},
+							pos:  position{line: 5475, col: 37, offset: 167054},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5473, col: 43, offset: 166988},
+							pos:   position{line: 5475, col: 43, offset: 167060},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5473, col: 51, offset: 166996},
+								pos:  position{line: 5475, col: 51, offset: 167068},
 								name: "Boolean",
 							},
 						},
@@ -13594,28 +13594,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5482, col: 1, offset: 167180},
+			pos:  position{line: 5484, col: 1, offset: 167252},
 			expr: &actionExpr{
-				pos: position{line: 5482, col: 28, offset: 167207},
+				pos: position{line: 5484, col: 28, offset: 167279},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5482, col: 28, offset: 167207},
+					pos: position{line: 5484, col: 28, offset: 167279},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5482, col: 28, offset: 167207},
+							pos:        position{line: 5484, col: 28, offset: 167279},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5482, col: 37, offset: 167216},
+							pos:  position{line: 5484, col: 37, offset: 167288},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5482, col: 43, offset: 167222},
+							pos:   position{line: 5484, col: 43, offset: 167294},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5482, col: 51, offset: 167230},
+								pos:  position{line: 5484, col: 51, offset: 167302},
 								name: "Boolean",
 							},
 						},
@@ -13625,28 +13625,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5491, col: 1, offset: 167414},
+			pos:  position{line: 5493, col: 1, offset: 167486},
 			expr: &actionExpr{
-				pos: position{line: 5491, col: 27, offset: 167440},
+				pos: position{line: 5493, col: 27, offset: 167512},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5491, col: 27, offset: 167440},
+					pos: position{line: 5493, col: 27, offset: 167512},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5491, col: 27, offset: 167440},
+							pos:        position{line: 5493, col: 27, offset: 167512},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5491, col: 35, offset: 167448},
+							pos:  position{line: 5493, col: 35, offset: 167520},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5491, col: 41, offset: 167454},
+							pos:   position{line: 5493, col: 41, offset: 167526},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5491, col: 48, offset: 167461},
+								pos:  position{line: 5493, col: 48, offset: 167533},
 								name: "PositiveInteger",
 							},
 						},
@@ -13656,28 +13656,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5500, col: 1, offset: 167652},
+			pos:  position{line: 5502, col: 1, offset: 167724},
 			expr: &actionExpr{
-				pos: position{line: 5500, col: 25, offset: 167676},
+				pos: position{line: 5502, col: 25, offset: 167748},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5500, col: 25, offset: 167676},
+					pos: position{line: 5502, col: 25, offset: 167748},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5500, col: 25, offset: 167676},
+							pos:        position{line: 5502, col: 25, offset: 167748},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5500, col: 31, offset: 167682},
+							pos:  position{line: 5502, col: 31, offset: 167754},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5500, col: 37, offset: 167688},
+							pos:   position{line: 5502, col: 37, offset: 167760},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5500, col: 44, offset: 167695},
+								pos:  position{line: 5502, col: 44, offset: 167767},
 								name: "PositiveInteger",
 							},
 						},
@@ -13687,30 +13687,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5509, col: 1, offset: 167882},
+			pos:  position{line: 5511, col: 1, offset: 167954},
 			expr: &actionExpr{
-				pos: position{line: 5509, col: 22, offset: 167903},
+				pos: position{line: 5511, col: 22, offset: 167975},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5509, col: 22, offset: 167903},
+					pos:   position{line: 5511, col: 22, offset: 167975},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5509, col: 41, offset: 167922},
+						pos: position{line: 5511, col: 41, offset: 167994},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5509, col: 41, offset: 167922},
+								pos:  position{line: 5511, col: 41, offset: 167994},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5509, col: 67, offset: 167948},
+								pos:  position{line: 5511, col: 67, offset: 168020},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5509, col: 93, offset: 167974},
+								pos:  position{line: 5511, col: 93, offset: 168046},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5509, col: 118, offset: 167999},
+								pos:  position{line: 5511, col: 118, offset: 168071},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13720,35 +13720,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5513, col: 1, offset: 168060},
+			pos:  position{line: 5515, col: 1, offset: 168132},
 			expr: &actionExpr{
-				pos: position{line: 5513, col: 26, offset: 168085},
+				pos: position{line: 5515, col: 26, offset: 168157},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5513, col: 26, offset: 168085},
+					pos: position{line: 5515, col: 26, offset: 168157},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5513, col: 26, offset: 168085},
+							pos:   position{line: 5515, col: 26, offset: 168157},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5513, col: 34, offset: 168093},
+								pos:  position{line: 5515, col: 34, offset: 168165},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5513, col: 53, offset: 168112},
+							pos:   position{line: 5515, col: 53, offset: 168184},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5513, col: 58, offset: 168117},
+								pos: position{line: 5515, col: 58, offset: 168189},
 								expr: &seqExpr{
-									pos: position{line: 5513, col: 59, offset: 168118},
+									pos: position{line: 5515, col: 59, offset: 168190},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5513, col: 59, offset: 168118},
+											pos:  position{line: 5515, col: 59, offset: 168190},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5513, col: 65, offset: 168124},
+											pos:  position{line: 5515, col: 65, offset: 168196},
 											name: "InputLookupOption",
 										},
 									},
@@ -13761,35 +13761,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5555, col: 1, offset: 169570},
+			pos:  position{line: 5557, col: 1, offset: 169642},
 			expr: &actionExpr{
-				pos: position{line: 5555, col: 21, offset: 169590},
+				pos: position{line: 5557, col: 21, offset: 169662},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5555, col: 21, offset: 169590},
+					pos: position{line: 5557, col: 21, offset: 169662},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5555, col: 21, offset: 169590},
+							pos:  position{line: 5557, col: 21, offset: 169662},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5555, col: 26, offset: 169595},
+							pos:  position{line: 5557, col: 26, offset: 169667},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5555, col: 42, offset: 169611},
+							pos:   position{line: 5557, col: 42, offset: 169683},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5555, col: 60, offset: 169629},
+								pos: position{line: 5557, col: 60, offset: 169701},
 								expr: &seqExpr{
-									pos: position{line: 5555, col: 61, offset: 169630},
+									pos: position{line: 5557, col: 61, offset: 169702},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5555, col: 61, offset: 169630},
+											pos:  position{line: 5557, col: 61, offset: 169702},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5555, col: 83, offset: 169652},
+											pos:  position{line: 5557, col: 83, offset: 169724},
 											name: "SPACE",
 										},
 									},
@@ -13797,20 +13797,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5555, col: 91, offset: 169660},
+							pos:   position{line: 5557, col: 91, offset: 169732},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5555, col: 101, offset: 169670},
+								pos:  position{line: 5557, col: 101, offset: 169742},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5555, col: 109, offset: 169678},
+							pos:   position{line: 5557, col: 109, offset: 169750},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5555, col: 121, offset: 169690},
+								pos: position{line: 5557, col: 121, offset: 169762},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5555, col: 122, offset: 169691},
+									pos:  position{line: 5557, col: 122, offset: 169763},
 									name: "WhereClause",
 								},
 							},
@@ -13821,15 +13821,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5578, col: 1, offset: 170379},
+			pos:  position{line: 5580, col: 1, offset: 170451},
 			expr: &actionExpr{
-				pos: position{line: 5578, col: 24, offset: 170402},
+				pos: position{line: 5580, col: 24, offset: 170474},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5578, col: 24, offset: 170402},
+					pos:   position{line: 5580, col: 24, offset: 170474},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5578, col: 41, offset: 170419},
+						pos:  position{line: 5580, col: 41, offset: 170491},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13837,26 +13837,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5589, col: 1, offset: 170818},
+			pos:  position{line: 5591, col: 1, offset: 170890},
 			expr: &actionExpr{
-				pos: position{line: 5589, col: 20, offset: 170837},
+				pos: position{line: 5591, col: 20, offset: 170909},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5589, col: 20, offset: 170837},
+					pos:   position{line: 5591, col: 20, offset: 170909},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5589, col: 28, offset: 170845},
+						pos: position{line: 5591, col: 28, offset: 170917},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5589, col: 28, offset: 170845},
+								pos:  position{line: 5591, col: 28, offset: 170917},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5589, col: 52, offset: 170869},
+								pos:  position{line: 5591, col: 52, offset: 170941},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5589, col: 68, offset: 170885},
+								pos:  position{line: 5591, col: 68, offset: 170957},
 								name: "MaxOutOption",
 							},
 						},
@@ -13866,28 +13866,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5594, col: 1, offset: 170983},
+			pos:  position{line: 5596, col: 1, offset: 171055},
 			expr: &actionExpr{
-				pos: position{line: 5594, col: 26, offset: 171008},
+				pos: position{line: 5596, col: 26, offset: 171080},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5594, col: 26, offset: 171008},
+					pos: position{line: 5596, col: 26, offset: 171080},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5594, col: 26, offset: 171008},
+							pos:        position{line: 5596, col: 26, offset: 171080},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5594, col: 44, offset: 171026},
+							pos:  position{line: 5596, col: 44, offset: 171098},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5594, col: 50, offset: 171032},
+							pos:   position{line: 5596, col: 50, offset: 171104},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5594, col: 58, offset: 171040},
+								pos:  position{line: 5596, col: 58, offset: 171112},
 								name: "Boolean",
 							},
 						},
@@ -13897,28 +13897,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5601, col: 1, offset: 171179},
+			pos:  position{line: 5603, col: 1, offset: 171251},
 			expr: &actionExpr{
-				pos: position{line: 5601, col: 18, offset: 171196},
+				pos: position{line: 5603, col: 18, offset: 171268},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5601, col: 18, offset: 171196},
+					pos: position{line: 5603, col: 18, offset: 171268},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5601, col: 18, offset: 171196},
+							pos:        position{line: 5603, col: 18, offset: 171268},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5601, col: 28, offset: 171206},
+							pos:  position{line: 5603, col: 28, offset: 171278},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5601, col: 34, offset: 171212},
+							pos:   position{line: 5603, col: 34, offset: 171284},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5601, col: 39, offset: 171217},
+								pos:  position{line: 5603, col: 39, offset: 171289},
 								name: "IntegerAsString",
 							},
 						},
@@ -13928,28 +13928,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5612, col: 1, offset: 171518},
+			pos:  position{line: 5614, col: 1, offset: 171590},
 			expr: &actionExpr{
-				pos: position{line: 5612, col: 17, offset: 171534},
+				pos: position{line: 5614, col: 17, offset: 171606},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5612, col: 17, offset: 171534},
+					pos: position{line: 5614, col: 17, offset: 171606},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5612, col: 17, offset: 171534},
+							pos:        position{line: 5614, col: 17, offset: 171606},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5612, col: 26, offset: 171543},
+							pos:  position{line: 5614, col: 26, offset: 171615},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5612, col: 32, offset: 171549},
+							pos:   position{line: 5614, col: 32, offset: 171621},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5612, col: 36, offset: 171553},
+								pos:  position{line: 5614, col: 36, offset: 171625},
 								name: "IntegerAsString",
 							},
 						},
@@ -13959,43 +13959,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5624, col: 1, offset: 171908},
+			pos:  position{line: 5626, col: 1, offset: 171980},
 			expr: &actionExpr{
-				pos: position{line: 5624, col: 14, offset: 171921},
+				pos: position{line: 5626, col: 14, offset: 171993},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5624, col: 14, offset: 171921},
+					pos: position{line: 5626, col: 14, offset: 171993},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5624, col: 14, offset: 171921},
+							pos:        position{line: 5626, col: 14, offset: 171993},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5624, col: 18, offset: 171925},
+							pos: position{line: 5626, col: 18, offset: 171997},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5624, col: 18, offset: 171925},
+								pos:  position{line: 5626, col: 18, offset: 171997},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5624, col: 25, offset: 171932},
+							pos:   position{line: 5626, col: 25, offset: 172004},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5624, col: 32, offset: 171939},
+								pos:  position{line: 5626, col: 32, offset: 172011},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5624, col: 44, offset: 171951},
+							pos: position{line: 5626, col: 44, offset: 172023},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5624, col: 44, offset: 171951},
+								pos:  position{line: 5626, col: 44, offset: 172023},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5624, col: 51, offset: 171958},
+							pos:        position{line: 5626, col: 51, offset: 172030},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14006,35 +14006,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5629, col: 1, offset: 172047},
+			pos:  position{line: 5631, col: 1, offset: 172119},
 			expr: &actionExpr{
-				pos: position{line: 5629, col: 25, offset: 172071},
+				pos: position{line: 5631, col: 25, offset: 172143},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5629, col: 25, offset: 172071},
+					pos: position{line: 5631, col: 25, offset: 172143},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5629, col: 25, offset: 172071},
+							pos:   position{line: 5631, col: 25, offset: 172143},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5629, col: 31, offset: 172077},
+								pos:  position{line: 5631, col: 31, offset: 172149},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5629, col: 47, offset: 172093},
+							pos:   position{line: 5631, col: 47, offset: 172165},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5629, col: 52, offset: 172098},
+								pos: position{line: 5631, col: 52, offset: 172170},
 								expr: &seqExpr{
-									pos: position{line: 5629, col: 53, offset: 172099},
+									pos: position{line: 5631, col: 53, offset: 172171},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5629, col: 53, offset: 172099},
+											pos:  position{line: 5631, col: 53, offset: 172171},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5629, col: 59, offset: 172105},
+											pos:  position{line: 5631, col: 59, offset: 172177},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14047,37 +14047,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5656, col: 1, offset: 172915},
+			pos:  position{line: 5658, col: 1, offset: 172987},
 			expr: &actionExpr{
-				pos: position{line: 5656, col: 16, offset: 172930},
+				pos: position{line: 5658, col: 16, offset: 173002},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5656, col: 16, offset: 172930},
+					pos: position{line: 5658, col: 16, offset: 173002},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5656, col: 16, offset: 172930},
+							pos:  position{line: 5658, col: 16, offset: 173002},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5656, col: 21, offset: 172935},
+							pos:  position{line: 5658, col: 21, offset: 173007},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 32, offset: 172946},
+							pos:   position{line: 5658, col: 32, offset: 173018},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5656, col: 40, offset: 172954},
+								pos: position{line: 5658, col: 40, offset: 173026},
 								expr: &seqExpr{
-									pos: position{line: 5656, col: 41, offset: 172955},
+									pos: position{line: 5658, col: 41, offset: 173027},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5656, col: 41, offset: 172955},
+											pos:  position{line: 5658, col: 41, offset: 173027},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5656, col: 57, offset: 172971},
+											pos: position{line: 5658, col: 57, offset: 173043},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5656, col: 57, offset: 172971},
+												pos:  position{line: 5658, col: 57, offset: 173043},
 												name: "SPACE",
 											},
 										},
@@ -14086,10 +14086,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 66, offset: 172980},
+							pos:   position{line: 5658, col: 66, offset: 173052},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5656, col: 76, offset: 172990},
+								pos:  position{line: 5658, col: 76, offset: 173062},
 								name: "Subsearch",
 							},
 						},
@@ -14099,45 +14099,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5698, col: 1, offset: 174527},
+			pos:  position{line: 5700, col: 1, offset: 174599},
 			expr: &actionExpr{
-				pos: position{line: 5698, col: 17, offset: 174543},
+				pos: position{line: 5700, col: 17, offset: 174615},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5698, col: 17, offset: 174543},
+					pos: position{line: 5700, col: 17, offset: 174615},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5698, col: 17, offset: 174543},
+							pos:  position{line: 5700, col: 17, offset: 174615},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5698, col: 23, offset: 174549},
+							pos:   position{line: 5700, col: 23, offset: 174621},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5698, col: 31, offset: 174557},
+								pos: position{line: 5700, col: 31, offset: 174629},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 31, offset: 174557},
+										pos:  position{line: 5700, col: 31, offset: 174629},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 54, offset: 174580},
+										pos:  position{line: 5700, col: 54, offset: 174652},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 74, offset: 174600},
+										pos:  position{line: 5700, col: 74, offset: 174672},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 91, offset: 174617},
+										pos:  position{line: 5700, col: 91, offset: 174689},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 115, offset: 174641},
+										pos:  position{line: 5700, col: 115, offset: 174713},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5698, col: 135, offset: 174661},
+										pos:  position{line: 5700, col: 135, offset: 174733},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14149,51 +14149,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5702, col: 1, offset: 174716},
+			pos:  position{line: 5704, col: 1, offset: 174788},
 			expr: &actionExpr{
-				pos: position{line: 5702, col: 25, offset: 174740},
+				pos: position{line: 5704, col: 25, offset: 174812},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5702, col: 26, offset: 174741},
+					pos: position{line: 5704, col: 26, offset: 174813},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5702, col: 26, offset: 174741},
+							pos:   position{line: 5704, col: 26, offset: 174813},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5702, col: 33, offset: 174748},
+								pos: position{line: 5704, col: 33, offset: 174820},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5702, col: 33, offset: 174748},
+										pos:        position{line: 5704, col: 33, offset: 174820},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5702, col: 42, offset: 174757},
+										pos:        position{line: 5704, col: 42, offset: 174829},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5702, col: 51, offset: 174766},
+										pos:        position{line: 5704, col: 51, offset: 174838},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5702, col: 60, offset: 174775},
+										pos:        position{line: 5704, col: 60, offset: 174847},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5702, col: 68, offset: 174783},
+										pos:        position{line: 5704, col: 68, offset: 174855},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5702, col: 76, offset: 174791},
+										pos:        position{line: 5704, col: 76, offset: 174863},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14202,19 +14202,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5702, col: 84, offset: 174799},
+							pos:  position{line: 5704, col: 84, offset: 174871},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5702, col: 92, offset: 174807},
+							pos:   position{line: 5704, col: 92, offset: 174879},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5702, col: 105, offset: 174820},
+								pos:  position{line: 5704, col: 105, offset: 174892},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5702, col: 116, offset: 174831},
+							pos:  position{line: 5704, col: 116, offset: 174903},
 							name: "R_PAREN",
 						},
 					},
@@ -14223,15 +14223,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5728, col: 1, offset: 175589},
+			pos:  position{line: 5730, col: 1, offset: 175661},
 			expr: &actionExpr{
-				pos: position{line: 5728, col: 30, offset: 175618},
+				pos: position{line: 5730, col: 30, offset: 175690},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5728, col: 30, offset: 175618},
+					pos:   position{line: 5730, col: 30, offset: 175690},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5728, col: 43, offset: 175631},
+						pos:  position{line: 5730, col: 43, offset: 175703},
 						name: "StringExpr",
 					},
 				},
@@ -14239,61 +14239,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5753, col: 1, offset: 176339},
+			pos:  position{line: 5755, col: 1, offset: 176411},
 			expr: &actionExpr{
-				pos: position{line: 5753, col: 22, offset: 176360},
+				pos: position{line: 5755, col: 22, offset: 176432},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5753, col: 22, offset: 176360},
+					pos: position{line: 5755, col: 22, offset: 176432},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5753, col: 22, offset: 176360},
+							pos:        position{line: 5755, col: 22, offset: 176432},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5753, col: 37, offset: 176375},
+							pos:  position{line: 5755, col: 37, offset: 176447},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5753, col: 43, offset: 176381},
+							pos:   position{line: 5755, col: 43, offset: 176453},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5753, col: 50, offset: 176388},
+								pos: position{line: 5755, col: 50, offset: 176460},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5753, col: 50, offset: 176388},
+										pos:        position{line: 5755, col: 50, offset: 176460},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5753, col: 59, offset: 176397},
+										pos:        position{line: 5755, col: 59, offset: 176469},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5753, col: 68, offset: 176406},
+										pos:        position{line: 5755, col: 68, offset: 176478},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5753, col: 77, offset: 176415},
+										pos:        position{line: 5755, col: 77, offset: 176487},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5753, col: 85, offset: 176423},
+										pos:        position{line: 5755, col: 85, offset: 176495},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5753, col: 93, offset: 176431},
+										pos:        position{line: 5755, col: 93, offset: 176503},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14307,28 +14307,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5766, col: 1, offset: 176760},
+			pos:  position{line: 5768, col: 1, offset: 176832},
 			expr: &actionExpr{
-				pos: position{line: 5766, col: 19, offset: 176778},
+				pos: position{line: 5768, col: 19, offset: 176850},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5766, col: 19, offset: 176778},
+					pos: position{line: 5768, col: 19, offset: 176850},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5766, col: 19, offset: 176778},
+							pos:        position{line: 5768, col: 19, offset: 176850},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5766, col: 31, offset: 176790},
+							pos:  position{line: 5768, col: 31, offset: 176862},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5766, col: 37, offset: 176796},
+							pos:   position{line: 5768, col: 37, offset: 176868},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5766, col: 45, offset: 176804},
+								pos:  position{line: 5768, col: 45, offset: 176876},
 								name: "Boolean",
 							},
 						},
@@ -14338,28 +14338,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5773, col: 1, offset: 176927},
+			pos:  position{line: 5775, col: 1, offset: 176999},
 			expr: &actionExpr{
-				pos: position{line: 5773, col: 26, offset: 176952},
+				pos: position{line: 5775, col: 26, offset: 177024},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5773, col: 26, offset: 176952},
+					pos: position{line: 5775, col: 26, offset: 177024},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5773, col: 26, offset: 176952},
+							pos:        position{line: 5775, col: 26, offset: 177024},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5773, col: 45, offset: 176971},
+							pos:  position{line: 5775, col: 45, offset: 177043},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5773, col: 51, offset: 176977},
+							pos:   position{line: 5775, col: 51, offset: 177049},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5773, col: 59, offset: 176985},
+								pos:  position{line: 5775, col: 59, offset: 177057},
 								name: "Boolean",
 							},
 						},
@@ -14369,28 +14369,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5780, col: 1, offset: 177115},
+			pos:  position{line: 5782, col: 1, offset: 177187},
 			expr: &actionExpr{
-				pos: position{line: 5780, col: 22, offset: 177136},
+				pos: position{line: 5782, col: 22, offset: 177208},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5780, col: 22, offset: 177136},
+					pos: position{line: 5782, col: 22, offset: 177208},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5780, col: 22, offset: 177136},
+							pos:        position{line: 5782, col: 22, offset: 177208},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5780, col: 37, offset: 177151},
+							pos:  position{line: 5782, col: 37, offset: 177223},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5780, col: 43, offset: 177157},
+							pos:   position{line: 5782, col: 43, offset: 177229},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5780, col: 50, offset: 177164},
+								pos:  position{line: 5782, col: 50, offset: 177236},
 								name: "String",
 							},
 						},
@@ -14400,28 +14400,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5787, col: 1, offset: 177290},
+			pos:  position{line: 5789, col: 1, offset: 177362},
 			expr: &actionExpr{
-				pos: position{line: 5787, col: 16, offset: 177305},
+				pos: position{line: 5789, col: 16, offset: 177377},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5787, col: 16, offset: 177305},
+					pos: position{line: 5789, col: 16, offset: 177377},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5787, col: 16, offset: 177305},
+							pos:  position{line: 5789, col: 16, offset: 177377},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5787, col: 21, offset: 177310},
+							pos:  position{line: 5789, col: 21, offset: 177382},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5787, col: 32, offset: 177321},
+							pos:   position{line: 5789, col: 32, offset: 177393},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5787, col: 40, offset: 177329},
+								pos: position{line: 5789, col: 40, offset: 177401},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5787, col: 41, offset: 177330},
+									pos:  position{line: 5789, col: 41, offset: 177402},
 									name: "ToJsonOption",
 								},
 							},
@@ -14432,132 +14432,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5840, col: 1, offset: 179412},
+			pos:  position{line: 5842, col: 1, offset: 179484},
 			expr: &choiceExpr{
-				pos: position{line: 5840, col: 12, offset: 179423},
+				pos: position{line: 5842, col: 12, offset: 179495},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 12, offset: 179423},
+						pos:  position{line: 5842, col: 12, offset: 179495},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 24, offset: 179435},
+						pos:  position{line: 5842, col: 24, offset: 179507},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 36, offset: 179447},
+						pos:  position{line: 5842, col: 36, offset: 179519},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 49, offset: 179460},
+						pos:  position{line: 5842, col: 49, offset: 179532},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 61, offset: 179472},
+						pos:  position{line: 5842, col: 61, offset: 179544},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 81, offset: 179492},
+						pos:  position{line: 5842, col: 81, offset: 179564},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 92, offset: 179503},
+						pos:  position{line: 5842, col: 92, offset: 179575},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 112, offset: 179523},
+						pos:  position{line: 5842, col: 112, offset: 179595},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 123, offset: 179534},
+						pos:  position{line: 5842, col: 123, offset: 179606},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 134, offset: 179545},
+						pos:  position{line: 5842, col: 134, offset: 179617},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 144, offset: 179555},
+						pos:  position{line: 5842, col: 144, offset: 179627},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 154, offset: 179565},
+						pos:  position{line: 5842, col: 154, offset: 179637},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 165, offset: 179576},
+						pos:  position{line: 5842, col: 165, offset: 179648},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 178, offset: 179589},
+						pos:  position{line: 5842, col: 178, offset: 179661},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 194, offset: 179605},
+						pos:  position{line: 5842, col: 194, offset: 179677},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 212, offset: 179623},
+						pos:  position{line: 5842, col: 212, offset: 179695},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 224, offset: 179635},
+						pos:  position{line: 5842, col: 224, offset: 179707},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 235, offset: 179646},
+						pos:  position{line: 5842, col: 235, offset: 179718},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 248, offset: 179659},
+						pos:  position{line: 5842, col: 248, offset: 179731},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 260, offset: 179671},
+						pos:  position{line: 5842, col: 260, offset: 179743},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 273, offset: 179684},
+						pos:  position{line: 5842, col: 273, offset: 179756},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 288, offset: 179699},
+						pos:  position{line: 5842, col: 288, offset: 179771},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 301, offset: 179712},
+						pos:  position{line: 5842, col: 301, offset: 179784},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 318, offset: 179729},
+						pos:  position{line: 5842, col: 318, offset: 179801},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 328, offset: 179739},
+						pos:  position{line: 5842, col: 328, offset: 179811},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 346, offset: 179757},
+						pos:  position{line: 5842, col: 346, offset: 179829},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 361, offset: 179772},
+						pos:  position{line: 5842, col: 361, offset: 179844},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 376, offset: 179787},
+						pos:  position{line: 5842, col: 376, offset: 179859},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 391, offset: 179802},
+						pos:  position{line: 5842, col: 391, offset: 179874},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 409, offset: 179820},
+						pos:  position{line: 5842, col: 409, offset: 179892},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5840, col: 422, offset: 179833},
+						pos:  position{line: 5842, col: 422, offset: 179905},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14565,18 +14565,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5841, col: 1, offset: 179845},
+			pos:  position{line: 5843, col: 1, offset: 179917},
 			expr: &seqExpr{
-				pos: position{line: 5841, col: 15, offset: 179859},
+				pos: position{line: 5843, col: 15, offset: 179931},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5841, col: 15, offset: 179859},
+						pos:        position{line: 5843, col: 15, offset: 179931},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5841, col: 24, offset: 179868},
+						pos:  position{line: 5843, col: 24, offset: 179940},
 						name: "SPACE",
 					},
 				},
@@ -14584,18 +14584,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5842, col: 1, offset: 179874},
+			pos:  position{line: 5844, col: 1, offset: 179946},
 			expr: &seqExpr{
-				pos: position{line: 5842, col: 14, offset: 179887},
+				pos: position{line: 5844, col: 14, offset: 179959},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5842, col: 14, offset: 179887},
+						pos:        position{line: 5844, col: 14, offset: 179959},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5842, col: 22, offset: 179895},
+						pos:  position{line: 5844, col: 22, offset: 179967},
 						name: "SPACE",
 					},
 				},
@@ -14603,18 +14603,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5843, col: 1, offset: 179901},
+			pos:  position{line: 5845, col: 1, offset: 179973},
 			expr: &seqExpr{
-				pos: position{line: 5843, col: 14, offset: 179914},
+				pos: position{line: 5845, col: 14, offset: 179986},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5843, col: 14, offset: 179914},
+						pos:        position{line: 5845, col: 14, offset: 179986},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5843, col: 22, offset: 179922},
+						pos:  position{line: 5845, col: 22, offset: 179994},
 						name: "SPACE",
 					},
 				},
@@ -14622,18 +14622,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5844, col: 1, offset: 179928},
+			pos:  position{line: 5846, col: 1, offset: 180000},
 			expr: &seqExpr{
-				pos: position{line: 5844, col: 20, offset: 179947},
+				pos: position{line: 5846, col: 20, offset: 180019},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5844, col: 20, offset: 179947},
+						pos:        position{line: 5846, col: 20, offset: 180019},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5844, col: 34, offset: 179961},
+						pos:  position{line: 5846, col: 34, offset: 180033},
 						name: "SPACE",
 					},
 				},
@@ -14641,18 +14641,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5845, col: 1, offset: 179967},
+			pos:  position{line: 5847, col: 1, offset: 180039},
 			expr: &seqExpr{
-				pos: position{line: 5845, col: 15, offset: 179981},
+				pos: position{line: 5847, col: 15, offset: 180053},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5845, col: 15, offset: 179981},
+						pos:        position{line: 5847, col: 15, offset: 180053},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5845, col: 24, offset: 179990},
+						pos:  position{line: 5847, col: 24, offset: 180062},
 						name: "SPACE",
 					},
 				},
@@ -14660,18 +14660,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5846, col: 1, offset: 179996},
+			pos:  position{line: 5848, col: 1, offset: 180068},
 			expr: &seqExpr{
-				pos: position{line: 5846, col: 14, offset: 180009},
+				pos: position{line: 5848, col: 14, offset: 180081},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5846, col: 14, offset: 180009},
+						pos:        position{line: 5848, col: 14, offset: 180081},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5846, col: 22, offset: 180017},
+						pos:  position{line: 5848, col: 22, offset: 180089},
 						name: "SPACE",
 					},
 				},
@@ -14679,9 +14679,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5847, col: 1, offset: 180023},
+			pos:  position{line: 5849, col: 1, offset: 180095},
 			expr: &litMatcher{
-				pos:        position{line: 5847, col: 22, offset: 180044},
+				pos:        position{line: 5849, col: 22, offset: 180116},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14689,16 +14689,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5848, col: 1, offset: 180051},
+			pos:  position{line: 5850, col: 1, offset: 180123},
 			expr: &seqExpr{
-				pos: position{line: 5848, col: 13, offset: 180063},
+				pos: position{line: 5850, col: 13, offset: 180135},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5848, col: 13, offset: 180063},
+						pos:  position{line: 5850, col: 13, offset: 180135},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5848, col: 31, offset: 180081},
+						pos:  position{line: 5850, col: 31, offset: 180153},
 						name: "SPACE",
 					},
 				},
@@ -14706,9 +14706,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5849, col: 1, offset: 180087},
+			pos:  position{line: 5851, col: 1, offset: 180159},
 			expr: &litMatcher{
-				pos:        position{line: 5849, col: 22, offset: 180108},
+				pos:        position{line: 5851, col: 22, offset: 180180},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14716,16 +14716,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5850, col: 1, offset: 180115},
+			pos:  position{line: 5852, col: 1, offset: 180187},
 			expr: &seqExpr{
-				pos: position{line: 5850, col: 13, offset: 180127},
+				pos: position{line: 5852, col: 13, offset: 180199},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5850, col: 13, offset: 180127},
+						pos:  position{line: 5852, col: 13, offset: 180199},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5850, col: 31, offset: 180145},
+						pos:  position{line: 5852, col: 31, offset: 180217},
 						name: "SPACE",
 					},
 				},
@@ -14733,18 +14733,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5851, col: 1, offset: 180151},
+			pos:  position{line: 5853, col: 1, offset: 180223},
 			expr: &seqExpr{
-				pos: position{line: 5851, col: 13, offset: 180163},
+				pos: position{line: 5853, col: 13, offset: 180235},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5851, col: 13, offset: 180163},
+						pos:        position{line: 5853, col: 13, offset: 180235},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5851, col: 20, offset: 180170},
+						pos:  position{line: 5853, col: 20, offset: 180242},
 						name: "SPACE",
 					},
 				},
@@ -14752,18 +14752,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5852, col: 1, offset: 180176},
+			pos:  position{line: 5854, col: 1, offset: 180248},
 			expr: &seqExpr{
-				pos: position{line: 5852, col: 12, offset: 180187},
+				pos: position{line: 5854, col: 12, offset: 180259},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5852, col: 12, offset: 180187},
+						pos:        position{line: 5854, col: 12, offset: 180259},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5852, col: 18, offset: 180193},
+						pos:  position{line: 5854, col: 18, offset: 180265},
 						name: "SPACE",
 					},
 				},
@@ -14771,18 +14771,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5853, col: 1, offset: 180199},
+			pos:  position{line: 5855, col: 1, offset: 180271},
 			expr: &seqExpr{
-				pos: position{line: 5853, col: 13, offset: 180211},
+				pos: position{line: 5855, col: 13, offset: 180283},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5853, col: 13, offset: 180211},
+						pos:        position{line: 5855, col: 13, offset: 180283},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5853, col: 20, offset: 180218},
+						pos:  position{line: 5855, col: 20, offset: 180290},
 						name: "SPACE",
 					},
 				},
@@ -14790,9 +14790,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5854, col: 1, offset: 180224},
+			pos:  position{line: 5856, col: 1, offset: 180296},
 			expr: &litMatcher{
-				pos:        position{line: 5854, col: 12, offset: 180235},
+				pos:        position{line: 5856, col: 12, offset: 180307},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -14800,9 +14800,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5855, col: 1, offset: 180241},
+			pos:  position{line: 5857, col: 1, offset: 180313},
 			expr: &litMatcher{
-				pos:        position{line: 5855, col: 13, offset: 180253},
+				pos:        position{line: 5857, col: 13, offset: 180325},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -14810,18 +14810,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5856, col: 1, offset: 180260},
+			pos:  position{line: 5858, col: 1, offset: 180332},
 			expr: &seqExpr{
-				pos: position{line: 5856, col: 15, offset: 180274},
+				pos: position{line: 5858, col: 15, offset: 180346},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5856, col: 15, offset: 180274},
+						pos:        position{line: 5858, col: 15, offset: 180346},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5856, col: 24, offset: 180283},
+						pos:  position{line: 5858, col: 24, offset: 180355},
 						name: "SPACE",
 					},
 				},
@@ -14829,18 +14829,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5857, col: 1, offset: 180289},
+			pos:  position{line: 5859, col: 1, offset: 180361},
 			expr: &seqExpr{
-				pos: position{line: 5857, col: 18, offset: 180306},
+				pos: position{line: 5859, col: 18, offset: 180378},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5857, col: 18, offset: 180306},
+						pos:        position{line: 5859, col: 18, offset: 180378},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5857, col: 30, offset: 180318},
+						pos:  position{line: 5859, col: 30, offset: 180390},
 						name: "SPACE",
 					},
 				},
@@ -14848,18 +14848,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5858, col: 1, offset: 180324},
+			pos:  position{line: 5860, col: 1, offset: 180396},
 			expr: &seqExpr{
-				pos: position{line: 5858, col: 12, offset: 180335},
+				pos: position{line: 5860, col: 12, offset: 180407},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5858, col: 12, offset: 180335},
+						pos:        position{line: 5860, col: 12, offset: 180407},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5858, col: 18, offset: 180341},
+						pos:  position{line: 5860, col: 18, offset: 180413},
 						name: "SPACE",
 					},
 				},
@@ -14867,9 +14867,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5859, col: 1, offset: 180347},
+			pos:  position{line: 5861, col: 1, offset: 180419},
 			expr: &litMatcher{
-				pos:        position{line: 5859, col: 13, offset: 180359},
+				pos:        position{line: 5861, col: 13, offset: 180431},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -14877,18 +14877,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5860, col: 1, offset: 180366},
+			pos:  position{line: 5862, col: 1, offset: 180438},
 			expr: &seqExpr{
-				pos: position{line: 5860, col: 20, offset: 180385},
+				pos: position{line: 5862, col: 20, offset: 180457},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5860, col: 20, offset: 180385},
+						pos:        position{line: 5862, col: 20, offset: 180457},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5860, col: 34, offset: 180399},
+						pos:  position{line: 5862, col: 34, offset: 180471},
 						name: "SPACE",
 					},
 				},
@@ -14896,9 +14896,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5861, col: 1, offset: 180405},
+			pos:  position{line: 5863, col: 1, offset: 180477},
 			expr: &litMatcher{
-				pos:        position{line: 5861, col: 14, offset: 180418},
+				pos:        position{line: 5863, col: 14, offset: 180490},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -14906,22 +14906,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5862, col: 1, offset: 180426},
+			pos:  position{line: 5864, col: 1, offset: 180498},
 			expr: &seqExpr{
-				pos: position{line: 5862, col: 21, offset: 180446},
+				pos: position{line: 5864, col: 21, offset: 180518},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5862, col: 21, offset: 180446},
+						pos:  position{line: 5864, col: 21, offset: 180518},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5862, col: 27, offset: 180452},
+						pos:        position{line: 5864, col: 27, offset: 180524},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5862, col: 36, offset: 180461},
+						pos:  position{line: 5864, col: 36, offset: 180533},
 						name: "SPACE",
 					},
 				},
@@ -14929,9 +14929,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5863, col: 1, offset: 180467},
+			pos:  position{line: 5865, col: 1, offset: 180539},
 			expr: &litMatcher{
-				pos:        position{line: 5863, col: 15, offset: 180481},
+				pos:        position{line: 5865, col: 15, offset: 180553},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14939,9 +14939,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5864, col: 1, offset: 180490},
+			pos:  position{line: 5866, col: 1, offset: 180562},
 			expr: &litMatcher{
-				pos:        position{line: 5864, col: 14, offset: 180503},
+				pos:        position{line: 5866, col: 14, offset: 180575},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14949,9 +14949,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5865, col: 1, offset: 180511},
+			pos:  position{line: 5867, col: 1, offset: 180583},
 			expr: &litMatcher{
-				pos:        position{line: 5865, col: 15, offset: 180525},
+				pos:        position{line: 5867, col: 15, offset: 180597},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14959,9 +14959,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5866, col: 1, offset: 180534},
+			pos:  position{line: 5868, col: 1, offset: 180606},
 			expr: &litMatcher{
-				pos:        position{line: 5866, col: 17, offset: 180550},
+				pos:        position{line: 5868, col: 17, offset: 180622},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14969,9 +14969,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5867, col: 1, offset: 180561},
+			pos:  position{line: 5869, col: 1, offset: 180633},
 			expr: &litMatcher{
-				pos:        position{line: 5867, col: 15, offset: 180575},
+				pos:        position{line: 5869, col: 15, offset: 180647},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14979,9 +14979,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5868, col: 1, offset: 180584},
+			pos:  position{line: 5870, col: 1, offset: 180656},
 			expr: &litMatcher{
-				pos:        position{line: 5868, col: 19, offset: 180602},
+				pos:        position{line: 5870, col: 19, offset: 180674},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14989,9 +14989,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5869, col: 1, offset: 180615},
+			pos:  position{line: 5871, col: 1, offset: 180687},
 			expr: &litMatcher{
-				pos:        position{line: 5869, col: 17, offset: 180631},
+				pos:        position{line: 5871, col: 17, offset: 180703},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -14999,9 +14999,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5870, col: 1, offset: 180642},
+			pos:  position{line: 5872, col: 1, offset: 180714},
 			expr: &litMatcher{
-				pos:        position{line: 5870, col: 17, offset: 180658},
+				pos:        position{line: 5872, col: 17, offset: 180730},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15009,18 +15009,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5871, col: 1, offset: 180669},
+			pos:  position{line: 5873, col: 1, offset: 180741},
 			expr: &seqExpr{
-				pos: position{line: 5871, col: 20, offset: 180688},
+				pos: position{line: 5873, col: 20, offset: 180760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5871, col: 20, offset: 180688},
+						pos:        position{line: 5873, col: 20, offset: 180760},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5871, col: 34, offset: 180702},
+						pos:  position{line: 5873, col: 34, offset: 180774},
 						name: "SPACE",
 					},
 				},
@@ -15028,28 +15028,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5872, col: 1, offset: 180708},
+			pos:  position{line: 5874, col: 1, offset: 180780},
 			expr: &seqExpr{
-				pos: position{line: 5872, col: 16, offset: 180723},
+				pos: position{line: 5874, col: 16, offset: 180795},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5872, col: 16, offset: 180723},
+						pos: position{line: 5874, col: 16, offset: 180795},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5872, col: 16, offset: 180723},
+							pos:  position{line: 5874, col: 16, offset: 180795},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5872, col: 24, offset: 180731},
+						pos: position{line: 5874, col: 24, offset: 180803},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5872, col: 24, offset: 180731},
+								pos:        position{line: 5874, col: 24, offset: 180803},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5872, col: 30, offset: 180737},
+								pos:        position{line: 5874, col: 30, offset: 180809},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15057,9 +15057,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5872, col: 35, offset: 180742},
+						pos: position{line: 5874, col: 35, offset: 180814},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5872, col: 35, offset: 180742},
+							pos:  position{line: 5874, col: 35, offset: 180814},
 							name: "SPACE",
 						},
 					},
@@ -15068,9 +15068,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5873, col: 1, offset: 180749},
+			pos:  position{line: 5875, col: 1, offset: 180821},
 			expr: &litMatcher{
-				pos:        position{line: 5873, col: 17, offset: 180765},
+				pos:        position{line: 5875, col: 17, offset: 180837},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15078,18 +15078,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5874, col: 1, offset: 180776},
+			pos:  position{line: 5876, col: 1, offset: 180848},
 			expr: &seqExpr{
-				pos: position{line: 5874, col: 15, offset: 180790},
+				pos: position{line: 5876, col: 15, offset: 180862},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5874, col: 15, offset: 180790},
+						pos:        position{line: 5876, col: 15, offset: 180862},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5874, col: 24, offset: 180799},
+						pos:  position{line: 5876, col: 24, offset: 180871},
 						name: "SPACE",
 					},
 				},
@@ -15097,9 +15097,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5875, col: 1, offset: 180805},
+			pos:  position{line: 5877, col: 1, offset: 180877},
 			expr: &litMatcher{
-				pos:        position{line: 5875, col: 15, offset: 180819},
+				pos:        position{line: 5877, col: 15, offset: 180891},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15107,115 +15107,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5878, col: 1, offset: 180932},
+			pos:  position{line: 5880, col: 1, offset: 181004},
 			expr: &choiceExpr{
-				pos: position{line: 5878, col: 16, offset: 180947},
+				pos: position{line: 5880, col: 16, offset: 181019},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5878, col: 16, offset: 180947},
+						pos:        position{line: 5880, col: 16, offset: 181019},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5878, col: 47, offset: 180978},
+						pos:        position{line: 5880, col: 47, offset: 181050},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5878, col: 55, offset: 180986},
+						pos:        position{line: 5880, col: 55, offset: 181058},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 16, offset: 181009},
+						pos:        position{line: 5881, col: 16, offset: 181081},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 26, offset: 181019},
+						pos:        position{line: 5881, col: 26, offset: 181091},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 34, offset: 181027},
+						pos:        position{line: 5881, col: 34, offset: 181099},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 42, offset: 181035},
+						pos:        position{line: 5881, col: 42, offset: 181107},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 50, offset: 181043},
+						pos:        position{line: 5881, col: 50, offset: 181115},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 58, offset: 181051},
+						pos:        position{line: 5881, col: 58, offset: 181123},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5879, col: 66, offset: 181059},
+						pos:        position{line: 5881, col: 66, offset: 181131},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 16, offset: 181081},
+						pos:        position{line: 5882, col: 16, offset: 181153},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 26, offset: 181091},
+						pos:        position{line: 5882, col: 26, offset: 181163},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 34, offset: 181099},
+						pos:        position{line: 5882, col: 34, offset: 181171},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 42, offset: 181107},
+						pos:        position{line: 5882, col: 42, offset: 181179},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 50, offset: 181115},
+						pos:        position{line: 5882, col: 50, offset: 181187},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 58, offset: 181123},
+						pos:        position{line: 5882, col: 58, offset: 181195},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 66, offset: 181131},
+						pos:        position{line: 5882, col: 66, offset: 181203},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5880, col: 74, offset: 181139},
+						pos:        position{line: 5882, col: 74, offset: 181211},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15225,25 +15225,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5881, col: 1, offset: 181145},
+			pos:  position{line: 5883, col: 1, offset: 181217},
 			expr: &choiceExpr{
-				pos: position{line: 5881, col: 16, offset: 181160},
+				pos: position{line: 5883, col: 16, offset: 181232},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5881, col: 16, offset: 181160},
+						pos:        position{line: 5883, col: 16, offset: 181232},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 30, offset: 181174},
+						pos:        position{line: 5883, col: 30, offset: 181246},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5881, col: 36, offset: 181180},
+						pos:        position{line: 5883, col: 36, offset: 181252},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15253,18 +15253,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5885, col: 1, offset: 181336},
+			pos:  position{line: 5887, col: 1, offset: 181408},
 			expr: &seqExpr{
-				pos: position{line: 5885, col: 8, offset: 181343},
+				pos: position{line: 5887, col: 8, offset: 181415},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5885, col: 8, offset: 181343},
+						pos:        position{line: 5887, col: 8, offset: 181415},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5885, col: 14, offset: 181349},
+						pos:  position{line: 5887, col: 14, offset: 181421},
 						name: "SPACE",
 					},
 				},
@@ -15272,22 +15272,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5886, col: 1, offset: 181355},
+			pos:  position{line: 5888, col: 1, offset: 181427},
 			expr: &seqExpr{
-				pos: position{line: 5886, col: 7, offset: 181361},
+				pos: position{line: 5888, col: 7, offset: 181433},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5886, col: 7, offset: 181361},
+						pos:  position{line: 5888, col: 7, offset: 181433},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5886, col: 13, offset: 181367},
+						pos:        position{line: 5888, col: 13, offset: 181439},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5886, col: 18, offset: 181372},
+						pos:  position{line: 5888, col: 18, offset: 181444},
 						name: "SPACE",
 					},
 				},
@@ -15295,22 +15295,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5887, col: 1, offset: 181378},
+			pos:  position{line: 5889, col: 1, offset: 181450},
 			expr: &seqExpr{
-				pos: position{line: 5887, col: 8, offset: 181385},
+				pos: position{line: 5889, col: 8, offset: 181457},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5887, col: 8, offset: 181385},
+						pos:  position{line: 5889, col: 8, offset: 181457},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5887, col: 14, offset: 181391},
+						pos:        position{line: 5889, col: 14, offset: 181463},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5887, col: 20, offset: 181397},
+						pos:  position{line: 5889, col: 20, offset: 181469},
 						name: "SPACE",
 					},
 				},
@@ -15318,22 +15318,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5888, col: 1, offset: 181403},
+			pos:  position{line: 5890, col: 1, offset: 181475},
 			expr: &seqExpr{
-				pos: position{line: 5888, col: 9, offset: 181411},
+				pos: position{line: 5890, col: 9, offset: 181483},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5888, col: 9, offset: 181411},
+						pos:  position{line: 5890, col: 9, offset: 181483},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5888, col: 24, offset: 181426},
+						pos:        position{line: 5890, col: 24, offset: 181498},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5888, col: 28, offset: 181430},
+						pos:  position{line: 5890, col: 28, offset: 181502},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15341,22 +15341,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5889, col: 1, offset: 181445},
+			pos:  position{line: 5891, col: 1, offset: 181517},
 			expr: &seqExpr{
-				pos: position{line: 5889, col: 7, offset: 181451},
+				pos: position{line: 5891, col: 7, offset: 181523},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 7, offset: 181451},
+						pos:  position{line: 5891, col: 7, offset: 181523},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5889, col: 13, offset: 181457},
+						pos:        position{line: 5891, col: 13, offset: 181529},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 19, offset: 181463},
+						pos:  position{line: 5891, col: 19, offset: 181535},
 						name: "SPACE",
 					},
 				},
@@ -15364,22 +15364,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5890, col: 1, offset: 181489},
+			pos:  position{line: 5892, col: 1, offset: 181561},
 			expr: &seqExpr{
-				pos: position{line: 5890, col: 7, offset: 181495},
+				pos: position{line: 5892, col: 7, offset: 181567},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5890, col: 7, offset: 181495},
+						pos:  position{line: 5892, col: 7, offset: 181567},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5890, col: 13, offset: 181501},
+						pos:        position{line: 5892, col: 13, offset: 181573},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5890, col: 19, offset: 181507},
+						pos:  position{line: 5892, col: 19, offset: 181579},
 						name: "SPACE",
 					},
 				},
@@ -15387,22 +15387,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5892, col: 1, offset: 181534},
+			pos:  position{line: 5894, col: 1, offset: 181606},
 			expr: &seqExpr{
-				pos: position{line: 5892, col: 10, offset: 181543},
+				pos: position{line: 5894, col: 10, offset: 181615},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5892, col: 10, offset: 181543},
+						pos:  position{line: 5894, col: 10, offset: 181615},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5892, col: 25, offset: 181558},
+						pos:        position{line: 5894, col: 25, offset: 181630},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5892, col: 29, offset: 181562},
+						pos:  position{line: 5894, col: 29, offset: 181634},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15410,22 +15410,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5893, col: 1, offset: 181577},
+			pos:  position{line: 5895, col: 1, offset: 181649},
 			expr: &seqExpr{
-				pos: position{line: 5893, col: 10, offset: 181586},
+				pos: position{line: 5895, col: 10, offset: 181658},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5893, col: 10, offset: 181586},
+						pos:  position{line: 5895, col: 10, offset: 181658},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5893, col: 25, offset: 181601},
+						pos:        position{line: 5895, col: 25, offset: 181673},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5893, col: 29, offset: 181605},
+						pos:  position{line: 5895, col: 29, offset: 181677},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15433,9 +15433,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5894, col: 1, offset: 181620},
+			pos:  position{line: 5896, col: 1, offset: 181692},
 			expr: &litMatcher{
-				pos:        position{line: 5894, col: 10, offset: 181629},
+				pos:        position{line: 5896, col: 10, offset: 181701},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15443,18 +15443,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5895, col: 1, offset: 181633},
+			pos:  position{line: 5897, col: 1, offset: 181705},
 			expr: &seqExpr{
-				pos: position{line: 5895, col: 12, offset: 181644},
+				pos: position{line: 5897, col: 12, offset: 181716},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5895, col: 12, offset: 181644},
+						pos:        position{line: 5897, col: 12, offset: 181716},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5895, col: 16, offset: 181648},
+						pos:  position{line: 5897, col: 16, offset: 181720},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15462,16 +15462,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5896, col: 1, offset: 181663},
+			pos:  position{line: 5898, col: 1, offset: 181735},
 			expr: &seqExpr{
-				pos: position{line: 5896, col: 12, offset: 181674},
+				pos: position{line: 5898, col: 12, offset: 181746},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5896, col: 12, offset: 181674},
+						pos:  position{line: 5898, col: 12, offset: 181746},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5896, col: 27, offset: 181689},
+						pos:        position{line: 5898, col: 27, offset: 181761},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15481,40 +15481,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5898, col: 1, offset: 181694},
+			pos:  position{line: 5900, col: 1, offset: 181766},
 			expr: &notExpr{
-				pos: position{line: 5898, col: 8, offset: 181701},
+				pos: position{line: 5900, col: 8, offset: 181773},
 				expr: &anyMatcher{
-					line: 5898, col: 9, offset: 181702,
+					line: 5900, col: 9, offset: 181774,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5899, col: 1, offset: 181704},
+			pos:  position{line: 5901, col: 1, offset: 181776},
 			expr: &choiceExpr{
-				pos: position{line: 5899, col: 15, offset: 181718},
+				pos: position{line: 5901, col: 15, offset: 181790},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5899, col: 15, offset: 181718},
+						pos:        position{line: 5901, col: 15, offset: 181790},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5899, col: 21, offset: 181724},
+						pos:        position{line: 5901, col: 21, offset: 181796},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5899, col: 28, offset: 181731},
+						pos:        position{line: 5901, col: 28, offset: 181803},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5899, col: 35, offset: 181738},
+						pos:        position{line: 5901, col: 35, offset: 181810},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15524,37 +15524,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5900, col: 1, offset: 181743},
+			pos:  position{line: 5902, col: 1, offset: 181815},
 			expr: &choiceExpr{
-				pos: position{line: 5900, col: 10, offset: 181752},
+				pos: position{line: 5902, col: 10, offset: 181824},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5900, col: 11, offset: 181753},
+						pos: position{line: 5902, col: 11, offset: 181825},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5900, col: 11, offset: 181753},
+								pos: position{line: 5902, col: 11, offset: 181825},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5900, col: 11, offset: 181753},
+									pos:  position{line: 5902, col: 11, offset: 181825},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5900, col: 23, offset: 181765},
+								pos:  position{line: 5902, col: 23, offset: 181837},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5900, col: 31, offset: 181773},
+								pos: position{line: 5902, col: 31, offset: 181845},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5900, col: 31, offset: 181773},
+									pos:  position{line: 5902, col: 31, offset: 181845},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5900, col: 46, offset: 181788},
+						pos: position{line: 5902, col: 46, offset: 181860},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5900, col: 46, offset: 181788},
+							pos:  position{line: 5902, col: 46, offset: 181860},
 							name: "WHITESPACE",
 						},
 					},
@@ -15563,38 +15563,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5901, col: 1, offset: 181800},
+			pos:  position{line: 5903, col: 1, offset: 181872},
 			expr: &seqExpr{
-				pos: position{line: 5901, col: 12, offset: 181811},
+				pos: position{line: 5903, col: 12, offset: 181883},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5901, col: 12, offset: 181811},
+						pos:        position{line: 5903, col: 12, offset: 181883},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5901, col: 18, offset: 181817},
+						pos: position{line: 5903, col: 18, offset: 181889},
 						expr: &seqExpr{
-							pos: position{line: 5901, col: 19, offset: 181818},
+							pos: position{line: 5903, col: 19, offset: 181890},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5901, col: 19, offset: 181818},
+									pos: position{line: 5903, col: 19, offset: 181890},
 									expr: &litMatcher{
-										pos:        position{line: 5901, col: 21, offset: 181820},
+										pos:        position{line: 5903, col: 21, offset: 181892},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5901, col: 28, offset: 181827,
+									line: 5903, col: 28, offset: 181899,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5901, col: 32, offset: 181831},
+						pos:        position{line: 5903, col: 32, offset: 181903},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15604,16 +15604,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5902, col: 1, offset: 181837},
+			pos:  position{line: 5904, col: 1, offset: 181909},
 			expr: &choiceExpr{
-				pos: position{line: 5902, col: 20, offset: 181856},
+				pos: position{line: 5904, col: 20, offset: 181928},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5902, col: 20, offset: 181856},
+						pos:  position{line: 5904, col: 20, offset: 181928},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5902, col: 28, offset: 181864},
+						pos:        position{line: 5904, col: 28, offset: 181936},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15623,16 +15623,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5903, col: 1, offset: 181867},
+			pos:  position{line: 5905, col: 1, offset: 181939},
 			expr: &choiceExpr{
-				pos: position{line: 5903, col: 19, offset: 181885},
+				pos: position{line: 5905, col: 19, offset: 181957},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5903, col: 19, offset: 181885},
+						pos:  position{line: 5905, col: 19, offset: 181957},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5903, col: 27, offset: 181893},
+						pos:  position{line: 5905, col: 27, offset: 181965},
 						name: "SPACE",
 					},
 				},
@@ -20177,6 +20177,7 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 
 	astDs[0] = &structs.JsonExpr{
 		JsonExprMode: structs.JEMKeyVal,
+		IsTerminal:   true,
 		Key:          key,
 		Value:        value,
 	}
@@ -20191,7 +20192,7 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 				return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
 			}
 
-			err := isValidJsonObjectKey(key)
+			err := isValidJsonObjectKey(restKey)
 			if err != nil {
 				return nil, err
 			}
@@ -20202,6 +20203,7 @@ func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
 			}
 			astDs = append(astDs, &structs.JsonExpr{
 				JsonExprMode: structs.JEMKeyVal,
+				IsTerminal:   true,
 				Key:          restKey,
 				Value:        restValue,
 			})

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -329,7 +329,7 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 	isValidKey := func(key *structs.JsonExpr) error {
 		// key can only be a string => either a field or a StringExpr
 		// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
-		if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+		if !(key.JsonExprMode == structs.JEMString || key.JsonExprMode == structs.JEMField) {
 			return fmt.Errorf("spl peg: key can only be a string")
 		}
 		return nil
@@ -728,177 +728,177 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 716, col: 1, offset: 21161},
+			pos:  position{line: 716, col: 1, offset: 21164},
 			expr: &choiceExpr{
-				pos: position{line: 716, col: 10, offset: 21170},
+				pos: position{line: 716, col: 10, offset: 21173},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 716, col: 10, offset: 21170},
+						pos: position{line: 716, col: 10, offset: 21173},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 716, col: 10, offset: 21170},
+							pos: position{line: 716, col: 10, offset: 21173},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 716, col: 10, offset: 21170},
+									pos:   position{line: 716, col: 10, offset: 21173},
 									label: "indexBlock",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 716, col: 21, offset: 21181},
+										pos: position{line: 716, col: 21, offset: 21184},
 										expr: &ruleRefExpr{
-											pos:  position{line: 716, col: 22, offset: 21182},
+											pos:  position{line: 716, col: 22, offset: 21185},
 											name: "IndexBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 716, col: 35, offset: 21195},
+									pos: position{line: 716, col: 35, offset: 21198},
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 35, offset: 21195},
+										pos:  position{line: 716, col: 35, offset: 21198},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 42, offset: 21202},
+									pos:   position{line: 716, col: 42, offset: 21205},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 57, offset: 21217},
+										pos:  position{line: 716, col: 57, offset: 21220},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 77, offset: 21237},
+									pos:   position{line: 716, col: 77, offset: 21240},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 716, col: 90, offset: 21250},
+										pos: position{line: 716, col: 90, offset: 21253},
 										expr: &ruleRefExpr{
-											pos:  position{line: 716, col: 91, offset: 21251},
+											pos:  position{line: 716, col: 91, offset: 21254},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 716, col: 105, offset: 21265},
+									pos:   position{line: 716, col: 105, offset: 21268},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 716, col: 120, offset: 21280},
+										pos: position{line: 716, col: 120, offset: 21283},
 										expr: &ruleRefExpr{
-											pos:  position{line: 716, col: 121, offset: 21281},
+											pos:  position{line: 716, col: 121, offset: 21284},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 716, col: 144, offset: 21304},
+									pos: position{line: 716, col: 144, offset: 21307},
 									expr: &ruleRefExpr{
-										pos:  position{line: 716, col: 144, offset: 21304},
+										pos:  position{line: 716, col: 144, offset: 21307},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 716, col: 151, offset: 21311},
+									pos:  position{line: 716, col: 151, offset: 21314},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 782, col: 3, offset: 23234},
+						pos: position{line: 782, col: 3, offset: 23237},
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
-							pos: position{line: 782, col: 3, offset: 23234},
+							pos: position{line: 782, col: 3, offset: 23237},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 782, col: 3, offset: 23234},
+									pos: position{line: 782, col: 3, offset: 23237},
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 3, offset: 23234},
+										pos:  position{line: 782, col: 3, offset: 23237},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 10, offset: 23241},
+									pos:  position{line: 782, col: 10, offset: 23244},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 15, offset: 23246},
+									pos:  position{line: 782, col: 15, offset: 23249},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 28, offset: 23259},
+									pos:  position{line: 782, col: 28, offset: 23262},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 34, offset: 23265},
+									pos:   position{line: 782, col: 34, offset: 23268},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 50, offset: 23281},
+										pos:  position{line: 782, col: 50, offset: 23284},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 782, col: 70, offset: 23301},
+									pos:   position{line: 782, col: 70, offset: 23304},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 782, col: 85, offset: 23316},
+										pos: position{line: 782, col: 85, offset: 23319},
 										expr: &ruleRefExpr{
-											pos:  position{line: 782, col: 86, offset: 23317},
+											pos:  position{line: 782, col: 86, offset: 23320},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 782, col: 109, offset: 23340},
+									pos: position{line: 782, col: 109, offset: 23343},
 									expr: &ruleRefExpr{
-										pos:  position{line: 782, col: 109, offset: 23340},
+										pos:  position{line: 782, col: 109, offset: 23343},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 782, col: 116, offset: 23347},
+									pos:  position{line: 782, col: 116, offset: 23350},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 801, col: 3, offset: 23860},
+						pos: position{line: 801, col: 3, offset: 23863},
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
-							pos: position{line: 801, col: 3, offset: 23860},
+							pos: position{line: 801, col: 3, offset: 23863},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 801, col: 3, offset: 23860},
+									pos: position{line: 801, col: 3, offset: 23863},
 									expr: &ruleRefExpr{
-										pos:  position{line: 801, col: 3, offset: 23860},
+										pos:  position{line: 801, col: 3, offset: 23863},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 801, col: 10, offset: 23867},
+									pos:   position{line: 801, col: 10, offset: 23870},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 801, col: 22, offset: 23879},
+										pos:  position{line: 801, col: 22, offset: 23882},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 801, col: 39, offset: 23896},
+									pos:   position{line: 801, col: 39, offset: 23899},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 801, col: 54, offset: 23911},
+										pos: position{line: 801, col: 54, offset: 23914},
 										expr: &ruleRefExpr{
-											pos:  position{line: 801, col: 55, offset: 23912},
+											pos:  position{line: 801, col: 55, offset: 23915},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 801, col: 78, offset: 23935},
+									pos: position{line: 801, col: 78, offset: 23938},
 									expr: &ruleRefExpr{
-										pos:  position{line: 801, col: 78, offset: 23935},
+										pos:  position{line: 801, col: 78, offset: 23938},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 801, col: 85, offset: 23942},
+									pos:  position{line: 801, col: 85, offset: 23945},
 									name: "EOF",
 								},
 							},
@@ -909,32 +909,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexAssign",
-			pos:  position{line: 817, col: 1, offset: 24324},
+			pos:  position{line: 817, col: 1, offset: 24327},
 			expr: &actionExpr{
-				pos: position{line: 817, col: 16, offset: 24339},
+				pos: position{line: 817, col: 16, offset: 24342},
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
-					pos: position{line: 817, col: 16, offset: 24339},
+					pos: position{line: 817, col: 16, offset: 24342},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 817, col: 16, offset: 24339},
+							pos:   position{line: 817, col: 16, offset: 24342},
 							label: "index",
 							expr: &litMatcher{
-								pos:        position{line: 817, col: 23, offset: 24346},
+								pos:        position{line: 817, col: 23, offset: 24349},
 								val:        "_index",
 								ignoreCase: false,
 								want:       "\"_index\"",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 817, col: 33, offset: 24356},
+							pos:  position{line: 817, col: 33, offset: 24359},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 817, col: 39, offset: 24362},
+							pos:   position{line: 817, col: 39, offset: 24365},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 817, col: 49, offset: 24372},
+								pos:  position{line: 817, col: 49, offset: 24375},
 								name: "String",
 							},
 						},
@@ -944,35 +944,35 @@ var g = &grammar{
 		},
 		{
 			name: "IndexExpression",
-			pos:  position{line: 822, col: 1, offset: 24561},
+			pos:  position{line: 822, col: 1, offset: 24564},
 			expr: &actionExpr{
-				pos: position{line: 822, col: 20, offset: 24580},
+				pos: position{line: 822, col: 20, offset: 24583},
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
-					pos: position{line: 822, col: 20, offset: 24580},
+					pos: position{line: 822, col: 20, offset: 24583},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 822, col: 20, offset: 24580},
+							pos:   position{line: 822, col: 20, offset: 24583},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 822, col: 27, offset: 24587},
+								pos:  position{line: 822, col: 27, offset: 24590},
 								name: "IndexAssign",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 822, col: 40, offset: 24600},
+							pos:   position{line: 822, col: 40, offset: 24603},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 822, col: 45, offset: 24605},
+								pos: position{line: 822, col: 45, offset: 24608},
 								expr: &seqExpr{
-									pos: position{line: 822, col: 46, offset: 24606},
+									pos: position{line: 822, col: 46, offset: 24609},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 822, col: 46, offset: 24606},
+											pos:  position{line: 822, col: 46, offset: 24609},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 822, col: 49, offset: 24609},
+											pos:  position{line: 822, col: 49, offset: 24612},
 											name: "IndexAssign",
 										},
 									},
@@ -985,32 +985,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexBlock",
-			pos:  position{line: 847, col: 1, offset: 25190},
+			pos:  position{line: 847, col: 1, offset: 25193},
 			expr: &actionExpr{
-				pos: position{line: 847, col: 15, offset: 25204},
+				pos: position{line: 847, col: 15, offset: 25207},
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 847, col: 15, offset: 25204},
+					pos: position{line: 847, col: 15, offset: 25207},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 847, col: 15, offset: 25204},
+							pos: position{line: 847, col: 15, offset: 25207},
 							expr: &ruleRefExpr{
-								pos:  position{line: 847, col: 15, offset: 25204},
+								pos:  position{line: 847, col: 15, offset: 25207},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 847, col: 22, offset: 25211},
+							pos:   position{line: 847, col: 22, offset: 25214},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 847, col: 33, offset: 25222},
+								pos:  position{line: 847, col: 33, offset: 25225},
 								name: "IndexExpression",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 847, col: 50, offset: 25239},
+							pos: position{line: 847, col: 50, offset: 25242},
 							expr: &ruleRefExpr{
-								pos:  position{line: 847, col: 50, offset: 25239},
+								pos:  position{line: 847, col: 50, offset: 25242},
 								name: "PIPE",
 							},
 						},
@@ -1020,76 +1020,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 851, col: 1, offset: 25276},
+			pos:  position{line: 851, col: 1, offset: 25279},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 21, offset: 25296},
+				pos: position{line: 851, col: 21, offset: 25299},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 851, col: 21, offset: 25296},
+					pos: position{line: 851, col: 21, offset: 25299},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 851, col: 21, offset: 25296},
+							pos:        position{line: 851, col: 21, offset: 25299},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 851, col: 26, offset: 25301},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 851, col: 32, offset: 25307},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 851, col: 36, offset: 25311},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 851, col: 41, offset: 25316},
+							pos:        position{line: 851, col: 26, offset: 25304},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 851, col: 47, offset: 25322},
+							pos:        position{line: 851, col: 32, offset: 25310},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 851, col: 51, offset: 25326},
+							pos:        position{line: 851, col: 36, offset: 25314},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 851, col: 56, offset: 25331},
+							pos:        position{line: 851, col: 41, offset: 25319},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 851, col: 47, offset: 25325},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 851, col: 51, offset: 25329},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 851, col: 61, offset: 25336},
+							pos:        position{line: 851, col: 56, offset: 25334},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 851, col: 66, offset: 25341},
+							pos:        position{line: 851, col: 61, offset: 25339},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 851, col: 66, offset: 25344},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -1101,15 +1101,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 858, col: 1, offset: 25482},
+			pos:  position{line: 858, col: 1, offset: 25485},
 			expr: &actionExpr{
-				pos: position{line: 858, col: 31, offset: 25512},
+				pos: position{line: 858, col: 31, offset: 25515},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 858, col: 31, offset: 25512},
+					pos:   position{line: 858, col: 31, offset: 25515},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 858, col: 38, offset: 25519},
+						pos:  position{line: 858, col: 38, offset: 25522},
 						name: "IntegerAsString",
 					},
 				},
@@ -1117,22 +1117,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 876, col: 1, offset: 26162},
+			pos:  position{line: 876, col: 1, offset: 26165},
 			expr: &actionExpr{
-				pos: position{line: 876, col: 26, offset: 26187},
+				pos: position{line: 876, col: 26, offset: 26190},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 876, col: 26, offset: 26187},
+					pos:   position{line: 876, col: 26, offset: 26190},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 876, col: 37, offset: 26198},
+						pos: position{line: 876, col: 37, offset: 26201},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 876, col: 37, offset: 26198},
+								pos:  position{line: 876, col: 37, offset: 26201},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 876, col: 53, offset: 26214},
+								pos:  position{line: 876, col: 53, offset: 26217},
 								name: "PartialTimestamp",
 							},
 						},
@@ -1142,22 +1142,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 885, col: 1, offset: 26472},
+			pos:  position{line: 885, col: 1, offset: 26475},
 			expr: &actionExpr{
-				pos: position{line: 885, col: 17, offset: 26488},
+				pos: position{line: 885, col: 17, offset: 26491},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 885, col: 17, offset: 26488},
+					pos:   position{line: 885, col: 17, offset: 26491},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 885, col: 31, offset: 26502},
+						pos: position{line: 885, col: 31, offset: 26505},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 885, col: 31, offset: 26502},
+								pos:  position{line: 885, col: 31, offset: 26505},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 885, col: 55, offset: 26526},
+								pos:  position{line: 885, col: 55, offset: 26529},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -1167,28 +1167,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 889, col: 1, offset: 26588},
+			pos:  position{line: 889, col: 1, offset: 26591},
 			expr: &actionExpr{
-				pos: position{line: 889, col: 22, offset: 26609},
+				pos: position{line: 889, col: 22, offset: 26612},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 889, col: 22, offset: 26609},
+					pos: position{line: 889, col: 22, offset: 26612},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 889, col: 22, offset: 26609},
+							pos:        position{line: 889, col: 22, offset: 26612},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 889, col: 28, offset: 26615},
+							pos:  position{line: 889, col: 28, offset: 26618},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 889, col: 34, offset: 26621},
+							pos:   position{line: 889, col: 34, offset: 26624},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 889, col: 45, offset: 26632},
+								pos:  position{line: 889, col: 45, offset: 26635},
 								name: "GenTimestamp",
 							},
 						},
@@ -1198,28 +1198,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 898, col: 1, offset: 26822},
+			pos:  position{line: 898, col: 1, offset: 26825},
 			expr: &actionExpr{
-				pos: position{line: 898, col: 24, offset: 26845},
+				pos: position{line: 898, col: 24, offset: 26848},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 898, col: 24, offset: 26845},
+					pos: position{line: 898, col: 24, offset: 26848},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 898, col: 24, offset: 26845},
+							pos:        position{line: 898, col: 24, offset: 26848},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 898, col: 32, offset: 26853},
+							pos:  position{line: 898, col: 32, offset: 26856},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 898, col: 38, offset: 26859},
+							pos:   position{line: 898, col: 38, offset: 26862},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 898, col: 49, offset: 26870},
+								pos:  position{line: 898, col: 49, offset: 26873},
 								name: "GenTimestamp",
 							},
 						},
@@ -1229,59 +1229,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 907, col: 1, offset: 27064},
+			pos:  position{line: 907, col: 1, offset: 27067},
 			expr: &actionExpr{
-				pos: position{line: 907, col: 28, offset: 27091},
+				pos: position{line: 907, col: 28, offset: 27094},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 907, col: 28, offset: 27091},
+					pos: position{line: 907, col: 28, offset: 27094},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 907, col: 28, offset: 27091},
+							pos:        position{line: 907, col: 28, offset: 27094},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 907, col: 40, offset: 27103},
+							pos:  position{line: 907, col: 40, offset: 27106},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 907, col: 46, offset: 27109},
+							pos:   position{line: 907, col: 46, offset: 27112},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 907, col: 53, offset: 27116},
+								pos:  position{line: 907, col: 53, offset: 27119},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 907, col: 69, offset: 27132},
+							pos:   position{line: 907, col: 69, offset: 27135},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 907, col: 77, offset: 27140},
+								pos: position{line: 907, col: 77, offset: 27143},
 								expr: &choiceExpr{
-									pos: position{line: 907, col: 78, offset: 27141},
+									pos: position{line: 907, col: 78, offset: 27144},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 907, col: 78, offset: 27141},
+											pos:        position{line: 907, col: 78, offset: 27144},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 907, col: 84, offset: 27147},
+											pos:        position{line: 907, col: 84, offset: 27150},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 907, col: 90, offset: 27153},
+											pos:        position{line: 907, col: 90, offset: 27156},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 907, col: 96, offset: 27159},
+											pos:        position{line: 907, col: 96, offset: 27162},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -1296,26 +1296,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 948, col: 1, offset: 28311},
+			pos:  position{line: 948, col: 1, offset: 28314},
 			expr: &actionExpr{
-				pos: position{line: 948, col: 19, offset: 28329},
+				pos: position{line: 948, col: 19, offset: 28332},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 948, col: 19, offset: 28329},
+					pos:   position{line: 948, col: 19, offset: 28332},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 948, col: 35, offset: 28345},
+						pos: position{line: 948, col: 35, offset: 28348},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 948, col: 35, offset: 28345},
+								pos:  position{line: 948, col: 35, offset: 28348},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 948, col: 55, offset: 28365},
+								pos:  position{line: 948, col: 55, offset: 28368},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 948, col: 77, offset: 28387},
+								pos:  position{line: 948, col: 77, offset: 28390},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -1325,35 +1325,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 952, col: 1, offset: 28448},
+			pos:  position{line: 952, col: 1, offset: 28451},
 			expr: &actionExpr{
-				pos: position{line: 952, col: 23, offset: 28470},
+				pos: position{line: 952, col: 23, offset: 28473},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 952, col: 23, offset: 28470},
+					pos: position{line: 952, col: 23, offset: 28473},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 952, col: 23, offset: 28470},
+							pos:   position{line: 952, col: 23, offset: 28473},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 952, col: 29, offset: 28476},
+								pos:  position{line: 952, col: 29, offset: 28479},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 952, col: 44, offset: 28491},
+							pos:   position{line: 952, col: 44, offset: 28494},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 952, col: 49, offset: 28496},
+								pos: position{line: 952, col: 49, offset: 28499},
 								expr: &seqExpr{
-									pos: position{line: 952, col: 50, offset: 28497},
+									pos: position{line: 952, col: 50, offset: 28500},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 952, col: 50, offset: 28497},
+											pos:  position{line: 952, col: 50, offset: 28500},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 952, col: 56, offset: 28503},
+											pos:  position{line: 952, col: 56, offset: 28506},
 											name: "GenTimesOption",
 										},
 									},
@@ -1366,25 +1366,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 1004, col: 1, offset: 30256},
+			pos:  position{line: 1004, col: 1, offset: 30259},
 			expr: &actionExpr{
-				pos: position{line: 1004, col: 23, offset: 30278},
+				pos: position{line: 1004, col: 23, offset: 30281},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1004, col: 23, offset: 30278},
+					pos: position{line: 1004, col: 23, offset: 30281},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 1004, col: 23, offset: 30278},
+							pos: position{line: 1004, col: 23, offset: 30281},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1004, col: 23, offset: 30278},
+								pos:  position{line: 1004, col: 23, offset: 30281},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1004, col: 35, offset: 30290},
+							pos:   position{line: 1004, col: 35, offset: 30293},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1004, col: 42, offset: 30297},
+								pos:  position{line: 1004, col: 42, offset: 30300},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1394,32 +1394,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 1008, col: 1, offset: 30338},
+			pos:  position{line: 1008, col: 1, offset: 30341},
 			expr: &actionExpr{
-				pos: position{line: 1008, col: 16, offset: 30353},
+				pos: position{line: 1008, col: 16, offset: 30356},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1008, col: 16, offset: 30353},
+					pos: position{line: 1008, col: 16, offset: 30356},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 1008, col: 16, offset: 30353},
+							pos: position{line: 1008, col: 16, offset: 30356},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 18, offset: 30355},
+								pos:  position{line: 1008, col: 18, offset: 30358},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 1008, col: 26, offset: 30363},
+							pos: position{line: 1008, col: 26, offset: 30366},
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 26, offset: 30363},
+								pos:  position{line: 1008, col: 26, offset: 30366},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1008, col: 38, offset: 30375},
+							pos:   position{line: 1008, col: 38, offset: 30378},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1008, col: 45, offset: 30382},
+								pos:  position{line: 1008, col: 45, offset: 30385},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1429,33 +1429,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 1012, col: 1, offset: 30423},
+			pos:  position{line: 1012, col: 1, offset: 30426},
 			expr: &actionExpr{
-				pos: position{line: 1012, col: 16, offset: 30438},
+				pos: position{line: 1012, col: 16, offset: 30441},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1012, col: 16, offset: 30438},
+					pos: position{line: 1012, col: 16, offset: 30441},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1012, col: 16, offset: 30438},
+							pos:  position{line: 1012, col: 16, offset: 30441},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1012, col: 21, offset: 30443},
+							pos:   position{line: 1012, col: 21, offset: 30446},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 1012, col: 28, offset: 30450},
+								pos: position{line: 1012, col: 28, offset: 30453},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 28, offset: 30450},
+										pos:  position{line: 1012, col: 28, offset: 30453},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 42, offset: 30464},
+										pos:  position{line: 1012, col: 42, offset: 30467},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1012, col: 55, offset: 30477},
+										pos:  position{line: 1012, col: 55, offset: 30480},
 										name: "TimeModifiers",
 									},
 								},
@@ -1467,114 +1467,114 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 1017, col: 1, offset: 30556},
+			pos:  position{line: 1017, col: 1, offset: 30559},
 			expr: &actionExpr{
-				pos: position{line: 1017, col: 25, offset: 30580},
+				pos: position{line: 1017, col: 25, offset: 30583},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 1017, col: 25, offset: 30580},
+					pos:   position{line: 1017, col: 25, offset: 30583},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 1017, col: 32, offset: 30587},
+						pos: position{line: 1017, col: 32, offset: 30590},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 32, offset: 30587},
+								pos:  position{line: 1017, col: 32, offset: 30590},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 51, offset: 30606},
+								pos:  position{line: 1017, col: 51, offset: 30609},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 69, offset: 30624},
+								pos:  position{line: 1017, col: 69, offset: 30627},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 81, offset: 30636},
+								pos:  position{line: 1017, col: 81, offset: 30639},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 94, offset: 30649},
+								pos:  position{line: 1017, col: 94, offset: 30652},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 106, offset: 30661},
+								pos:  position{line: 1017, col: 106, offset: 30664},
 								name: "RegexAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 122, offset: 30677},
+								pos:  position{line: 1017, col: 122, offset: 30680},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 133, offset: 30688},
+								pos:  position{line: 1017, col: 133, offset: 30691},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 150, offset: 30705},
+								pos:  position{line: 1017, col: 150, offset: 30708},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 164, offset: 30719},
+								pos:  position{line: 1017, col: 164, offset: 30722},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 181, offset: 30736},
+								pos:  position{line: 1017, col: 181, offset: 30739},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 200, offset: 30755},
+								pos:  position{line: 1017, col: 200, offset: 30758},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 213, offset: 30768},
+								pos:  position{line: 1017, col: 213, offset: 30771},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 225, offset: 30780},
+								pos:  position{line: 1017, col: 225, offset: 30783},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 243, offset: 30798},
+								pos:  position{line: 1017, col: 243, offset: 30801},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 256, offset: 30811},
+								pos:  position{line: 1017, col: 256, offset: 30814},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 270, offset: 30825},
+								pos:  position{line: 1017, col: 270, offset: 30828},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 288, offset: 30843},
+								pos:  position{line: 1017, col: 288, offset: 30846},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 300, offset: 30855},
+								pos:  position{line: 1017, col: 300, offset: 30858},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 311, offset: 30866},
+								pos:  position{line: 1017, col: 311, offset: 30869},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 330, offset: 30885},
+								pos:  position{line: 1017, col: 330, offset: 30888},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 346, offset: 30901},
+								pos:  position{line: 1017, col: 346, offset: 30904},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 362, offset: 30917},
+								pos:  position{line: 1017, col: 362, offset: 30920},
 								name: "InputLookupAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 384, offset: 30939},
+								pos:  position{line: 1017, col: 384, offset: 30942},
 								name: "AppendBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1017, col: 398, offset: 30953},
+								pos:  position{line: 1017, col: 398, offset: 30956},
 								name: "ToJsonBlock",
 							},
 						},
@@ -1584,37 +1584,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 1022, col: 1, offset: 31046},
+			pos:  position{line: 1022, col: 1, offset: 31049},
 			expr: &actionExpr{
-				pos: position{line: 1022, col: 21, offset: 31066},
+				pos: position{line: 1022, col: 21, offset: 31069},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1022, col: 21, offset: 31066},
+					pos: position{line: 1022, col: 21, offset: 31069},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 21, offset: 31066},
+							pos:  position{line: 1022, col: 21, offset: 31069},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 26, offset: 31071},
+							pos:  position{line: 1022, col: 26, offset: 31074},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1022, col: 37, offset: 31082},
+							pos:   position{line: 1022, col: 37, offset: 31085},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1022, col: 40, offset: 31085},
+								pos: position{line: 1022, col: 40, offset: 31088},
 								expr: &choiceExpr{
-									pos: position{line: 1022, col: 41, offset: 31086},
+									pos: position{line: 1022, col: 41, offset: 31089},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1022, col: 41, offset: 31086},
+											pos:        position{line: 1022, col: 41, offset: 31089},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1022, col: 47, offset: 31092},
+											pos:        position{line: 1022, col: 47, offset: 31095},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1624,14 +1624,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1022, col: 53, offset: 31098},
+							pos:  position{line: 1022, col: 53, offset: 31101},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1022, col: 68, offset: 31113},
+							pos:   position{line: 1022, col: 68, offset: 31116},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1022, col: 75, offset: 31120},
+								pos:  position{line: 1022, col: 75, offset: 31123},
 								name: "FieldNameList",
 							},
 						},
@@ -1641,28 +1641,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 1041, col: 1, offset: 31660},
+			pos:  position{line: 1041, col: 1, offset: 31663},
 			expr: &actionExpr{
-				pos: position{line: 1041, col: 26, offset: 31685},
+				pos: position{line: 1041, col: 26, offset: 31688},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1041, col: 26, offset: 31685},
+					pos: position{line: 1041, col: 26, offset: 31688},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1041, col: 26, offset: 31685},
+							pos:   position{line: 1041, col: 26, offset: 31688},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1041, col: 31, offset: 31690},
+								pos:  position{line: 1041, col: 31, offset: 31693},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1041, col: 47, offset: 31706},
+							pos:   position{line: 1041, col: 47, offset: 31709},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1041, col: 56, offset: 31715},
+								pos: position{line: 1041, col: 56, offset: 31718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1041, col: 57, offset: 31716},
+									pos:  position{line: 1041, col: 57, offset: 31719},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1673,36 +1673,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 1105, col: 1, offset: 34009},
+			pos:  position{line: 1105, col: 1, offset: 34012},
 			expr: &actionExpr{
-				pos: position{line: 1105, col: 20, offset: 34028},
+				pos: position{line: 1105, col: 20, offset: 34031},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1105, col: 20, offset: 34028},
+					pos: position{line: 1105, col: 20, offset: 34031},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1105, col: 20, offset: 34028},
+							pos:  position{line: 1105, col: 20, offset: 34031},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1105, col: 25, offset: 34033},
+							pos:  position{line: 1105, col: 25, offset: 34036},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 1105, col: 35, offset: 34043},
+							pos:   position{line: 1105, col: 35, offset: 34046},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1105, col: 41, offset: 34049},
+								pos:  position{line: 1105, col: 41, offset: 34052},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1105, col: 64, offset: 34072},
+							pos:   position{line: 1105, col: 64, offset: 34075},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1105, col: 72, offset: 34080},
+								pos: position{line: 1105, col: 72, offset: 34083},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1105, col: 73, offset: 34081},
+									pos:  position{line: 1105, col: 73, offset: 34084},
 									name: "StatsOptions",
 								},
 							},
@@ -1713,17 +1713,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 1119, col: 1, offset: 34414},
+			pos:  position{line: 1119, col: 1, offset: 34417},
 			expr: &actionExpr{
-				pos: position{line: 1119, col: 17, offset: 34430},
+				pos: position{line: 1119, col: 17, offset: 34433},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1119, col: 17, offset: 34430},
+					pos:   position{line: 1119, col: 17, offset: 34433},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 1119, col: 24, offset: 34437},
+						pos: position{line: 1119, col: 24, offset: 34440},
 						expr: &ruleRefExpr{
-							pos:  position{line: 1119, col: 25, offset: 34438},
+							pos:  position{line: 1119, col: 25, offset: 34441},
 							name: "StatsOption",
 						},
 					},
@@ -1732,45 +1732,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 1157, col: 1, offset: 35879},
+			pos:  position{line: 1157, col: 1, offset: 35882},
 			expr: &actionExpr{
-				pos: position{line: 1157, col: 16, offset: 35894},
+				pos: position{line: 1157, col: 16, offset: 35897},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 1157, col: 16, offset: 35894},
+					pos: position{line: 1157, col: 16, offset: 35897},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1157, col: 16, offset: 35894},
+							pos:  position{line: 1157, col: 16, offset: 35897},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1157, col: 22, offset: 35900},
+							pos:   position{line: 1157, col: 22, offset: 35903},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1157, col: 32, offset: 35910},
+								pos:  position{line: 1157, col: 32, offset: 35913},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1157, col: 47, offset: 35925},
+							pos:  position{line: 1157, col: 47, offset: 35928},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1157, col: 53, offset: 35931},
+							pos:   position{line: 1157, col: 53, offset: 35934},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 1157, col: 58, offset: 35936},
+								pos: position{line: 1157, col: 58, offset: 35939},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1157, col: 58, offset: 35936},
+										pos:  position{line: 1157, col: 58, offset: 35939},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1157, col: 76, offset: 35954},
+										pos:  position{line: 1157, col: 76, offset: 35957},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1157, col: 94, offset: 35972},
+										pos:  position{line: 1157, col: 94, offset: 35975},
 										name: "QuotedString",
 									},
 								},
@@ -1782,36 +1782,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 1162, col: 1, offset: 36077},
+			pos:  position{line: 1162, col: 1, offset: 36080},
 			expr: &actionExpr{
-				pos: position{line: 1162, col: 19, offset: 36095},
+				pos: position{line: 1162, col: 19, offset: 36098},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1162, col: 19, offset: 36095},
+					pos:   position{line: 1162, col: 19, offset: 36098},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1162, col: 27, offset: 36103},
+						pos: position{line: 1162, col: 27, offset: 36106},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1162, col: 27, offset: 36103},
+								pos:        position{line: 1162, col: 27, offset: 36106},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1162, col: 38, offset: 36114},
+								pos:        position{line: 1162, col: 38, offset: 36117},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1162, col: 58, offset: 36134},
+								pos:        position{line: 1162, col: 58, offset: 36137},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1162, col: 68, offset: 36144},
+								pos:        position{line: 1162, col: 68, offset: 36147},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1823,22 +1823,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 1170, col: 1, offset: 36334},
+			pos:  position{line: 1170, col: 1, offset: 36337},
 			expr: &actionExpr{
-				pos: position{line: 1170, col: 17, offset: 36350},
+				pos: position{line: 1170, col: 17, offset: 36353},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1170, col: 17, offset: 36350},
+					pos: position{line: 1170, col: 17, offset: 36353},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1170, col: 17, offset: 36350},
+							pos:  position{line: 1170, col: 17, offset: 36353},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1170, col: 20, offset: 36353},
+							pos:   position{line: 1170, col: 20, offset: 36356},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1170, col: 27, offset: 36360},
+								pos:  position{line: 1170, col: 27, offset: 36363},
 								name: "FieldNameList",
 							},
 						},
@@ -1848,28 +1848,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 1182, col: 1, offset: 36710},
+			pos:  position{line: 1182, col: 1, offset: 36713},
 			expr: &actionExpr{
-				pos: position{line: 1182, col: 35, offset: 36744},
+				pos: position{line: 1182, col: 35, offset: 36747},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 1182, col: 35, offset: 36744},
+					pos: position{line: 1182, col: 35, offset: 36747},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1182, col: 35, offset: 36744},
+							pos:        position{line: 1182, col: 35, offset: 36747},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1182, col: 53, offset: 36762},
+							pos:  position{line: 1182, col: 53, offset: 36765},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1182, col: 59, offset: 36768},
+							pos:   position{line: 1182, col: 59, offset: 36771},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1182, col: 67, offset: 36776},
+								pos:  position{line: 1182, col: 67, offset: 36779},
 								name: "Boolean",
 							},
 						},
@@ -1879,28 +1879,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 1194, col: 1, offset: 37037},
+			pos:  position{line: 1194, col: 1, offset: 37040},
 			expr: &actionExpr{
-				pos: position{line: 1194, col: 29, offset: 37065},
+				pos: position{line: 1194, col: 29, offset: 37068},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 1194, col: 29, offset: 37065},
+					pos: position{line: 1194, col: 29, offset: 37068},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1194, col: 29, offset: 37065},
+							pos:        position{line: 1194, col: 29, offset: 37068},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1194, col: 39, offset: 37075},
+							pos:  position{line: 1194, col: 39, offset: 37078},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1194, col: 45, offset: 37081},
+							pos:   position{line: 1194, col: 45, offset: 37084},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1194, col: 53, offset: 37089},
+								pos:  position{line: 1194, col: 53, offset: 37092},
 								name: "Boolean",
 							},
 						},
@@ -1910,28 +1910,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 1206, col: 1, offset: 37336},
+			pos:  position{line: 1206, col: 1, offset: 37339},
 			expr: &actionExpr{
-				pos: position{line: 1206, col: 28, offset: 37363},
+				pos: position{line: 1206, col: 28, offset: 37366},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 1206, col: 28, offset: 37363},
+					pos: position{line: 1206, col: 28, offset: 37366},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1206, col: 28, offset: 37363},
+							pos:        position{line: 1206, col: 28, offset: 37366},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1206, col: 37, offset: 37372},
+							pos:  position{line: 1206, col: 37, offset: 37375},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1206, col: 43, offset: 37378},
+							pos:   position{line: 1206, col: 43, offset: 37381},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1206, col: 51, offset: 37386},
+								pos:  position{line: 1206, col: 51, offset: 37389},
 								name: "Boolean",
 							},
 						},
@@ -1941,28 +1941,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 1219, col: 1, offset: 37720},
+			pos:  position{line: 1219, col: 1, offset: 37723},
 			expr: &actionExpr{
-				pos: position{line: 1219, col: 28, offset: 37747},
+				pos: position{line: 1219, col: 28, offset: 37750},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 1219, col: 28, offset: 37747},
+					pos: position{line: 1219, col: 28, offset: 37750},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1219, col: 28, offset: 37747},
+							pos:        position{line: 1219, col: 28, offset: 37750},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1219, col: 37, offset: 37756},
+							pos:  position{line: 1219, col: 37, offset: 37759},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1219, col: 43, offset: 37762},
+							pos:   position{line: 1219, col: 43, offset: 37765},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1219, col: 51, offset: 37770},
+								pos:  position{line: 1219, col: 51, offset: 37773},
 								name: "Boolean",
 							},
 						},
@@ -1972,28 +1972,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 1232, col: 1, offset: 38104},
+			pos:  position{line: 1232, col: 1, offset: 38107},
 			expr: &actionExpr{
-				pos: position{line: 1232, col: 28, offset: 38131},
+				pos: position{line: 1232, col: 28, offset: 38134},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1232, col: 28, offset: 38131},
+					pos: position{line: 1232, col: 28, offset: 38134},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1232, col: 28, offset: 38131},
+							pos:        position{line: 1232, col: 28, offset: 38134},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1232, col: 37, offset: 38140},
+							pos:  position{line: 1232, col: 37, offset: 38143},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1232, col: 43, offset: 38146},
+							pos:   position{line: 1232, col: 43, offset: 38149},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1232, col: 54, offset: 38157},
+								pos:  position{line: 1232, col: 54, offset: 38160},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -2003,37 +2003,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1252, col: 1, offset: 38761},
+			pos:  position{line: 1252, col: 1, offset: 38764},
 			expr: &actionExpr{
-				pos: position{line: 1252, col: 33, offset: 38793},
+				pos: position{line: 1252, col: 33, offset: 38796},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1252, col: 33, offset: 38793},
+					pos: position{line: 1252, col: 33, offset: 38796},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1252, col: 33, offset: 38793},
+							pos:        position{line: 1252, col: 33, offset: 38796},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1252, col: 48, offset: 38808},
+							pos:  position{line: 1252, col: 48, offset: 38811},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1252, col: 54, offset: 38814},
+							pos:  position{line: 1252, col: 54, offset: 38817},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1252, col: 62, offset: 38822},
+							pos:   position{line: 1252, col: 62, offset: 38825},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1252, col: 71, offset: 38831},
+								pos:  position{line: 1252, col: 71, offset: 38834},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1252, col: 80, offset: 38840},
+							pos:  position{line: 1252, col: 80, offset: 38843},
 							name: "R_PAREN",
 						},
 					},
@@ -2042,37 +2042,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1264, col: 1, offset: 39110},
+			pos:  position{line: 1264, col: 1, offset: 39113},
 			expr: &actionExpr{
-				pos: position{line: 1264, col: 32, offset: 39141},
+				pos: position{line: 1264, col: 32, offset: 39144},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1264, col: 32, offset: 39141},
+					pos: position{line: 1264, col: 32, offset: 39144},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1264, col: 32, offset: 39141},
+							pos:        position{line: 1264, col: 32, offset: 39144},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 46, offset: 39155},
+							pos:  position{line: 1264, col: 46, offset: 39158},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 52, offset: 39161},
+							pos:  position{line: 1264, col: 52, offset: 39164},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1264, col: 60, offset: 39169},
+							pos:   position{line: 1264, col: 60, offset: 39172},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1264, col: 69, offset: 39178},
+								pos:  position{line: 1264, col: 69, offset: 39181},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1264, col: 78, offset: 39187},
+							pos:  position{line: 1264, col: 78, offset: 39190},
 							name: "R_PAREN",
 						},
 					},
@@ -2081,28 +2081,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1276, col: 1, offset: 39455},
+			pos:  position{line: 1276, col: 1, offset: 39458},
 			expr: &actionExpr{
-				pos: position{line: 1276, col: 32, offset: 39486},
+				pos: position{line: 1276, col: 32, offset: 39489},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1276, col: 32, offset: 39486},
+					pos: position{line: 1276, col: 32, offset: 39489},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1276, col: 32, offset: 39486},
+							pos:        position{line: 1276, col: 32, offset: 39489},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1276, col: 46, offset: 39500},
+							pos:  position{line: 1276, col: 46, offset: 39503},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1276, col: 52, offset: 39506},
+							pos:   position{line: 1276, col: 52, offset: 39509},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1276, col: 63, offset: 39517},
+								pos:  position{line: 1276, col: 63, offset: 39520},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2112,46 +2112,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1292, col: 1, offset: 39980},
+			pos:  position{line: 1292, col: 1, offset: 39983},
 			expr: &actionExpr{
-				pos: position{line: 1292, col: 22, offset: 40001},
+				pos: position{line: 1292, col: 22, offset: 40004},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1292, col: 22, offset: 40001},
+					pos:   position{line: 1292, col: 22, offset: 40004},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1292, col: 32, offset: 40011},
+						pos: position{line: 1292, col: 32, offset: 40014},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 32, offset: 40011},
+								pos:  position{line: 1292, col: 32, offset: 40014},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 65, offset: 40044},
+								pos:  position{line: 1292, col: 65, offset: 40047},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 92, offset: 40071},
+								pos:  position{line: 1292, col: 92, offset: 40074},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 118, offset: 40097},
+								pos:  position{line: 1292, col: 118, offset: 40100},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 144, offset: 40123},
+								pos:  position{line: 1292, col: 144, offset: 40126},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 170, offset: 40149},
+								pos:  position{line: 1292, col: 170, offset: 40152},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 201, offset: 40180},
+								pos:  position{line: 1292, col: 201, offset: 40183},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1292, col: 231, offset: 40210},
+								pos:  position{line: 1292, col: 231, offset: 40213},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -2161,35 +2161,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1296, col: 1, offset: 40269},
+			pos:  position{line: 1296, col: 1, offset: 40272},
 			expr: &actionExpr{
-				pos: position{line: 1296, col: 26, offset: 40294},
+				pos: position{line: 1296, col: 26, offset: 40297},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1296, col: 26, offset: 40294},
+					pos: position{line: 1296, col: 26, offset: 40297},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1296, col: 26, offset: 40294},
+							pos:   position{line: 1296, col: 26, offset: 40297},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1296, col: 32, offset: 40300},
+								pos:  position{line: 1296, col: 32, offset: 40303},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1296, col: 50, offset: 40318},
+							pos:   position{line: 1296, col: 50, offset: 40321},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1296, col: 55, offset: 40323},
+								pos: position{line: 1296, col: 55, offset: 40326},
 								expr: &seqExpr{
-									pos: position{line: 1296, col: 56, offset: 40324},
+									pos: position{line: 1296, col: 56, offset: 40327},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1296, col: 56, offset: 40324},
+											pos:  position{line: 1296, col: 56, offset: 40327},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1296, col: 62, offset: 40330},
+											pos:  position{line: 1296, col: 62, offset: 40333},
 											name: "StreamStatsOption",
 										},
 									},
@@ -2202,41 +2202,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1355, col: 1, offset: 42519},
+			pos:  position{line: 1355, col: 1, offset: 42522},
 			expr: &choiceExpr{
-				pos: position{line: 1355, col: 21, offset: 42539},
+				pos: position{line: 1355, col: 21, offset: 42542},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1355, col: 21, offset: 42539},
+						pos: position{line: 1355, col: 21, offset: 42542},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1355, col: 21, offset: 42539},
+							pos: position{line: 1355, col: 21, offset: 42542},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1355, col: 21, offset: 42539},
+									pos:  position{line: 1355, col: 21, offset: 42542},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1355, col: 26, offset: 42544},
+									pos:  position{line: 1355, col: 26, offset: 42547},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1355, col: 42, offset: 42560},
+									pos:   position{line: 1355, col: 42, offset: 42563},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1355, col: 56, offset: 42574},
+										pos:  position{line: 1355, col: 56, offset: 42577},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1355, col: 79, offset: 42597},
+									pos:  position{line: 1355, col: 79, offset: 42600},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1355, col: 85, offset: 42603},
+									pos:   position{line: 1355, col: 85, offset: 42606},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1355, col: 91, offset: 42609},
+										pos:  position{line: 1355, col: 91, offset: 42612},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2244,24 +2244,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1366, col: 3, offset: 42994},
+						pos: position{line: 1366, col: 3, offset: 42997},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1366, col: 3, offset: 42994},
+							pos: position{line: 1366, col: 3, offset: 42997},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 3, offset: 42994},
+									pos:  position{line: 1366, col: 3, offset: 42997},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1366, col: 8, offset: 42999},
+									pos:  position{line: 1366, col: 8, offset: 43002},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1366, col: 24, offset: 43015},
+									pos:   position{line: 1366, col: 24, offset: 43018},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1366, col: 30, offset: 43021},
+										pos:  position{line: 1366, col: 30, offset: 43024},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2273,31 +2273,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1378, col: 1, offset: 43393},
+			pos:  position{line: 1378, col: 1, offset: 43396},
 			expr: &actionExpr{
-				pos: position{line: 1378, col: 15, offset: 43407},
+				pos: position{line: 1378, col: 15, offset: 43410},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1378, col: 15, offset: 43407},
+					pos: position{line: 1378, col: 15, offset: 43410},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1378, col: 15, offset: 43407},
+							pos:  position{line: 1378, col: 15, offset: 43410},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1378, col: 25, offset: 43417},
+							pos:   position{line: 1378, col: 25, offset: 43420},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1378, col: 34, offset: 43426},
+								pos: position{line: 1378, col: 34, offset: 43429},
 								expr: &seqExpr{
-									pos: position{line: 1378, col: 35, offset: 43427},
+									pos: position{line: 1378, col: 35, offset: 43430},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1378, col: 35, offset: 43427},
+											pos:  position{line: 1378, col: 35, offset: 43430},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1378, col: 45, offset: 43437},
+											pos:  position{line: 1378, col: 45, offset: 43440},
 											name: "EqualityOperator",
 										},
 									},
@@ -2305,10 +2305,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1378, col: 64, offset: 43456},
+							pos:   position{line: 1378, col: 64, offset: 43459},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1378, col: 68, offset: 43460},
+								pos:  position{line: 1378, col: 68, offset: 43463},
 								name: "QuotedString",
 							},
 						},
@@ -2318,22 +2318,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1406, col: 1, offset: 44039},
+			pos:  position{line: 1406, col: 1, offset: 44042},
 			expr: &actionExpr{
-				pos: position{line: 1406, col: 18, offset: 44056},
+				pos: position{line: 1406, col: 18, offset: 44059},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1406, col: 18, offset: 44056},
+					pos: position{line: 1406, col: 18, offset: 44059},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1406, col: 18, offset: 44056},
+							pos:  position{line: 1406, col: 18, offset: 44059},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1406, col: 23, offset: 44061},
+							pos:   position{line: 1406, col: 23, offset: 44064},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1406, col: 28, offset: 44066},
+								pos:  position{line: 1406, col: 28, offset: 44069},
 								name: "RegexBlock",
 							},
 						},
@@ -2343,44 +2343,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1434, col: 1, offset: 44848},
+			pos:  position{line: 1434, col: 1, offset: 44851},
 			expr: &actionExpr{
-				pos: position{line: 1434, col: 17, offset: 44864},
+				pos: position{line: 1434, col: 17, offset: 44867},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1434, col: 17, offset: 44864},
+					pos: position{line: 1434, col: 17, offset: 44867},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1434, col: 17, offset: 44864},
+							pos:   position{line: 1434, col: 17, offset: 44867},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1434, col: 23, offset: 44870},
+								pos:  position{line: 1434, col: 23, offset: 44873},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1434, col: 36, offset: 44883},
+							pos:   position{line: 1434, col: 36, offset: 44886},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1434, col: 41, offset: 44888},
+								pos: position{line: 1434, col: 41, offset: 44891},
 								expr: &seqExpr{
-									pos: position{line: 1434, col: 42, offset: 44889},
+									pos: position{line: 1434, col: 42, offset: 44892},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1434, col: 43, offset: 44890},
+											pos: position{line: 1434, col: 43, offset: 44893},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1434, col: 43, offset: 44890},
+													pos:  position{line: 1434, col: 43, offset: 44893},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1434, col: 49, offset: 44896},
+													pos:  position{line: 1434, col: 49, offset: 44899},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1434, col: 56, offset: 44903},
+											pos:  position{line: 1434, col: 56, offset: 44906},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2393,35 +2393,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1452, col: 1, offset: 45280},
+			pos:  position{line: 1452, col: 1, offset: 45283},
 			expr: &actionExpr{
-				pos: position{line: 1452, col: 17, offset: 45296},
+				pos: position{line: 1452, col: 17, offset: 45299},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1452, col: 17, offset: 45296},
+					pos: position{line: 1452, col: 17, offset: 45299},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1452, col: 17, offset: 45296},
+							pos:   position{line: 1452, col: 17, offset: 45299},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1452, col: 23, offset: 45302},
+								pos:  position{line: 1452, col: 23, offset: 45305},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1452, col: 36, offset: 45315},
+							pos:   position{line: 1452, col: 36, offset: 45318},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1452, col: 41, offset: 45320},
+								pos: position{line: 1452, col: 41, offset: 45323},
 								expr: &seqExpr{
-									pos: position{line: 1452, col: 42, offset: 45321},
+									pos: position{line: 1452, col: 42, offset: 45324},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1452, col: 42, offset: 45321},
+											pos:  position{line: 1452, col: 42, offset: 45324},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1452, col: 45, offset: 45324},
+											pos:  position{line: 1452, col: 45, offset: 45327},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2434,32 +2434,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1470, col: 1, offset: 45689},
+			pos:  position{line: 1470, col: 1, offset: 45692},
 			expr: &choiceExpr{
-				pos: position{line: 1470, col: 17, offset: 45705},
+				pos: position{line: 1470, col: 17, offset: 45708},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1470, col: 17, offset: 45705},
+						pos: position{line: 1470, col: 17, offset: 45708},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1470, col: 17, offset: 45705},
+							pos: position{line: 1470, col: 17, offset: 45708},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1470, col: 17, offset: 45705},
+									pos:   position{line: 1470, col: 17, offset: 45708},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1470, col: 25, offset: 45713},
+										pos: position{line: 1470, col: 25, offset: 45716},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1470, col: 25, offset: 45713},
+											pos:  position{line: 1470, col: 25, offset: 45716},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1470, col: 30, offset: 45718},
+									pos:   position{line: 1470, col: 30, offset: 45721},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1470, col: 36, offset: 45724},
+										pos:  position{line: 1470, col: 36, offset: 45727},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2467,13 +2467,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1481, col: 5, offset: 46020},
+						pos: position{line: 1481, col: 5, offset: 46023},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1481, col: 5, offset: 46020},
+							pos:   position{line: 1481, col: 5, offset: 46023},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1481, col: 12, offset: 46027},
+								pos:  position{line: 1481, col: 12, offset: 46030},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2483,43 +2483,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1485, col: 1, offset: 46068},
+			pos:  position{line: 1485, col: 1, offset: 46071},
 			expr: &choiceExpr{
-				pos: position{line: 1485, col: 17, offset: 46084},
+				pos: position{line: 1485, col: 17, offset: 46087},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1485, col: 17, offset: 46084},
+						pos: position{line: 1485, col: 17, offset: 46087},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1485, col: 17, offset: 46084},
+							pos: position{line: 1485, col: 17, offset: 46087},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 17, offset: 46084},
+									pos:  position{line: 1485, col: 17, offset: 46087},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1485, col: 25, offset: 46092},
+									pos:   position{line: 1485, col: 25, offset: 46095},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1485, col: 32, offset: 46099},
+										pos:  position{line: 1485, col: 32, offset: 46102},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1485, col: 45, offset: 46112},
+									pos:  position{line: 1485, col: 45, offset: 46115},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1487, col: 5, offset: 46149},
+						pos: position{line: 1487, col: 5, offset: 46152},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1487, col: 5, offset: 46149},
+							pos:   position{line: 1487, col: 5, offset: 46152},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1487, col: 10, offset: 46154},
+								pos:  position{line: 1487, col: 10, offset: 46157},
 								name: "SearchTerm",
 							},
 						},
@@ -2529,26 +2529,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1493, col: 1, offset: 46312},
+			pos:  position{line: 1493, col: 1, offset: 46315},
 			expr: &actionExpr{
-				pos: position{line: 1493, col: 15, offset: 46326},
+				pos: position{line: 1493, col: 15, offset: 46329},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1493, col: 15, offset: 46326},
+					pos:   position{line: 1493, col: 15, offset: 46329},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1493, col: 21, offset: 46332},
+						pos: position{line: 1493, col: 21, offset: 46335},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1493, col: 21, offset: 46332},
+								pos:  position{line: 1493, col: 21, offset: 46335},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1493, col: 44, offset: 46355},
+								pos:  position{line: 1493, col: 44, offset: 46358},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1493, col: 68, offset: 46379},
+								pos:  position{line: 1493, col: 68, offset: 46382},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2558,36 +2558,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1498, col: 1, offset: 46520},
+			pos:  position{line: 1498, col: 1, offset: 46523},
 			expr: &actionExpr{
-				pos: position{line: 1498, col: 19, offset: 46538},
+				pos: position{line: 1498, col: 19, offset: 46541},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1498, col: 19, offset: 46538},
+					pos: position{line: 1498, col: 19, offset: 46541},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1498, col: 19, offset: 46538},
+							pos:  position{line: 1498, col: 19, offset: 46541},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1498, col: 24, offset: 46543},
+							pos:  position{line: 1498, col: 24, offset: 46546},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1498, col: 38, offset: 46557},
+							pos:   position{line: 1498, col: 38, offset: 46560},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1498, col: 45, offset: 46564},
+								pos:  position{line: 1498, col: 45, offset: 46567},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1498, col: 68, offset: 46587},
+							pos:   position{line: 1498, col: 68, offset: 46590},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1498, col: 78, offset: 46597},
+								pos: position{line: 1498, col: 78, offset: 46600},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1498, col: 79, offset: 46598},
+									pos:  position{line: 1498, col: 79, offset: 46601},
 									name: "LimitExpr",
 								},
 							},
@@ -2598,35 +2598,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1591, col: 1, offset: 49569},
+			pos:  position{line: 1591, col: 1, offset: 49572},
 			expr: &actionExpr{
-				pos: position{line: 1591, col: 27, offset: 49595},
+				pos: position{line: 1591, col: 27, offset: 49598},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1591, col: 27, offset: 49595},
+					pos: position{line: 1591, col: 27, offset: 49598},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1591, col: 27, offset: 49595},
+							pos:   position{line: 1591, col: 27, offset: 49598},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1591, col: 33, offset: 49601},
+								pos:  position{line: 1591, col: 33, offset: 49604},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1591, col: 51, offset: 49619},
+							pos:   position{line: 1591, col: 51, offset: 49622},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1591, col: 56, offset: 49624},
+								pos: position{line: 1591, col: 56, offset: 49627},
 								expr: &seqExpr{
-									pos: position{line: 1591, col: 57, offset: 49625},
+									pos: position{line: 1591, col: 57, offset: 49628},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1591, col: 57, offset: 49625},
+											pos:  position{line: 1591, col: 57, offset: 49628},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1591, col: 63, offset: 49631},
+											pos:  position{line: 1591, col: 63, offset: 49634},
 											name: "TimechartArgument",
 										},
 									},
@@ -2639,22 +2639,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1620, col: 1, offset: 50365},
+			pos:  position{line: 1620, col: 1, offset: 50368},
 			expr: &actionExpr{
-				pos: position{line: 1620, col: 22, offset: 50386},
+				pos: position{line: 1620, col: 22, offset: 50389},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1620, col: 22, offset: 50386},
+					pos:   position{line: 1620, col: 22, offset: 50389},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1620, col: 29, offset: 50393},
+						pos: position{line: 1620, col: 29, offset: 50396},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1620, col: 29, offset: 50393},
+								pos:  position{line: 1620, col: 29, offset: 50396},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1620, col: 45, offset: 50409},
+								pos:  position{line: 1620, col: 45, offset: 50412},
 								name: "TcOptions",
 							},
 						},
@@ -2664,28 +2664,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1624, col: 1, offset: 50447},
+			pos:  position{line: 1624, col: 1, offset: 50450},
 			expr: &actionExpr{
-				pos: position{line: 1624, col: 18, offset: 50464},
+				pos: position{line: 1624, col: 18, offset: 50467},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1624, col: 18, offset: 50464},
+					pos: position{line: 1624, col: 18, offset: 50467},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1624, col: 18, offset: 50464},
+							pos:   position{line: 1624, col: 18, offset: 50467},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1624, col: 23, offset: 50469},
+								pos:  position{line: 1624, col: 23, offset: 50472},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1624, col: 39, offset: 50485},
+							pos:   position{line: 1624, col: 39, offset: 50488},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1624, col: 53, offset: 50499},
+								pos: position{line: 1624, col: 53, offset: 50502},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1624, col: 53, offset: 50499},
+									pos:  position{line: 1624, col: 53, offset: 50502},
 									name: "SplitByClause",
 								},
 							},
@@ -2696,22 +2696,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1638, col: 1, offset: 50838},
+			pos:  position{line: 1638, col: 1, offset: 50841},
 			expr: &actionExpr{
-				pos: position{line: 1638, col: 18, offset: 50855},
+				pos: position{line: 1638, col: 18, offset: 50858},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1638, col: 18, offset: 50855},
+					pos: position{line: 1638, col: 18, offset: 50858},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1638, col: 18, offset: 50855},
+							pos:  position{line: 1638, col: 18, offset: 50858},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1638, col: 21, offset: 50858},
+							pos:   position{line: 1638, col: 21, offset: 50861},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1638, col: 27, offset: 50864},
+								pos:  position{line: 1638, col: 27, offset: 50867},
 								name: "FieldName",
 							},
 						},
@@ -2721,24 +2721,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1646, col: 1, offset: 50993},
+			pos:  position{line: 1646, col: 1, offset: 50996},
 			expr: &actionExpr{
-				pos: position{line: 1646, col: 14, offset: 51006},
+				pos: position{line: 1646, col: 14, offset: 51009},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1646, col: 14, offset: 51006},
+					pos:   position{line: 1646, col: 14, offset: 51009},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1646, col: 22, offset: 51014},
+						pos: position{line: 1646, col: 22, offset: 51017},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1646, col: 22, offset: 51014},
+								pos:  position{line: 1646, col: 22, offset: 51017},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1646, col: 35, offset: 51027},
+								pos: position{line: 1646, col: 35, offset: 51030},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1646, col: 36, offset: 51028},
+									pos:  position{line: 1646, col: 36, offset: 51031},
 									name: "TcOption",
 								},
 							},
@@ -2749,34 +2749,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1688, col: 1, offset: 52548},
+			pos:  position{line: 1688, col: 1, offset: 52551},
 			expr: &actionExpr{
-				pos: position{line: 1688, col: 13, offset: 52560},
+				pos: position{line: 1688, col: 13, offset: 52563},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1688, col: 13, offset: 52560},
+					pos: position{line: 1688, col: 13, offset: 52563},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 13, offset: 52560},
+							pos:  position{line: 1688, col: 13, offset: 52563},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1688, col: 19, offset: 52566},
+							pos:   position{line: 1688, col: 19, offset: 52569},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1688, col: 31, offset: 52578},
+								pos:  position{line: 1688, col: 31, offset: 52581},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1688, col: 43, offset: 52590},
+							pos:  position{line: 1688, col: 43, offset: 52593},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1688, col: 49, offset: 52596},
+							pos:   position{line: 1688, col: 49, offset: 52599},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1688, col: 53, offset: 52600},
+								pos:  position{line: 1688, col: 53, offset: 52603},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2786,36 +2786,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1693, col: 1, offset: 52713},
+			pos:  position{line: 1693, col: 1, offset: 52716},
 			expr: &actionExpr{
-				pos: position{line: 1693, col: 16, offset: 52728},
+				pos: position{line: 1693, col: 16, offset: 52731},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1693, col: 16, offset: 52728},
+					pos:   position{line: 1693, col: 16, offset: 52731},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1693, col: 24, offset: 52736},
+						pos: position{line: 1693, col: 24, offset: 52739},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1693, col: 24, offset: 52736},
+								pos:        position{line: 1693, col: 24, offset: 52739},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1693, col: 36, offset: 52748},
+								pos:        position{line: 1693, col: 36, offset: 52751},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1693, col: 49, offset: 52761},
+								pos:        position{line: 1693, col: 49, offset: 52764},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1693, col: 61, offset: 52773},
+								pos:        position{line: 1693, col: 61, offset: 52776},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2827,50 +2827,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1701, col: 1, offset: 52969},
+			pos:  position{line: 1701, col: 1, offset: 52972},
 			expr: &actionExpr{
-				pos: position{line: 1701, col: 17, offset: 52985},
+				pos: position{line: 1701, col: 17, offset: 52988},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1701, col: 17, offset: 52985},
+					pos:   position{line: 1701, col: 17, offset: 52988},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1701, col: 27, offset: 52995},
+						pos: position{line: 1701, col: 27, offset: 52998},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 27, offset: 52995},
+								pos:  position{line: 1701, col: 27, offset: 52998},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 36, offset: 53004},
+								pos:  position{line: 1701, col: 36, offset: 53007},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 44, offset: 53012},
+								pos:  position{line: 1701, col: 44, offset: 53015},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 57, offset: 53025},
+								pos:  position{line: 1701, col: 57, offset: 53028},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 66, offset: 53034},
+								pos:  position{line: 1701, col: 66, offset: 53037},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 73, offset: 53041},
+								pos:  position{line: 1701, col: 73, offset: 53044},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 79, offset: 53047},
+								pos:  position{line: 1701, col: 79, offset: 53050},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 86, offset: 53054},
+								pos:  position{line: 1701, col: 86, offset: 53057},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1701, col: 96, offset: 53064},
+								pos:  position{line: 1701, col: 96, offset: 53067},
 								name: "Year",
 							},
 						},
@@ -2880,37 +2880,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1705, col: 1, offset: 53100},
+			pos:  position{line: 1705, col: 1, offset: 53103},
 			expr: &actionExpr{
-				pos: position{line: 1705, col: 21, offset: 53120},
+				pos: position{line: 1705, col: 21, offset: 53123},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1705, col: 21, offset: 53120},
+					pos: position{line: 1705, col: 21, offset: 53123},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1705, col: 21, offset: 53120},
+							pos:   position{line: 1705, col: 21, offset: 53123},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1705, col: 29, offset: 53128},
+								pos: position{line: 1705, col: 29, offset: 53131},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1705, col: 29, offset: 53128},
+										pos:  position{line: 1705, col: 29, offset: 53131},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1705, col: 45, offset: 53144},
+										pos:  position{line: 1705, col: 45, offset: 53147},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1705, col: 62, offset: 53161},
+							pos:   position{line: 1705, col: 62, offset: 53164},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1705, col: 72, offset: 53171},
+								pos: position{line: 1705, col: 72, offset: 53174},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1705, col: 73, offset: 53172},
+									pos:  position{line: 1705, col: 73, offset: 53175},
 									name: "AllTimeScale",
 								},
 							},
@@ -2921,28 +2921,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1764, col: 1, offset: 55863},
+			pos:  position{line: 1764, col: 1, offset: 55866},
 			expr: &actionExpr{
-				pos: position{line: 1764, col: 21, offset: 55883},
+				pos: position{line: 1764, col: 21, offset: 55886},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1764, col: 21, offset: 55883},
+					pos: position{line: 1764, col: 21, offset: 55886},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1764, col: 21, offset: 55883},
+							pos:        position{line: 1764, col: 21, offset: 55886},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1764, col: 31, offset: 55893},
+							pos:  position{line: 1764, col: 31, offset: 55896},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1764, col: 37, offset: 55899},
+							pos:   position{line: 1764, col: 37, offset: 55902},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1764, col: 48, offset: 55910},
+								pos:  position{line: 1764, col: 48, offset: 55913},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2952,28 +2952,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1775, col: 1, offset: 56151},
+			pos:  position{line: 1775, col: 1, offset: 56154},
 			expr: &actionExpr{
-				pos: position{line: 1775, col: 21, offset: 56171},
+				pos: position{line: 1775, col: 21, offset: 56174},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1775, col: 21, offset: 56171},
+					pos: position{line: 1775, col: 21, offset: 56174},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1775, col: 21, offset: 56171},
+							pos:        position{line: 1775, col: 21, offset: 56174},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1775, col: 28, offset: 56178},
+							pos:  position{line: 1775, col: 28, offset: 56181},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1775, col: 34, offset: 56184},
+							pos:   position{line: 1775, col: 34, offset: 56187},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1775, col: 43, offset: 56193},
+								pos:  position{line: 1775, col: 43, offset: 56196},
 								name: "IntegerAsString",
 							},
 						},
@@ -2983,31 +2983,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1796, col: 1, offset: 56772},
+			pos:  position{line: 1796, col: 1, offset: 56775},
 			expr: &choiceExpr{
-				pos: position{line: 1796, col: 23, offset: 56794},
+				pos: position{line: 1796, col: 23, offset: 56797},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1796, col: 23, offset: 56794},
+						pos: position{line: 1796, col: 23, offset: 56797},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1796, col: 23, offset: 56794},
+							pos: position{line: 1796, col: 23, offset: 56797},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1796, col: 23, offset: 56794},
+									pos:        position{line: 1796, col: 23, offset: 56797},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1796, col: 35, offset: 56806},
+									pos:  position{line: 1796, col: 35, offset: 56809},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1796, col: 41, offset: 56812},
+									pos:   position{line: 1796, col: 41, offset: 56815},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1796, col: 51, offset: 56822},
+										pos:  position{line: 1796, col: 51, offset: 56825},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -3015,33 +3015,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1810, col: 3, offset: 57241},
+						pos: position{line: 1810, col: 3, offset: 57244},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1810, col: 3, offset: 57241},
+							pos: position{line: 1810, col: 3, offset: 57244},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1810, col: 3, offset: 57241},
+									pos:        position{line: 1810, col: 3, offset: 57244},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1810, col: 15, offset: 57253},
+									pos:  position{line: 1810, col: 15, offset: 57256},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1810, col: 21, offset: 57259},
+									pos:   position{line: 1810, col: 21, offset: 57262},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1810, col: 32, offset: 57270},
+										pos: position{line: 1810, col: 32, offset: 57273},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1810, col: 32, offset: 57270},
+												pos:  position{line: 1810, col: 32, offset: 57273},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1810, col: 52, offset: 57290},
+												pos:  position{line: 1810, col: 52, offset: 57293},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -3055,35 +3055,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1830, col: 1, offset: 57759},
+			pos:  position{line: 1830, col: 1, offset: 57762},
 			expr: &actionExpr{
-				pos: position{line: 1830, col: 19, offset: 57777},
+				pos: position{line: 1830, col: 19, offset: 57780},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1830, col: 19, offset: 57777},
+					pos: position{line: 1830, col: 19, offset: 57780},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1830, col: 19, offset: 57777},
+							pos:        position{line: 1830, col: 19, offset: 57780},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1830, col: 27, offset: 57785},
+							pos:  position{line: 1830, col: 27, offset: 57788},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1830, col: 33, offset: 57791},
+							pos:   position{line: 1830, col: 33, offset: 57794},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1830, col: 41, offset: 57799},
+								pos: position{line: 1830, col: 41, offset: 57802},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1830, col: 41, offset: 57799},
+										pos:  position{line: 1830, col: 41, offset: 57802},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1830, col: 57, offset: 57815},
+										pos:  position{line: 1830, col: 57, offset: 57818},
 										name: "IntegerAsString",
 									},
 								},
@@ -3095,35 +3095,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1845, col: 1, offset: 58194},
+			pos:  position{line: 1845, col: 1, offset: 58197},
 			expr: &actionExpr{
-				pos: position{line: 1845, col: 17, offset: 58210},
+				pos: position{line: 1845, col: 17, offset: 58213},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1845, col: 17, offset: 58210},
+					pos: position{line: 1845, col: 17, offset: 58213},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1845, col: 17, offset: 58210},
+							pos:        position{line: 1845, col: 17, offset: 58213},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1845, col: 23, offset: 58216},
+							pos:  position{line: 1845, col: 23, offset: 58219},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1845, col: 29, offset: 58222},
+							pos:   position{line: 1845, col: 29, offset: 58225},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1845, col: 37, offset: 58230},
+								pos: position{line: 1845, col: 37, offset: 58233},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1845, col: 37, offset: 58230},
+										pos:  position{line: 1845, col: 37, offset: 58233},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1845, col: 53, offset: 58246},
+										pos:  position{line: 1845, col: 53, offset: 58249},
 										name: "IntegerAsString",
 									},
 								},
@@ -3135,40 +3135,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1860, col: 1, offset: 58617},
+			pos:  position{line: 1860, col: 1, offset: 58620},
 			expr: &choiceExpr{
-				pos: position{line: 1860, col: 18, offset: 58634},
+				pos: position{line: 1860, col: 18, offset: 58637},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1860, col: 18, offset: 58634},
+						pos: position{line: 1860, col: 18, offset: 58637},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1860, col: 18, offset: 58634},
+							pos: position{line: 1860, col: 18, offset: 58637},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1860, col: 18, offset: 58634},
+									pos:        position{line: 1860, col: 18, offset: 58637},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1860, col: 25, offset: 58641},
+									pos:  position{line: 1860, col: 25, offset: 58644},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1860, col: 31, offset: 58647},
+									pos:   position{line: 1860, col: 31, offset: 58650},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1860, col: 36, offset: 58652},
+										pos: position{line: 1860, col: 36, offset: 58655},
 										expr: &choiceExpr{
-											pos: position{line: 1860, col: 37, offset: 58653},
+											pos: position{line: 1860, col: 37, offset: 58656},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1860, col: 37, offset: 58653},
+													pos:  position{line: 1860, col: 37, offset: 58656},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1860, col: 53, offset: 58669},
+													pos:  position{line: 1860, col: 53, offset: 58672},
 													name: "IntegerAsString",
 												},
 											},
@@ -3176,25 +3176,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1860, col: 71, offset: 58687},
+									pos:        position{line: 1860, col: 71, offset: 58690},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1860, col: 77, offset: 58693},
+									pos:   position{line: 1860, col: 77, offset: 58696},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1860, col: 82, offset: 58698},
+										pos: position{line: 1860, col: 82, offset: 58701},
 										expr: &choiceExpr{
-											pos: position{line: 1860, col: 83, offset: 58699},
+											pos: position{line: 1860, col: 83, offset: 58702},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1860, col: 83, offset: 58699},
+													pos:  position{line: 1860, col: 83, offset: 58702},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1860, col: 99, offset: 58715},
+													pos:  position{line: 1860, col: 99, offset: 58718},
 													name: "IntegerAsString",
 												},
 											},
@@ -3205,26 +3205,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1903, col: 3, offset: 60151},
+						pos: position{line: 1903, col: 3, offset: 60154},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1903, col: 3, offset: 60151},
+							pos: position{line: 1903, col: 3, offset: 60154},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1903, col: 3, offset: 60151},
+									pos:        position{line: 1903, col: 3, offset: 60154},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1903, col: 10, offset: 60158},
+									pos:  position{line: 1903, col: 10, offset: 60161},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1903, col: 16, offset: 60164},
+									pos:   position{line: 1903, col: 16, offset: 60167},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1903, col: 24, offset: 60172},
+										pos:  position{line: 1903, col: 24, offset: 60175},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3236,38 +3236,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1918, col: 1, offset: 60503},
+			pos:  position{line: 1918, col: 1, offset: 60506},
 			expr: &actionExpr{
-				pos: position{line: 1918, col: 17, offset: 60519},
+				pos: position{line: 1918, col: 17, offset: 60522},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1918, col: 17, offset: 60519},
+					pos:   position{line: 1918, col: 17, offset: 60522},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1918, col: 25, offset: 60527},
+						pos: position{line: 1918, col: 25, offset: 60530},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 25, offset: 60527},
+								pos:  position{line: 1918, col: 25, offset: 60530},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 46, offset: 60548},
+								pos:  position{line: 1918, col: 46, offset: 60551},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 65, offset: 60567},
+								pos:  position{line: 1918, col: 65, offset: 60570},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 84, offset: 60586},
+								pos:  position{line: 1918, col: 84, offset: 60589},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 101, offset: 60603},
+								pos:  position{line: 1918, col: 101, offset: 60606},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1918, col: 116, offset: 60618},
+								pos:  position{line: 1918, col: 116, offset: 60621},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3277,35 +3277,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1922, col: 1, offset: 60661},
+			pos:  position{line: 1922, col: 1, offset: 60664},
 			expr: &actionExpr{
-				pos: position{line: 1922, col: 22, offset: 60682},
+				pos: position{line: 1922, col: 22, offset: 60685},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1922, col: 22, offset: 60682},
+					pos: position{line: 1922, col: 22, offset: 60685},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1922, col: 22, offset: 60682},
+							pos:   position{line: 1922, col: 22, offset: 60685},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1922, col: 29, offset: 60689},
+								pos:  position{line: 1922, col: 29, offset: 60692},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1922, col: 42, offset: 60702},
+							pos:   position{line: 1922, col: 42, offset: 60705},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1922, col: 48, offset: 60708},
+								pos: position{line: 1922, col: 48, offset: 60711},
 								expr: &seqExpr{
-									pos: position{line: 1922, col: 49, offset: 60709},
+									pos: position{line: 1922, col: 49, offset: 60712},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1922, col: 49, offset: 60709},
+											pos:  position{line: 1922, col: 49, offset: 60712},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1922, col: 55, offset: 60715},
+											pos:  position{line: 1922, col: 55, offset: 60718},
 											name: "BinCmdOption",
 										},
 									},
@@ -3318,51 +3318,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1968, col: 1, offset: 62199},
+			pos:  position{line: 1968, col: 1, offset: 62202},
 			expr: &choiceExpr{
-				pos: position{line: 1968, col: 13, offset: 62211},
+				pos: position{line: 1968, col: 13, offset: 62214},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1968, col: 13, offset: 62211},
+						pos: position{line: 1968, col: 13, offset: 62214},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1968, col: 13, offset: 62211},
+							pos: position{line: 1968, col: 13, offset: 62214},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1968, col: 13, offset: 62211},
+									pos:  position{line: 1968, col: 13, offset: 62214},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1968, col: 18, offset: 62216},
+									pos:  position{line: 1968, col: 18, offset: 62219},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1968, col: 26, offset: 62224},
+									pos:   position{line: 1968, col: 26, offset: 62227},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1968, col: 40, offset: 62238},
+										pos:  position{line: 1968, col: 40, offset: 62241},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1968, col: 59, offset: 62257},
+									pos:  position{line: 1968, col: 59, offset: 62260},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1968, col: 65, offset: 62263},
+									pos:   position{line: 1968, col: 65, offset: 62266},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1968, col: 71, offset: 62269},
+										pos:  position{line: 1968, col: 71, offset: 62272},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1968, col: 81, offset: 62279},
+									pos:   position{line: 1968, col: 81, offset: 62282},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1968, col: 94, offset: 62292},
+										pos: position{line: 1968, col: 94, offset: 62295},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1968, col: 95, offset: 62293},
+											pos:  position{line: 1968, col: 95, offset: 62296},
 											name: "AsField",
 										},
 									},
@@ -3371,34 +3371,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1995, col: 3, offset: 63119},
+						pos: position{line: 1995, col: 3, offset: 63122},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1995, col: 3, offset: 63119},
+							pos: position{line: 1995, col: 3, offset: 63122},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1995, col: 3, offset: 63119},
+									pos:  position{line: 1995, col: 3, offset: 63122},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1995, col: 8, offset: 63124},
+									pos:  position{line: 1995, col: 8, offset: 63127},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1995, col: 16, offset: 63132},
+									pos:   position{line: 1995, col: 16, offset: 63135},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1995, col: 22, offset: 63138},
+										pos:  position{line: 1995, col: 22, offset: 63141},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1995, col: 32, offset: 63148},
+									pos:   position{line: 1995, col: 32, offset: 63151},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1995, col: 45, offset: 63161},
+										pos: position{line: 1995, col: 45, offset: 63164},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1995, col: 46, offset: 63162},
+											pos:  position{line: 1995, col: 46, offset: 63165},
 											name: "AsField",
 										},
 									},
@@ -3411,15 +3411,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 2026, col: 1, offset: 64019},
+			pos:  position{line: 2026, col: 1, offset: 64022},
 			expr: &actionExpr{
-				pos: position{line: 2026, col: 15, offset: 64033},
+				pos: position{line: 2026, col: 15, offset: 64036},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2026, col: 15, offset: 64033},
+					pos:   position{line: 2026, col: 15, offset: 64036},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2026, col: 27, offset: 64045},
+						pos:  position{line: 2026, col: 27, offset: 64048},
 						name: "SpanOptions",
 					},
 				},
@@ -3427,26 +3427,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 2034, col: 1, offset: 64270},
+			pos:  position{line: 2034, col: 1, offset: 64273},
 			expr: &actionExpr{
-				pos: position{line: 2034, col: 16, offset: 64285},
+				pos: position{line: 2034, col: 16, offset: 64288},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 2034, col: 16, offset: 64285},
+					pos: position{line: 2034, col: 16, offset: 64288},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2034, col: 16, offset: 64285},
+							pos:  position{line: 2034, col: 16, offset: 64288},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2034, col: 25, offset: 64294},
+							pos:  position{line: 2034, col: 25, offset: 64297},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2034, col: 31, offset: 64300},
+							pos:   position{line: 2034, col: 31, offset: 64303},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2034, col: 42, offset: 64311},
+								pos:  position{line: 2034, col: 42, offset: 64314},
 								name: "SpanLength",
 							},
 						},
@@ -3456,26 +3456,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 2041, col: 1, offset: 64457},
+			pos:  position{line: 2041, col: 1, offset: 64460},
 			expr: &actionExpr{
-				pos: position{line: 2041, col: 15, offset: 64471},
+				pos: position{line: 2041, col: 15, offset: 64474},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 2041, col: 15, offset: 64471},
+					pos: position{line: 2041, col: 15, offset: 64474},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2041, col: 15, offset: 64471},
+							pos:   position{line: 2041, col: 15, offset: 64474},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 24, offset: 64480},
+								pos:  position{line: 2041, col: 24, offset: 64483},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2041, col: 40, offset: 64496},
+							pos:   position{line: 2041, col: 40, offset: 64499},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2041, col: 50, offset: 64506},
+								pos:  position{line: 2041, col: 50, offset: 64509},
 								name: "AllTimeScale",
 							},
 						},
@@ -3485,43 +3485,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 2058, col: 1, offset: 65055},
+			pos:  position{line: 2058, col: 1, offset: 65058},
 			expr: &actionExpr{
-				pos: position{line: 2058, col: 14, offset: 65068},
+				pos: position{line: 2058, col: 14, offset: 65071},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2058, col: 14, offset: 65068},
+					pos: position{line: 2058, col: 14, offset: 65071},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 14, offset: 65068},
+							pos:  position{line: 2058, col: 14, offset: 65071},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 2058, col: 20, offset: 65074},
+							pos:        position{line: 2058, col: 20, offset: 65077},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 28, offset: 65082},
+							pos:  position{line: 2058, col: 28, offset: 65085},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 34, offset: 65088},
+							pos:   position{line: 2058, col: 34, offset: 65091},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2058, col: 41, offset: 65095},
+								pos: position{line: 2058, col: 41, offset: 65098},
 								expr: &choiceExpr{
-									pos: position{line: 2058, col: 42, offset: 65096},
+									pos: position{line: 2058, col: 42, offset: 65099},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 2058, col: 42, offset: 65096},
+											pos:        position{line: 2058, col: 42, offset: 65099},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 2058, col: 50, offset: 65104},
+											pos:        position{line: 2058, col: 50, offset: 65107},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3531,14 +3531,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2058, col: 61, offset: 65115},
+							pos:  position{line: 2058, col: 61, offset: 65118},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2058, col: 76, offset: 65130},
+							pos:   position{line: 2058, col: 76, offset: 65133},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2058, col: 86, offset: 65140},
+								pos:  position{line: 2058, col: 86, offset: 65143},
 								name: "IntegerAsString",
 							},
 						},
@@ -3548,22 +3548,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 2082, col: 1, offset: 65721},
+			pos:  position{line: 2082, col: 1, offset: 65724},
 			expr: &actionExpr{
-				pos: position{line: 2082, col: 19, offset: 65739},
+				pos: position{line: 2082, col: 19, offset: 65742},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2082, col: 19, offset: 65739},
+					pos: position{line: 2082, col: 19, offset: 65742},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2082, col: 19, offset: 65739},
+							pos:  position{line: 2082, col: 19, offset: 65742},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2082, col: 24, offset: 65744},
+							pos:   position{line: 2082, col: 24, offset: 65747},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2082, col: 38, offset: 65758},
+								pos:  position{line: 2082, col: 38, offset: 65761},
 								name: "StatisticExpr",
 							},
 						},
@@ -3573,76 +3573,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 2119, col: 1, offset: 66896},
+			pos:  position{line: 2119, col: 1, offset: 66899},
 			expr: &actionExpr{
-				pos: position{line: 2119, col: 18, offset: 66913},
+				pos: position{line: 2119, col: 18, offset: 66916},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2119, col: 18, offset: 66913},
+					pos: position{line: 2119, col: 18, offset: 66916},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2119, col: 18, offset: 66913},
+							pos:   position{line: 2119, col: 18, offset: 66916},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 2119, col: 23, offset: 66918},
+								pos: position{line: 2119, col: 23, offset: 66921},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2119, col: 23, offset: 66918},
+										pos:  position{line: 2119, col: 23, offset: 66921},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2119, col: 33, offset: 66928},
+										pos:  position{line: 2119, col: 33, offset: 66931},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2119, col: 43, offset: 66938},
+							pos:   position{line: 2119, col: 43, offset: 66941},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2119, col: 49, offset: 66944},
+								pos: position{line: 2119, col: 49, offset: 66947},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2119, col: 50, offset: 66945},
+									pos:  position{line: 2119, col: 50, offset: 66948},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2119, col: 67, offset: 66962},
+							pos:   position{line: 2119, col: 67, offset: 66965},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 2119, col: 78, offset: 66973},
+								pos: position{line: 2119, col: 78, offset: 66976},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 2119, col: 78, offset: 66973},
+										pos:  position{line: 2119, col: 78, offset: 66976},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2119, col: 84, offset: 66979},
+										pos:  position{line: 2119, col: 84, offset: 66982},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2119, col: 99, offset: 66994},
+							pos:   position{line: 2119, col: 99, offset: 66997},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2119, col: 108, offset: 67003},
+								pos: position{line: 2119, col: 108, offset: 67006},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2119, col: 109, offset: 67004},
+									pos:  position{line: 2119, col: 109, offset: 67007},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2119, col: 120, offset: 67015},
+							pos:   position{line: 2119, col: 120, offset: 67018},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2119, col: 128, offset: 67023},
+								pos: position{line: 2119, col: 128, offset: 67026},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2119, col: 129, offset: 67024},
+									pos:  position{line: 2119, col: 129, offset: 67027},
 									name: "StatisticOptions",
 								},
 							},
@@ -3653,25 +3653,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 2161, col: 1, offset: 68109},
+			pos:  position{line: 2161, col: 1, offset: 68112},
 			expr: &choiceExpr{
-				pos: position{line: 2161, col: 19, offset: 68127},
+				pos: position{line: 2161, col: 19, offset: 68130},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2161, col: 19, offset: 68127},
+						pos: position{line: 2161, col: 19, offset: 68130},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 2161, col: 19, offset: 68127},
+							pos: position{line: 2161, col: 19, offset: 68130},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2161, col: 19, offset: 68127},
+									pos:  position{line: 2161, col: 19, offset: 68130},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 2161, col: 25, offset: 68133},
+									pos:   position{line: 2161, col: 25, offset: 68136},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2161, col: 32, offset: 68140},
+										pos:  position{line: 2161, col: 32, offset: 68143},
 										name: "IntegerAsString",
 									},
 								},
@@ -3679,30 +3679,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2164, col: 3, offset: 68194},
+						pos: position{line: 2164, col: 3, offset: 68197},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 2164, col: 3, offset: 68194},
+							pos: position{line: 2164, col: 3, offset: 68197},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2164, col: 3, offset: 68194},
+									pos:  position{line: 2164, col: 3, offset: 68197},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 2164, col: 9, offset: 68200},
+									pos:        position{line: 2164, col: 9, offset: 68203},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2164, col: 17, offset: 68208},
+									pos:  position{line: 2164, col: 17, offset: 68211},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 2164, col: 23, offset: 68214},
+									pos:   position{line: 2164, col: 23, offset: 68217},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2164, col: 30, offset: 68221},
+										pos:  position{line: 2164, col: 30, offset: 68224},
 										name: "IntegerAsString",
 									},
 								},
@@ -3714,17 +3714,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 2169, col: 1, offset: 68319},
+			pos:  position{line: 2169, col: 1, offset: 68322},
 			expr: &actionExpr{
-				pos: position{line: 2169, col: 21, offset: 68339},
+				pos: position{line: 2169, col: 21, offset: 68342},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2169, col: 21, offset: 68339},
+					pos:   position{line: 2169, col: 21, offset: 68342},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2169, col: 28, offset: 68346},
+						pos: position{line: 2169, col: 28, offset: 68349},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2169, col: 29, offset: 68347},
+							pos:  position{line: 2169, col: 29, offset: 68350},
 							name: "StatisticOption",
 						},
 					},
@@ -3733,34 +3733,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 2218, col: 1, offset: 69909},
+			pos:  position{line: 2218, col: 1, offset: 69912},
 			expr: &actionExpr{
-				pos: position{line: 2218, col: 20, offset: 69928},
+				pos: position{line: 2218, col: 20, offset: 69931},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 2218, col: 20, offset: 69928},
+					pos: position{line: 2218, col: 20, offset: 69931},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2218, col: 20, offset: 69928},
+							pos:  position{line: 2218, col: 20, offset: 69931},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2218, col: 26, offset: 69934},
+							pos:   position{line: 2218, col: 26, offset: 69937},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2218, col: 36, offset: 69944},
+								pos:  position{line: 2218, col: 36, offset: 69947},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2218, col: 55, offset: 69963},
+							pos:  position{line: 2218, col: 55, offset: 69966},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2218, col: 61, offset: 69969},
+							pos:   position{line: 2218, col: 61, offset: 69972},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2218, col: 67, offset: 69975},
+								pos:  position{line: 2218, col: 67, offset: 69978},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3770,48 +3770,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 2223, col: 1, offset: 70084},
+			pos:  position{line: 2223, col: 1, offset: 70087},
 			expr: &actionExpr{
-				pos: position{line: 2223, col: 23, offset: 70106},
+				pos: position{line: 2223, col: 23, offset: 70109},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2223, col: 23, offset: 70106},
+					pos:   position{line: 2223, col: 23, offset: 70109},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2223, col: 31, offset: 70114},
+						pos: position{line: 2223, col: 31, offset: 70117},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2223, col: 31, offset: 70114},
+								pos:        position{line: 2223, col: 31, offset: 70117},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2223, col: 46, offset: 70129},
+								pos:        position{line: 2223, col: 46, offset: 70132},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2223, col: 60, offset: 70143},
+								pos:        position{line: 2223, col: 60, offset: 70146},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2223, col: 73, offset: 70156},
+								pos:        position{line: 2223, col: 73, offset: 70159},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2223, col: 85, offset: 70168},
+								pos:        position{line: 2223, col: 85, offset: 70171},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2223, col: 102, offset: 70185},
+								pos:        position{line: 2223, col: 102, offset: 70188},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3823,25 +3823,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2231, col: 1, offset: 70372},
+			pos:  position{line: 2231, col: 1, offset: 70375},
 			expr: &choiceExpr{
-				pos: position{line: 2231, col: 13, offset: 70384},
+				pos: position{line: 2231, col: 13, offset: 70387},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2231, col: 13, offset: 70384},
+						pos: position{line: 2231, col: 13, offset: 70387},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2231, col: 13, offset: 70384},
+							pos: position{line: 2231, col: 13, offset: 70387},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2231, col: 13, offset: 70384},
+									pos:  position{line: 2231, col: 13, offset: 70387},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2231, col: 16, offset: 70387},
+									pos:   position{line: 2231, col: 16, offset: 70390},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2231, col: 26, offset: 70397},
+										pos:  position{line: 2231, col: 26, offset: 70400},
 										name: "FieldNameList",
 									},
 								},
@@ -3849,13 +3849,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2234, col: 3, offset: 70454},
+						pos: position{line: 2234, col: 3, offset: 70457},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2234, col: 3, offset: 70454},
+							pos:   position{line: 2234, col: 3, offset: 70457},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2234, col: 16, offset: 70467},
+								pos:  position{line: 2234, col: 16, offset: 70470},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3865,26 +3865,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2238, col: 1, offset: 70525},
+			pos:  position{line: 2238, col: 1, offset: 70528},
 			expr: &actionExpr{
-				pos: position{line: 2238, col: 15, offset: 70539},
+				pos: position{line: 2238, col: 15, offset: 70542},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2238, col: 15, offset: 70539},
+					pos: position{line: 2238, col: 15, offset: 70542},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2238, col: 15, offset: 70539},
+							pos:  position{line: 2238, col: 15, offset: 70542},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2238, col: 20, offset: 70544},
+							pos:  position{line: 2238, col: 20, offset: 70547},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2238, col: 30, offset: 70554},
+							pos:   position{line: 2238, col: 30, offset: 70557},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2238, col: 40, offset: 70564},
+								pos:  position{line: 2238, col: 40, offset: 70567},
 								name: "DedupExpr",
 							},
 						},
@@ -3894,27 +3894,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2284, col: 1, offset: 71893},
+			pos:  position{line: 2284, col: 1, offset: 71896},
 			expr: &actionExpr{
-				pos: position{line: 2284, col: 14, offset: 71906},
+				pos: position{line: 2284, col: 14, offset: 71909},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2284, col: 14, offset: 71906},
+					pos: position{line: 2284, col: 14, offset: 71909},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2284, col: 14, offset: 71906},
+							pos:   position{line: 2284, col: 14, offset: 71909},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2284, col: 23, offset: 71915},
+								pos: position{line: 2284, col: 23, offset: 71918},
 								expr: &seqExpr{
-									pos: position{line: 2284, col: 24, offset: 71916},
+									pos: position{line: 2284, col: 24, offset: 71919},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2284, col: 24, offset: 71916},
+											pos:  position{line: 2284, col: 24, offset: 71919},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2284, col: 30, offset: 71922},
+											pos:  position{line: 2284, col: 30, offset: 71925},
 											name: "IntegerAsString",
 										},
 									},
@@ -3922,45 +3922,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2284, col: 48, offset: 71940},
+							pos:   position{line: 2284, col: 48, offset: 71943},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2284, col: 57, offset: 71949},
+								pos: position{line: 2284, col: 57, offset: 71952},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2284, col: 58, offset: 71950},
+									pos:  position{line: 2284, col: 58, offset: 71953},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2284, col: 73, offset: 71965},
+							pos:   position{line: 2284, col: 73, offset: 71968},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2284, col: 83, offset: 71975},
+								pos: position{line: 2284, col: 83, offset: 71978},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2284, col: 84, offset: 71976},
+									pos:  position{line: 2284, col: 84, offset: 71979},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2284, col: 101, offset: 71993},
+							pos:   position{line: 2284, col: 101, offset: 71996},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2284, col: 110, offset: 72002},
+								pos: position{line: 2284, col: 110, offset: 72005},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2284, col: 111, offset: 72003},
+									pos:  position{line: 2284, col: 111, offset: 72006},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2284, col: 126, offset: 72018},
+							pos:   position{line: 2284, col: 126, offset: 72021},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2284, col: 139, offset: 72031},
+								pos: position{line: 2284, col: 139, offset: 72034},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2284, col: 140, offset: 72032},
+									pos:  position{line: 2284, col: 140, offset: 72035},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3971,27 +3971,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2341, col: 1, offset: 73770},
+			pos:  position{line: 2341, col: 1, offset: 73773},
 			expr: &actionExpr{
-				pos: position{line: 2341, col: 19, offset: 73788},
+				pos: position{line: 2341, col: 19, offset: 73791},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2341, col: 19, offset: 73788},
+					pos: position{line: 2341, col: 19, offset: 73791},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2341, col: 19, offset: 73788},
+							pos: position{line: 2341, col: 19, offset: 73791},
 							expr: &litMatcher{
-								pos:        position{line: 2341, col: 21, offset: 73790},
+								pos:        position{line: 2341, col: 21, offset: 73793},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2341, col: 31, offset: 73800},
+							pos:   position{line: 2341, col: 31, offset: 73803},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2341, col: 37, offset: 73806},
+								pos:  position{line: 2341, col: 37, offset: 73809},
 								name: "FieldName",
 							},
 						},
@@ -4001,48 +4001,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2347, col: 1, offset: 73945},
+			pos:  position{line: 2347, col: 1, offset: 73948},
 			expr: &actionExpr{
-				pos: position{line: 2347, col: 32, offset: 73976},
+				pos: position{line: 2347, col: 32, offset: 73979},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2347, col: 32, offset: 73976},
+					pos: position{line: 2347, col: 32, offset: 73979},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2347, col: 32, offset: 73976},
+							pos:   position{line: 2347, col: 32, offset: 73979},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2347, col: 38, offset: 73982},
+								pos:  position{line: 2347, col: 38, offset: 73985},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2347, col: 48, offset: 73992},
+							pos: position{line: 2347, col: 48, offset: 73995},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2347, col: 50, offset: 73994},
+								pos:  position{line: 2347, col: 50, offset: 73997},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2347, col: 57, offset: 74001},
+							pos:   position{line: 2347, col: 57, offset: 74004},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2347, col: 62, offset: 74006},
+								pos: position{line: 2347, col: 62, offset: 74009},
 								expr: &seqExpr{
-									pos: position{line: 2347, col: 63, offset: 74007},
+									pos: position{line: 2347, col: 63, offset: 74010},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2347, col: 63, offset: 74007},
+											pos:  position{line: 2347, col: 63, offset: 74010},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2347, col: 69, offset: 74013},
+											pos:  position{line: 2347, col: 69, offset: 74016},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2347, col: 79, offset: 74023},
+											pos: position{line: 2347, col: 79, offset: 74026},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2347, col: 81, offset: 74025},
+												pos:  position{line: 2347, col: 81, offset: 74028},
 												name: "EQUAL",
 											},
 										},
@@ -4056,45 +4056,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2358, col: 1, offset: 74300},
+			pos:  position{line: 2358, col: 1, offset: 74303},
 			expr: &actionExpr{
-				pos: position{line: 2358, col: 19, offset: 74318},
+				pos: position{line: 2358, col: 19, offset: 74321},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2358, col: 19, offset: 74318},
+					pos: position{line: 2358, col: 19, offset: 74321},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2358, col: 19, offset: 74318},
+							pos:  position{line: 2358, col: 19, offset: 74321},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2358, col: 25, offset: 74324},
+							pos:   position{line: 2358, col: 25, offset: 74327},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2358, col: 31, offset: 74330},
+								pos:  position{line: 2358, col: 31, offset: 74333},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2358, col: 46, offset: 74345},
+							pos:   position{line: 2358, col: 46, offset: 74348},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2358, col: 51, offset: 74350},
+								pos: position{line: 2358, col: 51, offset: 74353},
 								expr: &seqExpr{
-									pos: position{line: 2358, col: 52, offset: 74351},
+									pos: position{line: 2358, col: 52, offset: 74354},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2358, col: 52, offset: 74351},
+											pos:  position{line: 2358, col: 52, offset: 74354},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2358, col: 58, offset: 74357},
+											pos:  position{line: 2358, col: 58, offset: 74360},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2358, col: 73, offset: 74372},
+											pos: position{line: 2358, col: 73, offset: 74375},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2358, col: 74, offset: 74373},
+												pos:  position{line: 2358, col: 74, offset: 74376},
 												name: "EQUAL",
 											},
 										},
@@ -4108,17 +4108,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2376, col: 1, offset: 74901},
+			pos:  position{line: 2376, col: 1, offset: 74904},
 			expr: &actionExpr{
-				pos: position{line: 2376, col: 17, offset: 74917},
+				pos: position{line: 2376, col: 17, offset: 74920},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2376, col: 17, offset: 74917},
+					pos:   position{line: 2376, col: 17, offset: 74920},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2376, col: 24, offset: 74924},
+						pos: position{line: 2376, col: 24, offset: 74927},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2376, col: 25, offset: 74925},
+							pos:  position{line: 2376, col: 25, offset: 74928},
 							name: "DedupOption",
 						},
 					},
@@ -4127,36 +4127,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2416, col: 1, offset: 76191},
+			pos:  position{line: 2416, col: 1, offset: 76194},
 			expr: &actionExpr{
-				pos: position{line: 2416, col: 16, offset: 76206},
+				pos: position{line: 2416, col: 16, offset: 76209},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2416, col: 16, offset: 76206},
+					pos: position{line: 2416, col: 16, offset: 76209},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2416, col: 16, offset: 76206},
+							pos:  position{line: 2416, col: 16, offset: 76209},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2416, col: 22, offset: 76212},
+							pos:   position{line: 2416, col: 22, offset: 76215},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2416, col: 32, offset: 76222},
+								pos:  position{line: 2416, col: 32, offset: 76225},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2416, col: 47, offset: 76237},
+							pos:        position{line: 2416, col: 47, offset: 76240},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2416, col: 51, offset: 76241},
+							pos:   position{line: 2416, col: 51, offset: 76244},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2416, col: 57, offset: 76247},
+								pos:  position{line: 2416, col: 57, offset: 76250},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -4166,30 +4166,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2421, col: 1, offset: 76356},
+			pos:  position{line: 2421, col: 1, offset: 76359},
 			expr: &actionExpr{
-				pos: position{line: 2421, col: 19, offset: 76374},
+				pos: position{line: 2421, col: 19, offset: 76377},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2421, col: 19, offset: 76374},
+					pos:   position{line: 2421, col: 19, offset: 76377},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2421, col: 27, offset: 76382},
+						pos: position{line: 2421, col: 27, offset: 76385},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2421, col: 27, offset: 76382},
+								pos:        position{line: 2421, col: 27, offset: 76385},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2421, col: 43, offset: 76398},
+								pos:        position{line: 2421, col: 43, offset: 76401},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2421, col: 57, offset: 76412},
+								pos:        position{line: 2421, col: 57, offset: 76415},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -4201,22 +4201,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2429, col: 1, offset: 76597},
+			pos:  position{line: 2429, col: 1, offset: 76600},
 			expr: &actionExpr{
-				pos: position{line: 2429, col: 22, offset: 76618},
+				pos: position{line: 2429, col: 22, offset: 76621},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2429, col: 22, offset: 76618},
+					pos: position{line: 2429, col: 22, offset: 76621},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2429, col: 22, offset: 76618},
+							pos:  position{line: 2429, col: 22, offset: 76621},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2429, col: 39, offset: 76635},
+							pos:   position{line: 2429, col: 39, offset: 76638},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2429, col: 53, offset: 76649},
+								pos:  position{line: 2429, col: 53, offset: 76652},
 								name: "SortElements",
 							},
 						},
@@ -4226,35 +4226,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2434, col: 1, offset: 76757},
+			pos:  position{line: 2434, col: 1, offset: 76760},
 			expr: &actionExpr{
-				pos: position{line: 2434, col: 17, offset: 76773},
+				pos: position{line: 2434, col: 17, offset: 76776},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2434, col: 17, offset: 76773},
+					pos: position{line: 2434, col: 17, offset: 76776},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2434, col: 17, offset: 76773},
+							pos:   position{line: 2434, col: 17, offset: 76776},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2434, col: 23, offset: 76779},
+								pos:  position{line: 2434, col: 23, offset: 76782},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2434, col: 41, offset: 76797},
+							pos:   position{line: 2434, col: 41, offset: 76800},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2434, col: 46, offset: 76802},
+								pos: position{line: 2434, col: 46, offset: 76805},
 								expr: &seqExpr{
-									pos: position{line: 2434, col: 47, offset: 76803},
+									pos: position{line: 2434, col: 47, offset: 76806},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2434, col: 47, offset: 76803},
+											pos:  position{line: 2434, col: 47, offset: 76806},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2434, col: 62, offset: 76818},
+											pos:  position{line: 2434, col: 62, offset: 76821},
 											name: "SingleSortElement",
 										},
 									},
@@ -4267,22 +4267,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2449, col: 1, offset: 77176},
+			pos:  position{line: 2449, col: 1, offset: 77179},
 			expr: &actionExpr{
-				pos: position{line: 2449, col: 22, offset: 77197},
+				pos: position{line: 2449, col: 22, offset: 77200},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2449, col: 22, offset: 77197},
+					pos:   position{line: 2449, col: 22, offset: 77200},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2449, col: 31, offset: 77206},
+						pos: position{line: 2449, col: 31, offset: 77209},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2449, col: 31, offset: 77206},
+								pos:  position{line: 2449, col: 31, offset: 77209},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2449, col: 59, offset: 77234},
+								pos:  position{line: 2449, col: 59, offset: 77237},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4292,33 +4292,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2453, col: 1, offset: 77293},
+			pos:  position{line: 2453, col: 1, offset: 77296},
 			expr: &actionExpr{
-				pos: position{line: 2453, col: 33, offset: 77325},
+				pos: position{line: 2453, col: 33, offset: 77328},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2453, col: 33, offset: 77325},
+					pos: position{line: 2453, col: 33, offset: 77328},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2453, col: 33, offset: 77325},
+							pos:   position{line: 2453, col: 33, offset: 77328},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2453, col: 47, offset: 77339},
+								pos: position{line: 2453, col: 47, offset: 77342},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2453, col: 47, offset: 77339},
+										pos:        position{line: 2453, col: 47, offset: 77342},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2453, col: 53, offset: 77345},
+										pos:        position{line: 2453, col: 53, offset: 77348},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2453, col: 59, offset: 77351},
+										pos:        position{line: 2453, col: 59, offset: 77354},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4327,10 +4327,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2453, col: 63, offset: 77355},
+							pos:   position{line: 2453, col: 63, offset: 77358},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2453, col: 69, offset: 77361},
+								pos:  position{line: 2453, col: 69, offset: 77364},
 								name: "FieldName",
 							},
 						},
@@ -4340,33 +4340,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2468, col: 1, offset: 77636},
+			pos:  position{line: 2468, col: 1, offset: 77639},
 			expr: &actionExpr{
-				pos: position{line: 2468, col: 30, offset: 77665},
+				pos: position{line: 2468, col: 30, offset: 77668},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2468, col: 30, offset: 77665},
+					pos: position{line: 2468, col: 30, offset: 77668},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2468, col: 30, offset: 77665},
+							pos:   position{line: 2468, col: 30, offset: 77668},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2468, col: 44, offset: 77679},
+								pos: position{line: 2468, col: 44, offset: 77682},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2468, col: 44, offset: 77679},
+										pos:        position{line: 2468, col: 44, offset: 77682},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2468, col: 50, offset: 77685},
+										pos:        position{line: 2468, col: 50, offset: 77688},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2468, col: 56, offset: 77691},
+										pos:        position{line: 2468, col: 56, offset: 77694},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4375,31 +4375,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2468, col: 60, offset: 77695},
+							pos:   position{line: 2468, col: 60, offset: 77698},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2468, col: 64, offset: 77699},
+								pos: position{line: 2468, col: 64, offset: 77702},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2468, col: 64, offset: 77699},
+										pos:        position{line: 2468, col: 64, offset: 77702},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2468, col: 73, offset: 77708},
+										pos:        position{line: 2468, col: 73, offset: 77711},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2468, col: 81, offset: 77716},
+										pos:        position{line: 2468, col: 81, offset: 77719},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2468, col: 88, offset: 77723},
+										pos:        position{line: 2468, col: 88, offset: 77726},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4408,19 +4408,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2468, col: 95, offset: 77730},
+							pos:  position{line: 2468, col: 95, offset: 77733},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2468, col: 103, offset: 77738},
+							pos:   position{line: 2468, col: 103, offset: 77741},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2468, col: 109, offset: 77744},
+								pos:  position{line: 2468, col: 109, offset: 77747},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2468, col: 119, offset: 77754},
+							pos:  position{line: 2468, col: 119, offset: 77757},
 							name: "R_PAREN",
 						},
 					},
@@ -4429,26 +4429,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2488, col: 1, offset: 78179},
+			pos:  position{line: 2488, col: 1, offset: 78182},
 			expr: &actionExpr{
-				pos: position{line: 2488, col: 16, offset: 78194},
+				pos: position{line: 2488, col: 16, offset: 78197},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2488, col: 16, offset: 78194},
+					pos: position{line: 2488, col: 16, offset: 78197},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2488, col: 16, offset: 78194},
+							pos:  position{line: 2488, col: 16, offset: 78197},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2488, col: 21, offset: 78199},
+							pos:  position{line: 2488, col: 21, offset: 78202},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2488, col: 32, offset: 78210},
+							pos:   position{line: 2488, col: 32, offset: 78213},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2488, col: 43, offset: 78221},
+								pos:  position{line: 2488, col: 43, offset: 78224},
 								name: "RenameExpr",
 							},
 						},
@@ -4458,33 +4458,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2511, col: 1, offset: 78885},
+			pos:  position{line: 2511, col: 1, offset: 78888},
 			expr: &choiceExpr{
-				pos: position{line: 2511, col: 15, offset: 78899},
+				pos: position{line: 2511, col: 15, offset: 78902},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2511, col: 15, offset: 78899},
+						pos: position{line: 2511, col: 15, offset: 78902},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2511, col: 15, offset: 78899},
+							pos: position{line: 2511, col: 15, offset: 78902},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2511, col: 15, offset: 78899},
+									pos:   position{line: 2511, col: 15, offset: 78902},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 31, offset: 78915},
+										pos:  position{line: 2511, col: 31, offset: 78918},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2511, col: 41, offset: 78925},
+									pos:  position{line: 2511, col: 41, offset: 78928},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2511, col: 44, offset: 78928},
+									pos:   position{line: 2511, col: 44, offset: 78931},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2511, col: 55, offset: 78939},
+										pos:  position{line: 2511, col: 55, offset: 78942},
 										name: "QuotedString",
 									},
 								},
@@ -4492,28 +4492,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2522, col: 3, offset: 79258},
+						pos: position{line: 2522, col: 3, offset: 79261},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2522, col: 3, offset: 79258},
+							pos: position{line: 2522, col: 3, offset: 79261},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2522, col: 3, offset: 79258},
+									pos:   position{line: 2522, col: 3, offset: 79261},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2522, col: 19, offset: 79274},
+										pos:  position{line: 2522, col: 19, offset: 79277},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2522, col: 29, offset: 79284},
+									pos:  position{line: 2522, col: 29, offset: 79287},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2522, col: 32, offset: 79287},
+									pos:   position{line: 2522, col: 32, offset: 79290},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2522, col: 43, offset: 79298},
+										pos:  position{line: 2522, col: 43, offset: 79301},
 										name: "RenamePattern",
 									},
 								},
@@ -4525,48 +4525,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2544, col: 1, offset: 79864},
+			pos:  position{line: 2544, col: 1, offset: 79867},
 			expr: &actionExpr{
-				pos: position{line: 2544, col: 13, offset: 79876},
+				pos: position{line: 2544, col: 13, offset: 79879},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2544, col: 13, offset: 79876},
+					pos: position{line: 2544, col: 13, offset: 79879},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2544, col: 13, offset: 79876},
+							pos:  position{line: 2544, col: 13, offset: 79879},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2544, col: 18, offset: 79881},
+							pos:  position{line: 2544, col: 18, offset: 79884},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2544, col: 26, offset: 79889},
+							pos:        position{line: 2544, col: 26, offset: 79892},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2544, col: 34, offset: 79897},
+							pos:  position{line: 2544, col: 34, offset: 79900},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2544, col: 40, offset: 79903},
+							pos:   position{line: 2544, col: 40, offset: 79906},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2544, col: 46, offset: 79909},
+								pos:  position{line: 2544, col: 46, offset: 79912},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2544, col: 62, offset: 79925},
+							pos:  position{line: 2544, col: 62, offset: 79928},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2544, col: 68, offset: 79931},
+							pos:   position{line: 2544, col: 68, offset: 79934},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2544, col: 72, offset: 79935},
+								pos:  position{line: 2544, col: 72, offset: 79938},
 								name: "QuotedString",
 							},
 						},
@@ -4576,37 +4576,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2573, col: 1, offset: 80664},
+			pos:  position{line: 2573, col: 1, offset: 80667},
 			expr: &actionExpr{
-				pos: position{line: 2573, col: 14, offset: 80677},
+				pos: position{line: 2573, col: 14, offset: 80680},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2573, col: 14, offset: 80677},
+					pos: position{line: 2573, col: 14, offset: 80680},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2573, col: 14, offset: 80677},
+							pos:  position{line: 2573, col: 14, offset: 80680},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2573, col: 19, offset: 80682},
+							pos:  position{line: 2573, col: 19, offset: 80685},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2573, col: 28, offset: 80691},
+							pos:   position{line: 2573, col: 28, offset: 80694},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2573, col: 34, offset: 80697},
+								pos: position{line: 2573, col: 34, offset: 80700},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2573, col: 35, offset: 80698},
+									pos:  position{line: 2573, col: 35, offset: 80701},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2573, col: 47, offset: 80710},
+							pos:   position{line: 2573, col: 47, offset: 80713},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2573, col: 58, offset: 80721},
+								pos:  position{line: 2573, col: 58, offset: 80724},
 								name: "SortElements",
 							},
 						},
@@ -4616,41 +4616,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2611, col: 1, offset: 81600},
+			pos:  position{line: 2611, col: 1, offset: 81603},
 			expr: &actionExpr{
-				pos: position{line: 2611, col: 14, offset: 81613},
+				pos: position{line: 2611, col: 14, offset: 81616},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2611, col: 14, offset: 81613},
+					pos: position{line: 2611, col: 14, offset: 81616},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2611, col: 14, offset: 81613},
+							pos: position{line: 2611, col: 14, offset: 81616},
 							expr: &seqExpr{
-								pos: position{line: 2611, col: 15, offset: 81614},
+								pos: position{line: 2611, col: 15, offset: 81617},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2611, col: 15, offset: 81614},
+										pos:        position{line: 2611, col: 15, offset: 81617},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2611, col: 23, offset: 81622},
+										pos:  position{line: 2611, col: 23, offset: 81625},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2611, col: 31, offset: 81630},
+							pos:   position{line: 2611, col: 31, offset: 81633},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2611, col: 40, offset: 81639},
+								pos:  position{line: 2611, col: 40, offset: 81642},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2611, col: 56, offset: 81655},
+							pos:  position{line: 2611, col: 56, offset: 81658},
 							name: "SPACE",
 						},
 					},
@@ -4659,43 +4659,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2625, col: 1, offset: 81954},
+			pos:  position{line: 2625, col: 1, offset: 81957},
 			expr: &actionExpr{
-				pos: position{line: 2625, col: 14, offset: 81967},
+				pos: position{line: 2625, col: 14, offset: 81970},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2625, col: 14, offset: 81967},
+					pos: position{line: 2625, col: 14, offset: 81970},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2625, col: 14, offset: 81967},
+							pos:  position{line: 2625, col: 14, offset: 81970},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2625, col: 19, offset: 81972},
+							pos:  position{line: 2625, col: 19, offset: 81975},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2625, col: 28, offset: 81981},
+							pos:   position{line: 2625, col: 28, offset: 81984},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2625, col: 34, offset: 81987},
+								pos:  position{line: 2625, col: 34, offset: 81990},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2625, col: 45, offset: 81998},
+							pos:   position{line: 2625, col: 45, offset: 82001},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2625, col: 50, offset: 82003},
+								pos: position{line: 2625, col: 50, offset: 82006},
 								expr: &seqExpr{
-									pos: position{line: 2625, col: 51, offset: 82004},
+									pos: position{line: 2625, col: 51, offset: 82007},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2625, col: 51, offset: 82004},
+											pos:  position{line: 2625, col: 51, offset: 82007},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2625, col: 57, offset: 82010},
+											pos:  position{line: 2625, col: 57, offset: 82013},
 											name: "SingleEval",
 										},
 									},
@@ -4708,30 +4708,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2660, col: 1, offset: 83243},
+			pos:  position{line: 2660, col: 1, offset: 83246},
 			expr: &actionExpr{
-				pos: position{line: 2660, col: 15, offset: 83257},
+				pos: position{line: 2660, col: 15, offset: 83260},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2660, col: 15, offset: 83257},
+					pos: position{line: 2660, col: 15, offset: 83260},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2660, col: 15, offset: 83257},
+							pos:   position{line: 2660, col: 15, offset: 83260},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2660, col: 21, offset: 83263},
+								pos:  position{line: 2660, col: 21, offset: 83266},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2660, col: 31, offset: 83273},
+							pos:  position{line: 2660, col: 31, offset: 83276},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2660, col: 37, offset: 83279},
+							pos:   position{line: 2660, col: 37, offset: 83282},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2660, col: 42, offset: 83284},
+								pos:  position{line: 2660, col: 42, offset: 83287},
 								name: "EvalExpression",
 							},
 						},
@@ -4741,15 +4741,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2673, col: 1, offset: 83685},
+			pos:  position{line: 2673, col: 1, offset: 83688},
 			expr: &actionExpr{
-				pos: position{line: 2673, col: 19, offset: 83703},
+				pos: position{line: 2673, col: 19, offset: 83706},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2673, col: 19, offset: 83703},
+					pos:   position{line: 2673, col: 19, offset: 83706},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2673, col: 25, offset: 83709},
+						pos:  position{line: 2673, col: 25, offset: 83712},
 						name: "ValueExpr",
 					},
 				},
@@ -4757,85 +4757,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2685, col: 1, offset: 84097},
+			pos:  position{line: 2685, col: 1, offset: 84100},
 			expr: &choiceExpr{
-				pos: position{line: 2685, col: 18, offset: 84114},
+				pos: position{line: 2685, col: 18, offset: 84117},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2685, col: 18, offset: 84114},
+						pos: position{line: 2685, col: 18, offset: 84117},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2685, col: 18, offset: 84114},
+							pos: position{line: 2685, col: 18, offset: 84117},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2685, col: 18, offset: 84114},
+									pos:        position{line: 2685, col: 18, offset: 84117},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 23, offset: 84119},
+									pos:  position{line: 2685, col: 23, offset: 84122},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 31, offset: 84127},
+									pos:   position{line: 2685, col: 31, offset: 84130},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 41, offset: 84137},
+										pos:  position{line: 2685, col: 41, offset: 84140},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 50, offset: 84146},
+									pos:  position{line: 2685, col: 50, offset: 84149},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 56, offset: 84152},
+									pos:   position{line: 2685, col: 56, offset: 84155},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 66, offset: 84162},
+										pos:  position{line: 2685, col: 66, offset: 84165},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 76, offset: 84172},
+									pos:  position{line: 2685, col: 76, offset: 84175},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 82, offset: 84178},
+									pos:   position{line: 2685, col: 82, offset: 84181},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 93, offset: 84189},
+										pos:  position{line: 2685, col: 93, offset: 84192},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 103, offset: 84199},
+									pos:  position{line: 2685, col: 103, offset: 84202},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2696, col: 3, offset: 84450},
+						pos: position{line: 2696, col: 3, offset: 84453},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2696, col: 3, offset: 84450},
+							pos: position{line: 2696, col: 3, offset: 84453},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2696, col: 3, offset: 84450},
+									pos:   position{line: 2696, col: 3, offset: 84453},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2696, col: 11, offset: 84458},
+										pos: position{line: 2696, col: 11, offset: 84461},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2696, col: 11, offset: 84458},
+												pos:        position{line: 2696, col: 11, offset: 84461},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2696, col: 20, offset: 84467},
+												pos:        position{line: 2696, col: 20, offset: 84470},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4844,31 +4844,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2696, col: 32, offset: 84479},
+									pos:  position{line: 2696, col: 32, offset: 84482},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2696, col: 40, offset: 84487},
+									pos:   position{line: 2696, col: 40, offset: 84490},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2696, col: 45, offset: 84492},
+										pos:  position{line: 2696, col: 45, offset: 84495},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2696, col: 64, offset: 84511},
+									pos:   position{line: 2696, col: 64, offset: 84514},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2696, col: 69, offset: 84516},
+										pos: position{line: 2696, col: 69, offset: 84519},
 										expr: &seqExpr{
-											pos: position{line: 2696, col: 70, offset: 84517},
+											pos: position{line: 2696, col: 70, offset: 84520},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2696, col: 70, offset: 84517},
+													pos:  position{line: 2696, col: 70, offset: 84520},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2696, col: 76, offset: 84523},
+													pos:  position{line: 2696, col: 76, offset: 84526},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4876,50 +4876,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2696, col: 97, offset: 84544},
+									pos:  position{line: 2696, col: 97, offset: 84547},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2719, col: 3, offset: 85148},
+						pos: position{line: 2719, col: 3, offset: 85151},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2719, col: 3, offset: 85148},
+							pos: position{line: 2719, col: 3, offset: 85151},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2719, col: 3, offset: 85148},
+									pos:        position{line: 2719, col: 3, offset: 85151},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2719, col: 14, offset: 85159},
+									pos:  position{line: 2719, col: 14, offset: 85162},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2719, col: 22, offset: 85167},
+									pos:   position{line: 2719, col: 22, offset: 85170},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2719, col: 32, offset: 85177},
+										pos:  position{line: 2719, col: 32, offset: 85180},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2719, col: 42, offset: 85187},
+									pos:   position{line: 2719, col: 42, offset: 85190},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2719, col: 47, offset: 85192},
+										pos: position{line: 2719, col: 47, offset: 85195},
 										expr: &seqExpr{
-											pos: position{line: 2719, col: 48, offset: 85193},
+											pos: position{line: 2719, col: 48, offset: 85196},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2719, col: 48, offset: 85193},
+													pos:  position{line: 2719, col: 48, offset: 85196},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2719, col: 54, offset: 85199},
+													pos:  position{line: 2719, col: 54, offset: 85202},
 													name: "ValueExpr",
 												},
 											},
@@ -4927,73 +4927,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2719, col: 66, offset: 85211},
+									pos:  position{line: 2719, col: 66, offset: 85214},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2736, col: 3, offset: 85630},
+						pos: position{line: 2736, col: 3, offset: 85633},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2736, col: 3, offset: 85630},
+							pos: position{line: 2736, col: 3, offset: 85633},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2736, col: 3, offset: 85630},
+									pos:        position{line: 2736, col: 3, offset: 85633},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 12, offset: 85639},
+									pos:  position{line: 2736, col: 12, offset: 85642},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2736, col: 20, offset: 85647},
+									pos:   position{line: 2736, col: 20, offset: 85650},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2736, col: 30, offset: 85657},
+										pos:  position{line: 2736, col: 30, offset: 85660},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 40, offset: 85667},
+									pos:  position{line: 2736, col: 40, offset: 85670},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2736, col: 46, offset: 85673},
+									pos:   position{line: 2736, col: 46, offset: 85676},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2736, col: 57, offset: 85684},
+										pos:  position{line: 2736, col: 57, offset: 85687},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2736, col: 67, offset: 85694},
+									pos:  position{line: 2736, col: 67, offset: 85697},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2748, col: 3, offset: 85974},
+						pos: position{line: 2748, col: 3, offset: 85977},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2748, col: 3, offset: 85974},
+							pos: position{line: 2748, col: 3, offset: 85977},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2748, col: 3, offset: 85974},
+									pos:        position{line: 2748, col: 3, offset: 85977},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2748, col: 10, offset: 85981},
+									pos:  position{line: 2748, col: 10, offset: 85984},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2748, col: 18, offset: 85989},
+									pos:  position{line: 2748, col: 18, offset: 85992},
 									name: "R_PAREN",
 								},
 							},
@@ -5004,30 +5004,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2755, col: 1, offset: 86086},
+			pos:  position{line: 2755, col: 1, offset: 86089},
 			expr: &actionExpr{
-				pos: position{line: 2755, col: 23, offset: 86108},
+				pos: position{line: 2755, col: 23, offset: 86111},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2755, col: 23, offset: 86108},
+					pos: position{line: 2755, col: 23, offset: 86111},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2755, col: 23, offset: 86108},
+							pos:   position{line: 2755, col: 23, offset: 86111},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2755, col: 33, offset: 86118},
+								pos:  position{line: 2755, col: 33, offset: 86121},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2755, col: 42, offset: 86127},
+							pos:  position{line: 2755, col: 42, offset: 86130},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2755, col: 48, offset: 86133},
+							pos:   position{line: 2755, col: 48, offset: 86136},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2755, col: 54, offset: 86139},
+								pos:  position{line: 2755, col: 54, offset: 86142},
 								name: "ValueExpr",
 							},
 						},
@@ -5037,15 +5037,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2763, col: 1, offset: 86344},
+			pos:  position{line: 2763, col: 1, offset: 86347},
 			expr: &actionExpr{
-				pos: position{line: 2763, col: 26, offset: 86369},
+				pos: position{line: 2763, col: 26, offset: 86372},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2763, col: 26, offset: 86369},
+					pos:   position{line: 2763, col: 26, offset: 86372},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2763, col: 37, offset: 86380},
+						pos:  position{line: 2763, col: 37, offset: 86383},
 						name: "StringExpr",
 					},
 				},
@@ -5053,15 +5053,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2773, col: 1, offset: 86589},
+			pos:  position{line: 2773, col: 1, offset: 86592},
 			expr: &actionExpr{
-				pos: position{line: 2773, col: 30, offset: 86618},
+				pos: position{line: 2773, col: 30, offset: 86621},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2773, col: 30, offset: 86618},
+					pos:   position{line: 2773, col: 30, offset: 86621},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2773, col: 45, offset: 86633},
+						pos:  position{line: 2773, col: 45, offset: 86636},
 						name: "MultiValueExpr",
 					},
 				},
@@ -5069,22 +5069,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2782, col: 1, offset: 86839},
+			pos:  position{line: 2782, col: 1, offset: 86842},
 			expr: &actionExpr{
-				pos: position{line: 2782, col: 27, offset: 86865},
+				pos: position{line: 2782, col: 27, offset: 86868},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2782, col: 27, offset: 86865},
+					pos:   position{line: 2782, col: 27, offset: 86868},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2782, col: 40, offset: 86878},
+						pos: position{line: 2782, col: 40, offset: 86881},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2782, col: 40, offset: 86878},
+								pos:  position{line: 2782, col: 40, offset: 86881},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2782, col: 68, offset: 86906},
+								pos:  position{line: 2782, col: 68, offset: 86909},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -5094,182 +5094,182 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2786, col: 1, offset: 86983},
+			pos:  position{line: 2786, col: 1, offset: 86986},
 			expr: &choiceExpr{
-				pos: position{line: 2786, col: 19, offset: 87001},
+				pos: position{line: 2786, col: 19, offset: 87004},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2786, col: 19, offset: 87001},
+						pos: position{line: 2786, col: 19, offset: 87004},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2786, col: 20, offset: 87002},
+							pos: position{line: 2786, col: 20, offset: 87005},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2786, col: 20, offset: 87002},
+									pos:   position{line: 2786, col: 20, offset: 87005},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2786, col: 28, offset: 87010},
+										pos:        position{line: 2786, col: 28, offset: 87013},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2786, col: 37, offset: 87019},
+									pos:  position{line: 2786, col: 37, offset: 87022},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2786, col: 45, offset: 87027},
+									pos:   position{line: 2786, col: 45, offset: 87030},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2786, col: 56, offset: 87038},
+										pos:  position{line: 2786, col: 56, offset: 87041},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2786, col: 67, offset: 87049},
+									pos:  position{line: 2786, col: 67, offset: 87052},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2786, col: 73, offset: 87055},
+									pos:   position{line: 2786, col: 73, offset: 87058},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2786, col: 79, offset: 87061},
+										pos:  position{line: 2786, col: 79, offset: 87064},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2786, col: 90, offset: 87072},
+									pos:  position{line: 2786, col: 90, offset: 87075},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2798, col: 3, offset: 87433},
+						pos: position{line: 2798, col: 3, offset: 87436},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2798, col: 4, offset: 87434},
+							pos: position{line: 2798, col: 4, offset: 87437},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2798, col: 4, offset: 87434},
+									pos:   position{line: 2798, col: 4, offset: 87437},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2798, col: 12, offset: 87442},
+										pos:        position{line: 2798, col: 12, offset: 87445},
 										val:        "spath",
 										ignoreCase: false,
 										want:       "\"spath\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 21, offset: 87451},
+									pos:  position{line: 2798, col: 21, offset: 87454},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 29, offset: 87459},
+									pos:   position{line: 2798, col: 29, offset: 87462},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2798, col: 35, offset: 87465},
+										pos:  position{line: 2798, col: 35, offset: 87468},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 46, offset: 87476},
+									pos:  position{line: 2798, col: 46, offset: 87479},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2798, col: 52, offset: 87482},
+									pos:   position{line: 2798, col: 52, offset: 87485},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2798, col: 57, offset: 87487},
+										pos:  position{line: 2798, col: 57, offset: 87490},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2798, col: 68, offset: 87498},
+									pos:  position{line: 2798, col: 68, offset: 87501},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2810, col: 3, offset: 87853},
+						pos: position{line: 2810, col: 3, offset: 87856},
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
-							pos: position{line: 2810, col: 4, offset: 87854},
+							pos: position{line: 2810, col: 4, offset: 87857},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2810, col: 4, offset: 87854},
+									pos:   position{line: 2810, col: 4, offset: 87857},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2810, col: 12, offset: 87862},
+										pos:        position{line: 2810, col: 12, offset: 87865},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 23, offset: 87873},
+									pos:  position{line: 2810, col: 23, offset: 87876},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 31, offset: 87881},
+									pos:   position{line: 2810, col: 31, offset: 87884},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 46, offset: 87896},
+										pos:  position{line: 2810, col: 46, offset: 87899},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 61, offset: 87911},
+									pos:  position{line: 2810, col: 61, offset: 87914},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 67, offset: 87917},
+									pos:   position{line: 2810, col: 67, offset: 87920},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2810, col: 78, offset: 87928},
+										pos:  position{line: 2810, col: 78, offset: 87931},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2810, col: 90, offset: 87940},
+									pos:   position{line: 2810, col: 90, offset: 87943},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2810, col: 99, offset: 87949},
+										pos: position{line: 2810, col: 99, offset: 87952},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2810, col: 100, offset: 87950},
+											pos:  position{line: 2810, col: 100, offset: 87953},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2810, col: 119, offset: 87969},
+									pos:  position{line: 2810, col: 119, offset: 87972},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2826, col: 3, offset: 88531},
+						pos: position{line: 2826, col: 3, offset: 88534},
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
-							pos: position{line: 2826, col: 4, offset: 88532},
+							pos: position{line: 2826, col: 4, offset: 88535},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2826, col: 4, offset: 88532},
+									pos:   position{line: 2826, col: 4, offset: 88535},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2826, col: 12, offset: 88540},
+										pos: position{line: 2826, col: 12, offset: 88543},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2826, col: 12, offset: 88540},
+												pos:        position{line: 2826, col: 12, offset: 88543},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2826, col: 24, offset: 88552},
+												pos:        position{line: 2826, col: 24, offset: 88555},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -5278,222 +5278,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2826, col: 34, offset: 88562},
+									pos:  position{line: 2826, col: 34, offset: 88565},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2826, col: 42, offset: 88570},
+									pos:   position{line: 2826, col: 42, offset: 88573},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2826, col: 57, offset: 88585},
+										pos:  position{line: 2826, col: 57, offset: 88588},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2826, col: 72, offset: 88600},
+									pos:  position{line: 2826, col: 72, offset: 88603},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2838, col: 3, offset: 88948},
+						pos: position{line: 2838, col: 3, offset: 88951},
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
-							pos: position{line: 2838, col: 4, offset: 88949},
+							pos: position{line: 2838, col: 4, offset: 88952},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2838, col: 4, offset: 88949},
+									pos:   position{line: 2838, col: 4, offset: 88952},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2838, col: 12, offset: 88957},
+										pos:        position{line: 2838, col: 12, offset: 88960},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2838, col: 24, offset: 88969},
+									pos:  position{line: 2838, col: 24, offset: 88972},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2838, col: 32, offset: 88977},
+									pos:   position{line: 2838, col: 32, offset: 88980},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2838, col: 42, offset: 88987},
+										pos:  position{line: 2838, col: 42, offset: 88990},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2838, col: 51, offset: 88996},
+									pos:  position{line: 2838, col: 51, offset: 88999},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2851, col: 3, offset: 89343},
+						pos: position{line: 2851, col: 3, offset: 89346},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2851, col: 4, offset: 89344},
+							pos: position{line: 2851, col: 4, offset: 89347},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2851, col: 4, offset: 89344},
+									pos:   position{line: 2851, col: 4, offset: 89347},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2851, col: 12, offset: 89352},
+										pos:        position{line: 2851, col: 12, offset: 89355},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2851, col: 21, offset: 89361},
+									pos:  position{line: 2851, col: 21, offset: 89364},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2851, col: 29, offset: 89369},
+									pos:   position{line: 2851, col: 29, offset: 89372},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2851, col: 44, offset: 89384},
+										pos:  position{line: 2851, col: 44, offset: 89387},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2851, col: 59, offset: 89399},
+									pos:  position{line: 2851, col: 59, offset: 89402},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2851, col: 65, offset: 89405},
+									pos:   position{line: 2851, col: 65, offset: 89408},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2851, col: 70, offset: 89410},
+										pos:  position{line: 2851, col: 70, offset: 89413},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2851, col: 80, offset: 89420},
+									pos:  position{line: 2851, col: 80, offset: 89423},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2864, col: 3, offset: 89842},
+						pos: position{line: 2864, col: 3, offset: 89845},
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
-							pos: position{line: 2864, col: 4, offset: 89843},
+							pos: position{line: 2864, col: 4, offset: 89846},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2864, col: 4, offset: 89843},
+									pos:   position{line: 2864, col: 4, offset: 89846},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2864, col: 12, offset: 89851},
+										pos:        position{line: 2864, col: 12, offset: 89854},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2864, col: 23, offset: 89862},
+									pos:  position{line: 2864, col: 23, offset: 89865},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2864, col: 31, offset: 89870},
+									pos:   position{line: 2864, col: 31, offset: 89873},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2864, col: 42, offset: 89881},
+										pos:  position{line: 2864, col: 42, offset: 89884},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2864, col: 54, offset: 89893},
+									pos:  position{line: 2864, col: 54, offset: 89896},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2864, col: 60, offset: 89899},
+									pos:   position{line: 2864, col: 60, offset: 89902},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2864, col: 69, offset: 89908},
+										pos:  position{line: 2864, col: 69, offset: 89911},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2864, col: 81, offset: 89920},
+									pos:  position{line: 2864, col: 81, offset: 89923},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2864, col: 87, offset: 89926},
+									pos:   position{line: 2864, col: 87, offset: 89929},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2864, col: 98, offset: 89937},
+										pos: position{line: 2864, col: 98, offset: 89940},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2864, col: 99, offset: 89938},
+											pos:  position{line: 2864, col: 99, offset: 89941},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2864, col: 112, offset: 89951},
+									pos:  position{line: 2864, col: 112, offset: 89954},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2877, col: 3, offset: 90402},
+						pos: position{line: 2877, col: 3, offset: 90405},
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
-							pos: position{line: 2877, col: 4, offset: 90403},
+							pos: position{line: 2877, col: 4, offset: 90406},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2877, col: 4, offset: 90403},
+									pos:   position{line: 2877, col: 4, offset: 90406},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2877, col: 12, offset: 90411},
+										pos:        position{line: 2877, col: 12, offset: 90414},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2877, col: 21, offset: 90420},
+									pos:  position{line: 2877, col: 21, offset: 90423},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2877, col: 29, offset: 90428},
+									pos:   position{line: 2877, col: 29, offset: 90431},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2877, col: 36, offset: 90435},
+										pos:  position{line: 2877, col: 36, offset: 90438},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2877, col: 51, offset: 90450},
+									pos:  position{line: 2877, col: 51, offset: 90453},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2877, col: 57, offset: 90456},
+									pos:   position{line: 2877, col: 57, offset: 90459},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2877, col: 65, offset: 90464},
+										pos:  position{line: 2877, col: 65, offset: 90467},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2877, col: 80, offset: 90479},
+									pos:   position{line: 2877, col: 80, offset: 90482},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2877, col: 85, offset: 90484},
+										pos: position{line: 2877, col: 85, offset: 90487},
 										expr: &seqExpr{
-											pos: position{line: 2877, col: 86, offset: 90485},
+											pos: position{line: 2877, col: 86, offset: 90488},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2877, col: 86, offset: 90485},
+													pos:  position{line: 2877, col: 86, offset: 90488},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2877, col: 92, offset: 90491},
+													pos:  position{line: 2877, col: 92, offset: 90494},
 													name: "StringExpr",
 												},
 											},
@@ -5501,63 +5501,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2877, col: 105, offset: 90504},
+									pos:  position{line: 2877, col: 105, offset: 90507},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2894, col: 3, offset: 91032},
+						pos: position{line: 2894, col: 3, offset: 91035},
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
-							pos: position{line: 2894, col: 4, offset: 91033},
+							pos: position{line: 2894, col: 4, offset: 91036},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2894, col: 4, offset: 91033},
+									pos:   position{line: 2894, col: 4, offset: 91036},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2894, col: 12, offset: 91041},
+										pos:        position{line: 2894, col: 12, offset: 91044},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2894, col: 32, offset: 91061},
+									pos:  position{line: 2894, col: 32, offset: 91064},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2894, col: 40, offset: 91069},
+									pos:   position{line: 2894, col: 40, offset: 91072},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2894, col: 55, offset: 91084},
+										pos:  position{line: 2894, col: 55, offset: 91087},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2894, col: 70, offset: 91099},
+									pos:   position{line: 2894, col: 70, offset: 91102},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2894, col: 75, offset: 91104},
+										pos: position{line: 2894, col: 75, offset: 91107},
 										expr: &seqExpr{
-											pos: position{line: 2894, col: 76, offset: 91105},
+											pos: position{line: 2894, col: 76, offset: 91108},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2894, col: 76, offset: 91105},
+													pos:  position{line: 2894, col: 76, offset: 91108},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2894, col: 83, offset: 91112},
+													pos: position{line: 2894, col: 83, offset: 91115},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2894, col: 83, offset: 91112},
+															pos:        position{line: 2894, col: 83, offset: 91115},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2894, col: 92, offset: 91121},
+															pos:        position{line: 2894, col: 92, offset: 91124},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5565,7 +5565,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2894, col: 101, offset: 91130},
+													pos:        position{line: 2894, col: 101, offset: 91133},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5575,54 +5575,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2894, col: 108, offset: 91137},
+									pos:  position{line: 2894, col: 108, offset: 91140},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2919, col: 3, offset: 91840},
+						pos: position{line: 2919, col: 3, offset: 91843},
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
-							pos: position{line: 2919, col: 4, offset: 91841},
+							pos: position{line: 2919, col: 4, offset: 91844},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2919, col: 4, offset: 91841},
+									pos:   position{line: 2919, col: 4, offset: 91844},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2919, col: 12, offset: 91849},
+										pos:        position{line: 2919, col: 12, offset: 91852},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2919, col: 24, offset: 91861},
+									pos:  position{line: 2919, col: 24, offset: 91864},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2919, col: 32, offset: 91869},
+									pos:   position{line: 2919, col: 32, offset: 91872},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2919, col: 41, offset: 91878},
+										pos:  position{line: 2919, col: 41, offset: 91881},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2919, col: 64, offset: 91901},
+									pos:   position{line: 2919, col: 64, offset: 91904},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2919, col: 69, offset: 91906},
+										pos: position{line: 2919, col: 69, offset: 91909},
 										expr: &seqExpr{
-											pos: position{line: 2919, col: 70, offset: 91907},
+											pos: position{line: 2919, col: 70, offset: 91910},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2919, col: 70, offset: 91907},
+													pos:  position{line: 2919, col: 70, offset: 91910},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2919, col: 76, offset: 91913},
+													pos:  position{line: 2919, col: 76, offset: 91916},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5630,57 +5630,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2919, col: 101, offset: 91938},
+									pos:  position{line: 2919, col: 101, offset: 91941},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2939, col: 3, offset: 92526},
+						pos: position{line: 2939, col: 3, offset: 92529},
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
-							pos: position{line: 2939, col: 3, offset: 92526},
+							pos: position{line: 2939, col: 3, offset: 92529},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2939, col: 3, offset: 92526},
+									pos:   position{line: 2939, col: 3, offset: 92529},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2939, col: 9, offset: 92532},
+										pos:  position{line: 2939, col: 9, offset: 92535},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2939, col: 25, offset: 92548},
+									pos: position{line: 2939, col: 25, offset: 92551},
 									expr: &choiceExpr{
-										pos: position{line: 2939, col: 27, offset: 92550},
+										pos: position{line: 2939, col: 27, offset: 92553},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 27, offset: 92550},
+												pos:  position{line: 2939, col: 27, offset: 92553},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 36, offset: 92559},
+												pos:  position{line: 2939, col: 36, offset: 92562},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 46, offset: 92569},
+												pos:  position{line: 2939, col: 46, offset: 92572},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 54, offset: 92577},
+												pos:  position{line: 2939, col: 54, offset: 92580},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 62, offset: 92585},
+												pos:  position{line: 2939, col: 62, offset: 92588},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2939, col: 70, offset: 92593},
+												pos:  position{line: 2939, col: 70, offset: 92596},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2939, col: 84, offset: 92607},
+												pos:        position{line: 2939, col: 84, offset: 92610},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5696,36 +5696,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2951, col: 1, offset: 93002},
+			pos:  position{line: 2951, col: 1, offset: 93005},
 			expr: &choiceExpr{
-				pos: position{line: 2951, col: 13, offset: 93014},
+				pos: position{line: 2951, col: 13, offset: 93017},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2951, col: 13, offset: 93014},
+						pos: position{line: 2951, col: 13, offset: 93017},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2951, col: 14, offset: 93015},
+							pos: position{line: 2951, col: 14, offset: 93018},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2951, col: 14, offset: 93015},
+									pos:   position{line: 2951, col: 14, offset: 93018},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2951, col: 22, offset: 93023},
+										pos: position{line: 2951, col: 22, offset: 93026},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2951, col: 22, offset: 93023},
+												pos:        position{line: 2951, col: 22, offset: 93026},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2951, col: 32, offset: 93033},
+												pos:        position{line: 2951, col: 32, offset: 93036},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2951, col: 42, offset: 93043},
+												pos:        position{line: 2951, col: 42, offset: 93046},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5734,44 +5734,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 55, offset: 93056},
+									pos:  position{line: 2951, col: 55, offset: 93059},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2951, col: 63, offset: 93064},
+									pos:   position{line: 2951, col: 63, offset: 93067},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2951, col: 74, offset: 93075},
+										pos:  position{line: 2951, col: 74, offset: 93078},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2951, col: 85, offset: 93086},
+									pos:  position{line: 2951, col: 85, offset: 93089},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2963, col: 3, offset: 93400},
+						pos: position{line: 2963, col: 3, offset: 93403},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2963, col: 4, offset: 93401},
+							pos: position{line: 2963, col: 4, offset: 93404},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2963, col: 4, offset: 93401},
+									pos:   position{line: 2963, col: 4, offset: 93404},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2963, col: 12, offset: 93409},
+										pos: position{line: 2963, col: 12, offset: 93412},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2963, col: 12, offset: 93409},
+												pos:        position{line: 2963, col: 12, offset: 93412},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2963, col: 20, offset: 93417},
+												pos:        position{line: 2963, col: 20, offset: 93420},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5780,31 +5780,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 27, offset: 93424},
+									pos:  position{line: 2963, col: 27, offset: 93427},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 35, offset: 93432},
+									pos:   position{line: 2963, col: 35, offset: 93435},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2963, col: 44, offset: 93441},
+										pos:  position{line: 2963, col: 44, offset: 93444},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2963, col: 55, offset: 93452},
+									pos:   position{line: 2963, col: 55, offset: 93455},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2963, col: 60, offset: 93457},
+										pos: position{line: 2963, col: 60, offset: 93460},
 										expr: &seqExpr{
-											pos: position{line: 2963, col: 61, offset: 93458},
+											pos: position{line: 2963, col: 61, offset: 93461},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2963, col: 61, offset: 93458},
+													pos:  position{line: 2963, col: 61, offset: 93461},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2963, col: 67, offset: 93464},
+													pos:  position{line: 2963, col: 67, offset: 93467},
 													name: "StringExpr",
 												},
 											},
@@ -5812,195 +5812,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2963, col: 80, offset: 93477},
+									pos:  position{line: 2963, col: 80, offset: 93480},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2985, col: 3, offset: 94077},
+						pos: position{line: 2985, col: 3, offset: 94080},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2985, col: 4, offset: 94078},
+							pos: position{line: 2985, col: 4, offset: 94081},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2985, col: 4, offset: 94078},
+									pos:   position{line: 2985, col: 4, offset: 94081},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2985, col: 12, offset: 94086},
+										pos:        position{line: 2985, col: 12, offset: 94089},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2985, col: 23, offset: 94097},
+									pos:  position{line: 2985, col: 23, offset: 94100},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2985, col: 31, offset: 94105},
+									pos:   position{line: 2985, col: 31, offset: 94108},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2985, col: 46, offset: 94120},
+										pos:  position{line: 2985, col: 46, offset: 94123},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2985, col: 61, offset: 94135},
+									pos:  position{line: 2985, col: 61, offset: 94138},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2996, col: 3, offset: 94437},
+						pos: position{line: 2996, col: 3, offset: 94440},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2996, col: 4, offset: 94438},
+							pos: position{line: 2996, col: 4, offset: 94441},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2996, col: 4, offset: 94438},
+									pos:   position{line: 2996, col: 4, offset: 94441},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2996, col: 12, offset: 94446},
+										pos:        position{line: 2996, col: 12, offset: 94449},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2996, col: 22, offset: 94456},
+									pos:  position{line: 2996, col: 22, offset: 94459},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2996, col: 30, offset: 94464},
+									pos:   position{line: 2996, col: 30, offset: 94467},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2996, col: 45, offset: 94479},
+										pos:  position{line: 2996, col: 45, offset: 94482},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2996, col: 60, offset: 94494},
+									pos:  position{line: 2996, col: 60, offset: 94497},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2996, col: 66, offset: 94500},
+									pos:   position{line: 2996, col: 66, offset: 94503},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2996, col: 72, offset: 94506},
+										pos:  position{line: 2996, col: 72, offset: 94509},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2996, col: 83, offset: 94517},
+									pos:  position{line: 2996, col: 83, offset: 94520},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3008, col: 3, offset: 94867},
+						pos: position{line: 3008, col: 3, offset: 94870},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 3008, col: 4, offset: 94868},
+							pos: position{line: 3008, col: 4, offset: 94871},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3008, col: 4, offset: 94868},
+									pos:   position{line: 3008, col: 4, offset: 94871},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3008, col: 12, offset: 94876},
+										pos:        position{line: 3008, col: 12, offset: 94879},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3008, col: 22, offset: 94886},
+									pos:  position{line: 3008, col: 22, offset: 94889},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3008, col: 30, offset: 94894},
+									pos:   position{line: 3008, col: 30, offset: 94897},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3008, col: 45, offset: 94909},
+										pos:  position{line: 3008, col: 45, offset: 94912},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3008, col: 60, offset: 94924},
+									pos:  position{line: 3008, col: 60, offset: 94927},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3008, col: 66, offset: 94930},
+									pos:   position{line: 3008, col: 66, offset: 94933},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3008, col: 79, offset: 94943},
+										pos:  position{line: 3008, col: 79, offset: 94946},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3008, col: 90, offset: 94954},
+									pos:  position{line: 3008, col: 90, offset: 94957},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3032, col: 3, offset: 95620},
+						pos: position{line: 3032, col: 3, offset: 95623},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 3032, col: 4, offset: 95621},
+							pos: position{line: 3032, col: 4, offset: 95624},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3032, col: 4, offset: 95621},
+									pos:   position{line: 3032, col: 4, offset: 95624},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3032, col: 12, offset: 95629},
+										pos:        position{line: 3032, col: 12, offset: 95632},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3032, col: 22, offset: 95639},
+									pos:  position{line: 3032, col: 22, offset: 95642},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3032, col: 30, offset: 95647},
+									pos:   position{line: 3032, col: 30, offset: 95650},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3032, col: 41, offset: 95658},
+										pos:  position{line: 3032, col: 41, offset: 95661},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3032, col: 52, offset: 95669},
+									pos:  position{line: 3032, col: 52, offset: 95672},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3032, col: 58, offset: 95675},
+									pos:   position{line: 3032, col: 58, offset: 95678},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3032, col: 69, offset: 95686},
+										pos:  position{line: 3032, col: 69, offset: 95689},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3032, col: 81, offset: 95698},
+									pos:   position{line: 3032, col: 81, offset: 95701},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3032, col: 93, offset: 95710},
+										pos: position{line: 3032, col: 93, offset: 95713},
 										expr: &seqExpr{
-											pos: position{line: 3032, col: 94, offset: 95711},
+											pos: position{line: 3032, col: 94, offset: 95714},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3032, col: 94, offset: 95711},
+													pos:  position{line: 3032, col: 94, offset: 95714},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3032, col: 100, offset: 95717},
+													pos:  position{line: 3032, col: 100, offset: 95720},
 													name: "NumericExpr",
 												},
 											},
@@ -6008,50 +6008,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3032, col: 114, offset: 95731},
+									pos:  position{line: 3032, col: 114, offset: 95734},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3057, col: 3, offset: 96561},
+						pos: position{line: 3057, col: 3, offset: 96564},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 3057, col: 3, offset: 96561},
+							pos: position{line: 3057, col: 3, offset: 96564},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3057, col: 3, offset: 96561},
+									pos:        position{line: 3057, col: 3, offset: 96564},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3057, col: 14, offset: 96572},
+									pos:  position{line: 3057, col: 14, offset: 96575},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3057, col: 22, offset: 96580},
+									pos:   position{line: 3057, col: 22, offset: 96583},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3057, col: 28, offset: 96586},
+										pos:  position{line: 3057, col: 28, offset: 96589},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3057, col: 38, offset: 96596},
+									pos:   position{line: 3057, col: 38, offset: 96599},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3057, col: 45, offset: 96603},
+										pos: position{line: 3057, col: 45, offset: 96606},
 										expr: &seqExpr{
-											pos: position{line: 3057, col: 46, offset: 96604},
+											pos: position{line: 3057, col: 46, offset: 96607},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3057, col: 46, offset: 96604},
+													pos:  position{line: 3057, col: 46, offset: 96607},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3057, col: 52, offset: 96610},
+													pos:  position{line: 3057, col: 52, offset: 96613},
 													name: "StringExpr",
 												},
 											},
@@ -6059,38 +6059,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3057, col: 65, offset: 96623},
+									pos:  position{line: 3057, col: 65, offset: 96626},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3070, col: 3, offset: 96991},
+						pos: position{line: 3070, col: 3, offset: 96994},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 3070, col: 4, offset: 96992},
+							pos: position{line: 3070, col: 4, offset: 96995},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3070, col: 4, offset: 96992},
+									pos:   position{line: 3070, col: 4, offset: 96995},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3070, col: 12, offset: 97000},
+										pos: position{line: 3070, col: 12, offset: 97003},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3070, col: 12, offset: 97000},
+												pos:        position{line: 3070, col: 12, offset: 97003},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3070, col: 22, offset: 97010},
+												pos:        position{line: 3070, col: 22, offset: 97013},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3070, col: 32, offset: 97020},
+												pos:        position{line: 3070, col: 32, offset: 97023},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -6099,171 +6099,171 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3070, col: 40, offset: 97028},
+									pos:  position{line: 3070, col: 40, offset: 97031},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3070, col: 48, offset: 97036},
+									pos:   position{line: 3070, col: 48, offset: 97039},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3070, col: 54, offset: 97042},
+										pos:  position{line: 3070, col: 54, offset: 97045},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3070, col: 66, offset: 97054},
+									pos:   position{line: 3070, col: 66, offset: 97057},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3070, col: 82, offset: 97070},
+										pos: position{line: 3070, col: 82, offset: 97073},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3070, col: 83, offset: 97071},
+											pos:  position{line: 3070, col: 83, offset: 97074},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3070, col: 101, offset: 97089},
+									pos:  position{line: 3070, col: 101, offset: 97092},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3089, col: 3, offset: 97529},
+						pos: position{line: 3089, col: 3, offset: 97532},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 3089, col: 3, offset: 97529},
+							pos: position{line: 3089, col: 3, offset: 97532},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3089, col: 3, offset: 97529},
+									pos:        position{line: 3089, col: 3, offset: 97532},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3089, col: 12, offset: 97538},
+									pos:  position{line: 3089, col: 12, offset: 97541},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3089, col: 20, offset: 97546},
+									pos:   position{line: 3089, col: 20, offset: 97549},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3089, col: 25, offset: 97551},
+										pos:  position{line: 3089, col: 25, offset: 97554},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3089, col: 36, offset: 97562},
+									pos:  position{line: 3089, col: 36, offset: 97565},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3089, col: 42, offset: 97568},
+									pos:   position{line: 3089, col: 42, offset: 97571},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3089, col: 45, offset: 97571},
+										pos:  position{line: 3089, col: 45, offset: 97574},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3089, col: 55, offset: 97581},
+									pos:  position{line: 3089, col: 55, offset: 97584},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3096, col: 3, offset: 97739},
+						pos: position{line: 3096, col: 3, offset: 97742},
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
-							pos: position{line: 3096, col: 3, offset: 97739},
+							pos: position{line: 3096, col: 3, offset: 97742},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3096, col: 3, offset: 97739},
+									pos:        position{line: 3096, col: 3, offset: 97742},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3096, col: 21, offset: 97757},
+									pos:  position{line: 3096, col: 21, offset: 97760},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3096, col: 29, offset: 97765},
+									pos:   position{line: 3096, col: 29, offset: 97768},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3096, col: 33, offset: 97769},
+										pos:  position{line: 3096, col: 33, offset: 97772},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3096, col: 43, offset: 97779},
+									pos:  position{line: 3096, col: 43, offset: 97782},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3096, col: 49, offset: 97785},
+									pos:   position{line: 3096, col: 49, offset: 97788},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3096, col: 53, offset: 97789},
+										pos:  position{line: 3096, col: 53, offset: 97792},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3096, col: 66, offset: 97802},
+									pos:  position{line: 3096, col: 66, offset: 97805},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3096, col: 72, offset: 97808},
+									pos:   position{line: 3096, col: 72, offset: 97811},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3096, col: 78, offset: 97814},
+										pos:  position{line: 3096, col: 78, offset: 97817},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3096, col: 91, offset: 97827},
+									pos:  position{line: 3096, col: 91, offset: 97830},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3107, col: 3, offset: 98135},
+						pos: position{line: 3107, col: 3, offset: 98138},
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
-							pos: position{line: 3107, col: 3, offset: 98135},
+							pos: position{line: 3107, col: 3, offset: 98138},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3107, col: 3, offset: 98135},
+									pos:        position{line: 3107, col: 3, offset: 98138},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3107, col: 12, offset: 98144},
+									pos:  position{line: 3107, col: 12, offset: 98147},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3107, col: 20, offset: 98152},
+									pos:   position{line: 3107, col: 20, offset: 98155},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3107, col: 27, offset: 98159},
+										pos:  position{line: 3107, col: 27, offset: 98162},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3107, col: 38, offset: 98170},
+									pos:   position{line: 3107, col: 38, offset: 98173},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3107, col: 43, offset: 98175},
+										pos: position{line: 3107, col: 43, offset: 98178},
 										expr: &seqExpr{
-											pos: position{line: 3107, col: 44, offset: 98176},
+											pos: position{line: 3107, col: 44, offset: 98179},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3107, col: 44, offset: 98176},
+													pos:  position{line: 3107, col: 44, offset: 98179},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3107, col: 50, offset: 98182},
+													pos:  position{line: 3107, col: 50, offset: 98185},
 													name: "StringExpr",
 												},
 											},
@@ -6271,47 +6271,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3107, col: 63, offset: 98195},
+									pos:  position{line: 3107, col: 63, offset: 98198},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3125, col: 3, offset: 98662},
+						pos: position{line: 3125, col: 3, offset: 98665},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 3125, col: 3, offset: 98662},
+							pos: position{line: 3125, col: 3, offset: 98665},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3125, col: 3, offset: 98662},
+									pos:        position{line: 3125, col: 3, offset: 98665},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3125, col: 12, offset: 98671},
+									pos:  position{line: 3125, col: 12, offset: 98674},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3125, col: 20, offset: 98679},
+									pos:   position{line: 3125, col: 20, offset: 98682},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3125, col: 42, offset: 98701},
+										pos: position{line: 3125, col: 42, offset: 98704},
 										expr: &seqExpr{
-											pos: position{line: 3125, col: 43, offset: 98702},
+											pos: position{line: 3125, col: 43, offset: 98705},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 3125, col: 44, offset: 98703},
+													pos: position{line: 3125, col: 44, offset: 98706},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 3125, col: 44, offset: 98703},
+															pos:        position{line: 3125, col: 44, offset: 98706},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3125, col: 53, offset: 98712},
+															pos:        position{line: 3125, col: 53, offset: 98715},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6319,7 +6319,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 3125, col: 62, offset: 98721},
+													pos:        position{line: 3125, col: 62, offset: 98724},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6329,56 +6329,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3125, col: 69, offset: 98728},
+									pos:  position{line: 3125, col: 69, offset: 98731},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3147, col: 3, offset: 99325},
+						pos: position{line: 3147, col: 3, offset: 99328},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 3147, col: 3, offset: 99325},
+							pos: position{line: 3147, col: 3, offset: 99328},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3147, col: 3, offset: 99325},
+									pos:        position{line: 3147, col: 3, offset: 99328},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 13, offset: 99335},
+									pos:  position{line: 3147, col: 13, offset: 99338},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 21, offset: 99343},
+									pos:   position{line: 3147, col: 21, offset: 99346},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3147, col: 27, offset: 99349},
+										pos:  position{line: 3147, col: 27, offset: 99352},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 43, offset: 99365},
+									pos:   position{line: 3147, col: 43, offset: 99368},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3147, col: 53, offset: 99375},
+										pos: position{line: 3147, col: 53, offset: 99378},
 										expr: &seqExpr{
-											pos: position{line: 3147, col: 54, offset: 99376},
+											pos: position{line: 3147, col: 54, offset: 99379},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3147, col: 54, offset: 99376},
+													pos:  position{line: 3147, col: 54, offset: 99379},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3147, col: 60, offset: 99382},
+													pos:        position{line: 3147, col: 60, offset: 99385},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3147, col: 73, offset: 99395},
+													pos:  position{line: 3147, col: 73, offset: 99398},
 													name: "FloatAsString",
 												},
 											},
@@ -6386,40 +6386,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 89, offset: 99411},
+									pos:   position{line: 3147, col: 89, offset: 99414},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3147, col: 95, offset: 99417},
+										pos: position{line: 3147, col: 95, offset: 99420},
 										expr: &seqExpr{
-											pos: position{line: 3147, col: 96, offset: 99418},
+											pos: position{line: 3147, col: 96, offset: 99421},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3147, col: 96, offset: 99418},
+													pos:  position{line: 3147, col: 96, offset: 99421},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3147, col: 102, offset: 99424},
+													pos:        position{line: 3147, col: 102, offset: 99427},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 3147, col: 112, offset: 99434},
+													pos: position{line: 3147, col: 112, offset: 99437},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 3147, col: 112, offset: 99434},
+															pos:        position{line: 3147, col: 112, offset: 99437},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3147, col: 125, offset: 99447},
+															pos:        position{line: 3147, col: 125, offset: 99450},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 3147, col: 137, offset: 99459},
+															pos:        position{line: 3147, col: 137, offset: 99462},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6431,25 +6431,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 151, offset: 99473},
+									pos:   position{line: 3147, col: 151, offset: 99476},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3147, col: 158, offset: 99480},
+										pos: position{line: 3147, col: 158, offset: 99483},
 										expr: &seqExpr{
-											pos: position{line: 3147, col: 159, offset: 99481},
+											pos: position{line: 3147, col: 159, offset: 99484},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3147, col: 159, offset: 99481},
+													pos:  position{line: 3147, col: 159, offset: 99484},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 3147, col: 165, offset: 99487},
+													pos:        position{line: 3147, col: 165, offset: 99490},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3147, col: 175, offset: 99497},
+													pos:  position{line: 3147, col: 175, offset: 99500},
 													name: "QuotedString",
 												},
 											},
@@ -6457,213 +6457,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 190, offset: 99512},
+									pos:  position{line: 3147, col: 190, offset: 99515},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3187, col: 3, offset: 100507},
+						pos: position{line: 3187, col: 3, offset: 100510},
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
-							pos: position{line: 3187, col: 3, offset: 100507},
+							pos: position{line: 3187, col: 3, offset: 100510},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3187, col: 3, offset: 100507},
+									pos:        position{line: 3187, col: 3, offset: 100510},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3187, col: 15, offset: 100519},
+									pos:  position{line: 3187, col: 15, offset: 100522},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3187, col: 23, offset: 100527},
+									pos:   position{line: 3187, col: 23, offset: 100530},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3187, col: 30, offset: 100534},
+										pos: position{line: 3187, col: 30, offset: 100537},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3187, col: 31, offset: 100535},
+											pos:  position{line: 3187, col: 31, offset: 100538},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3187, col: 44, offset: 100548},
+									pos:  position{line: 3187, col: 44, offset: 100551},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3198, col: 3, offset: 100739},
+						pos: position{line: 3198, col: 3, offset: 100742},
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
-							pos: position{line: 3198, col: 3, offset: 100739},
+							pos: position{line: 3198, col: 3, offset: 100742},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3198, col: 3, offset: 100739},
+									pos:        position{line: 3198, col: 3, offset: 100742},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3198, col: 12, offset: 100748},
+									pos:  position{line: 3198, col: 12, offset: 100751},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3198, col: 20, offset: 100756},
+									pos:   position{line: 3198, col: 20, offset: 100759},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3198, col: 30, offset: 100766},
+										pos:  position{line: 3198, col: 30, offset: 100769},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3198, col: 40, offset: 100776},
+									pos:  position{line: 3198, col: 40, offset: 100779},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3204, col: 3, offset: 100899},
+						pos: position{line: 3204, col: 3, offset: 100902},
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
-							pos: position{line: 3204, col: 3, offset: 100899},
+							pos: position{line: 3204, col: 3, offset: 100902},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3204, col: 3, offset: 100899},
+									pos:        position{line: 3204, col: 3, offset: 100902},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3204, col: 13, offset: 100909},
+									pos:  position{line: 3204, col: 13, offset: 100912},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3204, col: 21, offset: 100917},
+									pos:   position{line: 3204, col: 21, offset: 100920},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3204, col: 25, offset: 100921},
+										pos:  position{line: 3204, col: 25, offset: 100924},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3204, col: 35, offset: 100931},
+									pos:  position{line: 3204, col: 35, offset: 100934},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3204, col: 41, offset: 100937},
+									pos:   position{line: 3204, col: 41, offset: 100940},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3204, col: 47, offset: 100943},
+										pos:  position{line: 3204, col: 47, offset: 100946},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3204, col: 58, offset: 100954},
+									pos:  position{line: 3204, col: 58, offset: 100957},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3204, col: 64, offset: 100960},
+									pos:   position{line: 3204, col: 64, offset: 100963},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3204, col: 76, offset: 100972},
+										pos:  position{line: 3204, col: 76, offset: 100975},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3204, col: 87, offset: 100983},
+									pos:  position{line: 3204, col: 87, offset: 100986},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3211, col: 3, offset: 101207},
+						pos: position{line: 3211, col: 3, offset: 101210},
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
-							pos: position{line: 3211, col: 3, offset: 101207},
+							pos: position{line: 3211, col: 3, offset: 101210},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3211, col: 3, offset: 101207},
+									pos:        position{line: 3211, col: 3, offset: 101210},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3211, col: 14, offset: 101218},
+									pos:  position{line: 3211, col: 14, offset: 101221},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3211, col: 22, offset: 101226},
+									pos:   position{line: 3211, col: 22, offset: 101229},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3211, col: 26, offset: 101230},
+										pos:  position{line: 3211, col: 26, offset: 101233},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3211, col: 36, offset: 101240},
+									pos:  position{line: 3211, col: 36, offset: 101243},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3211, col: 42, offset: 101246},
+									pos:   position{line: 3211, col: 42, offset: 101249},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3211, col: 49, offset: 101253},
+										pos:  position{line: 3211, col: 49, offset: 101256},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3211, col: 60, offset: 101264},
+									pos:  position{line: 3211, col: 60, offset: 101267},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3219, col: 3, offset: 101428},
+						pos: position{line: 3219, col: 3, offset: 101431},
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
-							pos: position{line: 3219, col: 3, offset: 101428},
+							pos: position{line: 3219, col: 3, offset: 101431},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3219, col: 3, offset: 101428},
+									pos:        position{line: 3219, col: 3, offset: 101431},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3219, col: 14, offset: 101439},
+									pos:  position{line: 3219, col: 14, offset: 101442},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3219, col: 22, offset: 101447},
+									pos:   position{line: 3219, col: 22, offset: 101450},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3219, col: 26, offset: 101451},
+										pos:  position{line: 3219, col: 26, offset: 101454},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3219, col: 36, offset: 101461},
+									pos:  position{line: 3219, col: 36, offset: 101464},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3219, col: 42, offset: 101467},
+									pos:   position{line: 3219, col: 42, offset: 101470},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3219, col: 49, offset: 101474},
+										pos:  position{line: 3219, col: 49, offset: 101477},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3219, col: 60, offset: 101485},
+									pos:  position{line: 3219, col: 60, offset: 101488},
 									name: "R_PAREN",
 								},
 							},
@@ -6674,15 +6674,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 3227, col: 1, offset: 101647},
+			pos:  position{line: 3227, col: 1, offset: 101650},
 			expr: &actionExpr{
-				pos: position{line: 3227, col: 21, offset: 101667},
+				pos: position{line: 3227, col: 21, offset: 101670},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3227, col: 21, offset: 101667},
+					pos:   position{line: 3227, col: 21, offset: 101670},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3227, col: 25, offset: 101671},
+						pos:  position{line: 3227, col: 25, offset: 101674},
 						name: "QuotedString",
 					},
 				},
@@ -6690,15 +6690,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3234, col: 1, offset: 101798},
+			pos:  position{line: 3234, col: 1, offset: 101801},
 			expr: &actionExpr{
-				pos: position{line: 3234, col: 22, offset: 101819},
+				pos: position{line: 3234, col: 22, offset: 101822},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3234, col: 22, offset: 101819},
+					pos:   position{line: 3234, col: 22, offset: 101822},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3234, col: 26, offset: 101823},
+						pos:  position{line: 3234, col: 26, offset: 101826},
 						name: "UnquotedString",
 					},
 				},
@@ -6706,22 +6706,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3241, col: 1, offset: 101951},
+			pos:  position{line: 3241, col: 1, offset: 101954},
 			expr: &actionExpr{
-				pos: position{line: 3241, col: 20, offset: 101970},
+				pos: position{line: 3241, col: 20, offset: 101973},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3241, col: 20, offset: 101970},
+					pos: position{line: 3241, col: 20, offset: 101973},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3241, col: 20, offset: 101970},
+							pos:  position{line: 3241, col: 20, offset: 101973},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3241, col: 26, offset: 101976},
+							pos:   position{line: 3241, col: 26, offset: 101979},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3241, col: 38, offset: 101988},
+								pos:  position{line: 3241, col: 38, offset: 101991},
 								name: "String",
 							},
 						},
@@ -6731,27 +6731,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3247, col: 1, offset: 102173},
+			pos:  position{line: 3247, col: 1, offset: 102176},
 			expr: &choiceExpr{
-				pos: position{line: 3247, col: 20, offset: 102192},
+				pos: position{line: 3247, col: 20, offset: 102195},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3247, col: 20, offset: 102192},
+						pos: position{line: 3247, col: 20, offset: 102195},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3247, col: 20, offset: 102192},
+							pos: position{line: 3247, col: 20, offset: 102195},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3247, col: 20, offset: 102192},
+									pos:        position{line: 3247, col: 20, offset: 102195},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3247, col: 28, offset: 102200},
+									pos: position{line: 3247, col: 28, offset: 102203},
 									expr: &charClassMatcher{
-										pos:        position{line: 3247, col: 28, offset: 102200},
+										pos:        position{line: 3247, col: 28, offset: 102203},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6760,9 +6760,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3247, col: 42, offset: 102214},
+									pos: position{line: 3247, col: 42, offset: 102217},
 									expr: &litMatcher{
-										pos:        position{line: 3247, col: 44, offset: 102216},
+										pos:        position{line: 3247, col: 44, offset: 102219},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6772,27 +6772,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3250, col: 3, offset: 102258},
+						pos: position{line: 3250, col: 3, offset: 102261},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3250, col: 3, offset: 102258},
+							pos: position{line: 3250, col: 3, offset: 102261},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3250, col: 3, offset: 102258},
+									pos:        position{line: 3250, col: 3, offset: 102261},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3250, col: 7, offset: 102262},
+									pos:   position{line: 3250, col: 7, offset: 102265},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3250, col: 13, offset: 102268},
+										pos:  position{line: 3250, col: 13, offset: 102271},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3250, col: 23, offset: 102278},
+									pos:        position{line: 3250, col: 23, offset: 102281},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6805,26 +6805,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3255, col: 1, offset: 102346},
+			pos:  position{line: 3255, col: 1, offset: 102349},
 			expr: &actionExpr{
-				pos: position{line: 3255, col: 15, offset: 102360},
+				pos: position{line: 3255, col: 15, offset: 102363},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3255, col: 15, offset: 102360},
+					pos: position{line: 3255, col: 15, offset: 102363},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3255, col: 15, offset: 102360},
+							pos:  position{line: 3255, col: 15, offset: 102363},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3255, col: 20, offset: 102365},
+							pos:  position{line: 3255, col: 20, offset: 102368},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3255, col: 30, offset: 102375},
+							pos:   position{line: 3255, col: 30, offset: 102378},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3255, col: 40, offset: 102385},
+								pos:  position{line: 3255, col: 40, offset: 102388},
 								name: "BoolExpr",
 							},
 						},
@@ -6834,15 +6834,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3268, col: 1, offset: 102728},
+			pos:  position{line: 3268, col: 1, offset: 102731},
 			expr: &actionExpr{
-				pos: position{line: 3268, col: 13, offset: 102740},
+				pos: position{line: 3268, col: 13, offset: 102743},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3268, col: 13, offset: 102740},
+					pos:   position{line: 3268, col: 13, offset: 102743},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3268, col: 18, offset: 102745},
+						pos:  position{line: 3268, col: 18, offset: 102748},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6850,35 +6850,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3273, col: 1, offset: 102815},
+			pos:  position{line: 3273, col: 1, offset: 102818},
 			expr: &actionExpr{
-				pos: position{line: 3273, col: 19, offset: 102833},
+				pos: position{line: 3273, col: 19, offset: 102836},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3273, col: 19, offset: 102833},
+					pos: position{line: 3273, col: 19, offset: 102836},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3273, col: 19, offset: 102833},
+							pos:   position{line: 3273, col: 19, offset: 102836},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3273, col: 25, offset: 102839},
+								pos:  position{line: 3273, col: 25, offset: 102842},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3273, col: 40, offset: 102854},
+							pos:   position{line: 3273, col: 40, offset: 102857},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3273, col: 45, offset: 102859},
+								pos: position{line: 3273, col: 45, offset: 102862},
 								expr: &seqExpr{
-									pos: position{line: 3273, col: 46, offset: 102860},
+									pos: position{line: 3273, col: 46, offset: 102863},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3273, col: 46, offset: 102860},
+											pos:  position{line: 3273, col: 46, offset: 102863},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3273, col: 49, offset: 102863},
+											pos:  position{line: 3273, col: 49, offset: 102866},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6891,35 +6891,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3293, col: 1, offset: 103301},
+			pos:  position{line: 3293, col: 1, offset: 103304},
 			expr: &actionExpr{
-				pos: position{line: 3293, col: 19, offset: 103319},
+				pos: position{line: 3293, col: 19, offset: 103322},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3293, col: 19, offset: 103319},
+					pos: position{line: 3293, col: 19, offset: 103322},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3293, col: 19, offset: 103319},
+							pos:   position{line: 3293, col: 19, offset: 103322},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3293, col: 25, offset: 103325},
+								pos:  position{line: 3293, col: 25, offset: 103328},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3293, col: 40, offset: 103340},
+							pos:   position{line: 3293, col: 40, offset: 103343},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3293, col: 45, offset: 103345},
+								pos: position{line: 3293, col: 45, offset: 103348},
 								expr: &seqExpr{
-									pos: position{line: 3293, col: 46, offset: 103346},
+									pos: position{line: 3293, col: 46, offset: 103349},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3293, col: 46, offset: 103346},
+											pos:  position{line: 3293, col: 46, offset: 103349},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3293, col: 50, offset: 103350},
+											pos:  position{line: 3293, col: 50, offset: 103353},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6932,47 +6932,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3313, col: 1, offset: 103789},
+			pos:  position{line: 3313, col: 1, offset: 103792},
 			expr: &choiceExpr{
-				pos: position{line: 3313, col: 19, offset: 103807},
+				pos: position{line: 3313, col: 19, offset: 103810},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3313, col: 19, offset: 103807},
+						pos: position{line: 3313, col: 19, offset: 103810},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3313, col: 19, offset: 103807},
+							pos: position{line: 3313, col: 19, offset: 103810},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 19, offset: 103807},
+									pos:  position{line: 3313, col: 19, offset: 103810},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 23, offset: 103811},
+									pos:  position{line: 3313, col: 23, offset: 103814},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3313, col: 31, offset: 103819},
+									pos:   position{line: 3313, col: 31, offset: 103822},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3313, col: 37, offset: 103825},
+										pos:  position{line: 3313, col: 37, offset: 103828},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 52, offset: 103840},
+									pos:  position{line: 3313, col: 52, offset: 103843},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3323, col: 3, offset: 104043},
+						pos: position{line: 3323, col: 3, offset: 104046},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3323, col: 3, offset: 104043},
+							pos:   position{line: 3323, col: 3, offset: 104046},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3323, col: 9, offset: 104049},
+								pos:  position{line: 3323, col: 9, offset: 104052},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6982,50 +6982,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3328, col: 1, offset: 104120},
+			pos:  position{line: 3328, col: 1, offset: 104123},
 			expr: &choiceExpr{
-				pos: position{line: 3328, col: 19, offset: 104138},
+				pos: position{line: 3328, col: 19, offset: 104141},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3328, col: 19, offset: 104138},
+						pos: position{line: 3328, col: 19, offset: 104141},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3328, col: 19, offset: 104138},
+							pos: position{line: 3328, col: 19, offset: 104141},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3328, col: 19, offset: 104138},
+									pos:  position{line: 3328, col: 19, offset: 104141},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3328, col: 27, offset: 104146},
+									pos:   position{line: 3328, col: 27, offset: 104149},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3328, col: 33, offset: 104152},
+										pos:  position{line: 3328, col: 33, offset: 104155},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3328, col: 48, offset: 104167},
+									pos:  position{line: 3328, col: 48, offset: 104170},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3331, col: 3, offset: 104203},
+						pos: position{line: 3331, col: 3, offset: 104206},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3331, col: 3, offset: 104203},
+							pos:   position{line: 3331, col: 3, offset: 104206},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3331, col: 10, offset: 104210},
+								pos: position{line: 3331, col: 10, offset: 104213},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3331, col: 10, offset: 104210},
+										pos:  position{line: 3331, col: 10, offset: 104213},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3331, col: 31, offset: 104231},
+										pos:  position{line: 3331, col: 31, offset: 104234},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -7037,72 +7037,72 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3336, col: 1, offset: 104351},
+			pos:  position{line: 3336, col: 1, offset: 104354},
 			expr: &choiceExpr{
-				pos: position{line: 3336, col: 23, offset: 104373},
+				pos: position{line: 3336, col: 23, offset: 104376},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3336, col: 23, offset: 104373},
+						pos: position{line: 3336, col: 23, offset: 104376},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3336, col: 24, offset: 104374},
+							pos: position{line: 3336, col: 24, offset: 104377},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3336, col: 24, offset: 104374},
+									pos:   position{line: 3336, col: 24, offset: 104377},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3336, col: 28, offset: 104378},
+										pos: position{line: 3336, col: 28, offset: 104381},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3336, col: 28, offset: 104378},
+												pos:        position{line: 3336, col: 28, offset: 104381},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 39, offset: 104389},
+												pos:        position{line: 3336, col: 39, offset: 104392},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 49, offset: 104399},
+												pos:        position{line: 3336, col: 49, offset: 104402},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 59, offset: 104409},
+												pos:        position{line: 3336, col: 59, offset: 104412},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 70, offset: 104420},
+												pos:        position{line: 3336, col: 70, offset: 104423},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 84, offset: 104434},
+												pos:        position{line: 3336, col: 84, offset: 104437},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 94, offset: 104444},
+												pos:        position{line: 3336, col: 94, offset: 104447},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 110, offset: 104460},
+												pos:        position{line: 3336, col: 110, offset: 104463},
 												val:        "ismv",
 												ignoreCase: false,
 												want:       "\"ismv\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3336, col: 119, offset: 104469},
+												pos:        position{line: 3336, col: 119, offset: 104472},
 												val:        "isobject",
 												ignoreCase: false,
 												want:       "\"isobject\"",
@@ -7111,56 +7111,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3336, col: 131, offset: 104481},
+									pos:  position{line: 3336, col: 131, offset: 104484},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3336, col: 139, offset: 104489},
+									pos:   position{line: 3336, col: 139, offset: 104492},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3336, col: 145, offset: 104495},
+										pos:  position{line: 3336, col: 145, offset: 104498},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3336, col: 155, offset: 104505},
+									pos:  position{line: 3336, col: 155, offset: 104508},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3366, col: 3, offset: 105376},
+						pos: position{line: 3366, col: 3, offset: 105379},
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3366, col: 3, offset: 105376},
+							pos: position{line: 3366, col: 3, offset: 105379},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3366, col: 3, offset: 105376},
+									pos:   position{line: 3366, col: 3, offset: 105379},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3366, col: 11, offset: 105384},
+										pos: position{line: 3366, col: 11, offset: 105387},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3366, col: 11, offset: 105384},
+												pos:        position{line: 3366, col: 11, offset: 105387},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3366, col: 20, offset: 105393},
+												pos:        position{line: 3366, col: 20, offset: 105396},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3366, col: 29, offset: 105402},
+												pos:        position{line: 3366, col: 29, offset: 105405},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3366, col: 39, offset: 105412},
+												pos:        position{line: 3366, col: 39, offset: 105415},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -7169,86 +7169,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3366, col: 52, offset: 105425},
+									pos:  position{line: 3366, col: 52, offset: 105428},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3366, col: 60, offset: 105433},
+									pos:   position{line: 3366, col: 60, offset: 105436},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3366, col: 70, offset: 105443},
+										pos:  position{line: 3366, col: 70, offset: 105446},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3366, col: 80, offset: 105453},
+									pos:  position{line: 3366, col: 80, offset: 105456},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3366, col: 86, offset: 105459},
+									pos:   position{line: 3366, col: 86, offset: 105462},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3366, col: 97, offset: 105470},
+										pos:  position{line: 3366, col: 97, offset: 105473},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3366, col: 107, offset: 105480},
+									pos:  position{line: 3366, col: 107, offset: 105483},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3379, col: 3, offset: 105850},
+						pos: position{line: 3379, col: 3, offset: 105853},
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
-							pos: position{line: 3379, col: 3, offset: 105850},
+							pos: position{line: 3379, col: 3, offset: 105853},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3379, col: 3, offset: 105850},
+									pos:   position{line: 3379, col: 3, offset: 105853},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3379, col: 8, offset: 105855},
+										pos:  position{line: 3379, col: 8, offset: 105858},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3379, col: 18, offset: 105865},
+									pos:  position{line: 3379, col: 18, offset: 105868},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3379, col: 24, offset: 105871},
+									pos:        position{line: 3379, col: 24, offset: 105874},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3379, col: 29, offset: 105876},
+									pos:  position{line: 3379, col: 29, offset: 105879},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3379, col: 37, offset: 105884},
+									pos:   position{line: 3379, col: 37, offset: 105887},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3379, col: 50, offset: 105897},
+										pos:  position{line: 3379, col: 50, offset: 105900},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3379, col: 60, offset: 105907},
+									pos:   position{line: 3379, col: 60, offset: 105910},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3379, col: 65, offset: 105912},
+										pos: position{line: 3379, col: 65, offset: 105915},
 										expr: &seqExpr{
-											pos: position{line: 3379, col: 66, offset: 105913},
+											pos: position{line: 3379, col: 66, offset: 105916},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3379, col: 66, offset: 105913},
+													pos:  position{line: 3379, col: 66, offset: 105916},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3379, col: 72, offset: 105919},
+													pos:  position{line: 3379, col: 72, offset: 105922},
 													name: "ValueExpr",
 												},
 											},
@@ -7256,50 +7256,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3379, col: 84, offset: 105931},
+									pos:  position{line: 3379, col: 84, offset: 105934},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3398, col: 3, offset: 106482},
+						pos: position{line: 3398, col: 3, offset: 106485},
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
-							pos: position{line: 3398, col: 3, offset: 106482},
+							pos: position{line: 3398, col: 3, offset: 106485},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3398, col: 3, offset: 106482},
+									pos:        position{line: 3398, col: 3, offset: 106485},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3398, col: 8, offset: 106487},
+									pos:  position{line: 3398, col: 8, offset: 106490},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3398, col: 16, offset: 106495},
+									pos:   position{line: 3398, col: 16, offset: 106498},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3398, col: 29, offset: 106508},
+										pos:  position{line: 3398, col: 29, offset: 106511},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3398, col: 39, offset: 106518},
+									pos:   position{line: 3398, col: 39, offset: 106521},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3398, col: 44, offset: 106523},
+										pos: position{line: 3398, col: 44, offset: 106526},
 										expr: &seqExpr{
-											pos: position{line: 3398, col: 45, offset: 106524},
+											pos: position{line: 3398, col: 45, offset: 106527},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3398, col: 45, offset: 106524},
+													pos:  position{line: 3398, col: 45, offset: 106527},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3398, col: 51, offset: 106530},
+													pos:  position{line: 3398, col: 51, offset: 106533},
 													name: "ValueExpr",
 												},
 											},
@@ -7307,7 +7307,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3398, col: 63, offset: 106542},
+									pos:  position{line: 3398, col: 63, offset: 106545},
 									name: "R_PAREN",
 								},
 							},
@@ -7318,34 +7318,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3416, col: 1, offset: 106963},
+			pos:  position{line: 3416, col: 1, offset: 106966},
 			expr: &actionExpr{
-				pos: position{line: 3416, col: 23, offset: 106985},
+				pos: position{line: 3416, col: 23, offset: 106988},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3416, col: 23, offset: 106985},
+					pos: position{line: 3416, col: 23, offset: 106988},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3416, col: 23, offset: 106985},
+							pos:   position{line: 3416, col: 23, offset: 106988},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3416, col: 28, offset: 106990},
+								pos:  position{line: 3416, col: 28, offset: 106993},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3416, col: 38, offset: 107000},
+							pos:   position{line: 3416, col: 38, offset: 107003},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3416, col: 41, offset: 107003},
+								pos:  position{line: 3416, col: 41, offset: 107006},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3416, col: 62, offset: 107024},
+							pos:   position{line: 3416, col: 62, offset: 107027},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3416, col: 68, offset: 107030},
+								pos:  position{line: 3416, col: 68, offset: 107033},
 								name: "ValueExpr",
 							},
 						},
@@ -7355,141 +7355,141 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3434, col: 1, offset: 107624},
+			pos:  position{line: 3434, col: 1, offset: 107627},
 			expr: &choiceExpr{
-				pos: position{line: 3434, col: 14, offset: 107637},
+				pos: position{line: 3434, col: 14, offset: 107640},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3434, col: 14, offset: 107637},
+						pos: position{line: 3434, col: 14, offset: 107640},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3434, col: 14, offset: 107637},
+							pos:   position{line: 3434, col: 14, offset: 107640},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3434, col: 24, offset: 107647},
+								pos:  position{line: 3434, col: 24, offset: 107650},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3443, col: 3, offset: 107837},
+						pos: position{line: 3443, col: 3, offset: 107840},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3443, col: 3, offset: 107837},
+							pos: position{line: 3443, col: 3, offset: 107840},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3443, col: 3, offset: 107837},
+									pos:  position{line: 3443, col: 3, offset: 107840},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3443, col: 12, offset: 107846},
+									pos:   position{line: 3443, col: 12, offset: 107849},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3443, col: 22, offset: 107856},
+										pos:  position{line: 3443, col: 22, offset: 107859},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3443, col: 37, offset: 107871},
+									pos:  position{line: 3443, col: 37, offset: 107874},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3452, col: 3, offset: 108055},
+						pos: position{line: 3452, col: 3, offset: 108058},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3452, col: 3, offset: 108055},
+							pos:   position{line: 3452, col: 3, offset: 108058},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3452, col: 11, offset: 108063},
+								pos:  position{line: 3452, col: 11, offset: 108066},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3461, col: 3, offset: 108243},
+						pos: position{line: 3461, col: 3, offset: 108246},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3461, col: 3, offset: 108243},
+							pos:   position{line: 3461, col: 3, offset: 108246},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3461, col: 7, offset: 108247},
+								pos:  position{line: 3461, col: 7, offset: 108250},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3470, col: 3, offset: 108419},
+						pos: position{line: 3470, col: 3, offset: 108422},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3470, col: 3, offset: 108419},
+							pos: position{line: 3470, col: 3, offset: 108422},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3470, col: 3, offset: 108419},
+									pos:  position{line: 3470, col: 3, offset: 108422},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3470, col: 12, offset: 108428},
+									pos:   position{line: 3470, col: 12, offset: 108431},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3470, col: 16, offset: 108432},
+										pos:  position{line: 3470, col: 16, offset: 108435},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3470, col: 28, offset: 108444},
+									pos:  position{line: 3470, col: 28, offset: 108447},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3479, col: 3, offset: 108613},
+						pos: position{line: 3479, col: 3, offset: 108616},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3479, col: 3, offset: 108613},
+							pos: position{line: 3479, col: 3, offset: 108616},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3479, col: 3, offset: 108613},
+									pos:  position{line: 3479, col: 3, offset: 108616},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3479, col: 11, offset: 108621},
+									pos:   position{line: 3479, col: 11, offset: 108624},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3479, col: 19, offset: 108629},
+										pos:  position{line: 3479, col: 19, offset: 108632},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3479, col: 28, offset: 108638},
+									pos:  position{line: 3479, col: 28, offset: 108641},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3488, col: 3, offset: 108810},
+						pos: position{line: 3488, col: 3, offset: 108813},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3488, col: 3, offset: 108810},
+							pos:   position{line: 3488, col: 3, offset: 108813},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3488, col: 18, offset: 108825},
+								pos:  position{line: 3488, col: 18, offset: 108828},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3497, col: 3, offset: 109023},
+						pos: position{line: 3497, col: 3, offset: 109026},
 						run: (*parser).callonValueExpr32,
 						expr: &labeledExpr{
-							pos:   position{line: 3497, col: 3, offset: 109023},
+							pos:   position{line: 3497, col: 3, offset: 109026},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3497, col: 12, offset: 109032},
+								pos:  position{line: 3497, col: 12, offset: 109035},
 								name: "JsonExpr",
 							},
 						},
@@ -7499,28 +7499,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3506, col: 1, offset: 109199},
+			pos:  position{line: 3506, col: 1, offset: 109202},
 			expr: &choiceExpr{
-				pos: position{line: 3506, col: 15, offset: 109213},
+				pos: position{line: 3506, col: 15, offset: 109216},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3506, col: 15, offset: 109213},
+						pos: position{line: 3506, col: 15, offset: 109216},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3506, col: 15, offset: 109213},
+							pos: position{line: 3506, col: 15, offset: 109216},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3506, col: 15, offset: 109213},
+									pos:   position{line: 3506, col: 15, offset: 109216},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3506, col: 20, offset: 109218},
+										pos:  position{line: 3506, col: 20, offset: 109221},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3506, col: 29, offset: 109227},
+									pos: position{line: 3506, col: 29, offset: 109230},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3506, col: 31, offset: 109229},
+										pos:  position{line: 3506, col: 31, offset: 109232},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7528,23 +7528,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3514, col: 3, offset: 109399},
+						pos: position{line: 3514, col: 3, offset: 109402},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3514, col: 3, offset: 109399},
+							pos: position{line: 3514, col: 3, offset: 109402},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3514, col: 3, offset: 109399},
+									pos:   position{line: 3514, col: 3, offset: 109402},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3514, col: 7, offset: 109403},
+										pos:  position{line: 3514, col: 7, offset: 109406},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3514, col: 20, offset: 109416},
+									pos: position{line: 3514, col: 20, offset: 109419},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3514, col: 22, offset: 109418},
+										pos:  position{line: 3514, col: 22, offset: 109421},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7552,50 +7552,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3522, col: 3, offset: 109583},
+						pos: position{line: 3522, col: 3, offset: 109586},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3522, col: 3, offset: 109583},
+							pos: position{line: 3522, col: 3, offset: 109586},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3522, col: 3, offset: 109583},
+									pos:   position{line: 3522, col: 3, offset: 109586},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3522, col: 9, offset: 109589},
+										pos:  position{line: 3522, col: 9, offset: 109592},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3522, col: 25, offset: 109605},
+									pos: position{line: 3522, col: 25, offset: 109608},
 									expr: &choiceExpr{
-										pos: position{line: 3522, col: 27, offset: 109607},
+										pos: position{line: 3522, col: 27, offset: 109610},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 27, offset: 109607},
+												pos:  position{line: 3522, col: 27, offset: 109610},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 36, offset: 109616},
+												pos:  position{line: 3522, col: 36, offset: 109619},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 46, offset: 109626},
+												pos:  position{line: 3522, col: 46, offset: 109629},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 54, offset: 109634},
+												pos:  position{line: 3522, col: 54, offset: 109637},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 62, offset: 109642},
+												pos:  position{line: 3522, col: 62, offset: 109645},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3522, col: 70, offset: 109650},
+												pos:  position{line: 3522, col: 70, offset: 109653},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3522, col: 84, offset: 109664},
+												pos:        position{line: 3522, col: 84, offset: 109667},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7607,13 +7607,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3530, col: 3, offset: 109814},
+						pos: position{line: 3530, col: 3, offset: 109817},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3530, col: 3, offset: 109814},
+							pos:   position{line: 3530, col: 3, offset: 109817},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3530, col: 10, offset: 109821},
+								pos:  position{line: 3530, col: 10, offset: 109824},
 								name: "ConcatExpr",
 							},
 						},
@@ -7623,35 +7623,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3540, col: 1, offset: 110027},
+			pos:  position{line: 3540, col: 1, offset: 110030},
 			expr: &actionExpr{
-				pos: position{line: 3540, col: 15, offset: 110041},
+				pos: position{line: 3540, col: 15, offset: 110044},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3540, col: 15, offset: 110041},
+					pos: position{line: 3540, col: 15, offset: 110044},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3540, col: 15, offset: 110041},
+							pos:   position{line: 3540, col: 15, offset: 110044},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3540, col: 21, offset: 110047},
+								pos:  position{line: 3540, col: 21, offset: 110050},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3540, col: 32, offset: 110058},
+							pos:   position{line: 3540, col: 32, offset: 110061},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3540, col: 37, offset: 110063},
+								pos: position{line: 3540, col: 37, offset: 110066},
 								expr: &seqExpr{
-									pos: position{line: 3540, col: 38, offset: 110064},
+									pos: position{line: 3540, col: 38, offset: 110067},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3540, col: 38, offset: 110064},
+											pos:  position{line: 3540, col: 38, offset: 110067},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3540, col: 50, offset: 110076},
+											pos:  position{line: 3540, col: 50, offset: 110079},
 											name: "ConcatAtom",
 										},
 									},
@@ -7659,28 +7659,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3540, col: 63, offset: 110089},
+							pos: position{line: 3540, col: 63, offset: 110092},
 							expr: &choiceExpr{
-								pos: position{line: 3540, col: 65, offset: 110091},
+								pos: position{line: 3540, col: 65, offset: 110094},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3540, col: 65, offset: 110091},
+										pos:  position{line: 3540, col: 65, offset: 110094},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3540, col: 74, offset: 110100},
+										pos:  position{line: 3540, col: 74, offset: 110103},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3540, col: 84, offset: 110110},
+										pos:  position{line: 3540, col: 84, offset: 110113},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3540, col: 92, offset: 110118},
+										pos:  position{line: 3540, col: 92, offset: 110121},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3540, col: 100, offset: 110126},
+										pos:        position{line: 3540, col: 100, offset: 110129},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7694,54 +7694,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3558, col: 1, offset: 110532},
+			pos:  position{line: 3558, col: 1, offset: 110535},
 			expr: &choiceExpr{
-				pos: position{line: 3558, col: 15, offset: 110546},
+				pos: position{line: 3558, col: 15, offset: 110549},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3558, col: 15, offset: 110546},
+						pos: position{line: 3558, col: 15, offset: 110549},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3558, col: 15, offset: 110546},
+							pos:   position{line: 3558, col: 15, offset: 110549},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3558, col: 20, offset: 110551},
+								pos:  position{line: 3558, col: 20, offset: 110554},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3567, col: 3, offset: 110715},
+						pos: position{line: 3567, col: 3, offset: 110718},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3567, col: 3, offset: 110715},
+							pos:   position{line: 3567, col: 3, offset: 110718},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3567, col: 7, offset: 110719},
+								pos:  position{line: 3567, col: 7, offset: 110722},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3575, col: 3, offset: 110858},
+						pos: position{line: 3575, col: 3, offset: 110861},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3575, col: 3, offset: 110858},
+							pos:   position{line: 3575, col: 3, offset: 110861},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3575, col: 10, offset: 110865},
+								pos:  position{line: 3575, col: 10, offset: 110868},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3583, col: 3, offset: 111004},
+						pos: position{line: 3583, col: 3, offset: 111007},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3583, col: 3, offset: 111004},
+							pos:   position{line: 3583, col: 3, offset: 111007},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3583, col: 9, offset: 111010},
+								pos:  position{line: 3583, col: 9, offset: 111013},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7751,32 +7751,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3593, col: 1, offset: 111179},
+			pos:  position{line: 3593, col: 1, offset: 111182},
 			expr: &actionExpr{
-				pos: position{line: 3593, col: 16, offset: 111194},
+				pos: position{line: 3593, col: 16, offset: 111197},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3593, col: 16, offset: 111194},
+					pos: position{line: 3593, col: 16, offset: 111197},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3593, col: 16, offset: 111194},
+							pos:   position{line: 3593, col: 16, offset: 111197},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3593, col: 21, offset: 111199},
+								pos:  position{line: 3593, col: 21, offset: 111202},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3593, col: 39, offset: 111217},
+							pos: position{line: 3593, col: 39, offset: 111220},
 							expr: &choiceExpr{
-								pos: position{line: 3593, col: 41, offset: 111219},
+								pos: position{line: 3593, col: 41, offset: 111222},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3593, col: 41, offset: 111219},
+										pos:  position{line: 3593, col: 41, offset: 111222},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3593, col: 55, offset: 111233},
+										pos:        position{line: 3593, col: 55, offset: 111236},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7790,44 +7790,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3598, col: 1, offset: 111298},
+			pos:  position{line: 3598, col: 1, offset: 111301},
 			expr: &actionExpr{
-				pos: position{line: 3598, col: 22, offset: 111319},
+				pos: position{line: 3598, col: 22, offset: 111322},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3598, col: 22, offset: 111319},
+					pos: position{line: 3598, col: 22, offset: 111322},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3598, col: 22, offset: 111319},
+							pos:   position{line: 3598, col: 22, offset: 111322},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3598, col: 28, offset: 111325},
+								pos:  position{line: 3598, col: 28, offset: 111328},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3598, col: 46, offset: 111343},
+							pos:   position{line: 3598, col: 46, offset: 111346},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3598, col: 51, offset: 111348},
+								pos: position{line: 3598, col: 51, offset: 111351},
 								expr: &seqExpr{
-									pos: position{line: 3598, col: 52, offset: 111349},
+									pos: position{line: 3598, col: 52, offset: 111352},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3598, col: 53, offset: 111350},
+											pos: position{line: 3598, col: 53, offset: 111353},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3598, col: 53, offset: 111350},
+													pos:  position{line: 3598, col: 53, offset: 111353},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3598, col: 62, offset: 111359},
+													pos:  position{line: 3598, col: 62, offset: 111362},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3598, col: 71, offset: 111368},
+											pos:  position{line: 3598, col: 71, offset: 111371},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7840,48 +7840,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3619, col: 1, offset: 111869},
+			pos:  position{line: 3619, col: 1, offset: 111872},
 			expr: &actionExpr{
-				pos: position{line: 3619, col: 22, offset: 111890},
+				pos: position{line: 3619, col: 22, offset: 111893},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3619, col: 22, offset: 111890},
+					pos: position{line: 3619, col: 22, offset: 111893},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3619, col: 22, offset: 111890},
+							pos:   position{line: 3619, col: 22, offset: 111893},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3619, col: 28, offset: 111896},
+								pos:  position{line: 3619, col: 28, offset: 111899},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3619, col: 46, offset: 111914},
+							pos:   position{line: 3619, col: 46, offset: 111917},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3619, col: 51, offset: 111919},
+								pos: position{line: 3619, col: 51, offset: 111922},
 								expr: &seqExpr{
-									pos: position{line: 3619, col: 52, offset: 111920},
+									pos: position{line: 3619, col: 52, offset: 111923},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3619, col: 53, offset: 111921},
+											pos: position{line: 3619, col: 53, offset: 111924},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3619, col: 53, offset: 111921},
+													pos:  position{line: 3619, col: 53, offset: 111924},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3619, col: 61, offset: 111929},
+													pos:  position{line: 3619, col: 61, offset: 111932},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3619, col: 69, offset: 111937},
+													pos:  position{line: 3619, col: 69, offset: 111940},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3619, col: 76, offset: 111944},
+											pos:  position{line: 3619, col: 76, offset: 111947},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7894,22 +7894,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3639, col: 1, offset: 112413},
+			pos:  position{line: 3639, col: 1, offset: 112416},
 			expr: &actionExpr{
-				pos: position{line: 3639, col: 21, offset: 112433},
+				pos: position{line: 3639, col: 21, offset: 112436},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3639, col: 21, offset: 112433},
+					pos: position{line: 3639, col: 21, offset: 112436},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3639, col: 21, offset: 112433},
+							pos:  position{line: 3639, col: 21, offset: 112436},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3639, col: 27, offset: 112439},
+							pos:   position{line: 3639, col: 27, offset: 112442},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3639, col: 32, offset: 112444},
+								pos:  position{line: 3639, col: 32, offset: 112447},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7919,67 +7919,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3649, col: 1, offset: 112688},
+			pos:  position{line: 3649, col: 1, offset: 112691},
 			expr: &choiceExpr{
-				pos: position{line: 3649, col: 22, offset: 112709},
+				pos: position{line: 3649, col: 22, offset: 112712},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3649, col: 22, offset: 112709},
+						pos: position{line: 3649, col: 22, offset: 112712},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3649, col: 22, offset: 112709},
+							pos: position{line: 3649, col: 22, offset: 112712},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3649, col: 22, offset: 112709},
+									pos:  position{line: 3649, col: 22, offset: 112712},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3649, col: 30, offset: 112717},
+									pos:   position{line: 3649, col: 30, offset: 112720},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3649, col: 35, offset: 112722},
+										pos:  position{line: 3649, col: 35, offset: 112725},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3649, col: 53, offset: 112740},
+									pos:  position{line: 3649, col: 53, offset: 112743},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3652, col: 3, offset: 112775},
+						pos: position{line: 3652, col: 3, offset: 112778},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3652, col: 3, offset: 112775},
+							pos:   position{line: 3652, col: 3, offset: 112778},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3652, col: 20, offset: 112792},
+								pos:  position{line: 3652, col: 20, offset: 112795},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3655, col: 3, offset: 112846},
+						pos: position{line: 3655, col: 3, offset: 112849},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3655, col: 3, offset: 112846},
+							pos:   position{line: 3655, col: 3, offset: 112849},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3655, col: 9, offset: 112852},
+								pos:  position{line: 3655, col: 9, offset: 112855},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3665, col: 3, offset: 113071},
+						pos: position{line: 3665, col: 3, offset: 113074},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3665, col: 3, offset: 113071},
+							pos:   position{line: 3665, col: 3, offset: 113074},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3665, col: 10, offset: 113078},
+								pos:  position{line: 3665, col: 10, offset: 113081},
 								name: "NumberAsString",
 							},
 						},
@@ -7989,144 +7989,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3678, col: 1, offset: 113456},
+			pos:  position{line: 3678, col: 1, offset: 113459},
 			expr: &choiceExpr{
-				pos: position{line: 3678, col: 20, offset: 113475},
+				pos: position{line: 3678, col: 20, offset: 113478},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3678, col: 20, offset: 113475},
+						pos: position{line: 3678, col: 20, offset: 113478},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3678, col: 21, offset: 113476},
+							pos: position{line: 3678, col: 21, offset: 113479},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3678, col: 21, offset: 113476},
+									pos:   position{line: 3678, col: 21, offset: 113479},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3678, col: 29, offset: 113484},
+										pos: position{line: 3678, col: 29, offset: 113487},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3678, col: 29, offset: 113484},
+												pos:        position{line: 3678, col: 29, offset: 113487},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 37, offset: 113492},
+												pos:        position{line: 3678, col: 37, offset: 113495},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 46, offset: 113501},
+												pos:        position{line: 3678, col: 46, offset: 113504},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 58, offset: 113513},
+												pos:        position{line: 3678, col: 58, offset: 113516},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 67, offset: 113522},
+												pos:        position{line: 3678, col: 67, offset: 113525},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 77, offset: 113532},
+												pos:        position{line: 3678, col: 77, offset: 113535},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 85, offset: 113540},
+												pos:        position{line: 3678, col: 85, offset: 113543},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 95, offset: 113550},
+												pos:        position{line: 3678, col: 95, offset: 113553},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 102, offset: 113557},
+												pos:        position{line: 3678, col: 102, offset: 113560},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 113, offset: 113568},
+												pos:        position{line: 3678, col: 113, offset: 113571},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 123, offset: 113578},
+												pos:        position{line: 3678, col: 123, offset: 113581},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 132, offset: 113587},
+												pos:        position{line: 3678, col: 132, offset: 113590},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 142, offset: 113597},
+												pos:        position{line: 3678, col: 142, offset: 113600},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 151, offset: 113606},
+												pos:        position{line: 3678, col: 151, offset: 113609},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 161, offset: 113616},
+												pos:        position{line: 3678, col: 161, offset: 113619},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 170, offset: 113625},
+												pos:        position{line: 3678, col: 170, offset: 113628},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 179, offset: 113634},
+												pos:        position{line: 3678, col: 179, offset: 113637},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 187, offset: 113642},
+												pos:        position{line: 3678, col: 187, offset: 113645},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 196, offset: 113651},
+												pos:        position{line: 3678, col: 196, offset: 113654},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 204, offset: 113659},
+												pos:        position{line: 3678, col: 204, offset: 113662},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3678, col: 213, offset: 113668},
+												pos:        position{line: 3678, col: 213, offset: 113671},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -8135,102 +8135,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3678, col: 220, offset: 113675},
+									pos:  position{line: 3678, col: 220, offset: 113678},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3678, col: 228, offset: 113683},
+									pos:   position{line: 3678, col: 228, offset: 113686},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3678, col: 234, offset: 113689},
+										pos:  position{line: 3678, col: 234, offset: 113692},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3678, col: 253, offset: 113708},
+									pos:  position{line: 3678, col: 253, offset: 113711},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3698, col: 3, offset: 114220},
+						pos: position{line: 3698, col: 3, offset: 114223},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3698, col: 3, offset: 114220},
+							pos: position{line: 3698, col: 3, offset: 114223},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3698, col: 3, offset: 114220},
+									pos:   position{line: 3698, col: 3, offset: 114223},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3698, col: 13, offset: 114230},
+										pos:        position{line: 3698, col: 13, offset: 114233},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3698, col: 21, offset: 114238},
+									pos:  position{line: 3698, col: 21, offset: 114241},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3698, col: 29, offset: 114246},
+									pos:   position{line: 3698, col: 29, offset: 114249},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3698, col: 35, offset: 114252},
+										pos:  position{line: 3698, col: 35, offset: 114255},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3698, col: 54, offset: 114271},
+									pos:   position{line: 3698, col: 54, offset: 114274},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3698, col: 69, offset: 114286},
+										pos: position{line: 3698, col: 69, offset: 114289},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3698, col: 70, offset: 114287},
+											pos:  position{line: 3698, col: 70, offset: 114290},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3698, col: 89, offset: 114306},
+									pos:  position{line: 3698, col: 89, offset: 114309},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3719, col: 3, offset: 114924},
+						pos: position{line: 3719, col: 3, offset: 114927},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3719, col: 4, offset: 114925},
+							pos: position{line: 3719, col: 4, offset: 114928},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3719, col: 4, offset: 114925},
+									pos:   position{line: 3719, col: 4, offset: 114928},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3719, col: 12, offset: 114933},
+										pos: position{line: 3719, col: 12, offset: 114936},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3719, col: 12, offset: 114933},
+												pos:        position{line: 3719, col: 12, offset: 114936},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3719, col: 20, offset: 114941},
+												pos:        position{line: 3719, col: 20, offset: 114944},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3719, col: 27, offset: 114948},
+												pos:        position{line: 3719, col: 27, offset: 114951},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3719, col: 38, offset: 114959},
+												pos:        position{line: 3719, col: 38, offset: 114962},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -8239,54 +8239,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 46, offset: 114967},
+									pos:  position{line: 3719, col: 46, offset: 114970},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 54, offset: 114975},
+									pos:  position{line: 3719, col: 54, offset: 114978},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3732, col: 3, offset: 115261},
+						pos: position{line: 3732, col: 3, offset: 115264},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3732, col: 3, offset: 115261},
+							pos: position{line: 3732, col: 3, offset: 115264},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3732, col: 3, offset: 115261},
+									pos:        position{line: 3732, col: 3, offset: 115264},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 14, offset: 115272},
+									pos:  position{line: 3732, col: 14, offset: 115275},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3732, col: 22, offset: 115280},
+									pos:   position{line: 3732, col: 22, offset: 115283},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3732, col: 33, offset: 115291},
+										pos:  position{line: 3732, col: 33, offset: 115294},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3732, col: 44, offset: 115302},
+									pos:   position{line: 3732, col: 44, offset: 115305},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3732, col: 53, offset: 115311},
+										pos: position{line: 3732, col: 53, offset: 115314},
 										expr: &seqExpr{
-											pos: position{line: 3732, col: 54, offset: 115312},
+											pos: position{line: 3732, col: 54, offset: 115315},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3732, col: 54, offset: 115312},
+													pos:  position{line: 3732, col: 54, offset: 115315},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3732, col: 60, offset: 115318},
+													pos:  position{line: 3732, col: 60, offset: 115321},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8294,38 +8294,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3732, col: 80, offset: 115338},
+									pos:  position{line: 3732, col: 80, offset: 115341},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3760, col: 3, offset: 116181},
+						pos: position{line: 3760, col: 3, offset: 116184},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3760, col: 4, offset: 116182},
+							pos: position{line: 3760, col: 4, offset: 116185},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3760, col: 4, offset: 116182},
+									pos:   position{line: 3760, col: 4, offset: 116185},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3760, col: 12, offset: 116190},
+										pos: position{line: 3760, col: 12, offset: 116193},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3760, col: 12, offset: 116190},
+												pos:        position{line: 3760, col: 12, offset: 116193},
 												val:        "bit_and",
 												ignoreCase: false,
 												want:       "\"bit_and\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3760, col: 24, offset: 116202},
+												pos:        position{line: 3760, col: 24, offset: 116205},
 												val:        "bit_or",
 												ignoreCase: false,
 												want:       "\"bit_or\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3760, col: 35, offset: 116213},
+												pos:        position{line: 3760, col: 35, offset: 116216},
 												val:        "bit_xor",
 												ignoreCase: false,
 												want:       "\"bit_xor\"",
@@ -8334,43 +8334,43 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3760, col: 46, offset: 116224},
+									pos:  position{line: 3760, col: 46, offset: 116227},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3760, col: 54, offset: 116232},
+									pos:   position{line: 3760, col: 54, offset: 116235},
 									label: "firstArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3760, col: 63, offset: 116241},
+										pos:  position{line: 3760, col: 63, offset: 116244},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3760, col: 81, offset: 116259},
+									pos:  position{line: 3760, col: 81, offset: 116262},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3760, col: 87, offset: 116265},
+									pos:   position{line: 3760, col: 87, offset: 116268},
 									label: "secondArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3760, col: 97, offset: 116275},
+										pos:  position{line: 3760, col: 97, offset: 116278},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3760, col: 115, offset: 116293},
+									pos:   position{line: 3760, col: 115, offset: 116296},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3760, col: 120, offset: 116298},
+										pos: position{line: 3760, col: 120, offset: 116301},
 										expr: &seqExpr{
-											pos: position{line: 3760, col: 121, offset: 116299},
+											pos: position{line: 3760, col: 121, offset: 116302},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3760, col: 121, offset: 116299},
+													pos:  position{line: 3760, col: 121, offset: 116302},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3760, col: 127, offset: 116305},
+													pos:  position{line: 3760, col: 127, offset: 116308},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8378,38 +8378,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3760, col: 147, offset: 116325},
+									pos:  position{line: 3760, col: 147, offset: 116328},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3796, col: 3, offset: 117422},
+						pos: position{line: 3796, col: 3, offset: 117425},
 						run: (*parser).callonNumericEvalExpr83,
 						expr: &seqExpr{
-							pos: position{line: 3796, col: 4, offset: 117423},
+							pos: position{line: 3796, col: 4, offset: 117426},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3796, col: 4, offset: 117423},
+									pos:   position{line: 3796, col: 4, offset: 117426},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3796, col: 12, offset: 117431},
+										pos: position{line: 3796, col: 12, offset: 117434},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3796, col: 12, offset: 117431},
+												pos:        position{line: 3796, col: 12, offset: 117434},
 												val:        "bit_not",
 												ignoreCase: false,
 												want:       "\"bit_not\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3796, col: 24, offset: 117443},
+												pos:        position{line: 3796, col: 24, offset: 117446},
 												val:        "bit_shift_left",
 												ignoreCase: false,
 												want:       "\"bit_shift_left\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3796, col: 43, offset: 117462},
+												pos:        position{line: 3796, col: 43, offset: 117465},
 												val:        "bit_shift_right",
 												ignoreCase: false,
 												want:       "\"bit_shift_right\"",
@@ -8418,31 +8418,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3796, col: 62, offset: 117481},
+									pos:  position{line: 3796, col: 62, offset: 117484},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3796, col: 70, offset: 117489},
+									pos:   position{line: 3796, col: 70, offset: 117492},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3796, col: 75, offset: 117494},
+										pos:  position{line: 3796, col: 75, offset: 117497},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3796, col: 93, offset: 117512},
+									pos:   position{line: 3796, col: 93, offset: 117515},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3796, col: 99, offset: 117518},
+										pos: position{line: 3796, col: 99, offset: 117521},
 										expr: &seqExpr{
-											pos: position{line: 3796, col: 100, offset: 117519},
+											pos: position{line: 3796, col: 100, offset: 117522},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3796, col: 100, offset: 117519},
+													pos:  position{line: 3796, col: 100, offset: 117522},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3796, col: 106, offset: 117525},
+													pos:  position{line: 3796, col: 106, offset: 117528},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8450,73 +8450,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3796, col: 126, offset: 117545},
+									pos:  position{line: 3796, col: 126, offset: 117548},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3823, col: 3, offset: 118469},
+						pos: position{line: 3823, col: 3, offset: 118472},
 						run: (*parser).callonNumericEvalExpr99,
 						expr: &seqExpr{
-							pos: position{line: 3823, col: 3, offset: 118469},
+							pos: position{line: 3823, col: 3, offset: 118472},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3823, col: 3, offset: 118469},
+									pos:   position{line: 3823, col: 3, offset: 118472},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3823, col: 12, offset: 118478},
+										pos:        position{line: 3823, col: 12, offset: 118481},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3823, col: 18, offset: 118484},
+									pos:  position{line: 3823, col: 18, offset: 118487},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3823, col: 26, offset: 118492},
+									pos:   position{line: 3823, col: 26, offset: 118495},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3823, col: 31, offset: 118497},
+										pos:  position{line: 3823, col: 31, offset: 118500},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3823, col: 39, offset: 118505},
+									pos:  position{line: 3823, col: 39, offset: 118508},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3826, col: 3, offset: 118540},
+						pos: position{line: 3826, col: 3, offset: 118543},
 						run: (*parser).callonNumericEvalExpr107,
 						expr: &seqExpr{
-							pos: position{line: 3826, col: 4, offset: 118541},
+							pos: position{line: 3826, col: 4, offset: 118544},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3826, col: 4, offset: 118541},
+									pos:   position{line: 3826, col: 4, offset: 118544},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3826, col: 12, offset: 118549},
+										pos: position{line: 3826, col: 12, offset: 118552},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3826, col: 12, offset: 118549},
+												pos:        position{line: 3826, col: 12, offset: 118552},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3826, col: 20, offset: 118557},
+												pos:        position{line: 3826, col: 20, offset: 118560},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3826, col: 30, offset: 118567},
+												pos:        position{line: 3826, col: 30, offset: 118570},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8525,128 +8525,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3826, col: 39, offset: 118576},
+									pos:  position{line: 3826, col: 39, offset: 118579},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3826, col: 47, offset: 118584},
+									pos:   position{line: 3826, col: 47, offset: 118587},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3826, col: 53, offset: 118590},
+										pos:  position{line: 3826, col: 53, offset: 118593},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3826, col: 72, offset: 118609},
+									pos:   position{line: 3826, col: 72, offset: 118612},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3826, col: 79, offset: 118616},
+										pos:  position{line: 3826, col: 79, offset: 118619},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3826, col: 97, offset: 118634},
+									pos:  position{line: 3826, col: 97, offset: 118637},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3856, col: 3, offset: 119473},
+						pos: position{line: 3856, col: 3, offset: 119476},
 						run: (*parser).callonNumericEvalExpr120,
 						expr: &seqExpr{
-							pos: position{line: 3856, col: 4, offset: 119474},
+							pos: position{line: 3856, col: 4, offset: 119477},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3856, col: 4, offset: 119474},
+									pos:   position{line: 3856, col: 4, offset: 119477},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3856, col: 11, offset: 119481},
+										pos:        position{line: 3856, col: 11, offset: 119484},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3856, col: 17, offset: 119487},
+									pos:  position{line: 3856, col: 17, offset: 119490},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3856, col: 25, offset: 119495},
+									pos:   position{line: 3856, col: 25, offset: 119498},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3856, col: 31, offset: 119501},
+										pos:  position{line: 3856, col: 31, offset: 119504},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3856, col: 50, offset: 119520},
+									pos:   position{line: 3856, col: 50, offset: 119523},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3856, col: 56, offset: 119526},
+										pos: position{line: 3856, col: 56, offset: 119529},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3856, col: 57, offset: 119527},
+											pos:  position{line: 3856, col: 57, offset: 119530},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3856, col: 76, offset: 119546},
+									pos:  position{line: 3856, col: 76, offset: 119549},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3885, col: 3, offset: 120319},
+						pos: position{line: 3885, col: 3, offset: 120322},
 						run: (*parser).callonNumericEvalExpr131,
 						expr: &seqExpr{
-							pos: position{line: 3885, col: 3, offset: 120319},
+							pos: position{line: 3885, col: 3, offset: 120322},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3885, col: 3, offset: 120319},
+									pos:   position{line: 3885, col: 3, offset: 120322},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3885, col: 11, offset: 120327},
+										pos:        position{line: 3885, col: 11, offset: 120330},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3885, col: 28, offset: 120344},
+									pos:  position{line: 3885, col: 28, offset: 120347},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3885, col: 36, offset: 120352},
+									pos:   position{line: 3885, col: 36, offset: 120355},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3885, col: 42, offset: 120358},
+										pos:  position{line: 3885, col: 42, offset: 120361},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3885, col: 61, offset: 120377},
+									pos:  position{line: 3885, col: 61, offset: 120380},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3885, col: 67, offset: 120383},
+									pos:  position{line: 3885, col: 67, offset: 120386},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3885, col: 73, offset: 120389},
+									pos:   position{line: 3885, col: 73, offset: 120392},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3885, col: 84, offset: 120400},
+										pos:  position{line: 3885, col: 84, offset: 120403},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3885, col: 120, offset: 120436},
+									pos:  position{line: 3885, col: 120, offset: 120439},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3885, col: 126, offset: 120442},
+									pos:  position{line: 3885, col: 126, offset: 120445},
 									name: "R_PAREN",
 								},
 							},
@@ -8657,103 +8657,141 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExprLevel1",
-			pos:  position{line: 3902, col: 1, offset: 120972},
+			pos:  position{line: 3902, col: 1, offset: 120975},
 			expr: &choiceExpr{
-				pos: position{line: 3902, col: 19, offset: 120990},
+				pos: position{line: 3902, col: 19, offset: 120993},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3902, col: 19, offset: 120990},
+						pos: position{line: 3902, col: 19, offset: 120993},
 						run: (*parser).callonJsonExprLevel12,
 						expr: &labeledExpr{
-							pos:   position{line: 3902, col: 19, offset: 120990},
+							pos:   position{line: 3902, col: 19, offset: 120993},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3902, col: 28, offset: 120999},
+								pos:  position{line: 3902, col: 28, offset: 121002},
 								name: "JsonExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3905, col: 3, offset: 121039},
+						pos: position{line: 3905, col: 3, offset: 121042},
 						run: (*parser).callonJsonExprLevel15,
 						expr: &labeledExpr{
-							pos:   position{line: 3905, col: 3, offset: 121039},
-							label: "field",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3905, col: 9, offset: 121045},
-								name: "EvalFieldToRead",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 3919, col: 3, offset: 121391},
-						run: (*parser).callonJsonExprLevel18,
-						expr: &labeledExpr{
-							pos:   position{line: 3919, col: 3, offset: 121391},
+							pos:   position{line: 3905, col: 3, offset: 121042},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3919, col: 9, offset: 121397},
-								name: "NumericEvalExpr",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 3933, col: 3, offset: 121761},
-						run: (*parser).callonJsonExprLevel111,
-						expr: &labeledExpr{
-							pos:   position{line: 3933, col: 3, offset: 121761},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3933, col: 9, offset: 121767},
-								name: "NumericExprLevel3",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 3947, col: 3, offset: 122133},
-						run: (*parser).callonJsonExprLevel114,
-						expr: &labeledExpr{
-							pos:   position{line: 3947, col: 3, offset: 122133},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3947, col: 9, offset: 122139},
-								name: "MultiValueExpr",
-							},
-						},
-					},
-					&actionExpr{
-						pos: position{line: 3961, col: 3, offset: 122516},
-						run: (*parser).callonJsonExprLevel117,
-						expr: &labeledExpr{
-							pos:   position{line: 3961, col: 3, offset: 122516},
-							label: "value",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3961, col: 9, offset: 122522},
+								pos:  position{line: 3905, col: 9, offset: 121048},
 								name: "BoolExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3975, col: 3, offset: 122877},
-						run: (*parser).callonJsonExprLevel120,
+						pos: position{line: 3919, col: 3, offset: 121403},
+						run: (*parser).callonJsonExprLevel18,
+						expr: &seqExpr{
+							pos: position{line: 3919, col: 3, offset: 121403},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 3919, col: 3, offset: 121403},
+									label: "value",
+									expr: &choiceExpr{
+										pos: position{line: 3919, col: 10, offset: 121410},
+										alternatives: []any{
+											&litMatcher{
+												pos:        position{line: 3919, col: 10, offset: 121410},
+												val:        "true",
+												ignoreCase: false,
+												want:       "\"true\"",
+											},
+											&litMatcher{
+												pos:        position{line: 3919, col: 19, offset: 121419},
+												val:        "false",
+												ignoreCase: false,
+												want:       "\"false\"",
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3919, col: 28, offset: 121428},
+									name: "L_PAREN",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3919, col: 36, offset: 121436},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3932, col: 3, offset: 121815},
+						run: (*parser).callonJsonExprLevel116,
 						expr: &labeledExpr{
-							pos:   position{line: 3975, col: 3, offset: 122877},
+							pos:   position{line: 3932, col: 3, offset: 121815},
+							label: "field",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3932, col: 9, offset: 121821},
+								name: "EvalFieldToRead",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3946, col: 3, offset: 122167},
+						run: (*parser).callonJsonExprLevel119,
+						expr: &labeledExpr{
+							pos:   position{line: 3946, col: 3, offset: 122167},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3946, col: 9, offset: 122173},
+								name: "NumericEvalExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3960, col: 3, offset: 122537},
+						run: (*parser).callonJsonExprLevel122,
+						expr: &labeledExpr{
+							pos:   position{line: 3960, col: 3, offset: 122537},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3960, col: 9, offset: 122543},
+								name: "NumericExprLevel3",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3974, col: 3, offset: 122909},
+						run: (*parser).callonJsonExprLevel125,
+						expr: &labeledExpr{
+							pos:   position{line: 3974, col: 3, offset: 122909},
+							label: "value",
+							expr: &ruleRefExpr{
+								pos:  position{line: 3974, col: 9, offset: 122915},
+								name: "MultiValueExpr",
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3988, col: 3, offset: 123292},
+						run: (*parser).callonJsonExprLevel128,
+						expr: &labeledExpr{
+							pos:   position{line: 3988, col: 3, offset: 123292},
 							label: "value",
 							expr: &seqExpr{
-								pos: position{line: 3975, col: 10, offset: 122884},
+								pos: position{line: 3988, col: 10, offset: 123299},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 3975, col: 10, offset: 122884},
+										pos:        position{line: 3988, col: 10, offset: 123299},
 										val:        "null",
 										ignoreCase: false,
 										want:       "\"null\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3975, col: 17, offset: 122891},
+										pos:  position{line: 3988, col: 17, offset: 123306},
 										name: "L_PAREN",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3975, col: 25, offset: 122899},
+										pos:  position{line: 3988, col: 25, offset: 123314},
 										name: "R_PAREN",
 									},
 								},
@@ -8761,13 +8799,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3985, col: 3, offset: 123094},
-						run: (*parser).callonJsonExprLevel126,
+						pos: position{line: 3998, col: 3, offset: 123509},
+						run: (*parser).callonJsonExprLevel134,
 						expr: &labeledExpr{
-							pos:   position{line: 3985, col: 3, offset: 123094},
+							pos:   position{line: 3998, col: 3, offset: 123509},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3985, col: 9, offset: 123100},
+								pos:  position{line: 3998, col: 9, offset: 123515},
 								name: "StringExpr",
 							},
 						},
@@ -8777,68 +8815,68 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExpr",
-			pos:  position{line: 4000, col: 1, offset: 123463},
+			pos:  position{line: 4013, col: 1, offset: 123878},
 			expr: &choiceExpr{
-				pos: position{line: 4000, col: 13, offset: 123475},
+				pos: position{line: 4013, col: 13, offset: 123890},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4000, col: 13, offset: 123475},
+						pos: position{line: 4013, col: 13, offset: 123890},
 						run: (*parser).callonJsonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 4000, col: 13, offset: 123475},
+							pos: position{line: 4013, col: 13, offset: 123890},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4000, col: 13, offset: 123475},
+									pos:        position{line: 4013, col: 13, offset: 123890},
 									val:        "json_object",
 									ignoreCase: false,
 									want:       "\"json_object\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4000, col: 27, offset: 123489},
+									pos:  position{line: 4013, col: 27, offset: 123904},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4000, col: 35, offset: 123497},
+									pos:   position{line: 4013, col: 35, offset: 123912},
 									label: "firstKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4000, col: 45, offset: 123507},
+										pos:  position{line: 4013, col: 45, offset: 123922},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4000, col: 61, offset: 123523},
+									pos:  position{line: 4013, col: 61, offset: 123938},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 4000, col: 67, offset: 123529},
+									pos:   position{line: 4013, col: 67, offset: 123944},
 									label: "firstValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4000, col: 79, offset: 123541},
+										pos:  position{line: 4013, col: 79, offset: 123956},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4000, col: 95, offset: 123557},
+									pos:   position{line: 4013, col: 95, offset: 123972},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4000, col: 100, offset: 123562},
+										pos: position{line: 4013, col: 100, offset: 123977},
 										expr: &seqExpr{
-											pos: position{line: 4000, col: 101, offset: 123563},
+											pos: position{line: 4013, col: 101, offset: 123978},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 101, offset: 123563},
+													pos:  position{line: 4013, col: 101, offset: 123978},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 107, offset: 123569},
+													pos:  position{line: 4013, col: 107, offset: 123984},
 													name: "JsonExprLevel1",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 122, offset: 123584},
+													pos:  position{line: 4013, col: 122, offset: 123999},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4000, col: 128, offset: 123590},
+													pos:  position{line: 4013, col: 128, offset: 124005},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -8846,44 +8884,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4000, col: 145, offset: 123607},
+									pos:  position{line: 4013, col: 145, offset: 124022},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4008, col: 3, offset: 123787},
+						pos: position{line: 4021, col: 3, offset: 124202},
 						run: (*parser).callonJsonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 4008, col: 3, offset: 123787},
+							pos: position{line: 4021, col: 3, offset: 124202},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4008, col: 3, offset: 123787},
+									pos:   position{line: 4021, col: 3, offset: 124202},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 4008, col: 11, offset: 123795},
+										pos: position{line: 4021, col: 11, offset: 124210},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 4008, col: 11, offset: 123795},
+												pos:        position{line: 4021, col: 11, offset: 124210},
 												val:        "json",
 												ignoreCase: false,
 												want:       "\"json\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4008, col: 20, offset: 123804},
+												pos:        position{line: 4021, col: 20, offset: 124219},
 												val:        "json_entries",
 												ignoreCase: false,
 												want:       "\"json_entries\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4008, col: 37, offset: 123821},
+												pos:        position{line: 4021, col: 37, offset: 124236},
 												val:        "json_keys",
 												ignoreCase: false,
 												want:       "\"json_keys\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4008, col: 51, offset: 123835},
+												pos:        position{line: 4021, col: 51, offset: 124250},
 												val:        "json_valid",
 												ignoreCase: false,
 												want:       "\"json_valid\"",
@@ -8892,56 +8930,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4008, col: 65, offset: 123849},
+									pos:  position{line: 4021, col: 65, offset: 124264},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4008, col: 73, offset: 123857},
+									pos:   position{line: 4021, col: 73, offset: 124272},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4008, col: 79, offset: 123863},
+										pos:  position{line: 4021, col: 79, offset: 124278},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4008, col: 94, offset: 123878},
+									pos:  position{line: 4021, col: 94, offset: 124293},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4034, col: 3, offset: 125088},
+						pos: position{line: 4047, col: 3, offset: 125506},
 						run: (*parser).callonJsonExpr31,
 						expr: &seqExpr{
-							pos: position{line: 4034, col: 3, offset: 125088},
+							pos: position{line: 4047, col: 3, offset: 125506},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4034, col: 3, offset: 125088},
+									pos:   position{line: 4047, col: 3, offset: 125506},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 4034, col: 11, offset: 125096},
+										pos: position{line: 4047, col: 11, offset: 125514},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 4034, col: 11, offset: 125096},
+												pos:        position{line: 4047, col: 11, offset: 125514},
 												val:        "json_append",
 												ignoreCase: false,
 												want:       "\"json_append\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4034, col: 27, offset: 125112},
+												pos:        position{line: 4047, col: 27, offset: 125530},
 												val:        "json_extend",
 												ignoreCase: false,
 												want:       "\"json_extend\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4034, col: 43, offset: 125128},
+												pos:        position{line: 4047, col: 43, offset: 125546},
 												val:        "json_set",
 												ignoreCase: false,
 												want:       "\"json_set\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4034, col: 56, offset: 125141},
+												pos:        position{line: 4047, col: 56, offset: 125559},
 												val:        "json_set_exact",
 												ignoreCase: false,
 												want:       "\"json_set_exact\"",
@@ -8950,63 +8988,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4034, col: 74, offset: 125159},
+									pos:  position{line: 4047, col: 74, offset: 125577},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4034, col: 82, offset: 125167},
+									pos:   position{line: 4047, col: 82, offset: 125585},
 									label: "json",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4034, col: 87, offset: 125172},
+										pos:  position{line: 4047, col: 87, offset: 125590},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4034, col: 102, offset: 125187},
+									pos:  position{line: 4047, col: 102, offset: 125605},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 4034, col: 108, offset: 125193},
+									pos:   position{line: 4047, col: 108, offset: 125611},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4034, col: 113, offset: 125198},
+										pos:  position{line: 4047, col: 113, offset: 125616},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4034, col: 128, offset: 125213},
+									pos:  position{line: 4047, col: 128, offset: 125631},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 4034, col: 134, offset: 125219},
+									pos:   position{line: 4047, col: 134, offset: 125637},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4034, col: 140, offset: 125225},
+										pos:  position{line: 4047, col: 140, offset: 125643},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4034, col: 155, offset: 125240},
+									pos:   position{line: 4047, col: 155, offset: 125658},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4034, col: 160, offset: 125245},
+										pos: position{line: 4047, col: 160, offset: 125663},
 										expr: &seqExpr{
-											pos: position{line: 4034, col: 161, offset: 125246},
+											pos: position{line: 4047, col: 161, offset: 125664},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4034, col: 161, offset: 125246},
+													pos:  position{line: 4047, col: 161, offset: 125664},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4034, col: 167, offset: 125252},
+													pos:  position{line: 4047, col: 167, offset: 125670},
 													name: "JsonExprLevel1",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4034, col: 182, offset: 125267},
+													pos:  position{line: 4047, col: 182, offset: 125685},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4034, col: 188, offset: 125273},
+													pos:  position{line: 4047, col: 188, offset: 125691},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -9014,50 +9052,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4034, col: 205, offset: 125290},
+									pos:  position{line: 4047, col: 205, offset: 125708},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4073, col: 3, offset: 126917},
+						pos: position{line: 4086, col: 3, offset: 127335},
 						run: (*parser).callonJsonExpr56,
 						expr: &seqExpr{
-							pos: position{line: 4073, col: 3, offset: 126917},
+							pos: position{line: 4086, col: 3, offset: 127335},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4073, col: 3, offset: 126917},
+									pos:        position{line: 4086, col: 3, offset: 127335},
 									val:        "json_array",
 									ignoreCase: false,
 									want:       "\"json_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4073, col: 16, offset: 126930},
+									pos:  position{line: 4086, col: 16, offset: 127348},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4073, col: 24, offset: 126938},
+									pos:   position{line: 4086, col: 24, offset: 127356},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4073, col: 30, offset: 126944},
+										pos:  position{line: 4086, col: 30, offset: 127362},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4073, col: 45, offset: 126959},
+									pos:   position{line: 4086, col: 45, offset: 127377},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4073, col: 50, offset: 126964},
+										pos: position{line: 4086, col: 50, offset: 127382},
 										expr: &seqExpr{
-											pos: position{line: 4073, col: 51, offset: 126965},
+											pos: position{line: 4086, col: 51, offset: 127383},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4073, col: 51, offset: 126965},
+													pos:  position{line: 4086, col: 51, offset: 127383},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4073, col: 57, offset: 126971},
+													pos:  position{line: 4086, col: 57, offset: 127389},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -9065,75 +9103,75 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4073, col: 74, offset: 126988},
+									pos:  position{line: 4086, col: 74, offset: 127406},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4081, col: 3, offset: 127143},
+						pos: position{line: 4094, col: 3, offset: 127561},
 						run: (*parser).callonJsonExpr68,
 						expr: &seqExpr{
-							pos: position{line: 4081, col: 3, offset: 127143},
+							pos: position{line: 4094, col: 3, offset: 127561},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4081, col: 3, offset: 127143},
+									pos:        position{line: 4094, col: 3, offset: 127561},
 									val:        "json_delete",
 									ignoreCase: false,
 									want:       "\"json_delete\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4081, col: 17, offset: 127157},
+									pos:  position{line: 4094, col: 17, offset: 127575},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4081, col: 25, offset: 127165},
+									pos:   position{line: 4094, col: 25, offset: 127583},
 									label: "object",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4081, col: 32, offset: 127172},
+										pos:  position{line: 4094, col: 32, offset: 127590},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4081, col: 47, offset: 127187},
+									pos:  position{line: 4094, col: 47, offset: 127605},
 									name: "COMMA",
 								},
 								&litMatcher{
-									pos:        position{line: 4081, col: 53, offset: 127193},
+									pos:        position{line: 4094, col: 53, offset: 127611},
 									val:        "[",
 									ignoreCase: false,
 									want:       "\"[\"",
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 4081, col: 57, offset: 127197},
+									pos: position{line: 4094, col: 57, offset: 127615},
 									expr: &ruleRefExpr{
-										pos:  position{line: 4081, col: 57, offset: 127197},
+										pos:  position{line: 4094, col: 57, offset: 127615},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4081, col: 64, offset: 127204},
+									pos:   position{line: 4094, col: 64, offset: 127622},
 									label: "firstKey",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4081, col: 73, offset: 127213},
+										pos:  position{line: 4094, col: 73, offset: 127631},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4081, col: 88, offset: 127228},
+									pos:   position{line: 4094, col: 88, offset: 127646},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4081, col: 93, offset: 127233},
+										pos: position{line: 4094, col: 93, offset: 127651},
 										expr: &seqExpr{
-											pos: position{line: 4081, col: 94, offset: 127234},
+											pos: position{line: 4094, col: 94, offset: 127652},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4081, col: 94, offset: 127234},
+													pos:  position{line: 4094, col: 94, offset: 127652},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4081, col: 100, offset: 127240},
+													pos:  position{line: 4094, col: 100, offset: 127658},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -9141,45 +9179,45 @@ var g = &grammar{
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 4081, col: 117, offset: 127257},
+									pos: position{line: 4094, col: 117, offset: 127675},
 									expr: &ruleRefExpr{
-										pos:  position{line: 4081, col: 117, offset: 127257},
+										pos:  position{line: 4094, col: 117, offset: 127675},
 										name: "SPACE",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 4081, col: 124, offset: 127264},
+									pos:        position{line: 4094, col: 124, offset: 127682},
 									val:        "]",
 									ignoreCase: false,
 									want:       "\"]\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4081, col: 128, offset: 127268},
+									pos:  position{line: 4094, col: 128, offset: 127686},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4099, col: 3, offset: 127742},
+						pos: position{line: 4112, col: 3, offset: 128160},
 						run: (*parser).callonJsonExpr89,
 						expr: &seqExpr{
-							pos: position{line: 4099, col: 3, offset: 127742},
+							pos: position{line: 4112, col: 3, offset: 128160},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4099, col: 3, offset: 127742},
+									pos:   position{line: 4112, col: 3, offset: 128160},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 4099, col: 11, offset: 127750},
+										pos: position{line: 4112, col: 11, offset: 128168},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 4099, col: 11, offset: 127750},
+												pos:        position{line: 4112, col: 11, offset: 128168},
 												val:        "json_extract",
 												ignoreCase: false,
 												want:       "\"json_extract\"",
 											},
 											&litMatcher{
-												pos:        position{line: 4099, col: 28, offset: 127767},
+												pos:        position{line: 4112, col: 28, offset: 128185},
 												val:        "json_extract_exact",
 												ignoreCase: false,
 												want:       "\"json_extract_exact\"",
@@ -9188,31 +9226,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4099, col: 50, offset: 127789},
+									pos:  position{line: 4112, col: 50, offset: 128207},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4099, col: 58, offset: 127797},
+									pos:   position{line: 4112, col: 58, offset: 128215},
 									label: "json",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4099, col: 63, offset: 127802},
+										pos:  position{line: 4112, col: 63, offset: 128220},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4099, col: 78, offset: 127817},
+									pos:   position{line: 4112, col: 78, offset: 128235},
 									label: "paths",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 4099, col: 84, offset: 127823},
+										pos: position{line: 4112, col: 84, offset: 128241},
 										expr: &seqExpr{
-											pos: position{line: 4099, col: 85, offset: 127824},
+											pos: position{line: 4112, col: 85, offset: 128242},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4099, col: 85, offset: 127824},
+													pos:  position{line: 4112, col: 85, offset: 128242},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4099, col: 91, offset: 127830},
+													pos:  position{line: 4112, col: 91, offset: 128248},
 													name: "JsonExprLevel1",
 												},
 											},
@@ -9220,46 +9258,46 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4099, col: 108, offset: 127847},
+									pos:  position{line: 4112, col: 108, offset: 128265},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4134, col: 3, offset: 129023},
+						pos: position{line: 4149, col: 3, offset: 129547},
 						run: (*parser).callonJsonExpr104,
 						expr: &seqExpr{
-							pos: position{line: 4134, col: 3, offset: 129023},
+							pos: position{line: 4149, col: 3, offset: 129547},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4134, col: 3, offset: 129023},
+									pos:        position{line: 4149, col: 3, offset: 129547},
 									val:        "json_has_key_exact",
 									ignoreCase: false,
 									want:       "\"json_has_key_exact\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4134, col: 24, offset: 129044},
+									pos:  position{line: 4149, col: 24, offset: 129568},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4134, col: 32, offset: 129052},
+									pos:   position{line: 4149, col: 32, offset: 129576},
 									label: "object",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4134, col: 39, offset: 129059},
+										pos:  position{line: 4149, col: 39, offset: 129583},
 										name: "JsonExprLevel1",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4134, col: 54, offset: 129074},
+									pos:   position{line: 4149, col: 54, offset: 129598},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4134, col: 58, offset: 129078},
+										pos:  position{line: 4149, col: 58, offset: 129602},
 										name: "JsonExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4134, col: 73, offset: 129093},
+									pos:  position{line: 4149, col: 73, offset: 129617},
 									name: "R_PAREN",
 								},
 							},
@@ -9270,28 +9308,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 4163, col: 1, offset: 130093},
+			pos:  position{line: 4178, col: 1, offset: 130617},
 			expr: &choiceExpr{
-				pos: position{line: 4163, col: 12, offset: 130104},
+				pos: position{line: 4178, col: 12, offset: 130628},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4163, col: 12, offset: 130104},
+						pos: position{line: 4178, col: 12, offset: 130628},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 4163, col: 12, offset: 130104},
+							pos: position{line: 4178, col: 12, offset: 130628},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4163, col: 12, offset: 130104},
+									pos:   position{line: 4178, col: 12, offset: 130628},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4163, col: 16, offset: 130108},
+										pos:  position{line: 4178, col: 16, offset: 130632},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4163, col: 29, offset: 130121},
+									pos: position{line: 4178, col: 29, offset: 130645},
 									expr: &ruleRefExpr{
-										pos:  position{line: 4163, col: 31, offset: 130123},
+										pos:  position{line: 4178, col: 31, offset: 130647},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -9299,50 +9337,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4179, col: 3, offset: 130498},
+						pos: position{line: 4194, col: 3, offset: 131022},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 4179, col: 3, offset: 130498},
+							pos: position{line: 4194, col: 3, offset: 131022},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4179, col: 3, offset: 130498},
+									pos:   position{line: 4194, col: 3, offset: 131022},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4179, col: 9, offset: 130504},
+										pos:  position{line: 4194, col: 9, offset: 131028},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 4179, col: 25, offset: 130520},
+									pos: position{line: 4194, col: 25, offset: 131044},
 									expr: &choiceExpr{
-										pos: position{line: 4179, col: 27, offset: 130522},
+										pos: position{line: 4194, col: 27, offset: 131046},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 27, offset: 130522},
+												pos:  position{line: 4194, col: 27, offset: 131046},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 36, offset: 130531},
+												pos:  position{line: 4194, col: 36, offset: 131055},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 46, offset: 130541},
+												pos:  position{line: 4194, col: 46, offset: 131065},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 54, offset: 130549},
+												pos:  position{line: 4194, col: 54, offset: 131073},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 62, offset: 130557},
+												pos:  position{line: 4194, col: 62, offset: 131081},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 4179, col: 70, offset: 130565},
+												pos:  position{line: 4194, col: 70, offset: 131089},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 4179, col: 84, offset: 130579},
+												pos:        position{line: 4194, col: 84, offset: 131103},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -9358,28 +9396,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 4196, col: 1, offset: 130930},
+			pos:  position{line: 4211, col: 1, offset: 131454},
 			expr: &actionExpr{
-				pos: position{line: 4196, col: 19, offset: 130948},
+				pos: position{line: 4211, col: 19, offset: 131472},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 4196, col: 19, offset: 130948},
+					pos: position{line: 4211, col: 19, offset: 131472},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4196, col: 19, offset: 130948},
+							pos:        position{line: 4211, col: 19, offset: 131472},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4196, col: 26, offset: 130955},
+							pos:  position{line: 4211, col: 26, offset: 131479},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4196, col: 32, offset: 130961},
+							pos:   position{line: 4211, col: 32, offset: 131485},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4196, col: 40, offset: 130969},
+								pos:  position{line: 4211, col: 40, offset: 131493},
 								name: "Boolean",
 							},
 						},
@@ -9389,28 +9427,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 4207, col: 1, offset: 131158},
+			pos:  position{line: 4222, col: 1, offset: 131682},
 			expr: &actionExpr{
-				pos: position{line: 4207, col: 23, offset: 131180},
+				pos: position{line: 4222, col: 23, offset: 131704},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 4207, col: 23, offset: 131180},
+					pos: position{line: 4222, col: 23, offset: 131704},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4207, col: 23, offset: 131180},
+							pos:        position{line: 4222, col: 23, offset: 131704},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4207, col: 34, offset: 131191},
+							pos:  position{line: 4222, col: 34, offset: 131715},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4207, col: 40, offset: 131197},
+							pos:   position{line: 4222, col: 40, offset: 131721},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4207, col: 48, offset: 131205},
+								pos:  position{line: 4222, col: 48, offset: 131729},
 								name: "Boolean",
 							},
 						},
@@ -9420,28 +9458,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 4218, col: 1, offset: 131402},
+			pos:  position{line: 4233, col: 1, offset: 131926},
 			expr: &actionExpr{
-				pos: position{line: 4218, col: 20, offset: 131421},
+				pos: position{line: 4233, col: 20, offset: 131945},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 4218, col: 20, offset: 131421},
+					pos: position{line: 4233, col: 20, offset: 131945},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4218, col: 20, offset: 131421},
+							pos:        position{line: 4233, col: 20, offset: 131945},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4218, col: 28, offset: 131429},
+							pos:  position{line: 4233, col: 28, offset: 131953},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4218, col: 34, offset: 131435},
+							pos:   position{line: 4233, col: 34, offset: 131959},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4218, col: 43, offset: 131444},
+								pos:  position{line: 4233, col: 43, offset: 131968},
 								name: "IntegerAsString",
 							},
 						},
@@ -9451,15 +9489,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 4233, col: 1, offset: 131806},
+			pos:  position{line: 4248, col: 1, offset: 132330},
 			expr: &actionExpr{
-				pos: position{line: 4233, col: 19, offset: 131824},
+				pos: position{line: 4248, col: 19, offset: 132348},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 4233, col: 19, offset: 131824},
+					pos:   position{line: 4248, col: 19, offset: 132348},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4233, col: 28, offset: 131833},
+						pos:  position{line: 4248, col: 28, offset: 132357},
 						name: "BoolExpr",
 					},
 				},
@@ -9467,30 +9505,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 4244, col: 1, offset: 132045},
+			pos:  position{line: 4259, col: 1, offset: 132569},
 			expr: &actionExpr{
-				pos: position{line: 4244, col: 15, offset: 132059},
+				pos: position{line: 4259, col: 15, offset: 132583},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4244, col: 15, offset: 132059},
+					pos:   position{line: 4259, col: 15, offset: 132583},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4244, col: 23, offset: 132067},
+						pos: position{line: 4259, col: 23, offset: 132591},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4244, col: 23, offset: 132067},
+								pos:  position{line: 4259, col: 23, offset: 132591},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4244, col: 44, offset: 132088},
+								pos:  position{line: 4259, col: 44, offset: 132612},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4244, col: 61, offset: 132105},
+								pos:  position{line: 4259, col: 61, offset: 132629},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4244, col: 79, offset: 132123},
+								pos:  position{line: 4259, col: 79, offset: 132647},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -9500,35 +9538,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 4248, col: 1, offset: 132167},
+			pos:  position{line: 4263, col: 1, offset: 132691},
 			expr: &actionExpr{
-				pos: position{line: 4248, col: 19, offset: 132185},
+				pos: position{line: 4263, col: 19, offset: 132709},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4248, col: 19, offset: 132185},
+					pos: position{line: 4263, col: 19, offset: 132709},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4248, col: 19, offset: 132185},
+							pos:   position{line: 4263, col: 19, offset: 132709},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4248, col: 26, offset: 132192},
+								pos:  position{line: 4263, col: 26, offset: 132716},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4248, col: 37, offset: 132203},
+							pos:   position{line: 4263, col: 37, offset: 132727},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4248, col: 43, offset: 132209},
+								pos: position{line: 4263, col: 43, offset: 132733},
 								expr: &seqExpr{
-									pos: position{line: 4248, col: 44, offset: 132210},
+									pos: position{line: 4263, col: 44, offset: 132734},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4248, col: 44, offset: 132210},
+											pos:  position{line: 4263, col: 44, offset: 132734},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4248, col: 50, offset: 132216},
+											pos:  position{line: 4263, col: 50, offset: 132740},
 											name: "HeadOption",
 										},
 									},
@@ -9541,29 +9579,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4305, col: 1, offset: 134016},
+			pos:  position{line: 4320, col: 1, offset: 134540},
 			expr: &choiceExpr{
-				pos: position{line: 4305, col: 14, offset: 134029},
+				pos: position{line: 4320, col: 14, offset: 134553},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4305, col: 14, offset: 134029},
+						pos: position{line: 4320, col: 14, offset: 134553},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4305, col: 14, offset: 134029},
+							pos: position{line: 4320, col: 14, offset: 134553},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4305, col: 14, offset: 134029},
+									pos:  position{line: 4320, col: 14, offset: 134553},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4305, col: 19, offset: 134034},
+									pos:  position{line: 4320, col: 19, offset: 134558},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4305, col: 28, offset: 134043},
+									pos:   position{line: 4320, col: 28, offset: 134567},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4305, col: 37, offset: 134052},
+										pos:  position{line: 4320, col: 37, offset: 134576},
 										name: "HeadOptionList",
 									},
 								},
@@ -9571,24 +9609,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4316, col: 3, offset: 134371},
+						pos: position{line: 4331, col: 3, offset: 134895},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4316, col: 3, offset: 134371},
+							pos: position{line: 4331, col: 3, offset: 134895},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4316, col: 3, offset: 134371},
+									pos:  position{line: 4331, col: 3, offset: 134895},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4316, col: 8, offset: 134376},
+									pos:  position{line: 4331, col: 8, offset: 134900},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4316, col: 17, offset: 134385},
+									pos:   position{line: 4331, col: 17, offset: 134909},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4316, col: 26, offset: 134394},
+										pos:  position{line: 4331, col: 26, offset: 134918},
 										name: "IntegerAsString",
 									},
 								},
@@ -9596,17 +9634,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4336, col: 3, offset: 134911},
+						pos: position{line: 4351, col: 3, offset: 135435},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4336, col: 3, offset: 134911},
+							pos: position{line: 4351, col: 3, offset: 135435},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4336, col: 3, offset: 134911},
+									pos:  position{line: 4351, col: 3, offset: 135435},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4336, col: 8, offset: 134916},
+									pos:  position{line: 4351, col: 8, offset: 135440},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9617,29 +9655,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4354, col: 1, offset: 135386},
+			pos:  position{line: 4369, col: 1, offset: 135910},
 			expr: &choiceExpr{
-				pos: position{line: 4354, col: 14, offset: 135399},
+				pos: position{line: 4369, col: 14, offset: 135923},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4354, col: 14, offset: 135399},
+						pos: position{line: 4369, col: 14, offset: 135923},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4354, col: 14, offset: 135399},
+							pos: position{line: 4369, col: 14, offset: 135923},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4354, col: 14, offset: 135399},
+									pos:  position{line: 4369, col: 14, offset: 135923},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4354, col: 19, offset: 135404},
+									pos:  position{line: 4369, col: 19, offset: 135928},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4354, col: 28, offset: 135413},
+									pos:   position{line: 4369, col: 28, offset: 135937},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4354, col: 37, offset: 135422},
+										pos:  position{line: 4369, col: 37, offset: 135946},
 										name: "IntegerAsString",
 									},
 								},
@@ -9647,17 +9685,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4375, col: 3, offset: 135996},
+						pos: position{line: 4390, col: 3, offset: 136520},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4375, col: 3, offset: 135996},
+							pos: position{line: 4390, col: 3, offset: 136520},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4375, col: 3, offset: 135996},
+									pos:  position{line: 4390, col: 3, offset: 136520},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4375, col: 8, offset: 136001},
+									pos:  position{line: 4390, col: 8, offset: 136525},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9668,44 +9706,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4396, col: 1, offset: 136619},
+			pos:  position{line: 4411, col: 1, offset: 137143},
 			expr: &actionExpr{
-				pos: position{line: 4396, col: 20, offset: 136638},
+				pos: position{line: 4411, col: 20, offset: 137162},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4396, col: 20, offset: 136638},
+					pos: position{line: 4411, col: 20, offset: 137162},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4396, col: 20, offset: 136638},
+							pos:   position{line: 4411, col: 20, offset: 137162},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4396, col: 26, offset: 136644},
+								pos:  position{line: 4411, col: 26, offset: 137168},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4396, col: 37, offset: 136655},
+							pos:   position{line: 4411, col: 37, offset: 137179},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4396, col: 42, offset: 136660},
+								pos: position{line: 4411, col: 42, offset: 137184},
 								expr: &seqExpr{
-									pos: position{line: 4396, col: 43, offset: 136661},
+									pos: position{line: 4411, col: 43, offset: 137185},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4396, col: 44, offset: 136662},
+											pos: position{line: 4411, col: 44, offset: 137186},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4396, col: 44, offset: 136662},
+													pos:  position{line: 4411, col: 44, offset: 137186},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4396, col: 52, offset: 136670},
+													pos:  position{line: 4411, col: 52, offset: 137194},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4396, col: 59, offset: 136677},
+											pos:  position{line: 4411, col: 59, offset: 137201},
 											name: "Aggregator",
 										},
 									},
@@ -9718,28 +9756,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4413, col: 1, offset: 137180},
+			pos:  position{line: 4428, col: 1, offset: 137704},
 			expr: &actionExpr{
-				pos: position{line: 4413, col: 15, offset: 137194},
+				pos: position{line: 4428, col: 15, offset: 137718},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4413, col: 15, offset: 137194},
+					pos: position{line: 4428, col: 15, offset: 137718},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4413, col: 15, offset: 137194},
+							pos:   position{line: 4428, col: 15, offset: 137718},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4413, col: 23, offset: 137202},
+								pos:  position{line: 4428, col: 23, offset: 137726},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4413, col: 35, offset: 137214},
+							pos:   position{line: 4428, col: 35, offset: 137738},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4413, col: 43, offset: 137222},
+								pos: position{line: 4428, col: 43, offset: 137746},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4413, col: 43, offset: 137222},
+									pos:  position{line: 4428, col: 43, offset: 137746},
 									name: "AsField",
 								},
 							},
@@ -9750,26 +9788,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4429, col: 1, offset: 138063},
+			pos:  position{line: 4444, col: 1, offset: 138587},
 			expr: &actionExpr{
-				pos: position{line: 4429, col: 16, offset: 138078},
+				pos: position{line: 4444, col: 16, offset: 138602},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4429, col: 16, offset: 138078},
+					pos:   position{line: 4444, col: 16, offset: 138602},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4429, col: 21, offset: 138083},
+						pos: position{line: 4444, col: 21, offset: 138607},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4429, col: 21, offset: 138083},
+								pos:  position{line: 4444, col: 21, offset: 138607},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4429, col: 32, offset: 138094},
+								pos:  position{line: 4444, col: 32, offset: 138618},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4429, col: 48, offset: 138110},
+								pos:  position{line: 4444, col: 48, offset: 138634},
 								name: "AggCommon",
 							},
 						},
@@ -9779,165 +9817,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4434, col: 1, offset: 138278},
+			pos:  position{line: 4449, col: 1, offset: 138802},
 			expr: &actionExpr{
-				pos: position{line: 4434, col: 18, offset: 138295},
+				pos: position{line: 4449, col: 18, offset: 138819},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4434, col: 19, offset: 138296},
+					pos: position{line: 4449, col: 19, offset: 138820},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4434, col: 19, offset: 138296},
+							pos:        position{line: 4449, col: 19, offset: 138820},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 30, offset: 138307},
+							pos:        position{line: 4449, col: 30, offset: 138831},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 39, offset: 138316},
+							pos:        position{line: 4449, col: 39, offset: 138840},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 47, offset: 138324},
+							pos:        position{line: 4449, col: 47, offset: 138848},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 57, offset: 138334},
+							pos:        position{line: 4449, col: 57, offset: 138858},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 65, offset: 138342},
+							pos:        position{line: 4449, col: 65, offset: 138866},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 76, offset: 138353},
+							pos:        position{line: 4449, col: 76, offset: 138877},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 86, offset: 138363},
+							pos:        position{line: 4449, col: 86, offset: 138887},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 95, offset: 138372},
+							pos:        position{line: 4449, col: 95, offset: 138896},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 105, offset: 138382},
+							pos:        position{line: 4449, col: 105, offset: 138906},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 114, offset: 138391},
+							pos:        position{line: 4449, col: 114, offset: 138915},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 122, offset: 138399},
+							pos:        position{line: 4449, col: 122, offset: 138923},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 133, offset: 138410},
+							pos:        position{line: 4449, col: 133, offset: 138934},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4434, col: 142, offset: 138419},
+							pos:        position{line: 4449, col: 142, offset: 138943},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 1, offset: 138428},
+							pos:        position{line: 4450, col: 1, offset: 138952},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 10, offset: 138437},
+							pos:        position{line: 4450, col: 10, offset: 138961},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 26, offset: 138453},
+							pos:        position{line: 4450, col: 26, offset: 138977},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 37, offset: 138464},
+							pos:        position{line: 4450, col: 37, offset: 138988},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 46, offset: 138473},
+							pos:        position{line: 4450, col: 46, offset: 138997},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 56, offset: 138483},
+							pos:        position{line: 4450, col: 56, offset: 139007},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 72, offset: 138499},
+							pos:        position{line: 4450, col: 72, offset: 139023},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 82, offset: 138509},
+							pos:        position{line: 4450, col: 82, offset: 139033},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 100, offset: 138527},
+							pos:        position{line: 4450, col: 100, offset: 139051},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 113, offset: 138540},
+							pos:        position{line: 4450, col: 113, offset: 139064},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 132, offset: 138559},
+							pos:        position{line: 4450, col: 132, offset: 139083},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4435, col: 139, offset: 138566},
+							pos:        position{line: 4450, col: 139, offset: 139090},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9948,33 +9986,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4439, col: 1, offset: 138609},
+			pos:  position{line: 4454, col: 1, offset: 139133},
 			expr: &actionExpr{
-				pos: position{line: 4439, col: 22, offset: 138630},
+				pos: position{line: 4454, col: 22, offset: 139154},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4439, col: 23, offset: 138631},
+					pos: position{line: 4454, col: 23, offset: 139155},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4439, col: 23, offset: 138631},
+							pos:        position{line: 4454, col: 23, offset: 139155},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 37, offset: 138645},
+							pos:        position{line: 4454, col: 37, offset: 139169},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 51, offset: 138659},
+							pos:        position{line: 4454, col: 51, offset: 139183},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4439, col: 60, offset: 138668},
+							pos:        position{line: 4454, col: 60, offset: 139192},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9985,29 +10023,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4443, col: 1, offset: 138709},
+			pos:  position{line: 4458, col: 1, offset: 139233},
 			expr: &actionExpr{
-				pos: position{line: 4443, col: 12, offset: 138720},
+				pos: position{line: 4458, col: 12, offset: 139244},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4443, col: 12, offset: 138720},
+					pos: position{line: 4458, col: 12, offset: 139244},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4443, col: 12, offset: 138720},
+							pos:  position{line: 4458, col: 12, offset: 139244},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4443, col: 15, offset: 138723},
+							pos:   position{line: 4458, col: 15, offset: 139247},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4443, col: 23, offset: 138731},
+								pos: position{line: 4458, col: 23, offset: 139255},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4443, col: 23, offset: 138731},
+										pos:  position{line: 4458, col: 23, offset: 139255},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4443, col: 35, offset: 138743},
+										pos:  position{line: 4458, col: 35, offset: 139267},
 										name: "String",
 									},
 								},
@@ -10019,27 +10057,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4457, col: 1, offset: 139072},
+			pos:  position{line: 4472, col: 1, offset: 139596},
 			expr: &choiceExpr{
-				pos: position{line: 4457, col: 13, offset: 139084},
+				pos: position{line: 4472, col: 13, offset: 139608},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4457, col: 13, offset: 139084},
+						pos: position{line: 4472, col: 13, offset: 139608},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4457, col: 13, offset: 139084},
+							pos: position{line: 4472, col: 13, offset: 139608},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4457, col: 14, offset: 139085},
+									pos: position{line: 4472, col: 14, offset: 139609},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4457, col: 14, offset: 139085},
+											pos:        position{line: 4472, col: 14, offset: 139609},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4457, col: 24, offset: 139095},
+											pos:        position{line: 4472, col: 24, offset: 139619},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -10047,47 +10085,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4457, col: 29, offset: 139100},
+									pos:  position{line: 4472, col: 29, offset: 139624},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4457, col: 37, offset: 139108},
+									pos:        position{line: 4472, col: 37, offset: 139632},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4457, col: 44, offset: 139115},
+									pos:   position{line: 4472, col: 44, offset: 139639},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4457, col: 54, offset: 139125},
+										pos:  position{line: 4472, col: 54, offset: 139649},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4457, col: 64, offset: 139135},
+									pos:  position{line: 4472, col: 64, offset: 139659},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4467, col: 3, offset: 139364},
+						pos: position{line: 4482, col: 3, offset: 139888},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4467, col: 3, offset: 139364},
+							pos: position{line: 4482, col: 3, offset: 139888},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4467, col: 4, offset: 139365},
+									pos: position{line: 4482, col: 4, offset: 139889},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4467, col: 4, offset: 139365},
+											pos:        position{line: 4482, col: 4, offset: 139889},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4467, col: 14, offset: 139375},
+											pos:        position{line: 4482, col: 14, offset: 139899},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -10095,38 +10133,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4467, col: 19, offset: 139380},
+									pos:  position{line: 4482, col: 19, offset: 139904},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4467, col: 27, offset: 139388},
+									pos:   position{line: 4482, col: 27, offset: 139912},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4467, col: 33, offset: 139394},
+										pos:  position{line: 4482, col: 33, offset: 139918},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4467, col: 43, offset: 139404},
+									pos:  position{line: 4482, col: 43, offset: 139928},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4474, col: 5, offset: 139556},
+						pos: position{line: 4489, col: 5, offset: 140080},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4474, col: 6, offset: 139557},
+							pos: position{line: 4489, col: 6, offset: 140081},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4474, col: 6, offset: 139557},
+									pos:        position{line: 4489, col: 6, offset: 140081},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4474, col: 16, offset: 139567},
+									pos:        position{line: 4489, col: 16, offset: 140091},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -10139,77 +10177,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4483, col: 1, offset: 139704},
+			pos:  position{line: 4498, col: 1, offset: 140228},
 			expr: &choiceExpr{
-				pos: position{line: 4483, col: 14, offset: 139717},
+				pos: position{line: 4498, col: 14, offset: 140241},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4483, col: 14, offset: 139717},
+						pos: position{line: 4498, col: 14, offset: 140241},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4483, col: 14, offset: 139717},
+							pos: position{line: 4498, col: 14, offset: 140241},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4483, col: 14, offset: 139717},
+									pos:   position{line: 4498, col: 14, offset: 140241},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4483, col: 22, offset: 139725},
+										pos:  position{line: 4498, col: 22, offset: 140249},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4483, col: 36, offset: 139739},
+									pos:  position{line: 4498, col: 36, offset: 140263},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4483, col: 44, offset: 139747},
+									pos:        position{line: 4498, col: 44, offset: 140271},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4483, col: 51, offset: 139754},
+									pos:   position{line: 4498, col: 51, offset: 140278},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4483, col: 61, offset: 139764},
+										pos:  position{line: 4498, col: 61, offset: 140288},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4483, col: 71, offset: 139774},
+									pos:  position{line: 4498, col: 71, offset: 140298},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4498, col: 3, offset: 140185},
+						pos: position{line: 4513, col: 3, offset: 140709},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4498, col: 3, offset: 140185},
+							pos: position{line: 4513, col: 3, offset: 140709},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4498, col: 3, offset: 140185},
+									pos:   position{line: 4513, col: 3, offset: 140709},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4498, col: 11, offset: 140193},
+										pos:  position{line: 4513, col: 11, offset: 140717},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4498, col: 25, offset: 140207},
+									pos:  position{line: 4513, col: 25, offset: 140731},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4498, col: 33, offset: 140215},
+									pos:   position{line: 4513, col: 33, offset: 140739},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4498, col: 39, offset: 140221},
+										pos:  position{line: 4513, col: 39, offset: 140745},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4498, col: 49, offset: 140231},
+									pos:  position{line: 4513, col: 49, offset: 140755},
 									name: "R_PAREN",
 								},
 							},
@@ -10220,22 +10258,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4528, col: 1, offset: 141212},
+			pos:  position{line: 4543, col: 1, offset: 141736},
 			expr: &actionExpr{
-				pos: position{line: 4528, col: 18, offset: 141229},
+				pos: position{line: 4543, col: 18, offset: 141753},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4528, col: 18, offset: 141229},
+					pos:   position{line: 4543, col: 18, offset: 141753},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4528, col: 26, offset: 141237},
+						pos: position{line: 4543, col: 26, offset: 141761},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4528, col: 26, offset: 141237},
+								pos:  position{line: 4543, col: 26, offset: 141761},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4528, col: 42, offset: 141253},
+								pos:  position{line: 4543, col: 42, offset: 141777},
 								name: "IntegerAsString",
 							},
 						},
@@ -10245,161 +10283,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4540, col: 1, offset: 141620},
+			pos:  position{line: 4555, col: 1, offset: 142144},
 			expr: &choiceExpr{
-				pos: position{line: 4540, col: 18, offset: 141637},
+				pos: position{line: 4555, col: 18, offset: 142161},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4540, col: 18, offset: 141637},
+						pos: position{line: 4555, col: 18, offset: 142161},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4540, col: 18, offset: 141637},
+							pos: position{line: 4555, col: 18, offset: 142161},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4540, col: 18, offset: 141637},
+									pos:   position{line: 4555, col: 18, offset: 142161},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4540, col: 26, offset: 141645},
+										pos:  position{line: 4555, col: 26, offset: 142169},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4540, col: 44, offset: 141663},
+									pos:   position{line: 4555, col: 44, offset: 142187},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4540, col: 58, offset: 141677},
+										pos:  position{line: 4555, col: 58, offset: 142201},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4540, col: 72, offset: 141691},
+									pos:  position{line: 4555, col: 72, offset: 142215},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4540, col: 80, offset: 141699},
+									pos:        position{line: 4555, col: 80, offset: 142223},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4540, col: 87, offset: 141706},
+									pos:   position{line: 4555, col: 87, offset: 142230},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4540, col: 97, offset: 141716},
+										pos:  position{line: 4555, col: 97, offset: 142240},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4540, col: 107, offset: 141726},
+									pos:  position{line: 4555, col: 107, offset: 142250},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4556, col: 3, offset: 142250},
+						pos: position{line: 4571, col: 3, offset: 142774},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4556, col: 3, offset: 142250},
+							pos: position{line: 4571, col: 3, offset: 142774},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4556, col: 3, offset: 142250},
+									pos:   position{line: 4571, col: 3, offset: 142774},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4556, col: 11, offset: 142258},
+										pos:  position{line: 4571, col: 11, offset: 142782},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4556, col: 29, offset: 142276},
+									pos:   position{line: 4571, col: 29, offset: 142800},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4556, col: 43, offset: 142290},
+										pos:  position{line: 4571, col: 43, offset: 142814},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4556, col: 57, offset: 142304},
+									pos:  position{line: 4571, col: 57, offset: 142828},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4556, col: 65, offset: 142312},
+									pos:   position{line: 4571, col: 65, offset: 142836},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4556, col: 71, offset: 142318},
+										pos:  position{line: 4571, col: 71, offset: 142842},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4556, col: 81, offset: 142328},
+									pos:  position{line: 4571, col: 81, offset: 142852},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4571, col: 3, offset: 142808},
+						pos: position{line: 4586, col: 3, offset: 143332},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4571, col: 3, offset: 142808},
+							pos: position{line: 4586, col: 3, offset: 143332},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4571, col: 4, offset: 142809},
+									pos:        position{line: 4586, col: 4, offset: 143333},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4571, col: 14, offset: 142819},
+									pos:  position{line: 4586, col: 14, offset: 143343},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4571, col: 22, offset: 142827},
+									pos:   position{line: 4586, col: 22, offset: 143351},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4571, col: 28, offset: 142833},
+										pos:  position{line: 4586, col: 28, offset: 143357},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4571, col: 38, offset: 142843},
+									pos:  position{line: 4586, col: 38, offset: 143367},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4586, col: 3, offset: 143230},
+						pos: position{line: 4601, col: 3, offset: 143754},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4586, col: 3, offset: 143230},
+							pos: position{line: 4601, col: 3, offset: 143754},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4586, col: 4, offset: 143231},
+									pos:        position{line: 4601, col: 4, offset: 143755},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4586, col: 14, offset: 143241},
+									pos:  position{line: 4601, col: 14, offset: 143765},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4586, col: 22, offset: 143249},
+									pos:        position{line: 4601, col: 22, offset: 143773},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4586, col: 29, offset: 143256},
+									pos:   position{line: 4601, col: 29, offset: 143780},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4586, col: 39, offset: 143266},
+										pos:  position{line: 4601, col: 39, offset: 143790},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4586, col: 49, offset: 143276},
+									pos:  position{line: 4601, col: 49, offset: 143800},
 									name: "R_PAREN",
 								},
 							},
@@ -10410,22 +10448,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4604, col: 1, offset: 143707},
+			pos:  position{line: 4619, col: 1, offset: 144231},
 			expr: &actionExpr{
-				pos: position{line: 4604, col: 25, offset: 143731},
+				pos: position{line: 4619, col: 25, offset: 144255},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4604, col: 25, offset: 143731},
+					pos:   position{line: 4619, col: 25, offset: 144255},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4604, col: 39, offset: 143745},
+						pos: position{line: 4619, col: 39, offset: 144269},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4604, col: 39, offset: 143745},
+								pos:  position{line: 4619, col: 39, offset: 144269},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4604, col: 67, offset: 143773},
+								pos:  position{line: 4619, col: 67, offset: 144297},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -10435,43 +10473,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4608, col: 1, offset: 143836},
+			pos:  position{line: 4623, col: 1, offset: 144360},
 			expr: &actionExpr{
-				pos: position{line: 4608, col: 30, offset: 143865},
+				pos: position{line: 4623, col: 30, offset: 144389},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4608, col: 30, offset: 143865},
+					pos: position{line: 4623, col: 30, offset: 144389},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4608, col: 30, offset: 143865},
+							pos:   position{line: 4623, col: 30, offset: 144389},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4608, col: 34, offset: 143869},
+								pos:  position{line: 4623, col: 34, offset: 144393},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4608, col: 44, offset: 143879},
+							pos:   position{line: 4623, col: 44, offset: 144403},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4608, col: 48, offset: 143883},
+								pos: position{line: 4623, col: 48, offset: 144407},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 48, offset: 143883},
+										pos:  position{line: 4623, col: 48, offset: 144407},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4608, col: 67, offset: 143902},
+										pos:  position{line: 4623, col: 67, offset: 144426},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4608, col: 87, offset: 143922},
+							pos:   position{line: 4623, col: 87, offset: 144446},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4608, col: 93, offset: 143928},
+								pos:  position{line: 4623, col: 93, offset: 144452},
 								name: "Number",
 							},
 						},
@@ -10481,15 +10519,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4621, col: 1, offset: 144162},
+			pos:  position{line: 4636, col: 1, offset: 144686},
 			expr: &actionExpr{
-				pos: position{line: 4621, col: 32, offset: 144193},
+				pos: position{line: 4636, col: 32, offset: 144717},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4621, col: 32, offset: 144193},
+					pos:   position{line: 4636, col: 32, offset: 144717},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4621, col: 38, offset: 144199},
+						pos:  position{line: 4636, col: 38, offset: 144723},
 						name: "Number",
 					},
 				},
@@ -10497,34 +10535,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4634, col: 1, offset: 144416},
+			pos:  position{line: 4649, col: 1, offset: 144940},
 			expr: &actionExpr{
-				pos: position{line: 4634, col: 26, offset: 144441},
+				pos: position{line: 4649, col: 26, offset: 144965},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4634, col: 26, offset: 144441},
+					pos: position{line: 4649, col: 26, offset: 144965},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4634, col: 26, offset: 144441},
+							pos:   position{line: 4649, col: 26, offset: 144965},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4634, col: 30, offset: 144445},
+								pos:  position{line: 4649, col: 30, offset: 144969},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4634, col: 40, offset: 144455},
+							pos:   position{line: 4649, col: 40, offset: 144979},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4634, col: 43, offset: 144458},
+								pos:  position{line: 4649, col: 43, offset: 144982},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4634, col: 60, offset: 144475},
+							pos:   position{line: 4649, col: 60, offset: 144999},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4634, col: 66, offset: 144481},
+								pos:  position{line: 4649, col: 66, offset: 145005},
 								name: "Boolean",
 							},
 						},
@@ -10534,22 +10572,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4647, col: 1, offset: 144716},
+			pos:  position{line: 4662, col: 1, offset: 145240},
 			expr: &actionExpr{
-				pos: position{line: 4647, col: 25, offset: 144740},
+				pos: position{line: 4662, col: 25, offset: 145264},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4647, col: 25, offset: 144740},
+					pos:   position{line: 4662, col: 25, offset: 145264},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4647, col: 39, offset: 144754},
+						pos: position{line: 4662, col: 39, offset: 145278},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4647, col: 39, offset: 144754},
+								pos:  position{line: 4662, col: 39, offset: 145278},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4647, col: 67, offset: 144782},
+								pos:  position{line: 4662, col: 67, offset: 145306},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -10559,41 +10597,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4651, col: 1, offset: 144845},
+			pos:  position{line: 4666, col: 1, offset: 145369},
 			expr: &actionExpr{
-				pos: position{line: 4651, col: 30, offset: 144874},
+				pos: position{line: 4666, col: 30, offset: 145398},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4651, col: 30, offset: 144874},
+					pos: position{line: 4666, col: 30, offset: 145398},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4651, col: 30, offset: 144874},
+							pos:   position{line: 4666, col: 30, offset: 145398},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4651, col: 34, offset: 144878},
+								pos:  position{line: 4666, col: 34, offset: 145402},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4651, col: 44, offset: 144888},
+							pos:   position{line: 4666, col: 44, offset: 145412},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4651, col: 47, offset: 144891},
+								pos:  position{line: 4666, col: 47, offset: 145415},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4651, col: 64, offset: 144908},
+							pos:   position{line: 4666, col: 64, offset: 145432},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4651, col: 81, offset: 144925},
+								pos: position{line: 4666, col: 81, offset: 145449},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4651, col: 81, offset: 144925},
+										pos:  position{line: 4666, col: 81, offset: 145449},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4651, col: 103, offset: 144947},
+										pos:  position{line: 4666, col: 103, offset: 145471},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10605,22 +10643,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4667, col: 1, offset: 145379},
+			pos:  position{line: 4682, col: 1, offset: 145903},
 			expr: &actionExpr{
-				pos: position{line: 4667, col: 32, offset: 145410},
+				pos: position{line: 4682, col: 32, offset: 145934},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4667, col: 32, offset: 145410},
+					pos:   position{line: 4682, col: 32, offset: 145934},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4667, col: 49, offset: 145427},
+						pos: position{line: 4682, col: 49, offset: 145951},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4667, col: 49, offset: 145427},
+								pos:  position{line: 4682, col: 49, offset: 145951},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4667, col: 71, offset: 145449},
+								pos:  position{line: 4682, col: 71, offset: 145973},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10630,33 +10668,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4684, col: 1, offset: 145960},
+			pos:  position{line: 4699, col: 1, offset: 146484},
 			expr: &actionExpr{
-				pos: position{line: 4684, col: 24, offset: 145983},
+				pos: position{line: 4699, col: 24, offset: 146507},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4684, col: 24, offset: 145983},
+					pos: position{line: 4699, col: 24, offset: 146507},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4684, col: 24, offset: 145983},
+							pos:        position{line: 4699, col: 24, offset: 146507},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4684, col: 31, offset: 145990},
+							pos:  position{line: 4699, col: 31, offset: 146514},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4684, col: 39, offset: 145998},
+							pos:   position{line: 4699, col: 39, offset: 146522},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4684, col: 45, offset: 146004},
+								pos:  position{line: 4699, col: 45, offset: 146528},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4684, col: 52, offset: 146011},
+							pos:  position{line: 4699, col: 52, offset: 146535},
 							name: "R_PAREN",
 						},
 					},
@@ -10665,49 +10703,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4693, col: 1, offset: 146248},
+			pos:  position{line: 4708, col: 1, offset: 146772},
 			expr: &choiceExpr{
-				pos: position{line: 4693, col: 26, offset: 146273},
+				pos: position{line: 4708, col: 26, offset: 146797},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4693, col: 26, offset: 146273},
+						pos: position{line: 4708, col: 26, offset: 146797},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4693, col: 26, offset: 146273},
+							pos: position{line: 4708, col: 26, offset: 146797},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4693, col: 26, offset: 146273},
+									pos:        position{line: 4708, col: 26, offset: 146797},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4693, col: 33, offset: 146280},
+									pos:  position{line: 4708, col: 33, offset: 146804},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4693, col: 41, offset: 146288},
+									pos:   position{line: 4708, col: 41, offset: 146812},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4693, col: 47, offset: 146294},
+										pos:  position{line: 4708, col: 47, offset: 146818},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4693, col: 54, offset: 146301},
+									pos:  position{line: 4708, col: 54, offset: 146825},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4702, col: 3, offset: 146491},
+						pos: position{line: 4717, col: 3, offset: 147015},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4702, col: 3, offset: 146491},
+							pos:   position{line: 4717, col: 3, offset: 147015},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4702, col: 9, offset: 146497},
+								pos:  position{line: 4717, col: 9, offset: 147021},
 								name: "String",
 							},
 						},
@@ -10717,35 +10755,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4712, col: 1, offset: 146777},
+			pos:  position{line: 4727, col: 1, offset: 147301},
 			expr: &actionExpr{
-				pos: position{line: 4712, col: 18, offset: 146794},
+				pos: position{line: 4727, col: 18, offset: 147318},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4712, col: 18, offset: 146794},
+					pos: position{line: 4727, col: 18, offset: 147318},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4712, col: 18, offset: 146794},
+							pos:   position{line: 4727, col: 18, offset: 147318},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4712, col: 24, offset: 146800},
+								pos:  position{line: 4727, col: 24, offset: 147324},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4712, col: 34, offset: 146810},
+							pos:   position{line: 4727, col: 34, offset: 147334},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4712, col: 39, offset: 146815},
+								pos: position{line: 4727, col: 39, offset: 147339},
 								expr: &seqExpr{
-									pos: position{line: 4712, col: 40, offset: 146816},
+									pos: position{line: 4727, col: 40, offset: 147340},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4712, col: 40, offset: 146816},
+											pos:  position{line: 4727, col: 40, offset: 147340},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4712, col: 46, offset: 146822},
+											pos:  position{line: 4727, col: 46, offset: 147346},
 											name: "FieldName",
 										},
 									},
@@ -10758,16 +10796,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4729, col: 1, offset: 147317},
+			pos:  position{line: 4744, col: 1, offset: 147841},
 			expr: &choiceExpr{
-				pos: position{line: 4729, col: 18, offset: 147334},
+				pos: position{line: 4744, col: 18, offset: 147858},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4729, col: 18, offset: 147334},
+						pos:  position{line: 4744, col: 18, offset: 147858},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4729, col: 38, offset: 147354},
+						pos:  position{line: 4744, col: 38, offset: 147878},
 						name: "EarliestOnly",
 					},
 				},
@@ -10775,62 +10813,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4731, col: 1, offset: 147368},
+			pos:  position{line: 4746, col: 1, offset: 147892},
 			expr: &actionExpr{
-				pos: position{line: 4731, col: 22, offset: 147389},
+				pos: position{line: 4746, col: 22, offset: 147913},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4731, col: 22, offset: 147389},
+					pos: position{line: 4746, col: 22, offset: 147913},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 22, offset: 147389},
+							pos:  position{line: 4746, col: 22, offset: 147913},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 35, offset: 147402},
+							pos:  position{line: 4746, col: 35, offset: 147926},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4731, col: 41, offset: 147408},
+							pos:   position{line: 4746, col: 41, offset: 147932},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4731, col: 55, offset: 147422},
+								pos: position{line: 4746, col: 55, offset: 147946},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4731, col: 55, offset: 147422},
+										pos:  position{line: 4746, col: 55, offset: 147946},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4731, col: 75, offset: 147442},
+										pos:  position{line: 4746, col: 75, offset: 147966},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 94, offset: 147461},
+							pos:  position{line: 4746, col: 94, offset: 147985},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 100, offset: 147467},
+							pos:  position{line: 4746, col: 100, offset: 147991},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4731, col: 111, offset: 147478},
+							pos:  position{line: 4746, col: 111, offset: 148002},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4731, col: 117, offset: 147484},
+							pos:   position{line: 4746, col: 117, offset: 148008},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4731, col: 129, offset: 147496},
+								pos: position{line: 4746, col: 129, offset: 148020},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4731, col: 129, offset: 147496},
+										pos:  position{line: 4746, col: 129, offset: 148020},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4731, col: 149, offset: 147516},
+										pos:  position{line: 4746, col: 149, offset: 148040},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10842,33 +10880,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4772, col: 1, offset: 148655},
+			pos:  position{line: 4787, col: 1, offset: 149179},
 			expr: &actionExpr{
-				pos: position{line: 4772, col: 17, offset: 148671},
+				pos: position{line: 4787, col: 17, offset: 149195},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4772, col: 17, offset: 148671},
+					pos: position{line: 4787, col: 17, offset: 149195},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4772, col: 17, offset: 148671},
+							pos:  position{line: 4787, col: 17, offset: 149195},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4772, col: 30, offset: 148684},
+							pos:  position{line: 4787, col: 30, offset: 149208},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4772, col: 36, offset: 148690},
+							pos:   position{line: 4787, col: 36, offset: 149214},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4772, col: 50, offset: 148704},
+								pos: position{line: 4787, col: 50, offset: 149228},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4772, col: 50, offset: 148704},
+										pos:  position{line: 4787, col: 50, offset: 149228},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4772, col: 70, offset: 148724},
+										pos:  position{line: 4787, col: 70, offset: 149248},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10880,24 +10918,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4800, col: 1, offset: 149432},
+			pos:  position{line: 4815, col: 1, offset: 149956},
 			expr: &actionExpr{
-				pos: position{line: 4800, col: 23, offset: 149454},
+				pos: position{line: 4815, col: 23, offset: 149978},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4800, col: 23, offset: 149454},
+					pos: position{line: 4815, col: 23, offset: 149978},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4800, col: 23, offset: 149454},
+							pos:        position{line: 4815, col: 23, offset: 149978},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4800, col: 27, offset: 149458},
+							pos: position{line: 4815, col: 27, offset: 149982},
 							expr: &charClassMatcher{
-								pos:        position{line: 4800, col: 27, offset: 149458},
+								pos:        position{line: 4815, col: 27, offset: 149982},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10910,21 +10948,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4804, col: 1, offset: 149501},
+			pos:  position{line: 4819, col: 1, offset: 150025},
 			expr: &actionExpr{
-				pos: position{line: 4804, col: 13, offset: 149513},
+				pos: position{line: 4819, col: 13, offset: 150037},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4804, col: 14, offset: 149514},
+					pos: position{line: 4819, col: 14, offset: 150038},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4804, col: 14, offset: 149514},
+							pos:        position{line: 4819, col: 14, offset: 150038},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4804, col: 17, offset: 149517},
+							pos:        position{line: 4819, col: 17, offset: 150041},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10936,15 +10974,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4808, col: 1, offset: 149560},
+			pos:  position{line: 4823, col: 1, offset: 150084},
 			expr: &actionExpr{
-				pos: position{line: 4808, col: 16, offset: 149575},
+				pos: position{line: 4823, col: 16, offset: 150099},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4808, col: 16, offset: 149575},
+					pos:   position{line: 4823, col: 16, offset: 150099},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4808, col: 26, offset: 149585},
+						pos:  position{line: 4823, col: 26, offset: 150109},
 						name: "AllTimeScale",
 					},
 				},
@@ -10952,31 +10990,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4815, col: 1, offset: 149812},
+			pos:  position{line: 4830, col: 1, offset: 150336},
 			expr: &actionExpr{
-				pos: position{line: 4815, col: 9, offset: 149820},
+				pos: position{line: 4830, col: 9, offset: 150344},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4815, col: 9, offset: 149820},
+					pos: position{line: 4830, col: 9, offset: 150344},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4815, col: 9, offset: 149820},
+							pos:        position{line: 4830, col: 9, offset: 150344},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4815, col: 13, offset: 149824},
+							pos:   position{line: 4830, col: 13, offset: 150348},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4815, col: 19, offset: 149830},
+								pos: position{line: 4830, col: 19, offset: 150354},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4815, col: 19, offset: 149830},
+										pos:  position{line: 4830, col: 19, offset: 150354},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4815, col: 30, offset: 149841},
+										pos:  position{line: 4830, col: 30, offset: 150365},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10988,26 +11026,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4819, col: 1, offset: 149889},
+			pos:  position{line: 4834, col: 1, offset: 150413},
 			expr: &actionExpr{
-				pos: position{line: 4819, col: 11, offset: 149899},
+				pos: position{line: 4834, col: 11, offset: 150423},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4819, col: 11, offset: 149899},
+					pos: position{line: 4834, col: 11, offset: 150423},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4819, col: 11, offset: 149899},
+							pos:   position{line: 4834, col: 11, offset: 150423},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4819, col: 16, offset: 149904},
+								pos:  position{line: 4834, col: 16, offset: 150428},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4819, col: 36, offset: 149924},
+							pos:   position{line: 4834, col: 36, offset: 150448},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4819, col: 43, offset: 149931},
+								pos:  position{line: 4834, col: 43, offset: 150455},
 								name: "RelTimeUnit",
 							},
 						},
@@ -11017,44 +11055,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4847, col: 1, offset: 150670},
+			pos:  position{line: 4862, col: 1, offset: 151194},
 			expr: &actionExpr{
-				pos: position{line: 4847, col: 29, offset: 150698},
+				pos: position{line: 4862, col: 29, offset: 151222},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4847, col: 29, offset: 150698},
+					pos: position{line: 4862, col: 29, offset: 151222},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4847, col: 29, offset: 150698},
+							pos:   position{line: 4862, col: 29, offset: 151222},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4847, col: 36, offset: 150705},
+								pos: position{line: 4862, col: 36, offset: 151229},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4847, col: 36, offset: 150705},
+										pos:  position{line: 4862, col: 36, offset: 151229},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4847, col: 45, offset: 150714},
+										pos:  position{line: 4862, col: 45, offset: 151238},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4847, col: 51, offset: 150720},
+							pos:   position{line: 4862, col: 51, offset: 151244},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4847, col: 57, offset: 150726},
+								pos: position{line: 4862, col: 57, offset: 151250},
 								expr: &choiceExpr{
-									pos: position{line: 4847, col: 58, offset: 150727},
+									pos: position{line: 4862, col: 58, offset: 151251},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4847, col: 58, offset: 150727},
+											pos:  position{line: 4862, col: 58, offset: 151251},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4847, col: 67, offset: 150736},
+											pos:  position{line: 4862, col: 67, offset: 151260},
 											name: "Snap",
 										},
 									},
@@ -11067,29 +11105,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4894, col: 1, offset: 152168},
+			pos:  position{line: 4909, col: 1, offset: 152692},
 			expr: &actionExpr{
-				pos: position{line: 4894, col: 22, offset: 152189},
+				pos: position{line: 4909, col: 22, offset: 152713},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4894, col: 22, offset: 152189},
+					pos: position{line: 4909, col: 22, offset: 152713},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4894, col: 22, offset: 152189},
+							pos:   position{line: 4909, col: 22, offset: 152713},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4894, col: 34, offset: 152201},
+								pos: position{line: 4909, col: 34, offset: 152725},
 								expr: &choiceExpr{
-									pos: position{line: 4894, col: 35, offset: 152202},
+									pos: position{line: 4909, col: 35, offset: 152726},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4894, col: 35, offset: 152202},
+											pos:        position{line: 4909, col: 35, offset: 152726},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4894, col: 43, offset: 152210},
+											pos:        position{line: 4909, col: 43, offset: 152734},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -11099,12 +11137,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4894, col: 49, offset: 152216},
+							pos:   position{line: 4909, col: 49, offset: 152740},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4894, col: 57, offset: 152224},
+								pos: position{line: 4909, col: 57, offset: 152748},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4894, col: 58, offset: 152225},
+									pos:  position{line: 4909, col: 58, offset: 152749},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -11115,31 +11153,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4919, col: 1, offset: 152908},
+			pos:  position{line: 4934, col: 1, offset: 153432},
 			expr: &actionExpr{
-				pos: position{line: 4919, col: 39, offset: 152946},
+				pos: position{line: 4934, col: 39, offset: 153470},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4919, col: 39, offset: 152946},
+					pos: position{line: 4934, col: 39, offset: 153470},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4919, col: 39, offset: 152946},
+							pos:   position{line: 4934, col: 39, offset: 153470},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4919, col: 46, offset: 152953},
+								pos: position{line: 4934, col: 46, offset: 153477},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4919, col: 47, offset: 152954},
+									pos:  position{line: 4934, col: 47, offset: 153478},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4919, col: 56, offset: 152963},
+							pos:   position{line: 4934, col: 56, offset: 153487},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4919, col: 66, offset: 152973},
+								pos: position{line: 4934, col: 66, offset: 153497},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4919, col: 67, offset: 152974},
+									pos:  position{line: 4934, col: 67, offset: 153498},
 									name: "Snap",
 								},
 							},
@@ -11150,136 +11188,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4946, col: 1, offset: 153604},
+			pos:  position{line: 4961, col: 1, offset: 154128},
 			expr: &actionExpr{
-				pos: position{line: 4946, col: 18, offset: 153621},
+				pos: position{line: 4961, col: 18, offset: 154145},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4946, col: 18, offset: 153621},
+					pos: position{line: 4961, col: 18, offset: 154145},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 18, offset: 153621},
+							pos:        position{line: 4961, col: 18, offset: 154145},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 23, offset: 153626},
+							pos:        position{line: 4961, col: 23, offset: 154150},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 29, offset: 153632},
+							pos:        position{line: 4961, col: 29, offset: 154156},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 33, offset: 153636},
+							pos:        position{line: 4961, col: 33, offset: 154160},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 38, offset: 153641},
+							pos:        position{line: 4961, col: 38, offset: 154165},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 44, offset: 153647},
+							pos:        position{line: 4961, col: 44, offset: 154171},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 48, offset: 153651},
+							pos:        position{line: 4961, col: 48, offset: 154175},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 53, offset: 153656},
+							pos:        position{line: 4961, col: 53, offset: 154180},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 58, offset: 153661},
+							pos:        position{line: 4961, col: 58, offset: 154185},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 63, offset: 153666},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4946, col: 69, offset: 153672},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4946, col: 73, offset: 153676},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4946, col: 78, offset: 153681},
+							pos:        position{line: 4961, col: 63, offset: 154190},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 84, offset: 153687},
+							pos:        position{line: 4961, col: 69, offset: 154196},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 88, offset: 153691},
+							pos:        position{line: 4961, col: 73, offset: 154200},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 93, offset: 153696},
+							pos:        position{line: 4961, col: 78, offset: 154205},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4946, col: 99, offset: 153702},
+							pos:        position{line: 4961, col: 84, offset: 154211},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 103, offset: 153706},
+							pos:        position{line: 4961, col: 88, offset: 154215},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4946, col: 108, offset: 153711},
+							pos:        position{line: 4961, col: 93, offset: 154220},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4961, col: 99, offset: 154226},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4961, col: 103, offset: 154230},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4961, col: 108, offset: 154235},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -11291,15 +11329,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4950, col: 1, offset: 153753},
+			pos:  position{line: 4965, col: 1, offset: 154277},
 			expr: &actionExpr{
-				pos: position{line: 4950, col: 22, offset: 153774},
+				pos: position{line: 4965, col: 22, offset: 154298},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4950, col: 22, offset: 153774},
+					pos:   position{line: 4965, col: 22, offset: 154298},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4950, col: 32, offset: 153784},
+						pos:  position{line: 4965, col: 32, offset: 154308},
 						name: "FullTimeStamp",
 					},
 				},
@@ -11307,18 +11345,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4961, col: 1, offset: 154227},
+			pos:  position{line: 4976, col: 1, offset: 154751},
 			expr: &choiceExpr{
-				pos: position{line: 4961, col: 14, offset: 154240},
+				pos: position{line: 4976, col: 14, offset: 154764},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4961, col: 14, offset: 154240},
+						pos: position{line: 4976, col: 14, offset: 154764},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4961, col: 14, offset: 154240},
+							pos: position{line: 4976, col: 14, offset: 154764},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4961, col: 14, offset: 154240},
+									pos:        position{line: 4976, col: 14, offset: 154764},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11326,9 +11364,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4961, col: 29, offset: 154255},
+									pos: position{line: 4976, col: 29, offset: 154779},
 									expr: &charClassMatcher{
-										pos:        position{line: 4961, col: 29, offset: 154255},
+										pos:        position{line: 4976, col: 29, offset: 154779},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11340,10 +11378,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4964, col: 3, offset: 154311},
+						pos: position{line: 4979, col: 3, offset: 154835},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4964, col: 3, offset: 154311},
+							pos:  position{line: 4979, col: 3, offset: 154835},
 							name: "QuotedString",
 						},
 					},
@@ -11352,15 +11390,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4968, col: 1, offset: 154374},
+			pos:  position{line: 4983, col: 1, offset: 154898},
 			expr: &actionExpr{
-				pos: position{line: 4968, col: 24, offset: 154397},
+				pos: position{line: 4983, col: 24, offset: 154921},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4968, col: 24, offset: 154397},
+					pos: position{line: 4983, col: 24, offset: 154921},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4968, col: 24, offset: 154397},
+							pos:        position{line: 4983, col: 24, offset: 154921},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11368,9 +11406,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4968, col: 39, offset: 154412},
+							pos: position{line: 4983, col: 39, offset: 154936},
 							expr: &charClassMatcher{
-								pos:        position{line: 4968, col: 39, offset: 154412},
+								pos:        position{line: 4983, col: 39, offset: 154936},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11384,22 +11422,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4972, col: 1, offset: 154465},
+			pos:  position{line: 4987, col: 1, offset: 154989},
 			expr: &actionExpr{
-				pos: position{line: 4972, col: 11, offset: 154475},
+				pos: position{line: 4987, col: 11, offset: 154999},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4972, col: 11, offset: 154475},
+					pos:   position{line: 4987, col: 11, offset: 154999},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4972, col: 16, offset: 154480},
+						pos: position{line: 4987, col: 16, offset: 155004},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4972, col: 16, offset: 154480},
+								pos:  position{line: 4987, col: 16, offset: 155004},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4972, col: 31, offset: 154495},
+								pos:  position{line: 4987, col: 31, offset: 155019},
 								name: "UnquotedString",
 							},
 						},
@@ -11409,38 +11447,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4976, col: 1, offset: 154536},
+			pos:  position{line: 4991, col: 1, offset: 155060},
 			expr: &actionExpr{
-				pos: position{line: 4976, col: 17, offset: 154552},
+				pos: position{line: 4991, col: 17, offset: 155076},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4976, col: 17, offset: 154552},
+					pos: position{line: 4991, col: 17, offset: 155076},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4976, col: 17, offset: 154552},
+							pos:        position{line: 4991, col: 17, offset: 155076},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4976, col: 21, offset: 154556},
+							pos: position{line: 4991, col: 21, offset: 155080},
 							expr: &choiceExpr{
-								pos: position{line: 4976, col: 22, offset: 154557},
+								pos: position{line: 4991, col: 22, offset: 155081},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4976, col: 22, offset: 154557},
+										pos: position{line: 4991, col: 22, offset: 155081},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4976, col: 22, offset: 154557},
+												pos: position{line: 4991, col: 22, offset: 155081},
 												expr: &litMatcher{
-													pos:        position{line: 4976, col: 23, offset: 154558},
+													pos:        position{line: 4991, col: 23, offset: 155082},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4976, col: 28, offset: 154563},
+												pos:        position{line: 4991, col: 28, offset: 155087},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -11449,16 +11487,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4976, col: 35, offset: 154570},
+										pos: position{line: 4991, col: 35, offset: 155094},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4976, col: 35, offset: 154570},
+												pos:        position{line: 4991, col: 35, offset: 155094},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4976, col: 40, offset: 154575,
+												line: 4991, col: 40, offset: 155099,
 											},
 										},
 									},
@@ -11466,7 +11504,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4976, col: 44, offset: 154579},
+							pos:        position{line: 4991, col: 44, offset: 155103},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -11477,48 +11515,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4981, col: 1, offset: 154690},
+			pos:  position{line: 4996, col: 1, offset: 155214},
 			expr: &actionExpr{
-				pos: position{line: 4981, col: 19, offset: 154708},
+				pos: position{line: 4996, col: 19, offset: 155232},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4981, col: 19, offset: 154708},
+					pos: position{line: 4996, col: 19, offset: 155232},
 					expr: &choiceExpr{
-						pos: position{line: 4981, col: 20, offset: 154709},
+						pos: position{line: 4996, col: 20, offset: 155233},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4981, col: 20, offset: 154709},
+								pos:        position{line: 4996, col: 20, offset: 155233},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4981, col: 27, offset: 154716},
+								pos: position{line: 4996, col: 27, offset: 155240},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4981, col: 27, offset: 154716},
+										pos: position{line: 4996, col: 27, offset: 155240},
 										expr: &choiceExpr{
-											pos: position{line: 4981, col: 29, offset: 154718},
+											pos: position{line: 4996, col: 29, offset: 155242},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4981, col: 29, offset: 154718},
+													pos:  position{line: 4996, col: 29, offset: 155242},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4981, col: 43, offset: 154732},
+													pos:        position{line: 4996, col: 43, offset: 155256},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4981, col: 49, offset: 154738},
+													pos:  position{line: 4996, col: 49, offset: 155262},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4981, col: 54, offset: 154743,
+										line: 4996, col: 54, offset: 155267,
 									},
 								},
 							},
@@ -11529,12 +11567,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4988, col: 1, offset: 154858},
+			pos:  position{line: 5003, col: 1, offset: 155382},
 			expr: &choiceExpr{
-				pos: position{line: 4988, col: 16, offset: 154873},
+				pos: position{line: 5003, col: 16, offset: 155397},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4988, col: 16, offset: 154873},
+						pos:        position{line: 5003, col: 16, offset: 155397},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11542,18 +11580,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4988, col: 37, offset: 154894},
+						pos: position{line: 5003, col: 37, offset: 155418},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4988, col: 37, offset: 154894},
+								pos:        position{line: 5003, col: 37, offset: 155418},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4988, col: 41, offset: 154898},
+								pos: position{line: 5003, col: 41, offset: 155422},
 								expr: &charClassMatcher{
-									pos:        position{line: 4988, col: 41, offset: 154898},
+									pos:        position{line: 5003, col: 41, offset: 155422},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -11561,7 +11599,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4988, col: 48, offset: 154905},
+								pos:        position{line: 5003, col: 48, offset: 155429},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -11573,46 +11611,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4990, col: 1, offset: 154911},
+			pos:  position{line: 5005, col: 1, offset: 155435},
 			expr: &actionExpr{
-				pos: position{line: 4990, col: 39, offset: 154949},
+				pos: position{line: 5005, col: 39, offset: 155473},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4990, col: 39, offset: 154949},
+					pos: position{line: 5005, col: 39, offset: 155473},
 					expr: &choiceExpr{
-						pos: position{line: 4990, col: 40, offset: 154950},
+						pos: position{line: 5005, col: 40, offset: 155474},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4990, col: 40, offset: 154950},
+								pos:  position{line: 5005, col: 40, offset: 155474},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4990, col: 54, offset: 154964},
+								pos: position{line: 5005, col: 54, offset: 155488},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4990, col: 54, offset: 154964},
+										pos: position{line: 5005, col: 54, offset: 155488},
 										expr: &choiceExpr{
-											pos: position{line: 4990, col: 56, offset: 154966},
+											pos: position{line: 5005, col: 56, offset: 155490},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4990, col: 56, offset: 154966},
+													pos:  position{line: 5005, col: 56, offset: 155490},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4990, col: 70, offset: 154980},
+													pos:        position{line: 5005, col: 70, offset: 155504},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4990, col: 76, offset: 154986},
+													pos:  position{line: 5005, col: 76, offset: 155510},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4990, col: 81, offset: 154991,
+										line: 5005, col: 81, offset: 155515,
 									},
 								},
 							},
@@ -11623,21 +11661,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4994, col: 1, offset: 155031},
+			pos:  position{line: 5009, col: 1, offset: 155555},
 			expr: &actionExpr{
-				pos: position{line: 4994, col: 12, offset: 155042},
+				pos: position{line: 5009, col: 12, offset: 155566},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4994, col: 13, offset: 155043},
+					pos: position{line: 5009, col: 13, offset: 155567},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4994, col: 13, offset: 155043},
+							pos:        position{line: 5009, col: 13, offset: 155567},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4994, col: 22, offset: 155052},
+							pos:        position{line: 5009, col: 22, offset: 155576},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11648,14 +11686,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 5000, col: 1, offset: 155206},
+			pos:  position{line: 5015, col: 1, offset: 155730},
 			expr: &actionExpr{
-				pos: position{line: 5000, col: 18, offset: 155223},
+				pos: position{line: 5015, col: 18, offset: 155747},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5000, col: 18, offset: 155223},
+					pos: position{line: 5015, col: 18, offset: 155747},
 					expr: &charClassMatcher{
-						pos:        position{line: 5000, col: 18, offset: 155223},
+						pos:        position{line: 5015, col: 18, offset: 155747},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11667,15 +11705,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 5004, col: 1, offset: 155274},
+			pos:  position{line: 5019, col: 1, offset: 155798},
 			expr: &actionExpr{
-				pos: position{line: 5004, col: 11, offset: 155284},
+				pos: position{line: 5019, col: 11, offset: 155808},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 5004, col: 11, offset: 155284},
+					pos:   position{line: 5019, col: 11, offset: 155808},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5004, col: 18, offset: 155291},
+						pos:  position{line: 5019, col: 18, offset: 155815},
 						name: "NumberAsString",
 					},
 				},
@@ -11683,59 +11721,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 5010, col: 1, offset: 155480},
+			pos:  position{line: 5025, col: 1, offset: 156004},
 			expr: &actionExpr{
-				pos: position{line: 5010, col: 19, offset: 155498},
+				pos: position{line: 5025, col: 19, offset: 156022},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 5010, col: 19, offset: 155498},
+					pos: position{line: 5025, col: 19, offset: 156022},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5010, col: 19, offset: 155498},
+							pos:   position{line: 5025, col: 19, offset: 156022},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 5010, col: 27, offset: 155506},
+								pos: position{line: 5025, col: 27, offset: 156030},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5010, col: 27, offset: 155506},
+										pos:  position{line: 5025, col: 27, offset: 156030},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5010, col: 43, offset: 155522},
+										pos:  position{line: 5025, col: 43, offset: 156046},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 5010, col: 60, offset: 155539},
+							pos: position{line: 5025, col: 60, offset: 156063},
 							expr: &choiceExpr{
-								pos: position{line: 5010, col: 62, offset: 155541},
+								pos: position{line: 5025, col: 62, offset: 156065},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5010, col: 62, offset: 155541},
+										pos:  position{line: 5025, col: 62, offset: 156065},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 5010, col: 70, offset: 155549},
+										pos:        position{line: 5025, col: 70, offset: 156073},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5010, col: 76, offset: 155555},
+										pos:        position{line: 5025, col: 76, offset: 156079},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5010, col: 82, offset: 155561},
+										pos:        position{line: 5025, col: 82, offset: 156085},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5010, col: 88, offset: 155567},
+										pos:  position{line: 5025, col: 88, offset: 156091},
 										name: "EOF",
 									},
 								},
@@ -11747,17 +11785,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 5016, col: 1, offset: 155696},
+			pos:  position{line: 5031, col: 1, offset: 156220},
 			expr: &actionExpr{
-				pos: position{line: 5016, col: 18, offset: 155713},
+				pos: position{line: 5031, col: 18, offset: 156237},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 5016, col: 18, offset: 155713},
+					pos: position{line: 5031, col: 18, offset: 156237},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 5016, col: 18, offset: 155713},
+							pos: position{line: 5031, col: 18, offset: 156237},
 							expr: &charClassMatcher{
-								pos:        position{line: 5016, col: 18, offset: 155713},
+								pos:        position{line: 5031, col: 18, offset: 156237},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11765,9 +11803,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 5016, col: 24, offset: 155719},
+							pos: position{line: 5031, col: 24, offset: 156243},
 							expr: &charClassMatcher{
-								pos:        position{line: 5016, col: 24, offset: 155719},
+								pos:        position{line: 5031, col: 24, offset: 156243},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11775,15 +11813,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5016, col: 31, offset: 155726},
+							pos:        position{line: 5031, col: 31, offset: 156250},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 5016, col: 35, offset: 155730},
+							pos: position{line: 5031, col: 35, offset: 156254},
 							expr: &charClassMatcher{
-								pos:        position{line: 5016, col: 35, offset: 155730},
+								pos:        position{line: 5031, col: 35, offset: 156254},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11796,17 +11834,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 5021, col: 1, offset: 155825},
+			pos:  position{line: 5036, col: 1, offset: 156349},
 			expr: &actionExpr{
-				pos: position{line: 5021, col: 20, offset: 155844},
+				pos: position{line: 5036, col: 20, offset: 156368},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 5021, col: 20, offset: 155844},
+					pos: position{line: 5036, col: 20, offset: 156368},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 5021, col: 20, offset: 155844},
+							pos: position{line: 5036, col: 20, offset: 156368},
 							expr: &charClassMatcher{
-								pos:        position{line: 5021, col: 20, offset: 155844},
+								pos:        position{line: 5036, col: 20, offset: 156368},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11814,9 +11852,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 5021, col: 26, offset: 155850},
+							pos: position{line: 5036, col: 26, offset: 156374},
 							expr: &charClassMatcher{
-								pos:        position{line: 5021, col: 26, offset: 155850},
+								pos:        position{line: 5036, col: 26, offset: 156374},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11829,14 +11867,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 5025, col: 1, offset: 155893},
+			pos:  position{line: 5040, col: 1, offset: 156417},
 			expr: &actionExpr{
-				pos: position{line: 5025, col: 28, offset: 155920},
+				pos: position{line: 5040, col: 28, offset: 156444},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5025, col: 28, offset: 155920},
+					pos: position{line: 5040, col: 28, offset: 156444},
 					expr: &charClassMatcher{
-						pos:        position{line: 5025, col: 28, offset: 155920},
+						pos:        position{line: 5040, col: 28, offset: 156444},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11847,15 +11885,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 5029, col: 1, offset: 155963},
+			pos:  position{line: 5044, col: 1, offset: 156487},
 			expr: &actionExpr{
-				pos: position{line: 5029, col: 20, offset: 155982},
+				pos: position{line: 5044, col: 20, offset: 156506},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 5029, col: 20, offset: 155982},
+					pos:   position{line: 5044, col: 20, offset: 156506},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5029, col: 27, offset: 155989},
+						pos:  position{line: 5044, col: 27, offset: 156513},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11863,37 +11901,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 5037, col: 1, offset: 156236},
+			pos:  position{line: 5052, col: 1, offset: 156760},
 			expr: &actionExpr{
-				pos: position{line: 5037, col: 21, offset: 156256},
+				pos: position{line: 5052, col: 21, offset: 156780},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 5037, col: 21, offset: 156256},
+					pos: position{line: 5052, col: 21, offset: 156780},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5037, col: 21, offset: 156256},
+							pos:  position{line: 5052, col: 21, offset: 156780},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5037, col: 36, offset: 156271},
+							pos:   position{line: 5052, col: 36, offset: 156795},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 5037, col: 40, offset: 156275},
+								pos: position{line: 5052, col: 40, offset: 156799},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5037, col: 40, offset: 156275},
+										pos:        position{line: 5052, col: 40, offset: 156799},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5037, col: 47, offset: 156282},
+										pos:        position{line: 5052, col: 47, offset: 156806},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5037, col: 53, offset: 156288},
+										pos:        position{line: 5052, col: 53, offset: 156812},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11902,7 +11940,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5037, col: 59, offset: 156294},
+							pos:  position{line: 5052, col: 59, offset: 156818},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11911,43 +11949,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 5048, col: 1, offset: 156524},
+			pos:  position{line: 5063, col: 1, offset: 157048},
 			expr: &actionExpr{
-				pos: position{line: 5048, col: 23, offset: 156546},
+				pos: position{line: 5063, col: 23, offset: 157070},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 5048, col: 23, offset: 156546},
+					pos: position{line: 5063, col: 23, offset: 157070},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5048, col: 23, offset: 156546},
+							pos:  position{line: 5063, col: 23, offset: 157070},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5048, col: 38, offset: 156561},
+							pos:   position{line: 5063, col: 38, offset: 157085},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 5048, col: 42, offset: 156565},
+								pos: position{line: 5063, col: 42, offset: 157089},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5048, col: 42, offset: 156565},
+										pos:        position{line: 5063, col: 42, offset: 157089},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5048, col: 49, offset: 156572},
+										pos:        position{line: 5063, col: 49, offset: 157096},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5048, col: 55, offset: 156578},
+										pos:        position{line: 5063, col: 55, offset: 157102},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5048, col: 62, offset: 156585},
+										pos:        position{line: 5063, col: 62, offset: 157109},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11956,7 +11994,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5048, col: 67, offset: 156590},
+							pos:  position{line: 5063, col: 67, offset: 157114},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11965,30 +12003,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 5056, col: 1, offset: 156773},
+			pos:  position{line: 5071, col: 1, offset: 157297},
 			expr: &choiceExpr{
-				pos: position{line: 5056, col: 25, offset: 156797},
+				pos: position{line: 5071, col: 25, offset: 157321},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 5056, col: 25, offset: 156797},
+						pos: position{line: 5071, col: 25, offset: 157321},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 5056, col: 25, offset: 156797},
+							pos:   position{line: 5071, col: 25, offset: 157321},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5056, col: 28, offset: 156800},
+								pos:  position{line: 5071, col: 28, offset: 157324},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 5059, col: 3, offset: 156842},
+						pos: position{line: 5074, col: 3, offset: 157366},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 5059, col: 3, offset: 156842},
+							pos:   position{line: 5074, col: 3, offset: 157366},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5059, col: 6, offset: 156845},
+								pos:  position{line: 5074, col: 6, offset: 157369},
 								name: "InequalityOperator",
 							},
 						},
@@ -11998,25 +12036,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 5063, col: 1, offset: 156888},
+			pos:  position{line: 5078, col: 1, offset: 157412},
 			expr: &actionExpr{
-				pos: position{line: 5063, col: 11, offset: 156898},
+				pos: position{line: 5078, col: 11, offset: 157422},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 5063, col: 11, offset: 156898},
+					pos: position{line: 5078, col: 11, offset: 157422},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5063, col: 11, offset: 156898},
+							pos:  position{line: 5078, col: 11, offset: 157422},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5063, col: 26, offset: 156913},
+							pos:        position{line: 5078, col: 26, offset: 157437},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5063, col: 30, offset: 156917},
+							pos:  position{line: 5078, col: 30, offset: 157441},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -12025,25 +12063,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 5067, col: 1, offset: 156957},
+			pos:  position{line: 5082, col: 1, offset: 157481},
 			expr: &actionExpr{
-				pos: position{line: 5067, col: 12, offset: 156968},
+				pos: position{line: 5082, col: 12, offset: 157492},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 5067, col: 12, offset: 156968},
+					pos: position{line: 5082, col: 12, offset: 157492},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5067, col: 12, offset: 156968},
+							pos:  position{line: 5082, col: 12, offset: 157492},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5067, col: 27, offset: 156983},
+							pos:        position{line: 5082, col: 27, offset: 157507},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5067, col: 31, offset: 156987},
+							pos:  position{line: 5082, col: 31, offset: 157511},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -12052,25 +12090,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 5071, col: 1, offset: 157027},
+			pos:  position{line: 5086, col: 1, offset: 157551},
 			expr: &actionExpr{
-				pos: position{line: 5071, col: 10, offset: 157036},
+				pos: position{line: 5086, col: 10, offset: 157560},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 5071, col: 10, offset: 157036},
+					pos: position{line: 5086, col: 10, offset: 157560},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5071, col: 10, offset: 157036},
+							pos:  position{line: 5086, col: 10, offset: 157560},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5071, col: 25, offset: 157051},
+							pos:        position{line: 5086, col: 25, offset: 157575},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5071, col: 29, offset: 157055},
+							pos:  position{line: 5086, col: 29, offset: 157579},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -12079,25 +12117,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 5075, col: 1, offset: 157095},
+			pos:  position{line: 5090, col: 1, offset: 157619},
 			expr: &actionExpr{
-				pos: position{line: 5075, col: 10, offset: 157104},
+				pos: position{line: 5090, col: 10, offset: 157628},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 5075, col: 10, offset: 157104},
+					pos: position{line: 5090, col: 10, offset: 157628},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5075, col: 10, offset: 157104},
+							pos:  position{line: 5090, col: 10, offset: 157628},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5075, col: 25, offset: 157119},
+							pos:        position{line: 5090, col: 25, offset: 157643},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5075, col: 29, offset: 157123},
+							pos:  position{line: 5090, col: 29, offset: 157647},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -12106,25 +12144,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 5079, col: 1, offset: 157163},
+			pos:  position{line: 5094, col: 1, offset: 157687},
 			expr: &actionExpr{
-				pos: position{line: 5079, col: 10, offset: 157172},
+				pos: position{line: 5094, col: 10, offset: 157696},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 5079, col: 10, offset: 157172},
+					pos: position{line: 5094, col: 10, offset: 157696},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5079, col: 10, offset: 157172},
+							pos:  position{line: 5094, col: 10, offset: 157696},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5079, col: 25, offset: 157187},
+							pos:        position{line: 5094, col: 25, offset: 157711},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5079, col: 29, offset: 157191},
+							pos:  position{line: 5094, col: 29, offset: 157715},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -12133,39 +12171,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 5084, col: 1, offset: 157255},
+			pos:  position{line: 5099, col: 1, offset: 157779},
 			expr: &actionExpr{
-				pos: position{line: 5084, col: 11, offset: 157265},
+				pos: position{line: 5099, col: 11, offset: 157789},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 5084, col: 12, offset: 157266},
+					pos: position{line: 5099, col: 12, offset: 157790},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5084, col: 12, offset: 157266},
+							pos:        position{line: 5099, col: 12, offset: 157790},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5084, col: 24, offset: 157278},
+							pos:        position{line: 5099, col: 24, offset: 157802},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5084, col: 35, offset: 157289},
+							pos:        position{line: 5099, col: 35, offset: 157813},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5084, col: 44, offset: 157298},
+							pos:        position{line: 5099, col: 44, offset: 157822},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5084, col: 52, offset: 157306},
+							pos:        position{line: 5099, col: 52, offset: 157830},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -12176,39 +12214,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 5088, col: 1, offset: 157348},
+			pos:  position{line: 5103, col: 1, offset: 157872},
 			expr: &actionExpr{
-				pos: position{line: 5088, col: 11, offset: 157358},
+				pos: position{line: 5103, col: 11, offset: 157882},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 5088, col: 12, offset: 157359},
+					pos: position{line: 5103, col: 12, offset: 157883},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5088, col: 12, offset: 157359},
+							pos:        position{line: 5103, col: 12, offset: 157883},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5088, col: 24, offset: 157371},
+							pos:        position{line: 5103, col: 24, offset: 157895},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5088, col: 35, offset: 157382},
+							pos:        position{line: 5103, col: 35, offset: 157906},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5088, col: 44, offset: 157391},
+							pos:        position{line: 5103, col: 44, offset: 157915},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5088, col: 52, offset: 157399},
+							pos:        position{line: 5103, col: 52, offset: 157923},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -12219,39 +12257,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 5092, col: 1, offset: 157441},
+			pos:  position{line: 5107, col: 1, offset: 157965},
 			expr: &actionExpr{
-				pos: position{line: 5092, col: 9, offset: 157449},
+				pos: position{line: 5107, col: 9, offset: 157973},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 5092, col: 10, offset: 157450},
+					pos: position{line: 5107, col: 10, offset: 157974},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5092, col: 10, offset: 157450},
+							pos:        position{line: 5107, col: 10, offset: 157974},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5092, col: 20, offset: 157460},
+							pos:        position{line: 5107, col: 20, offset: 157984},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5092, col: 29, offset: 157469},
+							pos:        position{line: 5107, col: 29, offset: 157993},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5092, col: 37, offset: 157477},
+							pos:        position{line: 5107, col: 37, offset: 158001},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5092, col: 44, offset: 157484},
+							pos:        position{line: 5107, col: 44, offset: 158008},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -12262,27 +12300,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 5096, col: 1, offset: 157524},
+			pos:  position{line: 5111, col: 1, offset: 158048},
 			expr: &actionExpr{
-				pos: position{line: 5096, col: 8, offset: 157531},
+				pos: position{line: 5111, col: 8, offset: 158055},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 5096, col: 9, offset: 157532},
+					pos: position{line: 5111, col: 9, offset: 158056},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5096, col: 9, offset: 157532},
+							pos:        position{line: 5111, col: 9, offset: 158056},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5096, col: 18, offset: 157541},
+							pos:        position{line: 5111, col: 18, offset: 158065},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5096, col: 26, offset: 157549},
+							pos:        position{line: 5111, col: 26, offset: 158073},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -12293,27 +12331,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 5100, col: 1, offset: 157588},
+			pos:  position{line: 5115, col: 1, offset: 158112},
 			expr: &actionExpr{
-				pos: position{line: 5100, col: 9, offset: 157596},
+				pos: position{line: 5115, col: 9, offset: 158120},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 5100, col: 10, offset: 157597},
+					pos: position{line: 5115, col: 10, offset: 158121},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5100, col: 10, offset: 157597},
+							pos:        position{line: 5115, col: 10, offset: 158121},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5100, col: 20, offset: 157607},
+							pos:        position{line: 5115, col: 20, offset: 158131},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5100, col: 29, offset: 157616},
+							pos:        position{line: 5115, col: 29, offset: 158140},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -12324,27 +12362,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 5104, col: 1, offset: 157656},
+			pos:  position{line: 5119, col: 1, offset: 158180},
 			expr: &actionExpr{
-				pos: position{line: 5104, col: 10, offset: 157665},
+				pos: position{line: 5119, col: 10, offset: 158189},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 5104, col: 11, offset: 157666},
+					pos: position{line: 5119, col: 11, offset: 158190},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5104, col: 11, offset: 157666},
+							pos:        position{line: 5119, col: 11, offset: 158190},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5104, col: 22, offset: 157677},
+							pos:        position{line: 5119, col: 22, offset: 158201},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5104, col: 32, offset: 157687},
+							pos:        position{line: 5119, col: 32, offset: 158211},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -12355,39 +12393,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 5108, col: 1, offset: 157730},
+			pos:  position{line: 5123, col: 1, offset: 158254},
 			expr: &actionExpr{
-				pos: position{line: 5108, col: 12, offset: 157741},
+				pos: position{line: 5123, col: 12, offset: 158265},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 5108, col: 13, offset: 157742},
+					pos: position{line: 5123, col: 13, offset: 158266},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5108, col: 13, offset: 157742},
+							pos:        position{line: 5123, col: 13, offset: 158266},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5108, col: 26, offset: 157755},
+							pos:        position{line: 5123, col: 26, offset: 158279},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5108, col: 38, offset: 157767},
+							pos:        position{line: 5123, col: 38, offset: 158291},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5108, col: 47, offset: 157776},
+							pos:        position{line: 5123, col: 47, offset: 158300},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5108, col: 55, offset: 157784},
+							pos:        position{line: 5123, col: 55, offset: 158308},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -12398,39 +12436,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 5112, col: 1, offset: 157827},
+			pos:  position{line: 5127, col: 1, offset: 158351},
 			expr: &actionExpr{
-				pos: position{line: 5112, col: 9, offset: 157835},
+				pos: position{line: 5127, col: 9, offset: 158359},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 5112, col: 10, offset: 157836},
+					pos: position{line: 5127, col: 10, offset: 158360},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5112, col: 10, offset: 157836},
+							pos:        position{line: 5127, col: 10, offset: 158360},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5112, col: 20, offset: 157846},
+							pos:        position{line: 5127, col: 20, offset: 158370},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5112, col: 29, offset: 157855},
+							pos:        position{line: 5127, col: 29, offset: 158379},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5112, col: 37, offset: 157863},
+							pos:        position{line: 5127, col: 37, offset: 158387},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5112, col: 44, offset: 157870},
+							pos:        position{line: 5127, col: 44, offset: 158394},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -12441,33 +12479,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 5117, col: 1, offset: 158002},
+			pos:  position{line: 5132, col: 1, offset: 158526},
 			expr: &actionExpr{
-				pos: position{line: 5117, col: 15, offset: 158016},
+				pos: position{line: 5132, col: 15, offset: 158540},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 5117, col: 16, offset: 158017},
+					pos: position{line: 5132, col: 16, offset: 158541},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 5117, col: 16, offset: 158017},
+							pos:        position{line: 5132, col: 16, offset: 158541},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5117, col: 23, offset: 158024},
+							pos:        position{line: 5132, col: 23, offset: 158548},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5117, col: 30, offset: 158031},
+							pos:        position{line: 5132, col: 30, offset: 158555},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 5117, col: 37, offset: 158038},
+							pos:        position{line: 5132, col: 37, offset: 158562},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -12478,26 +12516,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 5126, col: 1, offset: 158262},
+			pos:  position{line: 5141, col: 1, offset: 158786},
 			expr: &actionExpr{
-				pos: position{line: 5126, col: 21, offset: 158282},
+				pos: position{line: 5141, col: 21, offset: 158806},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5126, col: 21, offset: 158282},
+					pos: position{line: 5141, col: 21, offset: 158806},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5126, col: 21, offset: 158282},
+							pos:  position{line: 5141, col: 21, offset: 158806},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5126, col: 26, offset: 158287},
+							pos:  position{line: 5141, col: 26, offset: 158811},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 5126, col: 42, offset: 158303},
+							pos:   position{line: 5141, col: 42, offset: 158827},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5126, col: 53, offset: 158314},
+								pos:  position{line: 5141, col: 53, offset: 158838},
 								name: "TransactionOptions",
 							},
 						},
@@ -12507,17 +12545,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 5136, col: 1, offset: 158689},
+			pos:  position{line: 5151, col: 1, offset: 159213},
 			expr: &actionExpr{
-				pos: position{line: 5136, col: 23, offset: 158711},
+				pos: position{line: 5151, col: 23, offset: 159235},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 5136, col: 23, offset: 158711},
+					pos:   position{line: 5151, col: 23, offset: 159235},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 5136, col: 34, offset: 158722},
+						pos: position{line: 5151, col: 34, offset: 159246},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5136, col: 34, offset: 158722},
+							pos:  position{line: 5151, col: 34, offset: 159246},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -12526,35 +12564,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 5151, col: 1, offset: 159113},
+			pos:  position{line: 5166, col: 1, offset: 159637},
 			expr: &actionExpr{
-				pos: position{line: 5151, col: 37, offset: 159149},
+				pos: position{line: 5166, col: 37, offset: 159673},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5151, col: 37, offset: 159149},
+					pos: position{line: 5166, col: 37, offset: 159673},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5151, col: 37, offset: 159149},
+							pos:   position{line: 5166, col: 37, offset: 159673},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5151, col: 43, offset: 159155},
+								pos:  position{line: 5166, col: 43, offset: 159679},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5151, col: 71, offset: 159183},
+							pos:   position{line: 5166, col: 71, offset: 159707},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5151, col: 76, offset: 159188},
+								pos: position{line: 5166, col: 76, offset: 159712},
 								expr: &seqExpr{
-									pos: position{line: 5151, col: 77, offset: 159189},
+									pos: position{line: 5166, col: 77, offset: 159713},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5151, col: 77, offset: 159189},
+											pos:  position{line: 5166, col: 77, offset: 159713},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5151, col: 83, offset: 159195},
+											pos:  position{line: 5166, col: 83, offset: 159719},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -12567,26 +12605,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 5186, col: 1, offset: 160184},
+			pos:  position{line: 5201, col: 1, offset: 160708},
 			expr: &actionExpr{
-				pos: position{line: 5186, col: 32, offset: 160215},
+				pos: position{line: 5201, col: 32, offset: 160739},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5186, col: 32, offset: 160215},
+					pos:   position{line: 5201, col: 32, offset: 160739},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5186, col: 40, offset: 160223},
+						pos: position{line: 5201, col: 40, offset: 160747},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5186, col: 40, offset: 160223},
+								pos:  position{line: 5201, col: 40, offset: 160747},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5186, col: 77, offset: 160260},
+								pos:  position{line: 5201, col: 77, offset: 160784},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5186, col: 96, offset: 160279},
+								pos:  position{line: 5201, col: 96, offset: 160803},
 								name: "EndsWithOption",
 							},
 						},
@@ -12596,15 +12634,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 5190, col: 1, offset: 160323},
+			pos:  position{line: 5205, col: 1, offset: 160847},
 			expr: &actionExpr{
-				pos: position{line: 5190, col: 39, offset: 160361},
+				pos: position{line: 5205, col: 39, offset: 160885},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 5190, col: 39, offset: 160361},
+					pos:   position{line: 5205, col: 39, offset: 160885},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5190, col: 46, offset: 160368},
+						pos:  position{line: 5205, col: 46, offset: 160892},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12612,28 +12650,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 5201, col: 1, offset: 160584},
+			pos:  position{line: 5216, col: 1, offset: 161108},
 			expr: &actionExpr{
-				pos: position{line: 5201, col: 21, offset: 160604},
+				pos: position{line: 5216, col: 21, offset: 161128},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5201, col: 21, offset: 160604},
+					pos: position{line: 5216, col: 21, offset: 161128},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5201, col: 21, offset: 160604},
+							pos:        position{line: 5216, col: 21, offset: 161128},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5201, col: 34, offset: 160617},
+							pos:  position{line: 5216, col: 34, offset: 161141},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5201, col: 40, offset: 160623},
+							pos:   position{line: 5216, col: 40, offset: 161147},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5201, col: 48, offset: 160631},
+								pos:  position{line: 5216, col: 48, offset: 161155},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12643,28 +12681,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 5211, col: 1, offset: 160869},
+			pos:  position{line: 5226, col: 1, offset: 161393},
 			expr: &actionExpr{
-				pos: position{line: 5211, col: 19, offset: 160887},
+				pos: position{line: 5226, col: 19, offset: 161411},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 5211, col: 19, offset: 160887},
+					pos: position{line: 5226, col: 19, offset: 161411},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5211, col: 19, offset: 160887},
+							pos:        position{line: 5226, col: 19, offset: 161411},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5211, col: 30, offset: 160898},
+							pos:  position{line: 5226, col: 30, offset: 161422},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5211, col: 36, offset: 160904},
+							pos:   position{line: 5226, col: 36, offset: 161428},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5211, col: 44, offset: 160912},
+								pos:  position{line: 5226, col: 44, offset: 161436},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12674,26 +12712,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 5222, col: 1, offset: 161181},
+			pos:  position{line: 5237, col: 1, offset: 161705},
 			expr: &actionExpr{
-				pos: position{line: 5222, col: 28, offset: 161208},
+				pos: position{line: 5237, col: 28, offset: 161732},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5222, col: 28, offset: 161208},
+					pos:   position{line: 5237, col: 28, offset: 161732},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5222, col: 37, offset: 161217},
+						pos: position{line: 5237, col: 37, offset: 161741},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5222, col: 37, offset: 161217},
+								pos:  position{line: 5237, col: 37, offset: 161741},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5222, col: 63, offset: 161243},
+								pos:  position{line: 5237, col: 63, offset: 161767},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5222, col: 81, offset: 161261},
+								pos:  position{line: 5237, col: 81, offset: 161785},
 								name: "TransactionSearch",
 							},
 						},
@@ -12703,22 +12741,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 5226, col: 1, offset: 161309},
+			pos:  position{line: 5241, col: 1, offset: 161833},
 			expr: &actionExpr{
-				pos: position{line: 5226, col: 28, offset: 161336},
+				pos: position{line: 5241, col: 28, offset: 161860},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 5226, col: 28, offset: 161336},
+					pos:   position{line: 5241, col: 28, offset: 161860},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 5226, col: 33, offset: 161341},
+						pos: position{line: 5241, col: 33, offset: 161865},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5226, col: 33, offset: 161341},
+								pos:  position{line: 5241, col: 33, offset: 161865},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5226, col: 64, offset: 161372},
+								pos:  position{line: 5241, col: 64, offset: 161896},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12728,29 +12766,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 5230, col: 1, offset: 161432},
+			pos:  position{line: 5245, col: 1, offset: 161956},
 			expr: &actionExpr{
-				pos: position{line: 5230, col: 38, offset: 161469},
+				pos: position{line: 5245, col: 38, offset: 161993},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 5230, col: 38, offset: 161469},
+					pos: position{line: 5245, col: 38, offset: 161993},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5230, col: 38, offset: 161469},
+							pos:        position{line: 5245, col: 38, offset: 161993},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 5230, col: 42, offset: 161473},
+							pos:   position{line: 5245, col: 42, offset: 161997},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5230, col: 55, offset: 161486},
+								pos:  position{line: 5245, col: 55, offset: 162010},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5230, col: 68, offset: 161499},
+							pos:        position{line: 5245, col: 68, offset: 162023},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12761,23 +12799,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 5238, col: 1, offset: 161638},
+			pos:  position{line: 5253, col: 1, offset: 162162},
 			expr: &actionExpr{
-				pos: position{line: 5238, col: 21, offset: 161658},
+				pos: position{line: 5253, col: 21, offset: 162182},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 5238, col: 21, offset: 161658},
+					pos: position{line: 5253, col: 21, offset: 162182},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5238, col: 21, offset: 161658},
+							pos:        position{line: 5253, col: 21, offset: 162182},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 5238, col: 25, offset: 161662},
+							pos: position{line: 5253, col: 25, offset: 162186},
 							expr: &charClassMatcher{
-								pos:        position{line: 5238, col: 25, offset: 161662},
+								pos:        position{line: 5253, col: 25, offset: 162186},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12785,7 +12823,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5238, col: 44, offset: 161681},
+							pos:        position{line: 5253, col: 44, offset: 162205},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12796,15 +12834,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 5243, col: 1, offset: 161792},
+			pos:  position{line: 5258, col: 1, offset: 162316},
 			expr: &actionExpr{
-				pos: position{line: 5243, col: 33, offset: 161824},
+				pos: position{line: 5258, col: 33, offset: 162348},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 5243, col: 33, offset: 161824},
+					pos:   position{line: 5258, col: 33, offset: 162348},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5243, col: 37, offset: 161828},
+						pos:  position{line: 5258, col: 37, offset: 162352},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12812,15 +12850,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 5251, col: 1, offset: 161983},
+			pos:  position{line: 5266, col: 1, offset: 162507},
 			expr: &actionExpr{
-				pos: position{line: 5251, col: 22, offset: 162004},
+				pos: position{line: 5266, col: 22, offset: 162528},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 5251, col: 22, offset: 162004},
+					pos:   position{line: 5266, col: 22, offset: 162528},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5251, col: 27, offset: 162009},
+						pos:  position{line: 5266, col: 27, offset: 162533},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12828,37 +12866,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 5261, col: 1, offset: 162181},
+			pos:  position{line: 5276, col: 1, offset: 162705},
 			expr: &actionExpr{
-				pos: position{line: 5261, col: 20, offset: 162200},
+				pos: position{line: 5276, col: 20, offset: 162724},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 5261, col: 20, offset: 162200},
+					pos: position{line: 5276, col: 20, offset: 162724},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5261, col: 20, offset: 162200},
+							pos:        position{line: 5276, col: 20, offset: 162724},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5261, col: 27, offset: 162207},
+							pos:  position{line: 5276, col: 27, offset: 162731},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5261, col: 42, offset: 162222},
+							pos:  position{line: 5276, col: 42, offset: 162746},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5261, col: 50, offset: 162230},
+							pos:   position{line: 5276, col: 50, offset: 162754},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5261, col: 60, offset: 162240},
+								pos:  position{line: 5276, col: 60, offset: 162764},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5261, col: 69, offset: 162249},
+							pos:  position{line: 5276, col: 69, offset: 162773},
 							name: "R_PAREN",
 						},
 					},
@@ -12867,22 +12905,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5271, col: 1, offset: 162552},
+			pos:  position{line: 5286, col: 1, offset: 163076},
 			expr: &actionExpr{
-				pos: position{line: 5271, col: 20, offset: 162571},
+				pos: position{line: 5286, col: 20, offset: 163095},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5271, col: 20, offset: 162571},
+					pos: position{line: 5286, col: 20, offset: 163095},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5271, col: 20, offset: 162571},
+							pos:  position{line: 5286, col: 20, offset: 163095},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5271, col: 25, offset: 162576},
+							pos:   position{line: 5286, col: 25, offset: 163100},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5271, col: 42, offset: 162593},
+								pos:  position{line: 5286, col: 42, offset: 163117},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12892,41 +12930,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5275, col: 1, offset: 162642},
+			pos:  position{line: 5290, col: 1, offset: 163166},
 			expr: &actionExpr{
-				pos: position{line: 5275, col: 16, offset: 162657},
+				pos: position{line: 5290, col: 16, offset: 163181},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5275, col: 16, offset: 162657},
+					pos: position{line: 5290, col: 16, offset: 163181},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5275, col: 16, offset: 162657},
+							pos:  position{line: 5290, col: 16, offset: 163181},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5275, col: 27, offset: 162668},
+							pos:  position{line: 5290, col: 27, offset: 163192},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5275, col: 33, offset: 162674},
+							pos:   position{line: 5290, col: 33, offset: 163198},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5275, col: 50, offset: 162691},
+								pos: position{line: 5290, col: 50, offset: 163215},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5275, col: 50, offset: 162691},
+									pos:  position{line: 5290, col: 50, offset: 163215},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5275, col: 70, offset: 162711},
+							pos:  position{line: 5290, col: 70, offset: 163235},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5275, col: 85, offset: 162726},
+							pos:   position{line: 5290, col: 85, offset: 163250},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5275, col: 91, offset: 162732},
+								pos:  position{line: 5290, col: 91, offset: 163256},
 								name: "FieldName",
 							},
 						},
@@ -12936,35 +12974,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5304, col: 1, offset: 163503},
+			pos:  position{line: 5319, col: 1, offset: 164027},
 			expr: &actionExpr{
-				pos: position{line: 5304, col: 23, offset: 163525},
+				pos: position{line: 5319, col: 23, offset: 164049},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5304, col: 23, offset: 163525},
+					pos: position{line: 5319, col: 23, offset: 164049},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5304, col: 23, offset: 163525},
+							pos:   position{line: 5319, col: 23, offset: 164049},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5304, col: 31, offset: 163533},
+								pos:  position{line: 5319, col: 31, offset: 164057},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5304, col: 46, offset: 163548},
+							pos:   position{line: 5319, col: 46, offset: 164072},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5304, col: 52, offset: 163554},
+								pos: position{line: 5319, col: 52, offset: 164078},
 								expr: &seqExpr{
-									pos: position{line: 5304, col: 53, offset: 163555},
+									pos: position{line: 5319, col: 53, offset: 164079},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5304, col: 53, offset: 163555},
+											pos:  position{line: 5319, col: 53, offset: 164079},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5304, col: 59, offset: 163561},
+											pos:  position{line: 5319, col: 59, offset: 164085},
 											name: "MVBlockOption",
 										},
 									},
@@ -12977,26 +13015,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5338, col: 1, offset: 164617},
+			pos:  position{line: 5353, col: 1, offset: 165141},
 			expr: &actionExpr{
-				pos: position{line: 5338, col: 18, offset: 164634},
+				pos: position{line: 5353, col: 18, offset: 165158},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5338, col: 18, offset: 164634},
+					pos:   position{line: 5353, col: 18, offset: 165158},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5338, col: 27, offset: 164643},
+						pos: position{line: 5353, col: 27, offset: 165167},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5338, col: 27, offset: 164643},
+								pos:  position{line: 5353, col: 27, offset: 165167},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5338, col: 41, offset: 164657},
+								pos:  position{line: 5353, col: 41, offset: 165181},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5338, col: 60, offset: 164676},
+								pos:  position{line: 5353, col: 60, offset: 165200},
 								name: "SetSvOption",
 							},
 						},
@@ -13006,22 +13044,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5342, col: 1, offset: 164717},
+			pos:  position{line: 5357, col: 1, offset: 165241},
 			expr: &actionExpr{
-				pos: position{line: 5342, col: 16, offset: 164732},
+				pos: position{line: 5357, col: 16, offset: 165256},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5342, col: 16, offset: 164732},
+					pos:   position{line: 5357, col: 16, offset: 165256},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5342, col: 28, offset: 164744},
+						pos: position{line: 5357, col: 28, offset: 165268},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5342, col: 28, offset: 164744},
+								pos:  position{line: 5357, col: 28, offset: 165268},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5342, col: 46, offset: 164762},
+								pos:  position{line: 5357, col: 46, offset: 165286},
 								name: "RegexDelimiter",
 							},
 						},
@@ -13031,28 +13069,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5346, col: 1, offset: 164809},
+			pos:  position{line: 5361, col: 1, offset: 165333},
 			expr: &actionExpr{
-				pos: position{line: 5346, col: 20, offset: 164828},
+				pos: position{line: 5361, col: 20, offset: 165352},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5346, col: 20, offset: 164828},
+					pos: position{line: 5361, col: 20, offset: 165352},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5346, col: 20, offset: 164828},
+							pos:        position{line: 5361, col: 20, offset: 165352},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5346, col: 28, offset: 164836},
+							pos:  position{line: 5361, col: 28, offset: 165360},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5346, col: 34, offset: 164842},
+							pos:   position{line: 5361, col: 34, offset: 165366},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5346, col: 38, offset: 164846},
+								pos:  position{line: 5361, col: 38, offset: 165370},
 								name: "QuotedString",
 							},
 						},
@@ -13062,28 +13100,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5357, col: 1, offset: 165097},
+			pos:  position{line: 5372, col: 1, offset: 165621},
 			expr: &actionExpr{
-				pos: position{line: 5357, col: 19, offset: 165115},
+				pos: position{line: 5372, col: 19, offset: 165639},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5357, col: 19, offset: 165115},
+					pos: position{line: 5372, col: 19, offset: 165639},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5357, col: 19, offset: 165115},
+							pos:        position{line: 5372, col: 19, offset: 165639},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5357, col: 31, offset: 165127},
+							pos:  position{line: 5372, col: 31, offset: 165651},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5357, col: 37, offset: 165133},
+							pos:   position{line: 5372, col: 37, offset: 165657},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5357, col: 41, offset: 165137},
+								pos:  position{line: 5372, col: 41, offset: 165661},
 								name: "QuotedString",
 							},
 						},
@@ -13093,28 +13131,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5375, col: 1, offset: 165608},
+			pos:  position{line: 5390, col: 1, offset: 166132},
 			expr: &actionExpr{
-				pos: position{line: 5375, col: 21, offset: 165628},
+				pos: position{line: 5390, col: 21, offset: 166152},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5375, col: 21, offset: 165628},
+					pos: position{line: 5390, col: 21, offset: 166152},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5375, col: 21, offset: 165628},
+							pos:        position{line: 5390, col: 21, offset: 166152},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5375, col: 34, offset: 165641},
+							pos:  position{line: 5390, col: 34, offset: 166165},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5375, col: 40, offset: 165647},
+							pos:   position{line: 5390, col: 40, offset: 166171},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5375, col: 48, offset: 165655},
+								pos:  position{line: 5390, col: 48, offset: 166179},
 								name: "Boolean",
 							},
 						},
@@ -13124,28 +13162,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5387, col: 1, offset: 165895},
+			pos:  position{line: 5402, col: 1, offset: 166419},
 			expr: &actionExpr{
-				pos: position{line: 5387, col: 16, offset: 165910},
+				pos: position{line: 5402, col: 16, offset: 166434},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5387, col: 16, offset: 165910},
+					pos: position{line: 5402, col: 16, offset: 166434},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5387, col: 16, offset: 165910},
+							pos:        position{line: 5402, col: 16, offset: 166434},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5387, col: 24, offset: 165918},
+							pos:  position{line: 5402, col: 24, offset: 166442},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5387, col: 30, offset: 165924},
+							pos:   position{line: 5402, col: 30, offset: 166448},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5387, col: 38, offset: 165932},
+								pos:  position{line: 5402, col: 38, offset: 166456},
 								name: "Boolean",
 							},
 						},
@@ -13155,28 +13193,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5399, col: 1, offset: 166197},
+			pos:  position{line: 5414, col: 1, offset: 166721},
 			expr: &actionExpr{
-				pos: position{line: 5399, col: 15, offset: 166211},
+				pos: position{line: 5414, col: 15, offset: 166735},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5399, col: 15, offset: 166211},
+					pos: position{line: 5414, col: 15, offset: 166735},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5399, col: 15, offset: 166211},
+							pos:  position{line: 5414, col: 15, offset: 166735},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5399, col: 20, offset: 166216},
+							pos:  position{line: 5414, col: 20, offset: 166740},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5399, col: 30, offset: 166226},
+							pos:   position{line: 5414, col: 30, offset: 166750},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5399, col: 40, offset: 166236},
+								pos: position{line: 5414, col: 40, offset: 166760},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5399, col: 40, offset: 166236},
+									pos:  position{line: 5414, col: 40, offset: 166760},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -13187,39 +13225,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5406, col: 1, offset: 166362},
+			pos:  position{line: 5421, col: 1, offset: 166886},
 			expr: &actionExpr{
-				pos: position{line: 5406, col: 23, offset: 166384},
+				pos: position{line: 5421, col: 23, offset: 166908},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5406, col: 23, offset: 166384},
+					pos: position{line: 5421, col: 23, offset: 166908},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5406, col: 23, offset: 166384},
+							pos:  position{line: 5421, col: 23, offset: 166908},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5406, col: 29, offset: 166390},
+							pos:   position{line: 5421, col: 29, offset: 166914},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5406, col: 35, offset: 166396},
+								pos:  position{line: 5421, col: 35, offset: 166920},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5406, col: 49, offset: 166410},
+							pos:   position{line: 5421, col: 49, offset: 166934},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5406, col: 54, offset: 166415},
+								pos: position{line: 5421, col: 54, offset: 166939},
 								expr: &seqExpr{
-									pos: position{line: 5406, col: 55, offset: 166416},
+									pos: position{line: 5421, col: 55, offset: 166940},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5406, col: 55, offset: 166416},
+											pos:  position{line: 5421, col: 55, offset: 166940},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5406, col: 61, offset: 166422},
+											pos:  position{line: 5421, col: 61, offset: 166946},
 											name: "SPathArgument",
 										},
 									},
@@ -13232,26 +13270,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5438, col: 1, offset: 167315},
+			pos:  position{line: 5453, col: 1, offset: 167839},
 			expr: &actionExpr{
-				pos: position{line: 5438, col: 18, offset: 167332},
+				pos: position{line: 5453, col: 18, offset: 167856},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5438, col: 18, offset: 167332},
+					pos:   position{line: 5453, col: 18, offset: 167856},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5438, col: 23, offset: 167337},
+						pos: position{line: 5453, col: 23, offset: 167861},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5438, col: 23, offset: 167337},
+								pos:  position{line: 5453, col: 23, offset: 167861},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5438, col: 36, offset: 167350},
+								pos:  position{line: 5453, col: 36, offset: 167874},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5438, col: 50, offset: 167364},
+								pos:  position{line: 5453, col: 50, offset: 167888},
 								name: "PathField",
 							},
 						},
@@ -13261,28 +13299,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5442, col: 1, offset: 167400},
+			pos:  position{line: 5457, col: 1, offset: 167924},
 			expr: &actionExpr{
-				pos: position{line: 5442, col: 15, offset: 167414},
+				pos: position{line: 5457, col: 15, offset: 167938},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5442, col: 15, offset: 167414},
+					pos: position{line: 5457, col: 15, offset: 167938},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5442, col: 15, offset: 167414},
+							pos:        position{line: 5457, col: 15, offset: 167938},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5442, col: 23, offset: 167422},
+							pos:  position{line: 5457, col: 23, offset: 167946},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5442, col: 29, offset: 167428},
+							pos:   position{line: 5457, col: 29, offset: 167952},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5442, col: 35, offset: 167434},
+								pos:  position{line: 5457, col: 35, offset: 167958},
 								name: "FieldName",
 							},
 						},
@@ -13292,28 +13330,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5445, col: 1, offset: 167490},
+			pos:  position{line: 5460, col: 1, offset: 168014},
 			expr: &actionExpr{
-				pos: position{line: 5445, col: 16, offset: 167505},
+				pos: position{line: 5460, col: 16, offset: 168029},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5445, col: 16, offset: 167505},
+					pos: position{line: 5460, col: 16, offset: 168029},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5445, col: 16, offset: 167505},
+							pos:        position{line: 5460, col: 16, offset: 168029},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5445, col: 25, offset: 167514},
+							pos:  position{line: 5460, col: 25, offset: 168038},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5445, col: 31, offset: 167520},
+							pos:   position{line: 5460, col: 31, offset: 168044},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5445, col: 37, offset: 167526},
+								pos:  position{line: 5460, col: 37, offset: 168050},
 								name: "FieldName",
 							},
 						},
@@ -13323,34 +13361,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5448, col: 1, offset: 167583},
+			pos:  position{line: 5463, col: 1, offset: 168107},
 			expr: &actionExpr{
-				pos: position{line: 5448, col: 14, offset: 167596},
+				pos: position{line: 5463, col: 14, offset: 168120},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5448, col: 15, offset: 167597},
+					pos: position{line: 5463, col: 15, offset: 168121},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5448, col: 15, offset: 167597},
+							pos: position{line: 5463, col: 15, offset: 168121},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5448, col: 15, offset: 167597},
+									pos:        position{line: 5463, col: 15, offset: 168121},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5448, col: 22, offset: 167604},
+									pos:  position{line: 5463, col: 22, offset: 168128},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5448, col: 28, offset: 167610},
+									pos:  position{line: 5463, col: 28, offset: 168134},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5448, col: 47, offset: 167629},
+							pos:  position{line: 5463, col: 47, offset: 168153},
 							name: "SPathFieldString",
 						},
 					},
@@ -13359,16 +13397,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5460, col: 1, offset: 168041},
+			pos:  position{line: 5475, col: 1, offset: 168565},
 			expr: &choiceExpr{
-				pos: position{line: 5460, col: 21, offset: 168061},
+				pos: position{line: 5475, col: 21, offset: 168585},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5460, col: 21, offset: 168061},
+						pos:  position{line: 5475, col: 21, offset: 168585},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5460, col: 36, offset: 168076},
+						pos:  position{line: 5475, col: 36, offset: 168600},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -13376,28 +13414,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5463, col: 1, offset: 168149},
+			pos:  position{line: 5478, col: 1, offset: 168673},
 			expr: &actionExpr{
-				pos: position{line: 5463, col: 16, offset: 168164},
+				pos: position{line: 5478, col: 16, offset: 168688},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5463, col: 16, offset: 168164},
+					pos: position{line: 5478, col: 16, offset: 168688},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5463, col: 16, offset: 168164},
+							pos:  position{line: 5478, col: 16, offset: 168688},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5463, col: 21, offset: 168169},
+							pos:  position{line: 5478, col: 21, offset: 168693},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5463, col: 32, offset: 168180},
+							pos:   position{line: 5478, col: 32, offset: 168704},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5463, col: 46, offset: 168194},
+								pos: position{line: 5478, col: 46, offset: 168718},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5463, col: 46, offset: 168194},
+									pos:  position{line: 5478, col: 46, offset: 168718},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -13408,39 +13446,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5485, col: 1, offset: 168803},
+			pos:  position{line: 5500, col: 1, offset: 169327},
 			expr: &actionExpr{
-				pos: position{line: 5485, col: 24, offset: 168826},
+				pos: position{line: 5500, col: 24, offset: 169350},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5485, col: 24, offset: 168826},
+					pos: position{line: 5500, col: 24, offset: 169350},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5485, col: 24, offset: 168826},
+							pos:  position{line: 5500, col: 24, offset: 169350},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5485, col: 30, offset: 168832},
+							pos:   position{line: 5500, col: 30, offset: 169356},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5485, col: 37, offset: 168839},
+								pos:  position{line: 5500, col: 37, offset: 169363},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5485, col: 52, offset: 168854},
+							pos:   position{line: 5500, col: 52, offset: 169378},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5485, col: 57, offset: 168859},
+								pos: position{line: 5500, col: 57, offset: 169383},
 								expr: &seqExpr{
-									pos: position{line: 5485, col: 58, offset: 168860},
+									pos: position{line: 5500, col: 58, offset: 169384},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5485, col: 58, offset: 168860},
+											pos:  position{line: 5500, col: 58, offset: 169384},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5485, col: 64, offset: 168866},
+											pos:  position{line: 5500, col: 64, offset: 169390},
 											name: "FormatArgument",
 										},
 									},
@@ -13453,30 +13491,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5519, col: 1, offset: 170055},
+			pos:  position{line: 5534, col: 1, offset: 170579},
 			expr: &actionExpr{
-				pos: position{line: 5519, col: 19, offset: 170073},
+				pos: position{line: 5534, col: 19, offset: 170597},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5519, col: 19, offset: 170073},
+					pos:   position{line: 5534, col: 19, offset: 170597},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5519, col: 28, offset: 170082},
+						pos: position{line: 5534, col: 28, offset: 170606},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5519, col: 28, offset: 170082},
+								pos:  position{line: 5534, col: 28, offset: 170606},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5519, col: 46, offset: 170100},
+								pos:  position{line: 5534, col: 46, offset: 170624},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5519, col: 65, offset: 170119},
+								pos:  position{line: 5534, col: 65, offset: 170643},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5519, col: 82, offset: 170136},
+								pos:  position{line: 5534, col: 82, offset: 170660},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -13486,28 +13524,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5523, col: 1, offset: 170186},
+			pos:  position{line: 5538, col: 1, offset: 170710},
 			expr: &actionExpr{
-				pos: position{line: 5523, col: 20, offset: 170205},
+				pos: position{line: 5538, col: 20, offset: 170729},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5523, col: 20, offset: 170205},
+					pos: position{line: 5538, col: 20, offset: 170729},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5523, col: 20, offset: 170205},
+							pos:        position{line: 5538, col: 20, offset: 170729},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5523, col: 28, offset: 170213},
+							pos:  position{line: 5538, col: 28, offset: 170737},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5523, col: 34, offset: 170219},
+							pos:   position{line: 5538, col: 34, offset: 170743},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5523, col: 38, offset: 170223},
+								pos:  position{line: 5538, col: 38, offset: 170747},
 								name: "QuotedString",
 							},
 						},
@@ -13517,28 +13555,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5532, col: 1, offset: 170435},
+			pos:  position{line: 5547, col: 1, offset: 170959},
 			expr: &actionExpr{
-				pos: position{line: 5532, col: 21, offset: 170455},
+				pos: position{line: 5547, col: 21, offset: 170979},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5532, col: 21, offset: 170455},
+					pos: position{line: 5547, col: 21, offset: 170979},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5532, col: 21, offset: 170455},
+							pos:        position{line: 5547, col: 21, offset: 170979},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5532, col: 34, offset: 170468},
+							pos:  position{line: 5547, col: 34, offset: 170992},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5532, col: 40, offset: 170474},
+							pos:   position{line: 5547, col: 40, offset: 170998},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5532, col: 47, offset: 170481},
+								pos:  position{line: 5547, col: 47, offset: 171005},
 								name: "IntegerAsString",
 							},
 						},
@@ -13548,28 +13586,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5545, col: 1, offset: 170887},
+			pos:  position{line: 5560, col: 1, offset: 171411},
 			expr: &actionExpr{
-				pos: position{line: 5545, col: 19, offset: 170905},
+				pos: position{line: 5560, col: 19, offset: 171429},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5545, col: 19, offset: 170905},
+					pos: position{line: 5560, col: 19, offset: 171429},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5545, col: 19, offset: 170905},
+							pos:        position{line: 5560, col: 19, offset: 171429},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5545, col: 30, offset: 170916},
+							pos:  position{line: 5560, col: 30, offset: 171440},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5545, col: 36, offset: 170922},
+							pos:   position{line: 5560, col: 36, offset: 171446},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5545, col: 40, offset: 170926},
+								pos:  position{line: 5560, col: 40, offset: 171450},
 								name: "QuotedString",
 							},
 						},
@@ -13579,78 +13617,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5554, col: 1, offset: 171141},
+			pos:  position{line: 5569, col: 1, offset: 171665},
 			expr: &actionExpr{
-				pos: position{line: 5554, col: 24, offset: 171164},
+				pos: position{line: 5569, col: 24, offset: 171688},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5554, col: 24, offset: 171164},
+					pos: position{line: 5569, col: 24, offset: 171688},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5554, col: 24, offset: 171164},
+							pos:   position{line: 5569, col: 24, offset: 171688},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 34, offset: 171174},
+								pos:  position{line: 5569, col: 34, offset: 171698},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5554, col: 47, offset: 171187},
+							pos:  position{line: 5569, col: 47, offset: 171711},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5554, col: 53, offset: 171193},
+							pos:   position{line: 5569, col: 53, offset: 171717},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 63, offset: 171203},
+								pos:  position{line: 5569, col: 63, offset: 171727},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5554, col: 76, offset: 171216},
+							pos:  position{line: 5569, col: 76, offset: 171740},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5554, col: 82, offset: 171222},
+							pos:   position{line: 5569, col: 82, offset: 171746},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 95, offset: 171235},
+								pos:  position{line: 5569, col: 95, offset: 171759},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5554, col: 108, offset: 171248},
+							pos:  position{line: 5569, col: 108, offset: 171772},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5554, col: 114, offset: 171254},
+							pos:   position{line: 5569, col: 114, offset: 171778},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 121, offset: 171261},
+								pos:  position{line: 5569, col: 121, offset: 171785},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5554, col: 134, offset: 171274},
+							pos:  position{line: 5569, col: 134, offset: 171798},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5554, col: 140, offset: 171280},
+							pos:   position{line: 5569, col: 140, offset: 171804},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 153, offset: 171293},
+								pos:  position{line: 5569, col: 153, offset: 171817},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5554, col: 166, offset: 171306},
+							pos:  position{line: 5569, col: 166, offset: 171830},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5554, col: 172, offset: 171312},
+							pos:   position{line: 5569, col: 172, offset: 171836},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5554, col: 179, offset: 171319},
+								pos:  position{line: 5569, col: 179, offset: 171843},
 								name: "QuotedString",
 							},
 						},
@@ -13660,28 +13698,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5572, col: 1, offset: 171895},
+			pos:  position{line: 5587, col: 1, offset: 172419},
 			expr: &actionExpr{
-				pos: position{line: 5572, col: 20, offset: 171914},
+				pos: position{line: 5587, col: 20, offset: 172438},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5572, col: 20, offset: 171914},
+					pos: position{line: 5587, col: 20, offset: 172438},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5572, col: 20, offset: 171914},
+							pos:  position{line: 5587, col: 20, offset: 172438},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5572, col: 25, offset: 171919},
+							pos:  position{line: 5587, col: 25, offset: 172443},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5572, col: 40, offset: 171934},
+							pos:   position{line: 5587, col: 40, offset: 172458},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5572, col: 55, offset: 171949},
+								pos: position{line: 5587, col: 55, offset: 172473},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5572, col: 55, offset: 171949},
+									pos:  position{line: 5587, col: 55, offset: 172473},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13692,42 +13730,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5579, col: 1, offset: 172102},
+			pos:  position{line: 5594, col: 1, offset: 172626},
 			expr: &actionExpr{
-				pos: position{line: 5579, col: 28, offset: 172129},
+				pos: position{line: 5594, col: 28, offset: 172653},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5579, col: 28, offset: 172129},
+					pos: position{line: 5594, col: 28, offset: 172653},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5579, col: 28, offset: 172129},
+							pos:  position{line: 5594, col: 28, offset: 172653},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5579, col: 34, offset: 172135},
+							pos:   position{line: 5594, col: 34, offset: 172659},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5579, col: 40, offset: 172141},
+								pos: position{line: 5594, col: 40, offset: 172665},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5579, col: 40, offset: 172141},
+									pos:  position{line: 5594, col: 40, offset: 172665},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5579, col: 60, offset: 172161},
+							pos:   position{line: 5594, col: 60, offset: 172685},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5579, col: 65, offset: 172166},
+								pos: position{line: 5594, col: 65, offset: 172690},
 								expr: &seqExpr{
-									pos: position{line: 5579, col: 66, offset: 172167},
+									pos: position{line: 5594, col: 66, offset: 172691},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5579, col: 66, offset: 172167},
+											pos:  position{line: 5594, col: 66, offset: 172691},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5579, col: 72, offset: 172173},
+											pos:  position{line: 5594, col: 72, offset: 172697},
 											name: "EventCountArgument",
 										},
 									},
@@ -13740,30 +13778,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5635, col: 1, offset: 174050},
+			pos:  position{line: 5650, col: 1, offset: 174574},
 			expr: &actionExpr{
-				pos: position{line: 5635, col: 23, offset: 174072},
+				pos: position{line: 5650, col: 23, offset: 174596},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5635, col: 23, offset: 174072},
+					pos:   position{line: 5650, col: 23, offset: 174596},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5635, col: 28, offset: 174077},
+						pos: position{line: 5650, col: 28, offset: 174601},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5635, col: 28, offset: 174077},
+								pos:  position{line: 5650, col: 28, offset: 174601},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5635, col: 41, offset: 174090},
+								pos:  position{line: 5650, col: 41, offset: 174614},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5635, col: 58, offset: 174107},
+								pos:  position{line: 5650, col: 58, offset: 174631},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5635, col: 76, offset: 174125},
+								pos:  position{line: 5650, col: 76, offset: 174649},
 								name: "ListVixField",
 							},
 						},
@@ -13773,28 +13811,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5639, col: 1, offset: 174164},
+			pos:  position{line: 5654, col: 1, offset: 174688},
 			expr: &actionExpr{
-				pos: position{line: 5639, col: 15, offset: 174178},
+				pos: position{line: 5654, col: 15, offset: 174702},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5639, col: 15, offset: 174178},
+					pos: position{line: 5654, col: 15, offset: 174702},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5639, col: 15, offset: 174178},
+							pos:        position{line: 5654, col: 15, offset: 174702},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5639, col: 23, offset: 174186},
+							pos:  position{line: 5654, col: 23, offset: 174710},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5639, col: 29, offset: 174192},
+							pos:   position{line: 5654, col: 29, offset: 174716},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5639, col: 35, offset: 174198},
+								pos:  position{line: 5654, col: 35, offset: 174722},
 								name: "IndexName",
 							},
 						},
@@ -13804,28 +13842,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5642, col: 1, offset: 174254},
+			pos:  position{line: 5657, col: 1, offset: 174778},
 			expr: &actionExpr{
-				pos: position{line: 5642, col: 19, offset: 174272},
+				pos: position{line: 5657, col: 19, offset: 174796},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5642, col: 19, offset: 174272},
+					pos: position{line: 5657, col: 19, offset: 174796},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5642, col: 19, offset: 174272},
+							pos:        position{line: 5657, col: 19, offset: 174796},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5642, col: 31, offset: 174284},
+							pos:  position{line: 5657, col: 31, offset: 174808},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5642, col: 37, offset: 174290},
+							pos:   position{line: 5657, col: 37, offset: 174814},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5642, col: 43, offset: 174296},
+								pos:  position{line: 5657, col: 43, offset: 174820},
 								name: "Boolean",
 							},
 						},
@@ -13835,28 +13873,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5645, col: 1, offset: 174372},
+			pos:  position{line: 5660, col: 1, offset: 174896},
 			expr: &actionExpr{
-				pos: position{line: 5645, col: 20, offset: 174391},
+				pos: position{line: 5660, col: 20, offset: 174915},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5645, col: 20, offset: 174391},
+					pos: position{line: 5660, col: 20, offset: 174915},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5645, col: 20, offset: 174391},
+							pos:        position{line: 5660, col: 20, offset: 174915},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5645, col: 34, offset: 174405},
+							pos:  position{line: 5660, col: 34, offset: 174929},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5645, col: 40, offset: 174411},
+							pos:   position{line: 5660, col: 40, offset: 174935},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5645, col: 46, offset: 174417},
+								pos:  position{line: 5660, col: 46, offset: 174941},
 								name: "Boolean",
 							},
 						},
@@ -13866,28 +13904,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5648, col: 1, offset: 174495},
+			pos:  position{line: 5663, col: 1, offset: 175019},
 			expr: &actionExpr{
-				pos: position{line: 5648, col: 17, offset: 174511},
+				pos: position{line: 5663, col: 17, offset: 175035},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5648, col: 17, offset: 174511},
+					pos: position{line: 5663, col: 17, offset: 175035},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5648, col: 17, offset: 174511},
+							pos:        position{line: 5663, col: 17, offset: 175035},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5648, col: 28, offset: 174522},
+							pos:  position{line: 5663, col: 28, offset: 175046},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5648, col: 34, offset: 174528},
+							pos:   position{line: 5663, col: 34, offset: 175052},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5648, col: 40, offset: 174534},
+								pos:  position{line: 5663, col: 40, offset: 175058},
 								name: "Boolean",
 							},
 						},
@@ -13897,24 +13935,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5652, col: 1, offset: 174610},
+			pos:  position{line: 5667, col: 1, offset: 175134},
 			expr: &actionExpr{
-				pos: position{line: 5652, col: 14, offset: 174623},
+				pos: position{line: 5667, col: 14, offset: 175147},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5652, col: 14, offset: 174623},
+					pos: position{line: 5667, col: 14, offset: 175147},
 					expr: &seqExpr{
-						pos: position{line: 5652, col: 15, offset: 174624},
+						pos: position{line: 5667, col: 15, offset: 175148},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5652, col: 15, offset: 174624},
+								pos: position{line: 5667, col: 15, offset: 175148},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5652, col: 16, offset: 174625},
+									pos:  position{line: 5667, col: 16, offset: 175149},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5652, col: 22, offset: 174631,
+								line: 5667, col: 22, offset: 175155,
 							},
 						},
 					},
@@ -13923,39 +13961,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5657, col: 1, offset: 174704},
+			pos:  position{line: 5672, col: 1, offset: 175228},
 			expr: &actionExpr{
-				pos: position{line: 5657, col: 18, offset: 174721},
+				pos: position{line: 5672, col: 18, offset: 175245},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5657, col: 18, offset: 174721},
+					pos: position{line: 5672, col: 18, offset: 175245},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5657, col: 18, offset: 174721},
+							pos:  position{line: 5672, col: 18, offset: 175245},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5657, col: 23, offset: 174726},
+							pos:  position{line: 5672, col: 23, offset: 175250},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5657, col: 36, offset: 174739},
+							pos:   position{line: 5672, col: 36, offset: 175263},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5657, col: 49, offset: 174752},
+								pos: position{line: 5672, col: 49, offset: 175276},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5657, col: 49, offset: 174752},
+									pos:  position{line: 5672, col: 49, offset: 175276},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5657, col: 70, offset: 174773},
+							pos:   position{line: 5672, col: 70, offset: 175297},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5657, col: 77, offset: 174780},
+								pos: position{line: 5672, col: 77, offset: 175304},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5657, col: 77, offset: 174780},
+									pos:  position{line: 5672, col: 77, offset: 175304},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13966,32 +14004,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5687, col: 1, offset: 175543},
+			pos:  position{line: 5702, col: 1, offset: 176067},
 			expr: &actionExpr{
-				pos: position{line: 5687, col: 24, offset: 175566},
+				pos: position{line: 5702, col: 24, offset: 176090},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5687, col: 24, offset: 175566},
+					pos: position{line: 5702, col: 24, offset: 176090},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5687, col: 24, offset: 175566},
+							pos:  position{line: 5702, col: 24, offset: 176090},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5687, col: 30, offset: 175572},
+							pos:        position{line: 5702, col: 30, offset: 176096},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5687, col: 38, offset: 175580},
+							pos:  position{line: 5702, col: 38, offset: 176104},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5687, col: 44, offset: 175586},
+							pos:   position{line: 5702, col: 44, offset: 176110},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5687, col: 48, offset: 175590},
+								pos:  position{line: 5702, col: 48, offset: 176114},
 								name: "String",
 							},
 						},
@@ -14001,22 +14039,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5691, col: 1, offset: 175636},
+			pos:  position{line: 5706, col: 1, offset: 176160},
 			expr: &actionExpr{
-				pos: position{line: 5691, col: 22, offset: 175657},
+				pos: position{line: 5706, col: 22, offset: 176181},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5691, col: 22, offset: 175657},
+					pos: position{line: 5706, col: 22, offset: 176181},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5691, col: 22, offset: 175657},
+							pos:  position{line: 5706, col: 22, offset: 176181},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5691, col: 28, offset: 175663},
+							pos:   position{line: 5706, col: 28, offset: 176187},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5691, col: 38, offset: 175673},
+								pos:  position{line: 5706, col: 38, offset: 176197},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -14026,36 +14064,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5695, col: 1, offset: 175732},
+			pos:  position{line: 5710, col: 1, offset: 176256},
 			expr: &actionExpr{
-				pos: position{line: 5695, col: 18, offset: 175749},
+				pos: position{line: 5710, col: 18, offset: 176273},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5695, col: 18, offset: 175749},
+					pos: position{line: 5710, col: 18, offset: 176273},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5695, col: 18, offset: 175749},
+							pos:  position{line: 5710, col: 18, offset: 176273},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5695, col: 23, offset: 175754},
+							pos:  position{line: 5710, col: 23, offset: 176278},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 36, offset: 175767},
+							pos:   position{line: 5710, col: 36, offset: 176291},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5695, col: 42, offset: 175773},
+								pos:  position{line: 5710, col: 42, offset: 176297},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5695, col: 56, offset: 175787},
+							pos:   position{line: 5710, col: 56, offset: 176311},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5695, col: 65, offset: 175796},
+								pos: position{line: 5710, col: 65, offset: 176320},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5695, col: 65, offset: 175796},
+									pos:  position{line: 5710, col: 65, offset: 176320},
 									name: "MvexpandLimit",
 								},
 							},
@@ -14066,22 +14104,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5724, col: 1, offset: 176572},
+			pos:  position{line: 5739, col: 1, offset: 177096},
 			expr: &actionExpr{
-				pos: position{line: 5724, col: 18, offset: 176589},
+				pos: position{line: 5739, col: 18, offset: 177113},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5724, col: 18, offset: 176589},
+					pos: position{line: 5739, col: 18, offset: 177113},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5724, col: 18, offset: 176589},
+							pos:  position{line: 5739, col: 18, offset: 177113},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5724, col: 24, offset: 176595},
+							pos:   position{line: 5739, col: 24, offset: 177119},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5724, col: 34, offset: 176605},
+								pos:  position{line: 5739, col: 34, offset: 177129},
 								name: "FieldName",
 							},
 						},
@@ -14091,32 +14129,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5728, col: 1, offset: 176646},
+			pos:  position{line: 5743, col: 1, offset: 177170},
 			expr: &actionExpr{
-				pos: position{line: 5728, col: 18, offset: 176663},
+				pos: position{line: 5743, col: 18, offset: 177187},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5728, col: 18, offset: 176663},
+					pos: position{line: 5743, col: 18, offset: 177187},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5728, col: 18, offset: 176663},
+							pos:  position{line: 5743, col: 18, offset: 177187},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5728, col: 24, offset: 176669},
+							pos:        position{line: 5743, col: 24, offset: 177193},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5728, col: 32, offset: 176677},
+							pos:  position{line: 5743, col: 32, offset: 177201},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5728, col: 38, offset: 176683},
+							pos:   position{line: 5743, col: 38, offset: 177207},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5728, col: 47, offset: 176692},
+								pos:  position{line: 5743, col: 47, offset: 177216},
 								name: "IntegerAsString",
 							},
 						},
@@ -14126,26 +14164,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5732, col: 1, offset: 176738},
+			pos:  position{line: 5747, col: 1, offset: 177262},
 			expr: &actionExpr{
-				pos: position{line: 5732, col: 16, offset: 176753},
+				pos: position{line: 5747, col: 16, offset: 177277},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5732, col: 16, offset: 176753},
+					pos: position{line: 5747, col: 16, offset: 177277},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5732, col: 16, offset: 176753},
+							pos:  position{line: 5747, col: 16, offset: 177277},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5732, col: 22, offset: 176759},
+							pos:  position{line: 5747, col: 22, offset: 177283},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5732, col: 32, offset: 176769},
+							pos:   position{line: 5747, col: 32, offset: 177293},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5732, col: 42, offset: 176779},
+								pos:  position{line: 5747, col: 42, offset: 177303},
 								name: "BoolExpr",
 							},
 						},
@@ -14155,28 +14193,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5736, col: 1, offset: 176839},
+			pos:  position{line: 5751, col: 1, offset: 177363},
 			expr: &actionExpr{
-				pos: position{line: 5736, col: 28, offset: 176866},
+				pos: position{line: 5751, col: 28, offset: 177390},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5736, col: 28, offset: 176866},
+					pos: position{line: 5751, col: 28, offset: 177390},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5736, col: 28, offset: 176866},
+							pos:        position{line: 5751, col: 28, offset: 177390},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5736, col: 37, offset: 176875},
+							pos:  position{line: 5751, col: 37, offset: 177399},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5736, col: 43, offset: 176881},
+							pos:   position{line: 5751, col: 43, offset: 177405},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5736, col: 51, offset: 176889},
+								pos:  position{line: 5751, col: 51, offset: 177413},
 								name: "Boolean",
 							},
 						},
@@ -14186,28 +14224,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5745, col: 1, offset: 177073},
+			pos:  position{line: 5760, col: 1, offset: 177597},
 			expr: &actionExpr{
-				pos: position{line: 5745, col: 28, offset: 177100},
+				pos: position{line: 5760, col: 28, offset: 177624},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5745, col: 28, offset: 177100},
+					pos: position{line: 5760, col: 28, offset: 177624},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5745, col: 28, offset: 177100},
+							pos:        position{line: 5760, col: 28, offset: 177624},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5745, col: 37, offset: 177109},
+							pos:  position{line: 5760, col: 37, offset: 177633},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5745, col: 43, offset: 177115},
+							pos:   position{line: 5760, col: 43, offset: 177639},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5745, col: 51, offset: 177123},
+								pos:  position{line: 5760, col: 51, offset: 177647},
 								name: "Boolean",
 							},
 						},
@@ -14217,28 +14255,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5754, col: 1, offset: 177307},
+			pos:  position{line: 5769, col: 1, offset: 177831},
 			expr: &actionExpr{
-				pos: position{line: 5754, col: 27, offset: 177333},
+				pos: position{line: 5769, col: 27, offset: 177857},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5754, col: 27, offset: 177333},
+					pos: position{line: 5769, col: 27, offset: 177857},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5754, col: 27, offset: 177333},
+							pos:        position{line: 5769, col: 27, offset: 177857},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5754, col: 35, offset: 177341},
+							pos:  position{line: 5769, col: 35, offset: 177865},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5754, col: 41, offset: 177347},
+							pos:   position{line: 5769, col: 41, offset: 177871},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5754, col: 48, offset: 177354},
+								pos:  position{line: 5769, col: 48, offset: 177878},
 								name: "PositiveInteger",
 							},
 						},
@@ -14248,28 +14286,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5763, col: 1, offset: 177545},
+			pos:  position{line: 5778, col: 1, offset: 178069},
 			expr: &actionExpr{
-				pos: position{line: 5763, col: 25, offset: 177569},
+				pos: position{line: 5778, col: 25, offset: 178093},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5763, col: 25, offset: 177569},
+					pos: position{line: 5778, col: 25, offset: 178093},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5763, col: 25, offset: 177569},
+							pos:        position{line: 5778, col: 25, offset: 178093},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5763, col: 31, offset: 177575},
+							pos:  position{line: 5778, col: 31, offset: 178099},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5763, col: 37, offset: 177581},
+							pos:   position{line: 5778, col: 37, offset: 178105},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5763, col: 44, offset: 177588},
+								pos:  position{line: 5778, col: 44, offset: 178112},
 								name: "PositiveInteger",
 							},
 						},
@@ -14279,30 +14317,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5772, col: 1, offset: 177775},
+			pos:  position{line: 5787, col: 1, offset: 178299},
 			expr: &actionExpr{
-				pos: position{line: 5772, col: 22, offset: 177796},
+				pos: position{line: 5787, col: 22, offset: 178320},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5772, col: 22, offset: 177796},
+					pos:   position{line: 5787, col: 22, offset: 178320},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5772, col: 41, offset: 177815},
+						pos: position{line: 5787, col: 41, offset: 178339},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5772, col: 41, offset: 177815},
+								pos:  position{line: 5787, col: 41, offset: 178339},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5772, col: 67, offset: 177841},
+								pos:  position{line: 5787, col: 67, offset: 178365},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5772, col: 93, offset: 177867},
+								pos:  position{line: 5787, col: 93, offset: 178391},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5772, col: 118, offset: 177892},
+								pos:  position{line: 5787, col: 118, offset: 178416},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -14312,35 +14350,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5776, col: 1, offset: 177953},
+			pos:  position{line: 5791, col: 1, offset: 178477},
 			expr: &actionExpr{
-				pos: position{line: 5776, col: 26, offset: 177978},
+				pos: position{line: 5791, col: 26, offset: 178502},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5776, col: 26, offset: 177978},
+					pos: position{line: 5791, col: 26, offset: 178502},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5776, col: 26, offset: 177978},
+							pos:   position{line: 5791, col: 26, offset: 178502},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5776, col: 34, offset: 177986},
+								pos:  position{line: 5791, col: 34, offset: 178510},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5776, col: 53, offset: 178005},
+							pos:   position{line: 5791, col: 53, offset: 178529},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5776, col: 58, offset: 178010},
+								pos: position{line: 5791, col: 58, offset: 178534},
 								expr: &seqExpr{
-									pos: position{line: 5776, col: 59, offset: 178011},
+									pos: position{line: 5791, col: 59, offset: 178535},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5776, col: 59, offset: 178011},
+											pos:  position{line: 5791, col: 59, offset: 178535},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5776, col: 65, offset: 178017},
+											pos:  position{line: 5791, col: 65, offset: 178541},
 											name: "InputLookupOption",
 										},
 									},
@@ -14353,35 +14391,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5818, col: 1, offset: 179463},
+			pos:  position{line: 5833, col: 1, offset: 179987},
 			expr: &actionExpr{
-				pos: position{line: 5818, col: 21, offset: 179483},
+				pos: position{line: 5833, col: 21, offset: 180007},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5818, col: 21, offset: 179483},
+					pos: position{line: 5833, col: 21, offset: 180007},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5818, col: 21, offset: 179483},
+							pos:  position{line: 5833, col: 21, offset: 180007},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5818, col: 26, offset: 179488},
+							pos:  position{line: 5833, col: 26, offset: 180012},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5818, col: 42, offset: 179504},
+							pos:   position{line: 5833, col: 42, offset: 180028},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5818, col: 60, offset: 179522},
+								pos: position{line: 5833, col: 60, offset: 180046},
 								expr: &seqExpr{
-									pos: position{line: 5818, col: 61, offset: 179523},
+									pos: position{line: 5833, col: 61, offset: 180047},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5818, col: 61, offset: 179523},
+											pos:  position{line: 5833, col: 61, offset: 180047},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5818, col: 83, offset: 179545},
+											pos:  position{line: 5833, col: 83, offset: 180069},
 											name: "SPACE",
 										},
 									},
@@ -14389,20 +14427,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5818, col: 91, offset: 179553},
+							pos:   position{line: 5833, col: 91, offset: 180077},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5818, col: 101, offset: 179563},
+								pos:  position{line: 5833, col: 101, offset: 180087},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5818, col: 109, offset: 179571},
+							pos:   position{line: 5833, col: 109, offset: 180095},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5818, col: 121, offset: 179583},
+								pos: position{line: 5833, col: 121, offset: 180107},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5818, col: 122, offset: 179584},
+									pos:  position{line: 5833, col: 122, offset: 180108},
 									name: "WhereClause",
 								},
 							},
@@ -14413,15 +14451,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5841, col: 1, offset: 180272},
+			pos:  position{line: 5856, col: 1, offset: 180796},
 			expr: &actionExpr{
-				pos: position{line: 5841, col: 24, offset: 180295},
+				pos: position{line: 5856, col: 24, offset: 180819},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5841, col: 24, offset: 180295},
+					pos:   position{line: 5856, col: 24, offset: 180819},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5841, col: 41, offset: 180312},
+						pos:  position{line: 5856, col: 41, offset: 180836},
 						name: "InputLookupBlock",
 					},
 				},
@@ -14429,26 +14467,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5852, col: 1, offset: 180711},
+			pos:  position{line: 5867, col: 1, offset: 181235},
 			expr: &actionExpr{
-				pos: position{line: 5852, col: 20, offset: 180730},
+				pos: position{line: 5867, col: 20, offset: 181254},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5852, col: 20, offset: 180730},
+					pos:   position{line: 5867, col: 20, offset: 181254},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5852, col: 28, offset: 180738},
+						pos: position{line: 5867, col: 28, offset: 181262},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5852, col: 28, offset: 180738},
+								pos:  position{line: 5867, col: 28, offset: 181262},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5852, col: 52, offset: 180762},
+								pos:  position{line: 5867, col: 52, offset: 181286},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5852, col: 68, offset: 180778},
+								pos:  position{line: 5867, col: 68, offset: 181302},
 								name: "MaxOutOption",
 							},
 						},
@@ -14458,28 +14496,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5857, col: 1, offset: 180876},
+			pos:  position{line: 5872, col: 1, offset: 181400},
 			expr: &actionExpr{
-				pos: position{line: 5857, col: 26, offset: 180901},
+				pos: position{line: 5872, col: 26, offset: 181425},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5857, col: 26, offset: 180901},
+					pos: position{line: 5872, col: 26, offset: 181425},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5857, col: 26, offset: 180901},
+							pos:        position{line: 5872, col: 26, offset: 181425},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5857, col: 44, offset: 180919},
+							pos:  position{line: 5872, col: 44, offset: 181443},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5857, col: 50, offset: 180925},
+							pos:   position{line: 5872, col: 50, offset: 181449},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5857, col: 58, offset: 180933},
+								pos:  position{line: 5872, col: 58, offset: 181457},
 								name: "Boolean",
 							},
 						},
@@ -14489,28 +14527,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5864, col: 1, offset: 181072},
+			pos:  position{line: 5879, col: 1, offset: 181596},
 			expr: &actionExpr{
-				pos: position{line: 5864, col: 18, offset: 181089},
+				pos: position{line: 5879, col: 18, offset: 181613},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5864, col: 18, offset: 181089},
+					pos: position{line: 5879, col: 18, offset: 181613},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5864, col: 18, offset: 181089},
+							pos:        position{line: 5879, col: 18, offset: 181613},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5864, col: 28, offset: 181099},
+							pos:  position{line: 5879, col: 28, offset: 181623},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5864, col: 34, offset: 181105},
+							pos:   position{line: 5879, col: 34, offset: 181629},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5864, col: 39, offset: 181110},
+								pos:  position{line: 5879, col: 39, offset: 181634},
 								name: "IntegerAsString",
 							},
 						},
@@ -14520,28 +14558,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5875, col: 1, offset: 181411},
+			pos:  position{line: 5890, col: 1, offset: 181935},
 			expr: &actionExpr{
-				pos: position{line: 5875, col: 17, offset: 181427},
+				pos: position{line: 5890, col: 17, offset: 181951},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5875, col: 17, offset: 181427},
+					pos: position{line: 5890, col: 17, offset: 181951},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5875, col: 17, offset: 181427},
+							pos:        position{line: 5890, col: 17, offset: 181951},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5875, col: 26, offset: 181436},
+							pos:  position{line: 5890, col: 26, offset: 181960},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5875, col: 32, offset: 181442},
+							pos:   position{line: 5890, col: 32, offset: 181966},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5875, col: 36, offset: 181446},
+								pos:  position{line: 5890, col: 36, offset: 181970},
 								name: "IntegerAsString",
 							},
 						},
@@ -14551,43 +14589,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5887, col: 1, offset: 181801},
+			pos:  position{line: 5902, col: 1, offset: 182325},
 			expr: &actionExpr{
-				pos: position{line: 5887, col: 14, offset: 181814},
+				pos: position{line: 5902, col: 14, offset: 182338},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5887, col: 14, offset: 181814},
+					pos: position{line: 5902, col: 14, offset: 182338},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5887, col: 14, offset: 181814},
+							pos:        position{line: 5902, col: 14, offset: 182338},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5887, col: 18, offset: 181818},
+							pos: position{line: 5902, col: 18, offset: 182342},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5887, col: 18, offset: 181818},
+								pos:  position{line: 5902, col: 18, offset: 182342},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5887, col: 25, offset: 181825},
+							pos:   position{line: 5902, col: 25, offset: 182349},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5887, col: 32, offset: 181832},
+								pos:  position{line: 5902, col: 32, offset: 182356},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5887, col: 44, offset: 181844},
+							pos: position{line: 5902, col: 44, offset: 182368},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5887, col: 44, offset: 181844},
+								pos:  position{line: 5902, col: 44, offset: 182368},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5887, col: 51, offset: 181851},
+							pos:        position{line: 5902, col: 51, offset: 182375},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14598,35 +14636,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5892, col: 1, offset: 181940},
+			pos:  position{line: 5907, col: 1, offset: 182464},
 			expr: &actionExpr{
-				pos: position{line: 5892, col: 25, offset: 181964},
+				pos: position{line: 5907, col: 25, offset: 182488},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5892, col: 25, offset: 181964},
+					pos: position{line: 5907, col: 25, offset: 182488},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5892, col: 25, offset: 181964},
+							pos:   position{line: 5907, col: 25, offset: 182488},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5892, col: 31, offset: 181970},
+								pos:  position{line: 5907, col: 31, offset: 182494},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5892, col: 47, offset: 181986},
+							pos:   position{line: 5907, col: 47, offset: 182510},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5892, col: 52, offset: 181991},
+								pos: position{line: 5907, col: 52, offset: 182515},
 								expr: &seqExpr{
-									pos: position{line: 5892, col: 53, offset: 181992},
+									pos: position{line: 5907, col: 53, offset: 182516},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5892, col: 53, offset: 181992},
+											pos:  position{line: 5907, col: 53, offset: 182516},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5892, col: 59, offset: 181998},
+											pos:  position{line: 5907, col: 59, offset: 182522},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14639,37 +14677,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5919, col: 1, offset: 182808},
+			pos:  position{line: 5934, col: 1, offset: 183332},
 			expr: &actionExpr{
-				pos: position{line: 5919, col: 16, offset: 182823},
+				pos: position{line: 5934, col: 16, offset: 183347},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5919, col: 16, offset: 182823},
+					pos: position{line: 5934, col: 16, offset: 183347},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5919, col: 16, offset: 182823},
+							pos:  position{line: 5934, col: 16, offset: 183347},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5919, col: 21, offset: 182828},
+							pos:  position{line: 5934, col: 21, offset: 183352},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5919, col: 32, offset: 182839},
+							pos:   position{line: 5934, col: 32, offset: 183363},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5919, col: 40, offset: 182847},
+								pos: position{line: 5934, col: 40, offset: 183371},
 								expr: &seqExpr{
-									pos: position{line: 5919, col: 41, offset: 182848},
+									pos: position{line: 5934, col: 41, offset: 183372},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5919, col: 41, offset: 182848},
+											pos:  position{line: 5934, col: 41, offset: 183372},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5919, col: 57, offset: 182864},
+											pos: position{line: 5934, col: 57, offset: 183388},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5919, col: 57, offset: 182864},
+												pos:  position{line: 5934, col: 57, offset: 183388},
 												name: "SPACE",
 											},
 										},
@@ -14678,10 +14716,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5919, col: 66, offset: 182873},
+							pos:   position{line: 5934, col: 66, offset: 183397},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5919, col: 76, offset: 182883},
+								pos:  position{line: 5934, col: 76, offset: 183407},
 								name: "Subsearch",
 							},
 						},
@@ -14691,45 +14729,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5961, col: 1, offset: 184420},
+			pos:  position{line: 5976, col: 1, offset: 184944},
 			expr: &actionExpr{
-				pos: position{line: 5961, col: 17, offset: 184436},
+				pos: position{line: 5976, col: 17, offset: 184960},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5961, col: 17, offset: 184436},
+					pos: position{line: 5976, col: 17, offset: 184960},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5961, col: 17, offset: 184436},
+							pos:  position{line: 5976, col: 17, offset: 184960},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5961, col: 23, offset: 184442},
+							pos:   position{line: 5976, col: 23, offset: 184966},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5961, col: 31, offset: 184450},
+								pos: position{line: 5976, col: 31, offset: 184974},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 31, offset: 184450},
+										pos:  position{line: 5976, col: 31, offset: 184974},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 54, offset: 184473},
+										pos:  position{line: 5976, col: 54, offset: 184997},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 74, offset: 184493},
+										pos:  position{line: 5976, col: 74, offset: 185017},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 91, offset: 184510},
+										pos:  position{line: 5976, col: 91, offset: 185034},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 115, offset: 184534},
+										pos:  position{line: 5976, col: 115, offset: 185058},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5961, col: 135, offset: 184554},
+										pos:  position{line: 5976, col: 135, offset: 185078},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14741,51 +14779,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5965, col: 1, offset: 184609},
+			pos:  position{line: 5980, col: 1, offset: 185133},
 			expr: &actionExpr{
-				pos: position{line: 5965, col: 25, offset: 184633},
+				pos: position{line: 5980, col: 25, offset: 185157},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5965, col: 26, offset: 184634},
+					pos: position{line: 5980, col: 26, offset: 185158},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5965, col: 26, offset: 184634},
+							pos:   position{line: 5980, col: 26, offset: 185158},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5965, col: 33, offset: 184641},
+								pos: position{line: 5980, col: 33, offset: 185165},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5965, col: 33, offset: 184641},
+										pos:        position{line: 5980, col: 33, offset: 185165},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5965, col: 42, offset: 184650},
+										pos:        position{line: 5980, col: 42, offset: 185174},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5965, col: 51, offset: 184659},
+										pos:        position{line: 5980, col: 51, offset: 185183},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5965, col: 60, offset: 184668},
+										pos:        position{line: 5980, col: 60, offset: 185192},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5965, col: 68, offset: 184676},
+										pos:        position{line: 5980, col: 68, offset: 185200},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5965, col: 76, offset: 184684},
+										pos:        position{line: 5980, col: 76, offset: 185208},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14794,19 +14832,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5965, col: 84, offset: 184692},
+							pos:  position{line: 5980, col: 84, offset: 185216},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5965, col: 92, offset: 184700},
+							pos:   position{line: 5980, col: 92, offset: 185224},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5965, col: 105, offset: 184713},
+								pos:  position{line: 5980, col: 105, offset: 185237},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5965, col: 116, offset: 184724},
+							pos:  position{line: 5980, col: 116, offset: 185248},
 							name: "R_PAREN",
 						},
 					},
@@ -14815,15 +14853,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5991, col: 1, offset: 185482},
+			pos:  position{line: 6006, col: 1, offset: 186006},
 			expr: &actionExpr{
-				pos: position{line: 5991, col: 30, offset: 185511},
+				pos: position{line: 6006, col: 30, offset: 186035},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5991, col: 30, offset: 185511},
+					pos:   position{line: 6006, col: 30, offset: 186035},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5991, col: 43, offset: 185524},
+						pos:  position{line: 6006, col: 43, offset: 186048},
 						name: "StringExpr",
 					},
 				},
@@ -14831,61 +14869,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 6016, col: 1, offset: 186232},
+			pos:  position{line: 6031, col: 1, offset: 186756},
 			expr: &actionExpr{
-				pos: position{line: 6016, col: 22, offset: 186253},
+				pos: position{line: 6031, col: 22, offset: 186777},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 6016, col: 22, offset: 186253},
+					pos: position{line: 6031, col: 22, offset: 186777},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 6016, col: 22, offset: 186253},
+							pos:        position{line: 6031, col: 22, offset: 186777},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 6016, col: 37, offset: 186268},
+							pos:  position{line: 6031, col: 37, offset: 186792},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 6016, col: 43, offset: 186274},
+							pos:   position{line: 6031, col: 43, offset: 186798},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 6016, col: 50, offset: 186281},
+								pos: position{line: 6031, col: 50, offset: 186805},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 6016, col: 50, offset: 186281},
+										pos:        position{line: 6031, col: 50, offset: 186805},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 6016, col: 59, offset: 186290},
+										pos:        position{line: 6031, col: 59, offset: 186814},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 6016, col: 68, offset: 186299},
+										pos:        position{line: 6031, col: 68, offset: 186823},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 6016, col: 77, offset: 186308},
+										pos:        position{line: 6031, col: 77, offset: 186832},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 6016, col: 85, offset: 186316},
+										pos:        position{line: 6031, col: 85, offset: 186840},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 6016, col: 93, offset: 186324},
+										pos:        position{line: 6031, col: 93, offset: 186848},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14899,28 +14937,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 6029, col: 1, offset: 186653},
+			pos:  position{line: 6044, col: 1, offset: 187177},
 			expr: &actionExpr{
-				pos: position{line: 6029, col: 19, offset: 186671},
+				pos: position{line: 6044, col: 19, offset: 187195},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 6029, col: 19, offset: 186671},
+					pos: position{line: 6044, col: 19, offset: 187195},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 6029, col: 19, offset: 186671},
+							pos:        position{line: 6044, col: 19, offset: 187195},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 6029, col: 31, offset: 186683},
+							pos:  position{line: 6044, col: 31, offset: 187207},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 6029, col: 37, offset: 186689},
+							pos:   position{line: 6044, col: 37, offset: 187213},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 6029, col: 45, offset: 186697},
+								pos:  position{line: 6044, col: 45, offset: 187221},
 								name: "Boolean",
 							},
 						},
@@ -14930,28 +14968,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 6036, col: 1, offset: 186820},
+			pos:  position{line: 6051, col: 1, offset: 187344},
 			expr: &actionExpr{
-				pos: position{line: 6036, col: 26, offset: 186845},
+				pos: position{line: 6051, col: 26, offset: 187369},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 6036, col: 26, offset: 186845},
+					pos: position{line: 6051, col: 26, offset: 187369},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 6036, col: 26, offset: 186845},
+							pos:        position{line: 6051, col: 26, offset: 187369},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 6036, col: 45, offset: 186864},
+							pos:  position{line: 6051, col: 45, offset: 187388},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 6036, col: 51, offset: 186870},
+							pos:   position{line: 6051, col: 51, offset: 187394},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 6036, col: 59, offset: 186878},
+								pos:  position{line: 6051, col: 59, offset: 187402},
 								name: "Boolean",
 							},
 						},
@@ -14961,28 +14999,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 6043, col: 1, offset: 187008},
+			pos:  position{line: 6058, col: 1, offset: 187532},
 			expr: &actionExpr{
-				pos: position{line: 6043, col: 22, offset: 187029},
+				pos: position{line: 6058, col: 22, offset: 187553},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 6043, col: 22, offset: 187029},
+					pos: position{line: 6058, col: 22, offset: 187553},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 6043, col: 22, offset: 187029},
+							pos:        position{line: 6058, col: 22, offset: 187553},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 6043, col: 37, offset: 187044},
+							pos:  position{line: 6058, col: 37, offset: 187568},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 6043, col: 43, offset: 187050},
+							pos:   position{line: 6058, col: 43, offset: 187574},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 6043, col: 50, offset: 187057},
+								pos:  position{line: 6058, col: 50, offset: 187581},
 								name: "String",
 							},
 						},
@@ -14992,28 +15030,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 6050, col: 1, offset: 187183},
+			pos:  position{line: 6065, col: 1, offset: 187707},
 			expr: &actionExpr{
-				pos: position{line: 6050, col: 16, offset: 187198},
+				pos: position{line: 6065, col: 16, offset: 187722},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 6050, col: 16, offset: 187198},
+					pos: position{line: 6065, col: 16, offset: 187722},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 6050, col: 16, offset: 187198},
+							pos:  position{line: 6065, col: 16, offset: 187722},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 6050, col: 21, offset: 187203},
+							pos:  position{line: 6065, col: 21, offset: 187727},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 6050, col: 32, offset: 187214},
+							pos:   position{line: 6065, col: 32, offset: 187738},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 6050, col: 40, offset: 187222},
+								pos: position{line: 6065, col: 40, offset: 187746},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6050, col: 41, offset: 187223},
+									pos:  position{line: 6065, col: 41, offset: 187747},
 									name: "ToJsonOption",
 								},
 							},
@@ -15024,132 +15062,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 6103, col: 1, offset: 189305},
+			pos:  position{line: 6118, col: 1, offset: 189829},
 			expr: &choiceExpr{
-				pos: position{line: 6103, col: 12, offset: 189316},
+				pos: position{line: 6118, col: 12, offset: 189840},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 12, offset: 189316},
+						pos:  position{line: 6118, col: 12, offset: 189840},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 24, offset: 189328},
+						pos:  position{line: 6118, col: 24, offset: 189852},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 36, offset: 189340},
+						pos:  position{line: 6118, col: 36, offset: 189864},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 49, offset: 189353},
+						pos:  position{line: 6118, col: 49, offset: 189877},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 61, offset: 189365},
+						pos:  position{line: 6118, col: 61, offset: 189889},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 81, offset: 189385},
+						pos:  position{line: 6118, col: 81, offset: 189909},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 92, offset: 189396},
+						pos:  position{line: 6118, col: 92, offset: 189920},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 112, offset: 189416},
+						pos:  position{line: 6118, col: 112, offset: 189940},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 123, offset: 189427},
+						pos:  position{line: 6118, col: 123, offset: 189951},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 134, offset: 189438},
+						pos:  position{line: 6118, col: 134, offset: 189962},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 144, offset: 189448},
+						pos:  position{line: 6118, col: 144, offset: 189972},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 154, offset: 189458},
+						pos:  position{line: 6118, col: 154, offset: 189982},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 165, offset: 189469},
+						pos:  position{line: 6118, col: 165, offset: 189993},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 178, offset: 189482},
+						pos:  position{line: 6118, col: 178, offset: 190006},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 194, offset: 189498},
+						pos:  position{line: 6118, col: 194, offset: 190022},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 212, offset: 189516},
+						pos:  position{line: 6118, col: 212, offset: 190040},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 224, offset: 189528},
+						pos:  position{line: 6118, col: 224, offset: 190052},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 235, offset: 189539},
+						pos:  position{line: 6118, col: 235, offset: 190063},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 248, offset: 189552},
+						pos:  position{line: 6118, col: 248, offset: 190076},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 260, offset: 189564},
+						pos:  position{line: 6118, col: 260, offset: 190088},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 273, offset: 189577},
+						pos:  position{line: 6118, col: 273, offset: 190101},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 288, offset: 189592},
+						pos:  position{line: 6118, col: 288, offset: 190116},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 301, offset: 189605},
+						pos:  position{line: 6118, col: 301, offset: 190129},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 318, offset: 189622},
+						pos:  position{line: 6118, col: 318, offset: 190146},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 328, offset: 189632},
+						pos:  position{line: 6118, col: 328, offset: 190156},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 346, offset: 189650},
+						pos:  position{line: 6118, col: 346, offset: 190174},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 361, offset: 189665},
+						pos:  position{line: 6118, col: 361, offset: 190189},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 376, offset: 189680},
+						pos:  position{line: 6118, col: 376, offset: 190204},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 391, offset: 189695},
+						pos:  position{line: 6118, col: 391, offset: 190219},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 409, offset: 189713},
+						pos:  position{line: 6118, col: 409, offset: 190237},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6103, col: 422, offset: 189726},
+						pos:  position{line: 6118, col: 422, offset: 190250},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -15157,18 +15195,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 6104, col: 1, offset: 189738},
+			pos:  position{line: 6119, col: 1, offset: 190262},
 			expr: &seqExpr{
-				pos: position{line: 6104, col: 15, offset: 189752},
+				pos: position{line: 6119, col: 15, offset: 190276},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6104, col: 15, offset: 189752},
+						pos:        position{line: 6119, col: 15, offset: 190276},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6104, col: 24, offset: 189761},
+						pos:  position{line: 6119, col: 24, offset: 190285},
 						name: "SPACE",
 					},
 				},
@@ -15176,18 +15214,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 6105, col: 1, offset: 189767},
+			pos:  position{line: 6120, col: 1, offset: 190291},
 			expr: &seqExpr{
-				pos: position{line: 6105, col: 14, offset: 189780},
+				pos: position{line: 6120, col: 14, offset: 190304},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6105, col: 14, offset: 189780},
+						pos:        position{line: 6120, col: 14, offset: 190304},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6105, col: 22, offset: 189788},
+						pos:  position{line: 6120, col: 22, offset: 190312},
 						name: "SPACE",
 					},
 				},
@@ -15195,18 +15233,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 6106, col: 1, offset: 189794},
+			pos:  position{line: 6121, col: 1, offset: 190318},
 			expr: &seqExpr{
-				pos: position{line: 6106, col: 14, offset: 189807},
+				pos: position{line: 6121, col: 14, offset: 190331},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6106, col: 14, offset: 189807},
+						pos:        position{line: 6121, col: 14, offset: 190331},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6106, col: 22, offset: 189815},
+						pos:  position{line: 6121, col: 22, offset: 190339},
 						name: "SPACE",
 					},
 				},
@@ -15214,18 +15252,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 6107, col: 1, offset: 189821},
+			pos:  position{line: 6122, col: 1, offset: 190345},
 			expr: &seqExpr{
-				pos: position{line: 6107, col: 20, offset: 189840},
+				pos: position{line: 6122, col: 20, offset: 190364},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6107, col: 20, offset: 189840},
+						pos:        position{line: 6122, col: 20, offset: 190364},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6107, col: 34, offset: 189854},
+						pos:  position{line: 6122, col: 34, offset: 190378},
 						name: "SPACE",
 					},
 				},
@@ -15233,18 +15271,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 6108, col: 1, offset: 189860},
+			pos:  position{line: 6123, col: 1, offset: 190384},
 			expr: &seqExpr{
-				pos: position{line: 6108, col: 15, offset: 189874},
+				pos: position{line: 6123, col: 15, offset: 190398},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6108, col: 15, offset: 189874},
+						pos:        position{line: 6123, col: 15, offset: 190398},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6108, col: 24, offset: 189883},
+						pos:  position{line: 6123, col: 24, offset: 190407},
 						name: "SPACE",
 					},
 				},
@@ -15252,18 +15290,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 6109, col: 1, offset: 189889},
+			pos:  position{line: 6124, col: 1, offset: 190413},
 			expr: &seqExpr{
-				pos: position{line: 6109, col: 14, offset: 189902},
+				pos: position{line: 6124, col: 14, offset: 190426},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6109, col: 14, offset: 189902},
+						pos:        position{line: 6124, col: 14, offset: 190426},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6109, col: 22, offset: 189910},
+						pos:  position{line: 6124, col: 22, offset: 190434},
 						name: "SPACE",
 					},
 				},
@@ -15271,9 +15309,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 6110, col: 1, offset: 189916},
+			pos:  position{line: 6125, col: 1, offset: 190440},
 			expr: &litMatcher{
-				pos:        position{line: 6110, col: 22, offset: 189937},
+				pos:        position{line: 6125, col: 22, offset: 190461},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -15281,16 +15319,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 6111, col: 1, offset: 189944},
+			pos:  position{line: 6126, col: 1, offset: 190468},
 			expr: &seqExpr{
-				pos: position{line: 6111, col: 13, offset: 189956},
+				pos: position{line: 6126, col: 13, offset: 190480},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6111, col: 13, offset: 189956},
+						pos:  position{line: 6126, col: 13, offset: 190480},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6111, col: 31, offset: 189974},
+						pos:  position{line: 6126, col: 31, offset: 190498},
 						name: "SPACE",
 					},
 				},
@@ -15298,9 +15336,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 6112, col: 1, offset: 189980},
+			pos:  position{line: 6127, col: 1, offset: 190504},
 			expr: &litMatcher{
-				pos:        position{line: 6112, col: 22, offset: 190001},
+				pos:        position{line: 6127, col: 22, offset: 190525},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -15308,16 +15346,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 6113, col: 1, offset: 190008},
+			pos:  position{line: 6128, col: 1, offset: 190532},
 			expr: &seqExpr{
-				pos: position{line: 6113, col: 13, offset: 190020},
+				pos: position{line: 6128, col: 13, offset: 190544},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6113, col: 13, offset: 190020},
+						pos:  position{line: 6128, col: 13, offset: 190544},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6113, col: 31, offset: 190038},
+						pos:  position{line: 6128, col: 31, offset: 190562},
 						name: "SPACE",
 					},
 				},
@@ -15325,18 +15363,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 6114, col: 1, offset: 190044},
+			pos:  position{line: 6129, col: 1, offset: 190568},
 			expr: &seqExpr{
-				pos: position{line: 6114, col: 13, offset: 190056},
+				pos: position{line: 6129, col: 13, offset: 190580},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6114, col: 13, offset: 190056},
+						pos:        position{line: 6129, col: 13, offset: 190580},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6114, col: 20, offset: 190063},
+						pos:  position{line: 6129, col: 20, offset: 190587},
 						name: "SPACE",
 					},
 				},
@@ -15344,18 +15382,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 6115, col: 1, offset: 190069},
+			pos:  position{line: 6130, col: 1, offset: 190593},
 			expr: &seqExpr{
-				pos: position{line: 6115, col: 12, offset: 190080},
+				pos: position{line: 6130, col: 12, offset: 190604},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6115, col: 12, offset: 190080},
+						pos:        position{line: 6130, col: 12, offset: 190604},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6115, col: 18, offset: 190086},
+						pos:  position{line: 6130, col: 18, offset: 190610},
 						name: "SPACE",
 					},
 				},
@@ -15363,18 +15401,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 6116, col: 1, offset: 190092},
+			pos:  position{line: 6131, col: 1, offset: 190616},
 			expr: &seqExpr{
-				pos: position{line: 6116, col: 13, offset: 190104},
+				pos: position{line: 6131, col: 13, offset: 190628},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6116, col: 13, offset: 190104},
+						pos:        position{line: 6131, col: 13, offset: 190628},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6116, col: 20, offset: 190111},
+						pos:  position{line: 6131, col: 20, offset: 190635},
 						name: "SPACE",
 					},
 				},
@@ -15382,9 +15420,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 6117, col: 1, offset: 190117},
+			pos:  position{line: 6132, col: 1, offset: 190641},
 			expr: &litMatcher{
-				pos:        position{line: 6117, col: 12, offset: 190128},
+				pos:        position{line: 6132, col: 12, offset: 190652},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -15392,9 +15430,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 6118, col: 1, offset: 190134},
+			pos:  position{line: 6133, col: 1, offset: 190658},
 			expr: &litMatcher{
-				pos:        position{line: 6118, col: 13, offset: 190146},
+				pos:        position{line: 6133, col: 13, offset: 190670},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -15402,18 +15440,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 6119, col: 1, offset: 190153},
+			pos:  position{line: 6134, col: 1, offset: 190677},
 			expr: &seqExpr{
-				pos: position{line: 6119, col: 15, offset: 190167},
+				pos: position{line: 6134, col: 15, offset: 190691},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6119, col: 15, offset: 190167},
+						pos:        position{line: 6134, col: 15, offset: 190691},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6119, col: 24, offset: 190176},
+						pos:  position{line: 6134, col: 24, offset: 190700},
 						name: "SPACE",
 					},
 				},
@@ -15421,18 +15459,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 6120, col: 1, offset: 190182},
+			pos:  position{line: 6135, col: 1, offset: 190706},
 			expr: &seqExpr{
-				pos: position{line: 6120, col: 18, offset: 190199},
+				pos: position{line: 6135, col: 18, offset: 190723},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6120, col: 18, offset: 190199},
+						pos:        position{line: 6135, col: 18, offset: 190723},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6120, col: 30, offset: 190211},
+						pos:  position{line: 6135, col: 30, offset: 190735},
 						name: "SPACE",
 					},
 				},
@@ -15440,18 +15478,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 6121, col: 1, offset: 190217},
+			pos:  position{line: 6136, col: 1, offset: 190741},
 			expr: &seqExpr{
-				pos: position{line: 6121, col: 12, offset: 190228},
+				pos: position{line: 6136, col: 12, offset: 190752},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6121, col: 12, offset: 190228},
+						pos:        position{line: 6136, col: 12, offset: 190752},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6121, col: 18, offset: 190234},
+						pos:  position{line: 6136, col: 18, offset: 190758},
 						name: "SPACE",
 					},
 				},
@@ -15459,9 +15497,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 6122, col: 1, offset: 190240},
+			pos:  position{line: 6137, col: 1, offset: 190764},
 			expr: &litMatcher{
-				pos:        position{line: 6122, col: 13, offset: 190252},
+				pos:        position{line: 6137, col: 13, offset: 190776},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -15469,18 +15507,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 6123, col: 1, offset: 190259},
+			pos:  position{line: 6138, col: 1, offset: 190783},
 			expr: &seqExpr{
-				pos: position{line: 6123, col: 20, offset: 190278},
+				pos: position{line: 6138, col: 20, offset: 190802},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6123, col: 20, offset: 190278},
+						pos:        position{line: 6138, col: 20, offset: 190802},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6123, col: 34, offset: 190292},
+						pos:  position{line: 6138, col: 34, offset: 190816},
 						name: "SPACE",
 					},
 				},
@@ -15488,9 +15526,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 6124, col: 1, offset: 190298},
+			pos:  position{line: 6139, col: 1, offset: 190822},
 			expr: &litMatcher{
-				pos:        position{line: 6124, col: 14, offset: 190311},
+				pos:        position{line: 6139, col: 14, offset: 190835},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -15498,22 +15536,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 6125, col: 1, offset: 190319},
+			pos:  position{line: 6140, col: 1, offset: 190843},
 			expr: &seqExpr{
-				pos: position{line: 6125, col: 21, offset: 190339},
+				pos: position{line: 6140, col: 21, offset: 190863},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6125, col: 21, offset: 190339},
+						pos:  position{line: 6140, col: 21, offset: 190863},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6125, col: 27, offset: 190345},
+						pos:        position{line: 6140, col: 27, offset: 190869},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6125, col: 36, offset: 190354},
+						pos:  position{line: 6140, col: 36, offset: 190878},
 						name: "SPACE",
 					},
 				},
@@ -15521,9 +15559,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 6126, col: 1, offset: 190360},
+			pos:  position{line: 6141, col: 1, offset: 190884},
 			expr: &litMatcher{
-				pos:        position{line: 6126, col: 15, offset: 190374},
+				pos:        position{line: 6141, col: 15, offset: 190898},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -15531,9 +15569,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 6127, col: 1, offset: 190383},
+			pos:  position{line: 6142, col: 1, offset: 190907},
 			expr: &litMatcher{
-				pos:        position{line: 6127, col: 14, offset: 190396},
+				pos:        position{line: 6142, col: 14, offset: 190920},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -15541,9 +15579,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 6128, col: 1, offset: 190404},
+			pos:  position{line: 6143, col: 1, offset: 190928},
 			expr: &litMatcher{
-				pos:        position{line: 6128, col: 15, offset: 190418},
+				pos:        position{line: 6143, col: 15, offset: 190942},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -15551,9 +15589,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 6129, col: 1, offset: 190427},
+			pos:  position{line: 6144, col: 1, offset: 190951},
 			expr: &litMatcher{
-				pos:        position{line: 6129, col: 17, offset: 190443},
+				pos:        position{line: 6144, col: 17, offset: 190967},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -15561,9 +15599,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 6130, col: 1, offset: 190454},
+			pos:  position{line: 6145, col: 1, offset: 190978},
 			expr: &litMatcher{
-				pos:        position{line: 6130, col: 15, offset: 190468},
+				pos:        position{line: 6145, col: 15, offset: 190992},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -15571,9 +15609,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 6131, col: 1, offset: 190477},
+			pos:  position{line: 6146, col: 1, offset: 191001},
 			expr: &litMatcher{
-				pos:        position{line: 6131, col: 19, offset: 190495},
+				pos:        position{line: 6146, col: 19, offset: 191019},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -15581,9 +15619,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 6132, col: 1, offset: 190508},
+			pos:  position{line: 6147, col: 1, offset: 191032},
 			expr: &litMatcher{
-				pos:        position{line: 6132, col: 17, offset: 190524},
+				pos:        position{line: 6147, col: 17, offset: 191048},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -15591,9 +15629,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 6133, col: 1, offset: 190535},
+			pos:  position{line: 6148, col: 1, offset: 191059},
 			expr: &litMatcher{
-				pos:        position{line: 6133, col: 17, offset: 190551},
+				pos:        position{line: 6148, col: 17, offset: 191075},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15601,18 +15639,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 6134, col: 1, offset: 190562},
+			pos:  position{line: 6149, col: 1, offset: 191086},
 			expr: &seqExpr{
-				pos: position{line: 6134, col: 20, offset: 190581},
+				pos: position{line: 6149, col: 20, offset: 191105},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6134, col: 20, offset: 190581},
+						pos:        position{line: 6149, col: 20, offset: 191105},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6134, col: 34, offset: 190595},
+						pos:  position{line: 6149, col: 34, offset: 191119},
 						name: "SPACE",
 					},
 				},
@@ -15620,28 +15658,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 6135, col: 1, offset: 190601},
+			pos:  position{line: 6150, col: 1, offset: 191125},
 			expr: &seqExpr{
-				pos: position{line: 6135, col: 16, offset: 190616},
+				pos: position{line: 6150, col: 16, offset: 191140},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 6135, col: 16, offset: 190616},
+						pos: position{line: 6150, col: 16, offset: 191140},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6135, col: 16, offset: 190616},
+							pos:  position{line: 6150, col: 16, offset: 191140},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 6135, col: 24, offset: 190624},
+						pos: position{line: 6150, col: 24, offset: 191148},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 6135, col: 24, offset: 190624},
+								pos:        position{line: 6150, col: 24, offset: 191148},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 6135, col: 30, offset: 190630},
+								pos:        position{line: 6150, col: 30, offset: 191154},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15649,9 +15687,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 6135, col: 35, offset: 190635},
+						pos: position{line: 6150, col: 35, offset: 191159},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6135, col: 35, offset: 190635},
+							pos:  position{line: 6150, col: 35, offset: 191159},
 							name: "SPACE",
 						},
 					},
@@ -15660,9 +15698,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 6136, col: 1, offset: 190642},
+			pos:  position{line: 6151, col: 1, offset: 191166},
 			expr: &litMatcher{
-				pos:        position{line: 6136, col: 17, offset: 190658},
+				pos:        position{line: 6151, col: 17, offset: 191182},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15670,18 +15708,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 6137, col: 1, offset: 190669},
+			pos:  position{line: 6152, col: 1, offset: 191193},
 			expr: &seqExpr{
-				pos: position{line: 6137, col: 15, offset: 190683},
+				pos: position{line: 6152, col: 15, offset: 191207},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6137, col: 15, offset: 190683},
+						pos:        position{line: 6152, col: 15, offset: 191207},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6137, col: 24, offset: 190692},
+						pos:  position{line: 6152, col: 24, offset: 191216},
 						name: "SPACE",
 					},
 				},
@@ -15689,9 +15727,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 6138, col: 1, offset: 190698},
+			pos:  position{line: 6153, col: 1, offset: 191222},
 			expr: &litMatcher{
-				pos:        position{line: 6138, col: 15, offset: 190712},
+				pos:        position{line: 6153, col: 15, offset: 191236},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15699,115 +15737,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 6141, col: 1, offset: 190825},
+			pos:  position{line: 6156, col: 1, offset: 191349},
 			expr: &choiceExpr{
-				pos: position{line: 6141, col: 16, offset: 190840},
+				pos: position{line: 6156, col: 16, offset: 191364},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 6141, col: 16, offset: 190840},
+						pos:        position{line: 6156, col: 16, offset: 191364},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 6141, col: 47, offset: 190871},
+						pos:        position{line: 6156, col: 47, offset: 191395},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6141, col: 55, offset: 190879},
+						pos:        position{line: 6156, col: 55, offset: 191403},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 16, offset: 190902},
+						pos:        position{line: 6157, col: 16, offset: 191426},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 26, offset: 190912},
+						pos:        position{line: 6157, col: 26, offset: 191436},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 34, offset: 190920},
+						pos:        position{line: 6157, col: 34, offset: 191444},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 42, offset: 190928},
+						pos:        position{line: 6157, col: 42, offset: 191452},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 50, offset: 190936},
+						pos:        position{line: 6157, col: 50, offset: 191460},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 58, offset: 190944},
+						pos:        position{line: 6157, col: 58, offset: 191468},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6142, col: 66, offset: 190952},
+						pos:        position{line: 6157, col: 66, offset: 191476},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 16, offset: 190974},
+						pos:        position{line: 6158, col: 16, offset: 191498},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 26, offset: 190984},
+						pos:        position{line: 6158, col: 26, offset: 191508},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 34, offset: 190992},
+						pos:        position{line: 6158, col: 34, offset: 191516},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 42, offset: 191000},
+						pos:        position{line: 6158, col: 42, offset: 191524},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 50, offset: 191008},
+						pos:        position{line: 6158, col: 50, offset: 191532},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 58, offset: 191016},
+						pos:        position{line: 6158, col: 58, offset: 191540},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 66, offset: 191024},
+						pos:        position{line: 6158, col: 66, offset: 191548},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6143, col: 74, offset: 191032},
+						pos:        position{line: 6158, col: 74, offset: 191556},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15817,25 +15855,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 6144, col: 1, offset: 191038},
+			pos:  position{line: 6159, col: 1, offset: 191562},
 			expr: &choiceExpr{
-				pos: position{line: 6144, col: 16, offset: 191053},
+				pos: position{line: 6159, col: 16, offset: 191577},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 6144, col: 16, offset: 191053},
+						pos:        position{line: 6159, col: 16, offset: 191577},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 6144, col: 30, offset: 191067},
+						pos:        position{line: 6159, col: 30, offset: 191591},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6144, col: 36, offset: 191073},
+						pos:        position{line: 6159, col: 36, offset: 191597},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15845,18 +15883,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 6148, col: 1, offset: 191229},
+			pos:  position{line: 6163, col: 1, offset: 191753},
 			expr: &seqExpr{
-				pos: position{line: 6148, col: 8, offset: 191236},
+				pos: position{line: 6163, col: 8, offset: 191760},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6148, col: 8, offset: 191236},
+						pos:        position{line: 6163, col: 8, offset: 191760},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6148, col: 14, offset: 191242},
+						pos:  position{line: 6163, col: 14, offset: 191766},
 						name: "SPACE",
 					},
 				},
@@ -15864,22 +15902,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 6149, col: 1, offset: 191248},
+			pos:  position{line: 6164, col: 1, offset: 191772},
 			expr: &seqExpr{
-				pos: position{line: 6149, col: 7, offset: 191254},
+				pos: position{line: 6164, col: 7, offset: 191778},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6149, col: 7, offset: 191254},
+						pos:  position{line: 6164, col: 7, offset: 191778},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6149, col: 13, offset: 191260},
+						pos:        position{line: 6164, col: 13, offset: 191784},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6149, col: 18, offset: 191265},
+						pos:  position{line: 6164, col: 18, offset: 191789},
 						name: "SPACE",
 					},
 				},
@@ -15887,22 +15925,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 6150, col: 1, offset: 191271},
+			pos:  position{line: 6165, col: 1, offset: 191795},
 			expr: &seqExpr{
-				pos: position{line: 6150, col: 8, offset: 191278},
+				pos: position{line: 6165, col: 8, offset: 191802},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6150, col: 8, offset: 191278},
+						pos:  position{line: 6165, col: 8, offset: 191802},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6150, col: 14, offset: 191284},
+						pos:        position{line: 6165, col: 14, offset: 191808},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6150, col: 20, offset: 191290},
+						pos:  position{line: 6165, col: 20, offset: 191814},
 						name: "SPACE",
 					},
 				},
@@ -15910,22 +15948,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 6151, col: 1, offset: 191296},
+			pos:  position{line: 6166, col: 1, offset: 191820},
 			expr: &seqExpr{
-				pos: position{line: 6151, col: 9, offset: 191304},
+				pos: position{line: 6166, col: 9, offset: 191828},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6151, col: 9, offset: 191304},
+						pos:  position{line: 6166, col: 9, offset: 191828},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6151, col: 24, offset: 191319},
+						pos:        position{line: 6166, col: 24, offset: 191843},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6151, col: 28, offset: 191323},
+						pos:  position{line: 6166, col: 28, offset: 191847},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15933,22 +15971,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 6152, col: 1, offset: 191338},
+			pos:  position{line: 6167, col: 1, offset: 191862},
 			expr: &seqExpr{
-				pos: position{line: 6152, col: 7, offset: 191344},
+				pos: position{line: 6167, col: 7, offset: 191868},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6152, col: 7, offset: 191344},
+						pos:  position{line: 6167, col: 7, offset: 191868},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6152, col: 13, offset: 191350},
+						pos:        position{line: 6167, col: 13, offset: 191874},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6152, col: 19, offset: 191356},
+						pos:  position{line: 6167, col: 19, offset: 191880},
 						name: "SPACE",
 					},
 				},
@@ -15956,22 +15994,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 6153, col: 1, offset: 191382},
+			pos:  position{line: 6168, col: 1, offset: 191906},
 			expr: &seqExpr{
-				pos: position{line: 6153, col: 7, offset: 191388},
+				pos: position{line: 6168, col: 7, offset: 191912},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6153, col: 7, offset: 191388},
+						pos:  position{line: 6168, col: 7, offset: 191912},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6153, col: 13, offset: 191394},
+						pos:        position{line: 6168, col: 13, offset: 191918},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6153, col: 19, offset: 191400},
+						pos:  position{line: 6168, col: 19, offset: 191924},
 						name: "SPACE",
 					},
 				},
@@ -15979,22 +16017,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 6155, col: 1, offset: 191427},
+			pos:  position{line: 6170, col: 1, offset: 191951},
 			expr: &seqExpr{
-				pos: position{line: 6155, col: 10, offset: 191436},
+				pos: position{line: 6170, col: 10, offset: 191960},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6155, col: 10, offset: 191436},
+						pos:  position{line: 6170, col: 10, offset: 191960},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6155, col: 25, offset: 191451},
+						pos:        position{line: 6170, col: 25, offset: 191975},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6155, col: 29, offset: 191455},
+						pos:  position{line: 6170, col: 29, offset: 191979},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -16002,22 +16040,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 6156, col: 1, offset: 191470},
+			pos:  position{line: 6171, col: 1, offset: 191994},
 			expr: &seqExpr{
-				pos: position{line: 6156, col: 10, offset: 191479},
+				pos: position{line: 6171, col: 10, offset: 192003},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6156, col: 10, offset: 191479},
+						pos:  position{line: 6171, col: 10, offset: 192003},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6156, col: 25, offset: 191494},
+						pos:        position{line: 6171, col: 25, offset: 192018},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6156, col: 29, offset: 191498},
+						pos:  position{line: 6171, col: 29, offset: 192022},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -16025,9 +16063,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 6157, col: 1, offset: 191513},
+			pos:  position{line: 6172, col: 1, offset: 192037},
 			expr: &litMatcher{
-				pos:        position{line: 6157, col: 10, offset: 191522},
+				pos:        position{line: 6172, col: 10, offset: 192046},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -16035,18 +16073,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 6158, col: 1, offset: 191526},
+			pos:  position{line: 6173, col: 1, offset: 192050},
 			expr: &seqExpr{
-				pos: position{line: 6158, col: 12, offset: 191537},
+				pos: position{line: 6173, col: 12, offset: 192061},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6158, col: 12, offset: 191537},
+						pos:        position{line: 6173, col: 12, offset: 192061},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6158, col: 16, offset: 191541},
+						pos:  position{line: 6173, col: 16, offset: 192065},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -16054,16 +16092,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 6159, col: 1, offset: 191556},
+			pos:  position{line: 6174, col: 1, offset: 192080},
 			expr: &seqExpr{
-				pos: position{line: 6159, col: 12, offset: 191567},
+				pos: position{line: 6174, col: 12, offset: 192091},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6159, col: 12, offset: 191567},
+						pos:  position{line: 6174, col: 12, offset: 192091},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6159, col: 27, offset: 191582},
+						pos:        position{line: 6174, col: 27, offset: 192106},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -16073,40 +16111,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 6161, col: 1, offset: 191587},
+			pos:  position{line: 6176, col: 1, offset: 192111},
 			expr: &notExpr{
-				pos: position{line: 6161, col: 8, offset: 191594},
+				pos: position{line: 6176, col: 8, offset: 192118},
 				expr: &anyMatcher{
-					line: 6161, col: 9, offset: 191595,
+					line: 6176, col: 9, offset: 192119,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 6162, col: 1, offset: 191597},
+			pos:  position{line: 6177, col: 1, offset: 192121},
 			expr: &choiceExpr{
-				pos: position{line: 6162, col: 15, offset: 191611},
+				pos: position{line: 6177, col: 15, offset: 192135},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 6162, col: 15, offset: 191611},
+						pos:        position{line: 6177, col: 15, offset: 192135},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 6162, col: 21, offset: 191617},
+						pos:        position{line: 6177, col: 21, offset: 192141},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6162, col: 28, offset: 191624},
+						pos:        position{line: 6177, col: 28, offset: 192148},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 6162, col: 35, offset: 191631},
+						pos:        position{line: 6177, col: 35, offset: 192155},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -16116,37 +16154,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 6163, col: 1, offset: 191636},
+			pos:  position{line: 6178, col: 1, offset: 192160},
 			expr: &choiceExpr{
-				pos: position{line: 6163, col: 10, offset: 191645},
+				pos: position{line: 6178, col: 10, offset: 192169},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 6163, col: 11, offset: 191646},
+						pos: position{line: 6178, col: 11, offset: 192170},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 6163, col: 11, offset: 191646},
+								pos: position{line: 6178, col: 11, offset: 192170},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6163, col: 11, offset: 191646},
+									pos:  position{line: 6178, col: 11, offset: 192170},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 6163, col: 23, offset: 191658},
+								pos:  position{line: 6178, col: 23, offset: 192182},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 6163, col: 31, offset: 191666},
+								pos: position{line: 6178, col: 31, offset: 192190},
 								expr: &ruleRefExpr{
-									pos:  position{line: 6163, col: 31, offset: 191666},
+									pos:  position{line: 6178, col: 31, offset: 192190},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 6163, col: 46, offset: 191681},
+						pos: position{line: 6178, col: 46, offset: 192205},
 						expr: &ruleRefExpr{
-							pos:  position{line: 6163, col: 46, offset: 191681},
+							pos:  position{line: 6178, col: 46, offset: 192205},
 							name: "WHITESPACE",
 						},
 					},
@@ -16155,38 +16193,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 6164, col: 1, offset: 191693},
+			pos:  position{line: 6179, col: 1, offset: 192217},
 			expr: &seqExpr{
-				pos: position{line: 6164, col: 12, offset: 191704},
+				pos: position{line: 6179, col: 12, offset: 192228},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 6164, col: 12, offset: 191704},
+						pos:        position{line: 6179, col: 12, offset: 192228},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 6164, col: 18, offset: 191710},
+						pos: position{line: 6179, col: 18, offset: 192234},
 						expr: &seqExpr{
-							pos: position{line: 6164, col: 19, offset: 191711},
+							pos: position{line: 6179, col: 19, offset: 192235},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 6164, col: 19, offset: 191711},
+									pos: position{line: 6179, col: 19, offset: 192235},
 									expr: &litMatcher{
-										pos:        position{line: 6164, col: 21, offset: 191713},
+										pos:        position{line: 6179, col: 21, offset: 192237},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 6164, col: 28, offset: 191720,
+									line: 6179, col: 28, offset: 192244,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 6164, col: 32, offset: 191724},
+						pos:        position{line: 6179, col: 32, offset: 192248},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -16196,16 +16234,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 6165, col: 1, offset: 191730},
+			pos:  position{line: 6180, col: 1, offset: 192254},
 			expr: &choiceExpr{
-				pos: position{line: 6165, col: 20, offset: 191749},
+				pos: position{line: 6180, col: 20, offset: 192273},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6165, col: 20, offset: 191749},
+						pos:  position{line: 6180, col: 20, offset: 192273},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 6165, col: 28, offset: 191757},
+						pos:        position{line: 6180, col: 28, offset: 192281},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -16215,16 +16253,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 6166, col: 1, offset: 191760},
+			pos:  position{line: 6181, col: 1, offset: 192284},
 			expr: &choiceExpr{
-				pos: position{line: 6166, col: 19, offset: 191778},
+				pos: position{line: 6181, col: 19, offset: 192302},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 6166, col: 19, offset: 191778},
+						pos:  position{line: 6181, col: 19, offset: 192302},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 6166, col: 27, offset: 191786},
+						pos:  position{line: 6181, col: 27, offset: 192310},
 						name: "SPACE",
 					},
 				},
@@ -20596,91 +20634,7 @@ func (p *parser) callonJsonExprLevel12() (any, error) {
 	return p.cur.onJsonExprLevel12(stack["jsonExpr"])
 }
 
-func (c *current) onJsonExprLevel15(field any) (any, error) {
-	fieldStr, ok := field.(string)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: unable to assert EvalFieldToRead as string")
-	}
-	expr := &structs.JsonExpr{
-		JsonExprMode: structs.JEMField,
-		IsTerminal:   true,
-		ValueIsField: true,
-		FieldValue:   fieldStr,
-	}
-
-	return expr, nil
-}
-
-func (p *parser) callonJsonExprLevel15() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onJsonExprLevel15(stack["field"])
-}
-
-func (c *current) onJsonExprLevel18(value any) (any, error) {
-	numExpr, ok := value.(*structs.NumericExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
-	}
-	expr := &structs.JsonExpr{
-		JsonExprMode: structs.JEMNumber,
-		IsTerminal:   true,
-		ValueIsField: false,
-		InputNumber:  numExpr,
-	}
-
-	return expr, nil
-}
-
-func (p *parser) callonJsonExprLevel18() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onJsonExprLevel18(stack["value"])
-}
-
-func (c *current) onJsonExprLevel111(value any) (any, error) {
-	numExpr, ok := value.(*structs.NumericExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
-	}
-	expr := &structs.JsonExpr{
-		JsonExprMode: structs.JEMNumber,
-		IsTerminal:   true,
-		ValueIsField: false,
-		InputNumber:  numExpr,
-	}
-
-	return expr, nil
-}
-
-func (p *parser) callonJsonExprLevel111() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onJsonExprLevel111(stack["value"])
-}
-
-func (c *current) onJsonExprLevel114(value any) (any, error) {
-	multiExpr, ok := value.(*structs.MultiValueExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.MultiValueExpr")
-	}
-	expr := &structs.JsonExpr{
-		JsonExprMode:  structs.JEMMultiVal,
-		IsTerminal:    true,
-		ValueIsField:  false,
-		InputMultiVal: multiExpr,
-	}
-
-	return expr, nil
-}
-
-func (p *parser) callonJsonExprLevel114() (any, error) {
-	stack := p.vstack[len(p.vstack)-1]
-	_ = stack
-	return p.cur.onJsonExprLevel114(stack["value"])
-}
-
-func (c *current) onJsonExprLevel117(value any) (any, error) {
+func (c *current) onJsonExprLevel15(value any) (any, error) {
 	boolExpr, ok := value.(*structs.BoolExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.BoolExpr")
@@ -20695,13 +20649,117 @@ func (c *current) onJsonExprLevel117(value any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonJsonExprLevel117() (any, error) {
+func (p *parser) callonJsonExprLevel15() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExprLevel117(stack["value"])
+	return p.cur.onJsonExprLevel15(stack["value"])
 }
 
-func (c *current) onJsonExprLevel120(value any) (any, error) {
+func (c *current) onJsonExprLevel18(value any) (any, error) {
+	boolValue, err := transferUint8ToString(value)
+	if err != nil {
+		return nil, fmt.Errorf("spl peg: failed to convert literal true to string")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode:      structs.JEMBoolean,
+		IsTerminal:        true,
+		ValueIsField:      false,
+		InputBooleanValue: boolValue == "true",
+	}
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel18() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel18(stack["value"])
+}
+
+func (c *current) onJsonExprLevel116(field any) (any, error) {
+	fieldStr, ok := field.(string)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: unable to assert EvalFieldToRead as string")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMField,
+		IsTerminal:   true,
+		ValueIsField: true,
+		FieldValue:   fieldStr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel116() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel116(stack["field"])
+}
+
+func (c *current) onJsonExprLevel119(value any) (any, error) {
+	numExpr, ok := value.(*structs.NumericExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMNumber,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputNumber:  numExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel119() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel119(stack["value"])
+}
+
+func (c *current) onJsonExprLevel122(value any) (any, error) {
+	numExpr, ok := value.(*structs.NumericExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode: structs.JEMNumber,
+		IsTerminal:   true,
+		ValueIsField: false,
+		InputNumber:  numExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel122() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel122(stack["value"])
+}
+
+func (c *current) onJsonExprLevel125(value any) (any, error) {
+	multiExpr, ok := value.(*structs.MultiValueExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value as *structs.MultiValueExpr")
+	}
+	expr := &structs.JsonExpr{
+		JsonExprMode:  structs.JEMMultiVal,
+		IsTerminal:    true,
+		ValueIsField:  false,
+		InputMultiVal: multiExpr,
+	}
+
+	return expr, nil
+}
+
+func (p *parser) callonJsonExprLevel125() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExprLevel125(stack["value"])
+}
+
+func (c *current) onJsonExprLevel128(value any) (any, error) {
 	expr := &structs.JsonExpr{
 		JsonExprMode: structs.JEMNull,
 		IsTerminal:   true,
@@ -20712,13 +20770,13 @@ func (c *current) onJsonExprLevel120(value any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonJsonExprLevel120() (any, error) {
+func (p *parser) callonJsonExprLevel128() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExprLevel120(stack["value"])
+	return p.cur.onJsonExprLevel128(stack["value"])
 }
 
-func (c *current) onJsonExprLevel126(value any) (any, error) {
+func (c *current) onJsonExprLevel134(value any) (any, error) {
 	stringExpr, ok := value.(*structs.StringExpr)
 	if !ok {
 		return nil, fmt.Errorf("spl peg: failed to assert string as *structs.StringExpr")
@@ -20733,10 +20791,10 @@ func (c *current) onJsonExprLevel126(value any) (any, error) {
 	return expr, nil
 }
 
-func (p *parser) callonJsonExprLevel126() (any, error) {
+func (p *parser) callonJsonExprLevel134() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExprLevel126(stack["value"])
+	return p.cur.onJsonExprLevel134(stack["value"])
 }
 
 func (c *current) onJsonExpr2(firstKey, firstValue, rest any) (any, error) {
@@ -20766,7 +20824,7 @@ func (c *current) onJsonExpr19(opName, value any) (any, error) {
 	}
 
 	if opNameStr == "json_entries" || opNameStr == "json_keys" {
-		if leftJsonExpr.JsonExprMode != structs.JEMString || leftJsonExpr.JsonExprMode != structs.JEMField {
+		if !(leftJsonExpr.JsonExprMode == structs.JEMString || leftJsonExpr.JsonExprMode == structs.JEMField) {
 			// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/evaluation-functions/json-functions#e1d0bff6_e301_4880_8e8d_daf710234e07__json_delete.28.26lt.3Bobject.26gt.3B.2C.26lt.3Bkeys.26gt.3B.29
 			// text from documentation - The <value> argument can be a valid JSON object or the name of a field that contains a valid JSON object.
 			return nil, fmt.Errorf("spl peg: value argument can only take a json string or a field")
@@ -20888,16 +20946,18 @@ func (c *current) onJsonExpr89(opName, json, paths any) (any, error) {
 	if paths != nil {
 		// paths structure - [",", pathValue]
 		// if length is greater than 2 that means there are more than one paths
-		if len(paths.([]any)) > 2 {
-			// firstValue = first path value (i.e. value at index 1)
-			// rest of the values including commas are from index 2
-			result, err = createJsonExprAst(opNameStr, paths.([]any)[1], paths.([]any)[2:], 1)
-		} else {
-			// rest is nil here
-			result, err = createJsonExprAst(opNameStr, paths.([]any)[1], nil, 1)
-		}
-		if err != nil {
-			return nil, err
+		for _, pathArg := range paths.([]any) {
+			if len(paths.([]any)) > 2 {
+				// firstValue = first path value (i.e. value at index 1)
+				// rest of the values including commas are from index 2
+				result, err = createJsonExprAst(opNameStr, pathArg.([]any)[1], paths.([]any)[2:], 1)
+			} else {
+				// rest is nil here
+				result, err = createJsonExprAst(opNameStr, pathArg.([]any)[1], nil, 1)
+			}
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/ast/spl/spl.go
+++ b/pkg/ast/spl/spl.go
@@ -299,6 +299,12 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
 }
 
 func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+	if leftExpr.Op == "" {
+		leftExpr.Op = op
+	}
+	if rightExpr.Op == "" {
+		rightExpr.Op = op
+	}
 	return &structs.JsonExpr{
 		IsTerminal:   false,
 		Op:           op,
@@ -310,10 +316,116 @@ func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs
 
 func getRawValJsonObjectKey(key *structs.JsonExpr) string {
 	if key.JsonExprMode == structs.JEMField {
-		return key.FieldValue
+		return "__" + key.FieldValue + "__"
 	} else {
 		return key.InputString.RawString
 	}
+}
+
+func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, rest any) (*structs.JsonExpr, error) {
+	isValidKey := func(key *structs.JsonExpr) error {
+		// key can only be a string => either a field or a StringExpr
+		// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
+		if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+			return fmt.Errorf("spl peg: key in json_object can only be a string")
+		}
+		return nil
+	}
+
+	astDs := make([]*structs.JsonExpr, 1, 5)
+	keyToIdxMap := make(map[string]int)
+
+	key, ok := firstKey.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert key/path as *structs.JsonExpr; Check the first key/path of the function")
+	}
+
+	err := isValidKey(key)
+	if err != nil {
+		return nil, err
+	}
+	if key.Op == "" {
+		key.Op = opNameStr
+	}
+
+	var value *structs.JsonExpr
+	value, ok = firstValue.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert value argument as *structs.JsonExpr; Check the first value of the function")
+	}
+	if value.Op == "" {
+		value.Op = opNameStr
+	}
+
+	rawKey := getRawValJsonObjectKey(key)
+
+	keyToIdxMap[rawKey] = 0
+
+	astDs[0] = &structs.JsonExpr{
+		Op:           opNameStr,
+		JsonExprMode: structs.JEMKeyVal,
+		IsTerminal:   value.JsonExprMode != structs.JEMExpr,
+		Key:          key,
+		Value:        value,
+	}
+
+	if rest != nil {
+		var restKey *structs.JsonExpr
+		var restValue *structs.JsonExpr
+		for idx, arg := range rest.([]any) {
+			// Each item in rest is [",", Key, ",", Value]
+			restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert key as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+			}
+			if restKey.Op == "" {
+				restKey.Op = opNameStr
+			}
+
+			err := isValidKey(restKey)
+			if err != nil {
+				return nil, err
+			}
+
+			restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
+			if !ok {
+				return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+			}
+			if restValue.Op == "" {
+				restValue.Op = opNameStr
+			}
+
+			rawKey = getRawValJsonObjectKey(restKey)
+
+			keyValueStruct := &structs.JsonExpr{
+				Op:           opNameStr,
+				JsonExprMode: structs.JEMKeyVal,
+				IsTerminal:   restValue.JsonExprMode != structs.JEMExpr,
+				Key:          restKey,
+				Value:        restValue,
+			}
+
+			var v int
+			if v, ok = keyToIdxMap[rawKey]; ok {
+				astDs[v] = keyValueStruct
+			} else {
+				keyToIdxMap[rawKey] = len(astDs)
+				astDs = append(astDs, keyValueStruct)
+			}
+		}
+	}
+
+	// build ast tree
+	result := astDs[0]
+	for i := 1; i < len(astDs); i++ {
+		var err error
+		result, err = createJsonExprAst(opNameStr, result, astDs[i], structs.JEMExpr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
 }
 
 func transferUint8ToString(opName interface{}) (string, error) {
@@ -562,177 +674,177 @@ var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Start",
-			pos:  position{line: 550, col: 1, offset: 15507},
+			pos:  position{line: 662, col: 1, offset: 19078},
 			expr: &choiceExpr{
-				pos: position{line: 550, col: 10, offset: 15516},
+				pos: position{line: 662, col: 10, offset: 19087},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 550, col: 10, offset: 15516},
+						pos: position{line: 662, col: 10, offset: 19087},
 						run: (*parser).callonStart2,
 						expr: &seqExpr{
-							pos: position{line: 550, col: 10, offset: 15516},
+							pos: position{line: 662, col: 10, offset: 19087},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 550, col: 10, offset: 15516},
+									pos:   position{line: 662, col: 10, offset: 19087},
 									label: "indexBlock",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 550, col: 21, offset: 15527},
+										pos: position{line: 662, col: 21, offset: 19098},
 										expr: &ruleRefExpr{
-											pos:  position{line: 550, col: 22, offset: 15528},
+											pos:  position{line: 662, col: 22, offset: 19099},
 											name: "IndexBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 550, col: 35, offset: 15541},
+									pos: position{line: 662, col: 35, offset: 19112},
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 35, offset: 15541},
+										pos:  position{line: 662, col: 35, offset: 19112},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 42, offset: 15548},
+									pos:   position{line: 662, col: 42, offset: 19119},
 									label: "initialSearch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 57, offset: 15563},
+										pos:  position{line: 662, col: 57, offset: 19134},
 										name: "InitialSearchBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 77, offset: 15583},
+									pos:   position{line: 662, col: 77, offset: 19154},
 									label: "filterBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 550, col: 90, offset: 15596},
+										pos: position{line: 662, col: 90, offset: 19167},
 										expr: &ruleRefExpr{
-											pos:  position{line: 550, col: 91, offset: 15597},
+											pos:  position{line: 662, col: 91, offset: 19168},
 											name: "FilterBlock",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 550, col: 105, offset: 15611},
+									pos:   position{line: 662, col: 105, offset: 19182},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 550, col: 120, offset: 15626},
+										pos: position{line: 662, col: 120, offset: 19197},
 										expr: &ruleRefExpr{
-											pos:  position{line: 550, col: 121, offset: 15627},
+											pos:  position{line: 662, col: 121, offset: 19198},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 550, col: 144, offset: 15650},
+									pos: position{line: 662, col: 144, offset: 19221},
 									expr: &ruleRefExpr{
-										pos:  position{line: 550, col: 144, offset: 15650},
+										pos:  position{line: 662, col: 144, offset: 19221},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 550, col: 151, offset: 15657},
+									pos:  position{line: 662, col: 151, offset: 19228},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 616, col: 3, offset: 17580},
+						pos: position{line: 728, col: 3, offset: 21151},
 						run: (*parser).callonStart20,
 						expr: &seqExpr{
-							pos: position{line: 616, col: 3, offset: 17580},
+							pos: position{line: 728, col: 3, offset: 21151},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 616, col: 3, offset: 17580},
+									pos: position{line: 728, col: 3, offset: 21151},
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 3, offset: 17580},
+										pos:  position{line: 728, col: 3, offset: 21151},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 616, col: 10, offset: 17587},
+									pos:  position{line: 728, col: 10, offset: 21158},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 616, col: 15, offset: 17592},
+									pos:  position{line: 728, col: 15, offset: 21163},
 									name: "CMD_GENTIMES",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 616, col: 28, offset: 17605},
+									pos:  position{line: 728, col: 28, offset: 21176},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 34, offset: 17611},
+									pos:   position{line: 728, col: 34, offset: 21182},
 									label: "genTimesOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 50, offset: 17627},
+										pos:  position{line: 728, col: 50, offset: 21198},
 										name: "GenTimesOptionList",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 616, col: 70, offset: 17647},
+									pos:   position{line: 728, col: 70, offset: 21218},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 616, col: 85, offset: 17662},
+										pos: position{line: 728, col: 85, offset: 21233},
 										expr: &ruleRefExpr{
-											pos:  position{line: 616, col: 86, offset: 17663},
+											pos:  position{line: 728, col: 86, offset: 21234},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 616, col: 109, offset: 17686},
+									pos: position{line: 728, col: 109, offset: 21257},
 									expr: &ruleRefExpr{
-										pos:  position{line: 616, col: 109, offset: 17686},
+										pos:  position{line: 728, col: 109, offset: 21257},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 616, col: 116, offset: 17693},
+									pos:  position{line: 728, col: 116, offset: 21264},
 									name: "EOF",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 635, col: 3, offset: 18206},
+						pos: position{line: 747, col: 3, offset: 21777},
 						run: (*parser).callonStart35,
 						expr: &seqExpr{
-							pos: position{line: 635, col: 3, offset: 18206},
+							pos: position{line: 747, col: 3, offset: 21777},
 							exprs: []any{
 								&zeroOrOneExpr{
-									pos: position{line: 635, col: 3, offset: 18206},
+									pos: position{line: 747, col: 3, offset: 21777},
 									expr: &ruleRefExpr{
-										pos:  position{line: 635, col: 3, offset: 18206},
+										pos:  position{line: 747, col: 3, offset: 21777},
 										name: "SPACE",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 635, col: 10, offset: 18213},
+									pos:   position{line: 747, col: 10, offset: 21784},
 									label: "inputLookup",
 									expr: &ruleRefExpr{
-										pos:  position{line: 635, col: 22, offset: 18225},
+										pos:  position{line: 747, col: 22, offset: 21796},
 										name: "InputLookupBlock",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 635, col: 39, offset: 18242},
+									pos:   position{line: 747, col: 39, offset: 21813},
 									label: "queryAggBlocks",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 635, col: 54, offset: 18257},
+										pos: position{line: 747, col: 54, offset: 21828},
 										expr: &ruleRefExpr{
-											pos:  position{line: 635, col: 55, offset: 18258},
+											pos:  position{line: 747, col: 55, offset: 21829},
 											name: "QueryAggergatorBlock",
 										},
 									},
 								},
 								&zeroOrOneExpr{
-									pos: position{line: 635, col: 78, offset: 18281},
+									pos: position{line: 747, col: 78, offset: 21852},
 									expr: &ruleRefExpr{
-										pos:  position{line: 635, col: 78, offset: 18281},
+										pos:  position{line: 747, col: 78, offset: 21852},
 										name: "SPACE",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 635, col: 85, offset: 18288},
+									pos:  position{line: 747, col: 85, offset: 21859},
 									name: "EOF",
 								},
 							},
@@ -743,32 +855,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexAssign",
-			pos:  position{line: 651, col: 1, offset: 18670},
+			pos:  position{line: 763, col: 1, offset: 22241},
 			expr: &actionExpr{
-				pos: position{line: 651, col: 16, offset: 18685},
+				pos: position{line: 763, col: 16, offset: 22256},
 				run: (*parser).callonIndexAssign1,
 				expr: &seqExpr{
-					pos: position{line: 651, col: 16, offset: 18685},
+					pos: position{line: 763, col: 16, offset: 22256},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 651, col: 16, offset: 18685},
+							pos:   position{line: 763, col: 16, offset: 22256},
 							label: "index",
 							expr: &litMatcher{
-								pos:        position{line: 651, col: 23, offset: 18692},
+								pos:        position{line: 763, col: 23, offset: 22263},
 								val:        "_index",
 								ignoreCase: false,
 								want:       "\"_index\"",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 651, col: 33, offset: 18702},
+							pos:  position{line: 763, col: 33, offset: 22273},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 651, col: 39, offset: 18708},
+							pos:   position{line: 763, col: 39, offset: 22279},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 651, col: 49, offset: 18718},
+								pos:  position{line: 763, col: 49, offset: 22289},
 								name: "String",
 							},
 						},
@@ -778,35 +890,35 @@ var g = &grammar{
 		},
 		{
 			name: "IndexExpression",
-			pos:  position{line: 656, col: 1, offset: 18907},
+			pos:  position{line: 768, col: 1, offset: 22478},
 			expr: &actionExpr{
-				pos: position{line: 656, col: 20, offset: 18926},
+				pos: position{line: 768, col: 20, offset: 22497},
 				run: (*parser).callonIndexExpression1,
 				expr: &seqExpr{
-					pos: position{line: 656, col: 20, offset: 18926},
+					pos: position{line: 768, col: 20, offset: 22497},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 656, col: 20, offset: 18926},
+							pos:   position{line: 768, col: 20, offset: 22497},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 656, col: 27, offset: 18933},
+								pos:  position{line: 768, col: 27, offset: 22504},
 								name: "IndexAssign",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 656, col: 40, offset: 18946},
+							pos:   position{line: 768, col: 40, offset: 22517},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 656, col: 45, offset: 18951},
+								pos: position{line: 768, col: 45, offset: 22522},
 								expr: &seqExpr{
-									pos: position{line: 656, col: 46, offset: 18952},
+									pos: position{line: 768, col: 46, offset: 22523},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 656, col: 46, offset: 18952},
+											pos:  position{line: 768, col: 46, offset: 22523},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 656, col: 49, offset: 18955},
+											pos:  position{line: 768, col: 49, offset: 22526},
 											name: "IndexAssign",
 										},
 									},
@@ -819,32 +931,32 @@ var g = &grammar{
 		},
 		{
 			name: "IndexBlock",
-			pos:  position{line: 681, col: 1, offset: 19536},
+			pos:  position{line: 793, col: 1, offset: 23107},
 			expr: &actionExpr{
-				pos: position{line: 681, col: 15, offset: 19550},
+				pos: position{line: 793, col: 15, offset: 23121},
 				run: (*parser).callonIndexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 681, col: 15, offset: 19550},
+					pos: position{line: 793, col: 15, offset: 23121},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 681, col: 15, offset: 19550},
+							pos: position{line: 793, col: 15, offset: 23121},
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 15, offset: 19550},
+								pos:  position{line: 793, col: 15, offset: 23121},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 681, col: 22, offset: 19557},
+							pos:   position{line: 793, col: 22, offset: 23128},
 							label: "indexName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 33, offset: 19568},
+								pos:  position{line: 793, col: 33, offset: 23139},
 								name: "IndexExpression",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 681, col: 50, offset: 19585},
+							pos: position{line: 793, col: 50, offset: 23156},
 							expr: &ruleRefExpr{
-								pos:  position{line: 681, col: 50, offset: 19585},
+								pos:  position{line: 793, col: 50, offset: 23156},
 								name: "PIPE",
 							},
 						},
@@ -854,76 +966,76 @@ var g = &grammar{
 		},
 		{
 			name: "PartialTimestamp",
-			pos:  position{line: 685, col: 1, offset: 19622},
+			pos:  position{line: 797, col: 1, offset: 23193},
 			expr: &actionExpr{
-				pos: position{line: 685, col: 21, offset: 19642},
+				pos: position{line: 797, col: 21, offset: 23213},
 				run: (*parser).callonPartialTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 685, col: 21, offset: 19642},
+					pos: position{line: 797, col: 21, offset: 23213},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 685, col: 21, offset: 19642},
+							pos:        position{line: 797, col: 21, offset: 23213},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 685, col: 26, offset: 19647},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 685, col: 32, offset: 19653},
-							val:        "/",
-							ignoreCase: false,
-							want:       "\"/\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 685, col: 36, offset: 19657},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 685, col: 41, offset: 19662},
+							pos:        position{line: 797, col: 26, offset: 23218},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 685, col: 47, offset: 19668},
+							pos:        position{line: 797, col: 32, offset: 23224},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 685, col: 51, offset: 19672},
+							pos:        position{line: 797, col: 36, offset: 23228},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 685, col: 56, offset: 19677},
+							pos:        position{line: 797, col: 41, offset: 23233},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 797, col: 47, offset: 23239},
+							val:        "/",
+							ignoreCase: false,
+							want:       "\"/\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 797, col: 51, offset: 23243},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 685, col: 61, offset: 19682},
+							pos:        position{line: 797, col: 56, offset: 23248},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 685, col: 66, offset: 19687},
+							pos:        position{line: 797, col: 61, offset: 23253},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 797, col: 66, offset: 23258},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -935,15 +1047,15 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsTimeToUnixEpochMs",
-			pos:  position{line: 692, col: 1, offset: 19828},
+			pos:  position{line: 804, col: 1, offset: 23399},
 			expr: &actionExpr{
-				pos: position{line: 692, col: 31, offset: 19858},
+				pos: position{line: 804, col: 31, offset: 23429},
 				run: (*parser).callonIntegerAsTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 692, col: 31, offset: 19858},
+					pos:   position{line: 804, col: 31, offset: 23429},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 692, col: 38, offset: 19865},
+						pos:  position{line: 804, col: 38, offset: 23436},
 						name: "IntegerAsString",
 					},
 				},
@@ -951,22 +1063,22 @@ var g = &grammar{
 		},
 		{
 			name: "DateTimeToUnixEpochMs",
-			pos:  position{line: 710, col: 1, offset: 20508},
+			pos:  position{line: 822, col: 1, offset: 24079},
 			expr: &actionExpr{
-				pos: position{line: 710, col: 26, offset: 20533},
+				pos: position{line: 822, col: 26, offset: 24104},
 				run: (*parser).callonDateTimeToUnixEpochMs1,
 				expr: &labeledExpr{
-					pos:   position{line: 710, col: 26, offset: 20533},
+					pos:   position{line: 822, col: 26, offset: 24104},
 					label: "timeStamp",
 					expr: &choiceExpr{
-						pos: position{line: 710, col: 37, offset: 20544},
+						pos: position{line: 822, col: 37, offset: 24115},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 710, col: 37, offset: 20544},
+								pos:  position{line: 822, col: 37, offset: 24115},
 								name: "FullTimeStamp",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 710, col: 53, offset: 20560},
+								pos:  position{line: 822, col: 53, offset: 24131},
 								name: "PartialTimestamp",
 							},
 						},
@@ -976,22 +1088,22 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimestamp",
-			pos:  position{line: 719, col: 1, offset: 20818},
+			pos:  position{line: 831, col: 1, offset: 24389},
 			expr: &actionExpr{
-				pos: position{line: 719, col: 17, offset: 20834},
+				pos: position{line: 831, col: 17, offset: 24405},
 				run: (*parser).callonGenTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 719, col: 17, offset: 20834},
+					pos:   position{line: 831, col: 17, offset: 24405},
 					label: "epochInMilli",
 					expr: &choiceExpr{
-						pos: position{line: 719, col: 31, offset: 20848},
+						pos: position{line: 831, col: 31, offset: 24419},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 719, col: 31, offset: 20848},
+								pos:  position{line: 831, col: 31, offset: 24419},
 								name: "DateTimeToUnixEpochMs",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 719, col: 55, offset: 20872},
+								pos:  position{line: 831, col: 55, offset: 24443},
 								name: "IntegerAsTimeToUnixEpochMs",
 							},
 						},
@@ -1001,28 +1113,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionEnd",
-			pos:  position{line: 723, col: 1, offset: 20934},
+			pos:  position{line: 835, col: 1, offset: 24505},
 			expr: &actionExpr{
-				pos: position{line: 723, col: 22, offset: 20955},
+				pos: position{line: 835, col: 22, offset: 24526},
 				run: (*parser).callonGenTimesOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 723, col: 22, offset: 20955},
+					pos: position{line: 835, col: 22, offset: 24526},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 723, col: 22, offset: 20955},
+							pos:        position{line: 835, col: 22, offset: 24526},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 723, col: 28, offset: 20961},
+							pos:  position{line: 835, col: 28, offset: 24532},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 723, col: 34, offset: 20967},
+							pos:   position{line: 835, col: 34, offset: 24538},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 723, col: 45, offset: 20978},
+								pos:  position{line: 835, col: 45, offset: 24549},
 								name: "GenTimestamp",
 							},
 						},
@@ -1032,28 +1144,28 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionStart",
-			pos:  position{line: 732, col: 1, offset: 21168},
+			pos:  position{line: 844, col: 1, offset: 24739},
 			expr: &actionExpr{
-				pos: position{line: 732, col: 24, offset: 21191},
+				pos: position{line: 844, col: 24, offset: 24762},
 				run: (*parser).callonGenTimesOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 732, col: 24, offset: 21191},
+					pos: position{line: 844, col: 24, offset: 24762},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 732, col: 24, offset: 21191},
+							pos:        position{line: 844, col: 24, offset: 24762},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 732, col: 32, offset: 21199},
+							pos:  position{line: 844, col: 32, offset: 24770},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 732, col: 38, offset: 21205},
+							pos:   position{line: 844, col: 38, offset: 24776},
 							label: "timeStamp",
 							expr: &ruleRefExpr{
-								pos:  position{line: 732, col: 49, offset: 21216},
+								pos:  position{line: 844, col: 49, offset: 24787},
 								name: "GenTimestamp",
 							},
 						},
@@ -1063,59 +1175,59 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionIncrement",
-			pos:  position{line: 741, col: 1, offset: 21410},
+			pos:  position{line: 853, col: 1, offset: 24981},
 			expr: &actionExpr{
-				pos: position{line: 741, col: 28, offset: 21437},
+				pos: position{line: 853, col: 28, offset: 25008},
 				run: (*parser).callonGenTimesOptionIncrement1,
 				expr: &seqExpr{
-					pos: position{line: 741, col: 28, offset: 21437},
+					pos: position{line: 853, col: 28, offset: 25008},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 741, col: 28, offset: 21437},
+							pos:        position{line: 853, col: 28, offset: 25008},
 							val:        "increment",
 							ignoreCase: false,
 							want:       "\"increment\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 741, col: 40, offset: 21449},
+							pos:  position{line: 853, col: 40, offset: 25020},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 741, col: 46, offset: 21455},
+							pos:   position{line: 853, col: 46, offset: 25026},
 							label: "intStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 741, col: 53, offset: 21462},
+								pos:  position{line: 853, col: 53, offset: 25033},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 741, col: 69, offset: 21478},
+							pos:   position{line: 853, col: 69, offset: 25049},
 							label: "unitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 741, col: 77, offset: 21486},
+								pos: position{line: 853, col: 77, offset: 25057},
 								expr: &choiceExpr{
-									pos: position{line: 741, col: 78, offset: 21487},
+									pos: position{line: 853, col: 78, offset: 25058},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 741, col: 78, offset: 21487},
+											pos:        position{line: 853, col: 78, offset: 25058},
 											val:        "s",
 											ignoreCase: false,
 											want:       "\"s\"",
 										},
 										&litMatcher{
-											pos:        position{line: 741, col: 84, offset: 21493},
+											pos:        position{line: 853, col: 84, offset: 25064},
 											val:        "m",
 											ignoreCase: false,
 											want:       "\"m\"",
 										},
 										&litMatcher{
-											pos:        position{line: 741, col: 90, offset: 21499},
+											pos:        position{line: 853, col: 90, offset: 25070},
 											val:        "d",
 											ignoreCase: false,
 											want:       "\"d\"",
 										},
 										&litMatcher{
-											pos:        position{line: 741, col: 96, offset: 21505},
+											pos:        position{line: 853, col: 96, offset: 25076},
 											val:        "h",
 											ignoreCase: false,
 											want:       "\"h\"",
@@ -1130,26 +1242,26 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOption",
-			pos:  position{line: 782, col: 1, offset: 22657},
+			pos:  position{line: 894, col: 1, offset: 26228},
 			expr: &actionExpr{
-				pos: position{line: 782, col: 19, offset: 22675},
+				pos: position{line: 894, col: 19, offset: 26246},
 				run: (*parser).callonGenTimesOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 782, col: 19, offset: 22675},
+					pos:   position{line: 894, col: 19, offset: 26246},
 					label: "genTimesOption",
 					expr: &choiceExpr{
-						pos: position{line: 782, col: 35, offset: 22691},
+						pos: position{line: 894, col: 35, offset: 26262},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 782, col: 35, offset: 22691},
+								pos:  position{line: 894, col: 35, offset: 26262},
 								name: "GenTimesOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 782, col: 55, offset: 22711},
+								pos:  position{line: 894, col: 55, offset: 26282},
 								name: "GenTimesOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 782, col: 77, offset: 22733},
+								pos:  position{line: 894, col: 77, offset: 26304},
 								name: "GenTimesOptionIncrement",
 							},
 						},
@@ -1159,35 +1271,35 @@ var g = &grammar{
 		},
 		{
 			name: "GenTimesOptionList",
-			pos:  position{line: 786, col: 1, offset: 22794},
+			pos:  position{line: 898, col: 1, offset: 26365},
 			expr: &actionExpr{
-				pos: position{line: 786, col: 23, offset: 22816},
+				pos: position{line: 898, col: 23, offset: 26387},
 				run: (*parser).callonGenTimesOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 786, col: 23, offset: 22816},
+					pos: position{line: 898, col: 23, offset: 26387},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 786, col: 23, offset: 22816},
+							pos:   position{line: 898, col: 23, offset: 26387},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 786, col: 29, offset: 22822},
+								pos:  position{line: 898, col: 29, offset: 26393},
 								name: "GenTimesOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 786, col: 44, offset: 22837},
+							pos:   position{line: 898, col: 44, offset: 26408},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 786, col: 49, offset: 22842},
+								pos: position{line: 898, col: 49, offset: 26413},
 								expr: &seqExpr{
-									pos: position{line: 786, col: 50, offset: 22843},
+									pos: position{line: 898, col: 50, offset: 26414},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 786, col: 50, offset: 22843},
+											pos:  position{line: 898, col: 50, offset: 26414},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 786, col: 56, offset: 22849},
+											pos:  position{line: 898, col: 56, offset: 26420},
 											name: "GenTimesOption",
 										},
 									},
@@ -1200,25 +1312,25 @@ var g = &grammar{
 		},
 		{
 			name: "InitialSearchBlock",
-			pos:  position{line: 838, col: 1, offset: 24602},
+			pos:  position{line: 950, col: 1, offset: 28173},
 			expr: &actionExpr{
-				pos: position{line: 838, col: 23, offset: 24624},
+				pos: position{line: 950, col: 23, offset: 28195},
 				run: (*parser).callonInitialSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 838, col: 23, offset: 24624},
+					pos: position{line: 950, col: 23, offset: 28195},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 838, col: 23, offset: 24624},
+							pos: position{line: 950, col: 23, offset: 28195},
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 23, offset: 24624},
+								pos:  position{line: 950, col: 23, offset: 28195},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 838, col: 35, offset: 24636},
+							pos:   position{line: 950, col: 35, offset: 28207},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 838, col: 42, offset: 24643},
+								pos:  position{line: 950, col: 42, offset: 28214},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1228,32 +1340,32 @@ var g = &grammar{
 		},
 		{
 			name: "SearchBlock",
-			pos:  position{line: 842, col: 1, offset: 24684},
+			pos:  position{line: 954, col: 1, offset: 28255},
 			expr: &actionExpr{
-				pos: position{line: 842, col: 16, offset: 24699},
+				pos: position{line: 954, col: 16, offset: 28270},
 				run: (*parser).callonSearchBlock1,
 				expr: &seqExpr{
-					pos: position{line: 842, col: 16, offset: 24699},
+					pos: position{line: 954, col: 16, offset: 28270},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 842, col: 16, offset: 24699},
+							pos: position{line: 954, col: 16, offset: 28270},
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 18, offset: 24701},
+								pos:  position{line: 954, col: 18, offset: 28272},
 								name: "ALLCMD",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 842, col: 26, offset: 24709},
+							pos: position{line: 954, col: 26, offset: 28280},
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 26, offset: 24709},
+								pos:  position{line: 954, col: 26, offset: 28280},
 								name: "CMD_SEARCH",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 842, col: 38, offset: 24721},
+							pos:   position{line: 954, col: 38, offset: 28292},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 842, col: 45, offset: 24728},
+								pos:  position{line: 954, col: 45, offset: 28299},
 								name: "ClauseLevel4",
 							},
 						},
@@ -1263,33 +1375,33 @@ var g = &grammar{
 		},
 		{
 			name: "FilterBlock",
-			pos:  position{line: 846, col: 1, offset: 24769},
+			pos:  position{line: 958, col: 1, offset: 28340},
 			expr: &actionExpr{
-				pos: position{line: 846, col: 16, offset: 24784},
+				pos: position{line: 958, col: 16, offset: 28355},
 				run: (*parser).callonFilterBlock1,
 				expr: &seqExpr{
-					pos: position{line: 846, col: 16, offset: 24784},
+					pos: position{line: 958, col: 16, offset: 28355},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 846, col: 16, offset: 24784},
+							pos:  position{line: 958, col: 16, offset: 28355},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 846, col: 21, offset: 24789},
+							pos:   position{line: 958, col: 21, offset: 28360},
 							label: "block",
 							expr: &choiceExpr{
-								pos: position{line: 846, col: 28, offset: 24796},
+								pos: position{line: 958, col: 28, offset: 28367},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 846, col: 28, offset: 24796},
+										pos:  position{line: 958, col: 28, offset: 28367},
 										name: "SearchBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 846, col: 42, offset: 24810},
+										pos:  position{line: 958, col: 42, offset: 28381},
 										name: "RegexBlock",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 846, col: 55, offset: 24823},
+										pos:  position{line: 958, col: 55, offset: 28394},
 										name: "TimeModifiers",
 									},
 								},
@@ -1301,114 +1413,114 @@ var g = &grammar{
 		},
 		{
 			name: "QueryAggergatorBlock",
-			pos:  position{line: 851, col: 1, offset: 24902},
+			pos:  position{line: 963, col: 1, offset: 28473},
 			expr: &actionExpr{
-				pos: position{line: 851, col: 25, offset: 24926},
+				pos: position{line: 963, col: 25, offset: 28497},
 				run: (*parser).callonQueryAggergatorBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 851, col: 25, offset: 24926},
+					pos:   position{line: 963, col: 25, offset: 28497},
 					label: "block",
 					expr: &choiceExpr{
-						pos: position{line: 851, col: 32, offset: 24933},
+						pos: position{line: 963, col: 32, offset: 28504},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 32, offset: 24933},
+								pos:  position{line: 963, col: 32, offset: 28504},
 								name: "FieldSelectBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 51, offset: 24952},
+								pos:  position{line: 963, col: 51, offset: 28523},
 								name: "AggregatorBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 69, offset: 24970},
+								pos:  position{line: 963, col: 69, offset: 28541},
 								name: "EvalBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 81, offset: 24982},
+								pos:  position{line: 963, col: 81, offset: 28553},
 								name: "WhereBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 94, offset: 24995},
+								pos:  position{line: 963, col: 94, offset: 28566},
 								name: "HeadBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 106, offset: 25007},
+								pos:  position{line: 963, col: 106, offset: 28578},
 								name: "RegexAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 122, offset: 25023},
+								pos:  position{line: 963, col: 122, offset: 28594},
 								name: "RexBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 133, offset: 25034},
+								pos:  position{line: 963, col: 133, offset: 28605},
 								name: "StatisticBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 150, offset: 25051},
+								pos:  position{line: 963, col: 150, offset: 28622},
 								name: "RenameBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 164, offset: 25065},
+								pos:  position{line: 963, col: 164, offset: 28636},
 								name: "TimechartBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 181, offset: 25082},
+								pos:  position{line: 963, col: 181, offset: 28653},
 								name: "TransactionBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 200, offset: 25101},
+								pos:  position{line: 963, col: 200, offset: 28672},
 								name: "DedupBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 213, offset: 25114},
+								pos:  position{line: 963, col: 213, offset: 28685},
 								name: "SortBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 225, offset: 25126},
+								pos:  position{line: 963, col: 225, offset: 28697},
 								name: "MultiValueBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 243, offset: 25144},
+								pos:  position{line: 963, col: 243, offset: 28715},
 								name: "SPathBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 256, offset: 25157},
+								pos:  position{line: 963, col: 256, offset: 28728},
 								name: "FormatBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 270, offset: 25171},
+								pos:  position{line: 963, col: 270, offset: 28742},
 								name: "EventCountBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 288, offset: 25189},
+								pos:  position{line: 963, col: 288, offset: 28760},
 								name: "TailBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 300, offset: 25201},
+								pos:  position{line: 963, col: 300, offset: 28772},
 								name: "BinBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 311, offset: 25212},
+								pos:  position{line: 963, col: 311, offset: 28783},
 								name: "StreamStatsBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 330, offset: 25231},
+								pos:  position{line: 963, col: 330, offset: 28802},
 								name: "FillNullBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 346, offset: 25247},
+								pos:  position{line: 963, col: 346, offset: 28818},
 								name: "MvexpandBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 362, offset: 25263},
+								pos:  position{line: 963, col: 362, offset: 28834},
 								name: "InputLookupAggBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 384, offset: 25285},
+								pos:  position{line: 963, col: 384, offset: 28856},
 								name: "AppendBlock",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 851, col: 398, offset: 25299},
+								pos:  position{line: 963, col: 398, offset: 28870},
 								name: "ToJsonBlock",
 							},
 						},
@@ -1418,37 +1530,37 @@ var g = &grammar{
 		},
 		{
 			name: "FieldSelectBlock",
-			pos:  position{line: 856, col: 1, offset: 25392},
+			pos:  position{line: 968, col: 1, offset: 28963},
 			expr: &actionExpr{
-				pos: position{line: 856, col: 21, offset: 25412},
+				pos: position{line: 968, col: 21, offset: 28983},
 				run: (*parser).callonFieldSelectBlock1,
 				expr: &seqExpr{
-					pos: position{line: 856, col: 21, offset: 25412},
+					pos: position{line: 968, col: 21, offset: 28983},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 21, offset: 25412},
+							pos:  position{line: 968, col: 21, offset: 28983},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 26, offset: 25417},
+							pos:  position{line: 968, col: 26, offset: 28988},
 							name: "CMD_FIELDS",
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 37, offset: 25428},
+							pos:   position{line: 968, col: 37, offset: 28999},
 							label: "op",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 856, col: 40, offset: 25431},
+								pos: position{line: 968, col: 40, offset: 29002},
 								expr: &choiceExpr{
-									pos: position{line: 856, col: 41, offset: 25432},
+									pos: position{line: 968, col: 41, offset: 29003},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 856, col: 41, offset: 25432},
+											pos:        position{line: 968, col: 41, offset: 29003},
 											val:        "-",
 											ignoreCase: false,
 											want:       "\"-\"",
 										},
 										&litMatcher{
-											pos:        position{line: 856, col: 47, offset: 25438},
+											pos:        position{line: 968, col: 47, offset: 29009},
 											val:        "+",
 											ignoreCase: false,
 											want:       "\"+\"",
@@ -1458,14 +1570,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 856, col: 53, offset: 25444},
+							pos:  position{line: 968, col: 53, offset: 29015},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 856, col: 68, offset: 25459},
+							pos:   position{line: 968, col: 68, offset: 29030},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 856, col: 75, offset: 25466},
+								pos:  position{line: 968, col: 75, offset: 29037},
 								name: "FieldNameList",
 							},
 						},
@@ -1475,28 +1587,28 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggregatorBlock",
-			pos:  position{line: 875, col: 1, offset: 26006},
+			pos:  position{line: 987, col: 1, offset: 29577},
 			expr: &actionExpr{
-				pos: position{line: 875, col: 26, offset: 26031},
+				pos: position{line: 987, col: 26, offset: 29602},
 				run: (*parser).callonCommonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 875, col: 26, offset: 26031},
+					pos: position{line: 987, col: 26, offset: 29602},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 875, col: 26, offset: 26031},
+							pos:   position{line: 987, col: 26, offset: 29602},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 875, col: 31, offset: 26036},
+								pos:  position{line: 987, col: 31, offset: 29607},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 875, col: 47, offset: 26052},
+							pos:   position{line: 987, col: 47, offset: 29623},
 							label: "byFields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 875, col: 56, offset: 26061},
+								pos: position{line: 987, col: 56, offset: 29632},
 								expr: &ruleRefExpr{
-									pos:  position{line: 875, col: 57, offset: 26062},
+									pos:  position{line: 987, col: 57, offset: 29633},
 									name: "GroupbyBlock",
 								},
 							},
@@ -1507,36 +1619,36 @@ var g = &grammar{
 		},
 		{
 			name: "AggregatorBlock",
-			pos:  position{line: 939, col: 1, offset: 28355},
+			pos:  position{line: 1051, col: 1, offset: 31926},
 			expr: &actionExpr{
-				pos: position{line: 939, col: 20, offset: 28374},
+				pos: position{line: 1051, col: 20, offset: 31945},
 				run: (*parser).callonAggregatorBlock1,
 				expr: &seqExpr{
-					pos: position{line: 939, col: 20, offset: 28374},
+					pos: position{line: 1051, col: 20, offset: 31945},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 939, col: 20, offset: 28374},
+							pos:  position{line: 1051, col: 20, offset: 31945},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 939, col: 25, offset: 28379},
+							pos:  position{line: 1051, col: 25, offset: 31950},
 							name: "CMD_STATS",
 						},
 						&labeledExpr{
-							pos:   position{line: 939, col: 35, offset: 28389},
+							pos:   position{line: 1051, col: 35, offset: 31960},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 939, col: 41, offset: 28395},
+								pos:  position{line: 1051, col: 41, offset: 31966},
 								name: "CommonAggregatorBlock",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 939, col: 64, offset: 28418},
+							pos:   position{line: 1051, col: 64, offset: 31989},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 939, col: 72, offset: 28426},
+								pos: position{line: 1051, col: 72, offset: 31997},
 								expr: &ruleRefExpr{
-									pos:  position{line: 939, col: 73, offset: 28427},
+									pos:  position{line: 1051, col: 73, offset: 31998},
 									name: "StatsOptions",
 								},
 							},
@@ -1547,17 +1659,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptions",
-			pos:  position{line: 953, col: 1, offset: 28760},
+			pos:  position{line: 1065, col: 1, offset: 32331},
 			expr: &actionExpr{
-				pos: position{line: 953, col: 17, offset: 28776},
+				pos: position{line: 1065, col: 17, offset: 32347},
 				run: (*parser).callonStatsOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 953, col: 17, offset: 28776},
+					pos:   position{line: 1065, col: 17, offset: 32347},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 953, col: 24, offset: 28783},
+						pos: position{line: 1065, col: 24, offset: 32354},
 						expr: &ruleRefExpr{
-							pos:  position{line: 953, col: 25, offset: 28784},
+							pos:  position{line: 1065, col: 25, offset: 32355},
 							name: "StatsOption",
 						},
 					},
@@ -1566,45 +1678,45 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOption",
-			pos:  position{line: 991, col: 1, offset: 30225},
+			pos:  position{line: 1103, col: 1, offset: 33796},
 			expr: &actionExpr{
-				pos: position{line: 991, col: 16, offset: 30240},
+				pos: position{line: 1103, col: 16, offset: 33811},
 				run: (*parser).callonStatsOption1,
 				expr: &seqExpr{
-					pos: position{line: 991, col: 16, offset: 30240},
+					pos: position{line: 1103, col: 16, offset: 33811},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 991, col: 16, offset: 30240},
+							pos:  position{line: 1103, col: 16, offset: 33811},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 991, col: 22, offset: 30246},
+							pos:   position{line: 1103, col: 22, offset: 33817},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 991, col: 32, offset: 30256},
+								pos:  position{line: 1103, col: 32, offset: 33827},
 								name: "StatsOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 991, col: 47, offset: 30271},
+							pos:  position{line: 1103, col: 47, offset: 33842},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 991, col: 53, offset: 30277},
+							pos:   position{line: 1103, col: 53, offset: 33848},
 							label: "str",
 							expr: &choiceExpr{
-								pos: position{line: 991, col: 58, offset: 30282},
+								pos: position{line: 1103, col: 58, offset: 33853},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 991, col: 58, offset: 30282},
+										pos:  position{line: 1103, col: 58, offset: 33853},
 										name: "IntegerAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 991, col: 76, offset: 30300},
+										pos:  position{line: 1103, col: 76, offset: 33871},
 										name: "EvalFieldToRead",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 991, col: 94, offset: 30318},
+										pos:  position{line: 1103, col: 94, offset: 33889},
 										name: "QuotedString",
 									},
 								},
@@ -1616,36 +1728,36 @@ var g = &grammar{
 		},
 		{
 			name: "StatsOptionCMD",
-			pos:  position{line: 996, col: 1, offset: 30423},
+			pos:  position{line: 1108, col: 1, offset: 33994},
 			expr: &actionExpr{
-				pos: position{line: 996, col: 19, offset: 30441},
+				pos: position{line: 1108, col: 19, offset: 34012},
 				run: (*parser).callonStatsOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 996, col: 19, offset: 30441},
+					pos:   position{line: 1108, col: 19, offset: 34012},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 996, col: 27, offset: 30449},
+						pos: position{line: 1108, col: 27, offset: 34020},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 996, col: 27, offset: 30449},
+								pos:        position{line: 1108, col: 27, offset: 34020},
 								val:        "allnum",
 								ignoreCase: false,
 								want:       "\"allnum\"",
 							},
 							&litMatcher{
-								pos:        position{line: 996, col: 38, offset: 30460},
+								pos:        position{line: 1108, col: 38, offset: 34031},
 								val:        "dedup_splitvals",
 								ignoreCase: false,
 								want:       "\"dedup_splitvals\"",
 							},
 							&litMatcher{
-								pos:        position{line: 996, col: 58, offset: 30480},
+								pos:        position{line: 1108, col: 58, offset: 34051},
 								val:        "delim",
 								ignoreCase: false,
 								want:       "\"delim\"",
 							},
 							&litMatcher{
-								pos:        position{line: 996, col: 68, offset: 30490},
+								pos:        position{line: 1108, col: 68, offset: 34061},
 								val:        "partitions",
 								ignoreCase: false,
 								want:       "\"partitions\"",
@@ -1657,22 +1769,22 @@ var g = &grammar{
 		},
 		{
 			name: "GroupbyBlock",
-			pos:  position{line: 1004, col: 1, offset: 30680},
+			pos:  position{line: 1116, col: 1, offset: 34251},
 			expr: &actionExpr{
-				pos: position{line: 1004, col: 17, offset: 30696},
+				pos: position{line: 1116, col: 17, offset: 34267},
 				run: (*parser).callonGroupbyBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1004, col: 17, offset: 30696},
+					pos: position{line: 1116, col: 17, offset: 34267},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1004, col: 17, offset: 30696},
+							pos:  position{line: 1116, col: 17, offset: 34267},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1004, col: 20, offset: 30699},
+							pos:   position{line: 1116, col: 20, offset: 34270},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1004, col: 27, offset: 30706},
+								pos:  position{line: 1116, col: 27, offset: 34277},
 								name: "FieldNameList",
 							},
 						},
@@ -1682,28 +1794,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetOnChange",
-			pos:  position{line: 1016, col: 1, offset: 31056},
+			pos:  position{line: 1128, col: 1, offset: 34627},
 			expr: &actionExpr{
-				pos: position{line: 1016, col: 35, offset: 31090},
+				pos: position{line: 1128, col: 35, offset: 34661},
 				run: (*parser).callonStreamStatsOptionResetOnChange1,
 				expr: &seqExpr{
-					pos: position{line: 1016, col: 35, offset: 31090},
+					pos: position{line: 1128, col: 35, offset: 34661},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1016, col: 35, offset: 31090},
+							pos:        position{line: 1128, col: 35, offset: 34661},
 							val:        "reset_on_change",
 							ignoreCase: false,
 							want:       "\"reset_on_change\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1016, col: 53, offset: 31108},
+							pos:  position{line: 1128, col: 53, offset: 34679},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1016, col: 59, offset: 31114},
+							pos:   position{line: 1128, col: 59, offset: 34685},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1016, col: 67, offset: 31122},
+								pos:  position{line: 1128, col: 67, offset: 34693},
 								name: "Boolean",
 							},
 						},
@@ -1713,28 +1825,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionCurrent",
-			pos:  position{line: 1028, col: 1, offset: 31383},
+			pos:  position{line: 1140, col: 1, offset: 34954},
 			expr: &actionExpr{
-				pos: position{line: 1028, col: 29, offset: 31411},
+				pos: position{line: 1140, col: 29, offset: 34982},
 				run: (*parser).callonStreamStatsOptionCurrent1,
 				expr: &seqExpr{
-					pos: position{line: 1028, col: 29, offset: 31411},
+					pos: position{line: 1140, col: 29, offset: 34982},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1028, col: 29, offset: 31411},
+							pos:        position{line: 1140, col: 29, offset: 34982},
 							val:        "current",
 							ignoreCase: false,
 							want:       "\"current\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1028, col: 39, offset: 31421},
+							pos:  position{line: 1140, col: 39, offset: 34992},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1028, col: 45, offset: 31427},
+							pos:   position{line: 1140, col: 45, offset: 34998},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1028, col: 53, offset: 31435},
+								pos:  position{line: 1140, col: 53, offset: 35006},
 								name: "Boolean",
 							},
 						},
@@ -1744,28 +1856,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionGlobal",
-			pos:  position{line: 1040, col: 1, offset: 31682},
+			pos:  position{line: 1152, col: 1, offset: 35253},
 			expr: &actionExpr{
-				pos: position{line: 1040, col: 28, offset: 31709},
+				pos: position{line: 1152, col: 28, offset: 35280},
 				run: (*parser).callonStreamStatsOptionGlobal1,
 				expr: &seqExpr{
-					pos: position{line: 1040, col: 28, offset: 31709},
+					pos: position{line: 1152, col: 28, offset: 35280},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1040, col: 28, offset: 31709},
+							pos:        position{line: 1152, col: 28, offset: 35280},
 							val:        "global",
 							ignoreCase: false,
 							want:       "\"global\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1040, col: 37, offset: 31718},
+							pos:  position{line: 1152, col: 37, offset: 35289},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1040, col: 43, offset: 31724},
+							pos:   position{line: 1152, col: 43, offset: 35295},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1040, col: 51, offset: 31732},
+								pos:  position{line: 1152, col: 51, offset: 35303},
 								name: "Boolean",
 							},
 						},
@@ -1775,28 +1887,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionAllNum",
-			pos:  position{line: 1053, col: 1, offset: 32066},
+			pos:  position{line: 1165, col: 1, offset: 35637},
 			expr: &actionExpr{
-				pos: position{line: 1053, col: 28, offset: 32093},
+				pos: position{line: 1165, col: 28, offset: 35664},
 				run: (*parser).callonStreamStatsOptionAllNum1,
 				expr: &seqExpr{
-					pos: position{line: 1053, col: 28, offset: 32093},
+					pos: position{line: 1165, col: 28, offset: 35664},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1053, col: 28, offset: 32093},
+							pos:        position{line: 1165, col: 28, offset: 35664},
 							val:        "allnum",
 							ignoreCase: false,
 							want:       "\"allnum\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1053, col: 37, offset: 32102},
+							pos:  position{line: 1165, col: 37, offset: 35673},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1053, col: 43, offset: 32108},
+							pos:   position{line: 1165, col: 43, offset: 35679},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1053, col: 51, offset: 32116},
+								pos:  position{line: 1165, col: 51, offset: 35687},
 								name: "Boolean",
 							},
 						},
@@ -1806,28 +1918,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionWindow",
-			pos:  position{line: 1066, col: 1, offset: 32450},
+			pos:  position{line: 1178, col: 1, offset: 36021},
 			expr: &actionExpr{
-				pos: position{line: 1066, col: 28, offset: 32477},
+				pos: position{line: 1178, col: 28, offset: 36048},
 				run: (*parser).callonStreamStatsOptionWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1066, col: 28, offset: 32477},
+					pos: position{line: 1178, col: 28, offset: 36048},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1066, col: 28, offset: 32477},
+							pos:        position{line: 1178, col: 28, offset: 36048},
 							val:        "window",
 							ignoreCase: false,
 							want:       "\"window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1066, col: 37, offset: 32486},
+							pos:  position{line: 1178, col: 37, offset: 36057},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1066, col: 43, offset: 32492},
+							pos:   position{line: 1178, col: 43, offset: 36063},
 							label: "windowSize",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1066, col: 54, offset: 32503},
+								pos:  position{line: 1178, col: 54, offset: 36074},
 								name: "PositiveIntegerAsString",
 							},
 						},
@@ -1837,37 +1949,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetBefore",
-			pos:  position{line: 1086, col: 1, offset: 33107},
+			pos:  position{line: 1198, col: 1, offset: 36678},
 			expr: &actionExpr{
-				pos: position{line: 1086, col: 33, offset: 33139},
+				pos: position{line: 1198, col: 33, offset: 36710},
 				run: (*parser).callonStreamStatsOptionResetBefore1,
 				expr: &seqExpr{
-					pos: position{line: 1086, col: 33, offset: 33139},
+					pos: position{line: 1198, col: 33, offset: 36710},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1086, col: 33, offset: 33139},
+							pos:        position{line: 1198, col: 33, offset: 36710},
 							val:        "reset_before",
 							ignoreCase: false,
 							want:       "\"reset_before\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1086, col: 48, offset: 33154},
+							pos:  position{line: 1198, col: 48, offset: 36725},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1086, col: 54, offset: 33160},
+							pos:  position{line: 1198, col: 54, offset: 36731},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1086, col: 62, offset: 33168},
+							pos:   position{line: 1198, col: 62, offset: 36739},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1086, col: 71, offset: 33177},
+								pos:  position{line: 1198, col: 71, offset: 36748},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1086, col: 80, offset: 33186},
+							pos:  position{line: 1198, col: 80, offset: 36757},
 							name: "R_PAREN",
 						},
 					},
@@ -1876,37 +1988,37 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionResetAfter",
-			pos:  position{line: 1098, col: 1, offset: 33456},
+			pos:  position{line: 1210, col: 1, offset: 37027},
 			expr: &actionExpr{
-				pos: position{line: 1098, col: 32, offset: 33487},
+				pos: position{line: 1210, col: 32, offset: 37058},
 				run: (*parser).callonStreamStatsOptionResetAfter1,
 				expr: &seqExpr{
-					pos: position{line: 1098, col: 32, offset: 33487},
+					pos: position{line: 1210, col: 32, offset: 37058},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1098, col: 32, offset: 33487},
+							pos:        position{line: 1210, col: 32, offset: 37058},
 							val:        "reset_after",
 							ignoreCase: false,
 							want:       "\"reset_after\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 46, offset: 33501},
+							pos:  position{line: 1210, col: 46, offset: 37072},
 							name: "EQUAL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 52, offset: 33507},
+							pos:  position{line: 1210, col: 52, offset: 37078},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 1098, col: 60, offset: 33515},
+							pos:   position{line: 1210, col: 60, offset: 37086},
 							label: "boolExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1098, col: 69, offset: 33524},
+								pos:  position{line: 1210, col: 69, offset: 37095},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1098, col: 78, offset: 33533},
+							pos:  position{line: 1210, col: 78, offset: 37104},
 							name: "R_PAREN",
 						},
 					},
@@ -1915,28 +2027,28 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionTimeWindow",
-			pos:  position{line: 1110, col: 1, offset: 33801},
+			pos:  position{line: 1222, col: 1, offset: 37372},
 			expr: &actionExpr{
-				pos: position{line: 1110, col: 32, offset: 33832},
+				pos: position{line: 1222, col: 32, offset: 37403},
 				run: (*parser).callonStreamStatsOptionTimeWindow1,
 				expr: &seqExpr{
-					pos: position{line: 1110, col: 32, offset: 33832},
+					pos: position{line: 1222, col: 32, offset: 37403},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1110, col: 32, offset: 33832},
+							pos:        position{line: 1222, col: 32, offset: 37403},
 							val:        "time_window",
 							ignoreCase: false,
 							want:       "\"time_window\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1110, col: 46, offset: 33846},
+							pos:  position{line: 1222, col: 46, offset: 37417},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1110, col: 52, offset: 33852},
+							pos:   position{line: 1222, col: 52, offset: 37423},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1110, col: 63, offset: 33863},
+								pos:  position{line: 1222, col: 63, offset: 37434},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -1946,46 +2058,46 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOption",
-			pos:  position{line: 1126, col: 1, offset: 34326},
+			pos:  position{line: 1238, col: 1, offset: 37897},
 			expr: &actionExpr{
-				pos: position{line: 1126, col: 22, offset: 34347},
+				pos: position{line: 1238, col: 22, offset: 37918},
 				run: (*parser).callonStreamStatsOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1126, col: 22, offset: 34347},
+					pos:   position{line: 1238, col: 22, offset: 37918},
 					label: "ssOption",
 					expr: &choiceExpr{
-						pos: position{line: 1126, col: 32, offset: 34357},
+						pos: position{line: 1238, col: 32, offset: 37928},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 32, offset: 34357},
+								pos:  position{line: 1238, col: 32, offset: 37928},
 								name: "StreamStatsOptionResetOnChange",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 65, offset: 34390},
+								pos:  position{line: 1238, col: 65, offset: 37961},
 								name: "StreamStatsOptionCurrent",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 92, offset: 34417},
+								pos:  position{line: 1238, col: 92, offset: 37988},
 								name: "StreamStatsOptionGlobal",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 118, offset: 34443},
+								pos:  position{line: 1238, col: 118, offset: 38014},
 								name: "StreamStatsOptionAllNum",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 144, offset: 34469},
+								pos:  position{line: 1238, col: 144, offset: 38040},
 								name: "StreamStatsOptionWindow",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 170, offset: 34495},
+								pos:  position{line: 1238, col: 170, offset: 38066},
 								name: "StreamStatsOptionResetBefore",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 201, offset: 34526},
+								pos:  position{line: 1238, col: 201, offset: 38097},
 								name: "StreamStatsOptionResetAfter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1126, col: 231, offset: 34556},
+								pos:  position{line: 1238, col: 231, offset: 38127},
 								name: "StreamStatsOptionTimeWindow",
 							},
 						},
@@ -1995,35 +2107,35 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsOptionList",
-			pos:  position{line: 1130, col: 1, offset: 34615},
+			pos:  position{line: 1242, col: 1, offset: 38186},
 			expr: &actionExpr{
-				pos: position{line: 1130, col: 26, offset: 34640},
+				pos: position{line: 1242, col: 26, offset: 38211},
 				run: (*parser).callonStreamStatsOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 1130, col: 26, offset: 34640},
+					pos: position{line: 1242, col: 26, offset: 38211},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1130, col: 26, offset: 34640},
+							pos:   position{line: 1242, col: 26, offset: 38211},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1130, col: 32, offset: 34646},
+								pos:  position{line: 1242, col: 32, offset: 38217},
 								name: "StreamStatsOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1130, col: 50, offset: 34664},
+							pos:   position{line: 1242, col: 50, offset: 38235},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1130, col: 55, offset: 34669},
+								pos: position{line: 1242, col: 55, offset: 38240},
 								expr: &seqExpr{
-									pos: position{line: 1130, col: 56, offset: 34670},
+									pos: position{line: 1242, col: 56, offset: 38241},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1130, col: 56, offset: 34670},
+											pos:  position{line: 1242, col: 56, offset: 38241},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1130, col: 62, offset: 34676},
+											pos:  position{line: 1242, col: 62, offset: 38247},
 											name: "StreamStatsOption",
 										},
 									},
@@ -2036,41 +2148,41 @@ var g = &grammar{
 		},
 		{
 			name: "StreamStatsBlock",
-			pos:  position{line: 1189, col: 1, offset: 36865},
+			pos:  position{line: 1301, col: 1, offset: 40436},
 			expr: &choiceExpr{
-				pos: position{line: 1189, col: 21, offset: 36885},
+				pos: position{line: 1301, col: 21, offset: 40456},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1189, col: 21, offset: 36885},
+						pos: position{line: 1301, col: 21, offset: 40456},
 						run: (*parser).callonStreamStatsBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1189, col: 21, offset: 36885},
+							pos: position{line: 1301, col: 21, offset: 40456},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1189, col: 21, offset: 36885},
+									pos:  position{line: 1301, col: 21, offset: 40456},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1189, col: 26, offset: 36890},
+									pos:  position{line: 1301, col: 26, offset: 40461},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 42, offset: 36906},
+									pos:   position{line: 1301, col: 42, offset: 40477},
 									label: "ssOptionList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 56, offset: 36920},
+										pos:  position{line: 1301, col: 56, offset: 40491},
 										name: "StreamStatsOptionList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1189, col: 79, offset: 36943},
+									pos:  position{line: 1301, col: 79, offset: 40514},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1189, col: 85, offset: 36949},
+									pos:   position{line: 1301, col: 85, offset: 40520},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1189, col: 91, offset: 36955},
+										pos:  position{line: 1301, col: 91, offset: 40526},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2078,24 +2190,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1200, col: 3, offset: 37340},
+						pos: position{line: 1312, col: 3, offset: 40911},
 						run: (*parser).callonStreamStatsBlock11,
 						expr: &seqExpr{
-							pos: position{line: 1200, col: 3, offset: 37340},
+							pos: position{line: 1312, col: 3, offset: 40911},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1200, col: 3, offset: 37340},
+									pos:  position{line: 1312, col: 3, offset: 40911},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1200, col: 8, offset: 37345},
+									pos:  position{line: 1312, col: 8, offset: 40916},
 									name: "CMD_STREAMSTATS",
 								},
 								&labeledExpr{
-									pos:   position{line: 1200, col: 24, offset: 37361},
+									pos:   position{line: 1312, col: 24, offset: 40932},
 									label: "aggs",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1200, col: 30, offset: 37367},
+										pos:  position{line: 1312, col: 30, offset: 40938},
 										name: "CommonAggregatorBlock",
 									},
 								},
@@ -2107,31 +2219,31 @@ var g = &grammar{
 		},
 		{
 			name: "RegexBlock",
-			pos:  position{line: 1212, col: 1, offset: 37739},
+			pos:  position{line: 1324, col: 1, offset: 41310},
 			expr: &actionExpr{
-				pos: position{line: 1212, col: 15, offset: 37753},
+				pos: position{line: 1324, col: 15, offset: 41324},
 				run: (*parser).callonRegexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1212, col: 15, offset: 37753},
+					pos: position{line: 1324, col: 15, offset: 41324},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1212, col: 15, offset: 37753},
+							pos:  position{line: 1324, col: 15, offset: 41324},
 							name: "CMD_REGEX",
 						},
 						&labeledExpr{
-							pos:   position{line: 1212, col: 25, offset: 37763},
+							pos:   position{line: 1324, col: 25, offset: 41334},
 							label: "keyAndOp",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1212, col: 34, offset: 37772},
+								pos: position{line: 1324, col: 34, offset: 41343},
 								expr: &seqExpr{
-									pos: position{line: 1212, col: 35, offset: 37773},
+									pos: position{line: 1324, col: 35, offset: 41344},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1212, col: 35, offset: 37773},
+											pos:  position{line: 1324, col: 35, offset: 41344},
 											name: "FieldName",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1212, col: 45, offset: 37783},
+											pos:  position{line: 1324, col: 45, offset: 41354},
 											name: "EqualityOperator",
 										},
 									},
@@ -2139,10 +2251,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1212, col: 64, offset: 37802},
+							pos:   position{line: 1324, col: 64, offset: 41373},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1212, col: 68, offset: 37806},
+								pos:  position{line: 1324, col: 68, offset: 41377},
 								name: "QuotedString",
 							},
 						},
@@ -2152,22 +2264,22 @@ var g = &grammar{
 		},
 		{
 			name: "RegexAggBlock",
-			pos:  position{line: 1240, col: 1, offset: 38385},
+			pos:  position{line: 1352, col: 1, offset: 41956},
 			expr: &actionExpr{
-				pos: position{line: 1240, col: 18, offset: 38402},
+				pos: position{line: 1352, col: 18, offset: 41973},
 				run: (*parser).callonRegexAggBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1240, col: 18, offset: 38402},
+					pos: position{line: 1352, col: 18, offset: 41973},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1240, col: 18, offset: 38402},
+							pos:  position{line: 1352, col: 18, offset: 41973},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1240, col: 23, offset: 38407},
+							pos:   position{line: 1352, col: 23, offset: 41978},
 							label: "node",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1240, col: 28, offset: 38412},
+								pos:  position{line: 1352, col: 28, offset: 41983},
 								name: "RegexBlock",
 							},
 						},
@@ -2177,44 +2289,44 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel4",
-			pos:  position{line: 1268, col: 1, offset: 39194},
+			pos:  position{line: 1380, col: 1, offset: 42765},
 			expr: &actionExpr{
-				pos: position{line: 1268, col: 17, offset: 39210},
+				pos: position{line: 1380, col: 17, offset: 42781},
 				run: (*parser).callonClauseLevel41,
 				expr: &seqExpr{
-					pos: position{line: 1268, col: 17, offset: 39210},
+					pos: position{line: 1380, col: 17, offset: 42781},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1268, col: 17, offset: 39210},
+							pos:   position{line: 1380, col: 17, offset: 42781},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1268, col: 23, offset: 39216},
+								pos:  position{line: 1380, col: 23, offset: 42787},
 								name: "ClauseLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1268, col: 36, offset: 39229},
+							pos:   position{line: 1380, col: 36, offset: 42800},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1268, col: 41, offset: 39234},
+								pos: position{line: 1380, col: 41, offset: 42805},
 								expr: &seqExpr{
-									pos: position{line: 1268, col: 42, offset: 39235},
+									pos: position{line: 1380, col: 42, offset: 42806},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 1268, col: 43, offset: 39236},
+											pos: position{line: 1380, col: 43, offset: 42807},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1268, col: 43, offset: 39236},
+													pos:  position{line: 1380, col: 43, offset: 42807},
 													name: "AND",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1268, col: 49, offset: 39242},
+													pos:  position{line: 1380, col: 49, offset: 42813},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1268, col: 56, offset: 39249},
+											pos:  position{line: 1380, col: 56, offset: 42820},
 											name: "ClauseLevel3",
 										},
 									},
@@ -2227,35 +2339,35 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel3",
-			pos:  position{line: 1286, col: 1, offset: 39626},
+			pos:  position{line: 1398, col: 1, offset: 43197},
 			expr: &actionExpr{
-				pos: position{line: 1286, col: 17, offset: 39642},
+				pos: position{line: 1398, col: 17, offset: 43213},
 				run: (*parser).callonClauseLevel31,
 				expr: &seqExpr{
-					pos: position{line: 1286, col: 17, offset: 39642},
+					pos: position{line: 1398, col: 17, offset: 43213},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1286, col: 17, offset: 39642},
+							pos:   position{line: 1398, col: 17, offset: 43213},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1286, col: 23, offset: 39648},
+								pos:  position{line: 1398, col: 23, offset: 43219},
 								name: "ClauseLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1286, col: 36, offset: 39661},
+							pos:   position{line: 1398, col: 36, offset: 43232},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1286, col: 41, offset: 39666},
+								pos: position{line: 1398, col: 41, offset: 43237},
 								expr: &seqExpr{
-									pos: position{line: 1286, col: 42, offset: 39667},
+									pos: position{line: 1398, col: 42, offset: 43238},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1286, col: 42, offset: 39667},
+											pos:  position{line: 1398, col: 42, offset: 43238},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1286, col: 45, offset: 39670},
+											pos:  position{line: 1398, col: 45, offset: 43241},
 											name: "ClauseLevel2",
 										},
 									},
@@ -2268,32 +2380,32 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel2",
-			pos:  position{line: 1304, col: 1, offset: 40035},
+			pos:  position{line: 1416, col: 1, offset: 43606},
 			expr: &choiceExpr{
-				pos: position{line: 1304, col: 17, offset: 40051},
+				pos: position{line: 1416, col: 17, offset: 43622},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1304, col: 17, offset: 40051},
+						pos: position{line: 1416, col: 17, offset: 43622},
 						run: (*parser).callonClauseLevel22,
 						expr: &seqExpr{
-							pos: position{line: 1304, col: 17, offset: 40051},
+							pos: position{line: 1416, col: 17, offset: 43622},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 1304, col: 17, offset: 40051},
+									pos:   position{line: 1416, col: 17, offset: 43622},
 									label: "notList",
 									expr: &oneOrMoreExpr{
-										pos: position{line: 1304, col: 25, offset: 40059},
+										pos: position{line: 1416, col: 25, offset: 43630},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1304, col: 25, offset: 40059},
+											pos:  position{line: 1416, col: 25, offset: 43630},
 											name: "NOT",
 										},
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1304, col: 30, offset: 40064},
+									pos:   position{line: 1416, col: 30, offset: 43635},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1304, col: 36, offset: 40070},
+										pos:  position{line: 1416, col: 36, offset: 43641},
 										name: "ClauseLevel1",
 									},
 								},
@@ -2301,13 +2413,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1315, col: 5, offset: 40366},
+						pos: position{line: 1427, col: 5, offset: 43937},
 						run: (*parser).callonClauseLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 1315, col: 5, offset: 40366},
+							pos:   position{line: 1427, col: 5, offset: 43937},
 							label: "clause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1315, col: 12, offset: 40373},
+								pos:  position{line: 1427, col: 12, offset: 43944},
 								name: "ClauseLevel1",
 							},
 						},
@@ -2317,43 +2429,43 @@ var g = &grammar{
 		},
 		{
 			name: "ClauseLevel1",
-			pos:  position{line: 1319, col: 1, offset: 40414},
+			pos:  position{line: 1431, col: 1, offset: 43985},
 			expr: &choiceExpr{
-				pos: position{line: 1319, col: 17, offset: 40430},
+				pos: position{line: 1431, col: 17, offset: 44001},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1319, col: 17, offset: 40430},
+						pos: position{line: 1431, col: 17, offset: 44001},
 						run: (*parser).callonClauseLevel12,
 						expr: &seqExpr{
-							pos: position{line: 1319, col: 17, offset: 40430},
+							pos: position{line: 1431, col: 17, offset: 44001},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1319, col: 17, offset: 40430},
+									pos:  position{line: 1431, col: 17, offset: 44001},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1319, col: 25, offset: 40438},
+									pos:   position{line: 1431, col: 25, offset: 44009},
 									label: "clause",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1319, col: 32, offset: 40445},
+										pos:  position{line: 1431, col: 32, offset: 44016},
 										name: "ClauseLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1319, col: 45, offset: 40458},
+									pos:  position{line: 1431, col: 45, offset: 44029},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1321, col: 5, offset: 40495},
+						pos: position{line: 1433, col: 5, offset: 44066},
 						run: (*parser).callonClauseLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 1321, col: 5, offset: 40495},
+							pos:   position{line: 1433, col: 5, offset: 44066},
 							label: "term",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1321, col: 10, offset: 40500},
+								pos:  position{line: 1433, col: 10, offset: 44071},
 								name: "SearchTerm",
 							},
 						},
@@ -2363,26 +2475,26 @@ var g = &grammar{
 		},
 		{
 			name: "SearchTerm",
-			pos:  position{line: 1327, col: 1, offset: 40658},
+			pos:  position{line: 1439, col: 1, offset: 44229},
 			expr: &actionExpr{
-				pos: position{line: 1327, col: 15, offset: 40672},
+				pos: position{line: 1439, col: 15, offset: 44243},
 				run: (*parser).callonSearchTerm1,
 				expr: &labeledExpr{
-					pos:   position{line: 1327, col: 15, offset: 40672},
+					pos:   position{line: 1439, col: 15, offset: 44243},
 					label: "term",
 					expr: &choiceExpr{
-						pos: position{line: 1327, col: 21, offset: 40678},
+						pos: position{line: 1439, col: 21, offset: 44249},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1327, col: 21, offset: 40678},
+								pos:  position{line: 1439, col: 21, offset: 44249},
 								name: "FieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1327, col: 44, offset: 40701},
+								pos:  position{line: 1439, col: 44, offset: 44272},
 								name: "FieldWithBooleanValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1327, col: 68, offset: 40725},
+								pos:  position{line: 1439, col: 68, offset: 44296},
 								name: "FieldWithStringValue",
 							},
 						},
@@ -2392,36 +2504,36 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartBlock",
-			pos:  position{line: 1332, col: 1, offset: 40866},
+			pos:  position{line: 1444, col: 1, offset: 44437},
 			expr: &actionExpr{
-				pos: position{line: 1332, col: 19, offset: 40884},
+				pos: position{line: 1444, col: 19, offset: 44455},
 				run: (*parser).callonTimechartBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1332, col: 19, offset: 40884},
+					pos: position{line: 1444, col: 19, offset: 44455},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 19, offset: 40884},
+							pos:  position{line: 1444, col: 19, offset: 44455},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1332, col: 24, offset: 40889},
+							pos:  position{line: 1444, col: 24, offset: 44460},
 							name: "CMD_TIMECHART",
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 38, offset: 40903},
+							pos:   position{line: 1444, col: 38, offset: 44474},
 							label: "tcArgs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1332, col: 45, offset: 40910},
+								pos:  position{line: 1444, col: 45, offset: 44481},
 								name: "TimechartArgumentsList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1332, col: 68, offset: 40933},
+							pos:   position{line: 1444, col: 68, offset: 44504},
 							label: "limitExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1332, col: 78, offset: 40943},
+								pos: position{line: 1444, col: 78, offset: 44514},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1332, col: 79, offset: 40944},
+									pos:  position{line: 1444, col: 79, offset: 44515},
 									name: "LimitExpr",
 								},
 							},
@@ -2432,35 +2544,35 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgumentsList",
-			pos:  position{line: 1425, col: 1, offset: 43915},
+			pos:  position{line: 1537, col: 1, offset: 47486},
 			expr: &actionExpr{
-				pos: position{line: 1425, col: 27, offset: 43941},
+				pos: position{line: 1537, col: 27, offset: 47512},
 				run: (*parser).callonTimechartArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 1425, col: 27, offset: 43941},
+					pos: position{line: 1537, col: 27, offset: 47512},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1425, col: 27, offset: 43941},
+							pos:   position{line: 1537, col: 27, offset: 47512},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1425, col: 33, offset: 43947},
+								pos:  position{line: 1537, col: 33, offset: 47518},
 								name: "TimechartArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1425, col: 51, offset: 43965},
+							pos:   position{line: 1537, col: 51, offset: 47536},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1425, col: 56, offset: 43970},
+								pos: position{line: 1537, col: 56, offset: 47541},
 								expr: &seqExpr{
-									pos: position{line: 1425, col: 57, offset: 43971},
+									pos: position{line: 1537, col: 57, offset: 47542},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1425, col: 57, offset: 43971},
+											pos:  position{line: 1537, col: 57, offset: 47542},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1425, col: 63, offset: 43977},
+											pos:  position{line: 1537, col: 63, offset: 47548},
 											name: "TimechartArgument",
 										},
 									},
@@ -2473,22 +2585,22 @@ var g = &grammar{
 		},
 		{
 			name: "TimechartArgument",
-			pos:  position{line: 1454, col: 1, offset: 44711},
+			pos:  position{line: 1566, col: 1, offset: 48282},
 			expr: &actionExpr{
-				pos: position{line: 1454, col: 22, offset: 44732},
+				pos: position{line: 1566, col: 22, offset: 48303},
 				run: (*parser).callonTimechartArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 1454, col: 22, offset: 44732},
+					pos:   position{line: 1566, col: 22, offset: 48303},
 					label: "tcArg",
 					expr: &choiceExpr{
-						pos: position{line: 1454, col: 29, offset: 44739},
+						pos: position{line: 1566, col: 29, offset: 48310},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 29, offset: 44739},
+								pos:  position{line: 1566, col: 29, offset: 48310},
 								name: "SingleAggExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1454, col: 45, offset: 44755},
+								pos:  position{line: 1566, col: 45, offset: 48326},
 								name: "TcOptions",
 							},
 						},
@@ -2498,28 +2610,28 @@ var g = &grammar{
 		},
 		{
 			name: "SingleAggExpr",
-			pos:  position{line: 1458, col: 1, offset: 44793},
+			pos:  position{line: 1570, col: 1, offset: 48364},
 			expr: &actionExpr{
-				pos: position{line: 1458, col: 18, offset: 44810},
+				pos: position{line: 1570, col: 18, offset: 48381},
 				run: (*parser).callonSingleAggExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1458, col: 18, offset: 44810},
+					pos: position{line: 1570, col: 18, offset: 48381},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1458, col: 18, offset: 44810},
+							pos:   position{line: 1570, col: 18, offset: 48381},
 							label: "aggs",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1458, col: 23, offset: 44815},
+								pos:  position{line: 1570, col: 23, offset: 48386},
 								name: "AggregationList",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1458, col: 39, offset: 44831},
+							pos:   position{line: 1570, col: 39, offset: 48402},
 							label: "splitByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1458, col: 53, offset: 44845},
+								pos: position{line: 1570, col: 53, offset: 48416},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1458, col: 53, offset: 44845},
+									pos:  position{line: 1570, col: 53, offset: 48416},
 									name: "SplitByClause",
 								},
 							},
@@ -2530,22 +2642,22 @@ var g = &grammar{
 		},
 		{
 			name: "SplitByClause",
-			pos:  position{line: 1472, col: 1, offset: 45184},
+			pos:  position{line: 1584, col: 1, offset: 48755},
 			expr: &actionExpr{
-				pos: position{line: 1472, col: 18, offset: 45201},
+				pos: position{line: 1584, col: 18, offset: 48772},
 				run: (*parser).callonSplitByClause1,
 				expr: &seqExpr{
-					pos: position{line: 1472, col: 18, offset: 45201},
+					pos: position{line: 1584, col: 18, offset: 48772},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1472, col: 18, offset: 45201},
+							pos:  position{line: 1584, col: 18, offset: 48772},
 							name: "BY",
 						},
 						&labeledExpr{
-							pos:   position{line: 1472, col: 21, offset: 45204},
+							pos:   position{line: 1584, col: 21, offset: 48775},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1472, col: 27, offset: 45210},
+								pos:  position{line: 1584, col: 27, offset: 48781},
 								name: "FieldName",
 							},
 						},
@@ -2555,24 +2667,24 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptions",
-			pos:  position{line: 1480, col: 1, offset: 45339},
+			pos:  position{line: 1592, col: 1, offset: 48910},
 			expr: &actionExpr{
-				pos: position{line: 1480, col: 14, offset: 45352},
+				pos: position{line: 1592, col: 14, offset: 48923},
 				run: (*parser).callonTcOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1480, col: 14, offset: 45352},
+					pos:   position{line: 1592, col: 14, offset: 48923},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1480, col: 22, offset: 45360},
+						pos: position{line: 1592, col: 22, offset: 48931},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1480, col: 22, offset: 45360},
+								pos:  position{line: 1592, col: 22, offset: 48931},
 								name: "BinOptions",
 							},
 							&oneOrMoreExpr{
-								pos: position{line: 1480, col: 35, offset: 45373},
+								pos: position{line: 1592, col: 35, offset: 48944},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1480, col: 36, offset: 45374},
+									pos:  position{line: 1592, col: 36, offset: 48945},
 									name: "TcOption",
 								},
 							},
@@ -2583,34 +2695,34 @@ var g = &grammar{
 		},
 		{
 			name: "TcOption",
-			pos:  position{line: 1522, col: 1, offset: 46894},
+			pos:  position{line: 1634, col: 1, offset: 50465},
 			expr: &actionExpr{
-				pos: position{line: 1522, col: 13, offset: 46906},
+				pos: position{line: 1634, col: 13, offset: 50477},
 				run: (*parser).callonTcOption1,
 				expr: &seqExpr{
-					pos: position{line: 1522, col: 13, offset: 46906},
+					pos: position{line: 1634, col: 13, offset: 50477},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1522, col: 13, offset: 46906},
+							pos:  position{line: 1634, col: 13, offset: 50477},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1522, col: 19, offset: 46912},
+							pos:   position{line: 1634, col: 19, offset: 50483},
 							label: "tcOptionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 31, offset: 46924},
+								pos:  position{line: 1634, col: 31, offset: 50495},
 								name: "TcOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1522, col: 43, offset: 46936},
+							pos:  position{line: 1634, col: 43, offset: 50507},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1522, col: 49, offset: 46942},
+							pos:   position{line: 1634, col: 49, offset: 50513},
 							label: "val",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1522, col: 53, offset: 46946},
+								pos:  position{line: 1634, col: 53, offset: 50517},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -2620,36 +2732,36 @@ var g = &grammar{
 		},
 		{
 			name: "TcOptionCMD",
-			pos:  position{line: 1527, col: 1, offset: 47059},
+			pos:  position{line: 1639, col: 1, offset: 50630},
 			expr: &actionExpr{
-				pos: position{line: 1527, col: 16, offset: 47074},
+				pos: position{line: 1639, col: 16, offset: 50645},
 				run: (*parser).callonTcOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 1527, col: 16, offset: 47074},
+					pos:   position{line: 1639, col: 16, offset: 50645},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1527, col: 24, offset: 47082},
+						pos: position{line: 1639, col: 24, offset: 50653},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 1527, col: 24, offset: 47082},
+								pos:        position{line: 1639, col: 24, offset: 50653},
 								val:        "usenull",
 								ignoreCase: false,
 								want:       "\"usenull\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1527, col: 36, offset: 47094},
+								pos:        position{line: 1639, col: 36, offset: 50665},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1527, col: 49, offset: 47107},
+								pos:        position{line: 1639, col: 49, offset: 50678},
 								val:        "nullstr",
 								ignoreCase: false,
 								want:       "\"nullstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 1527, col: 61, offset: 47119},
+								pos:        position{line: 1639, col: 61, offset: 50690},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
@@ -2661,50 +2773,50 @@ var g = &grammar{
 		},
 		{
 			name: "AllTimeScale",
-			pos:  position{line: 1535, col: 1, offset: 47315},
+			pos:  position{line: 1647, col: 1, offset: 50886},
 			expr: &actionExpr{
-				pos: position{line: 1535, col: 17, offset: 47331},
+				pos: position{line: 1647, col: 17, offset: 50902},
 				run: (*parser).callonAllTimeScale1,
 				expr: &labeledExpr{
-					pos:   position{line: 1535, col: 17, offset: 47331},
+					pos:   position{line: 1647, col: 17, offset: 50902},
 					label: "timeUnit",
 					expr: &choiceExpr{
-						pos: position{line: 1535, col: 27, offset: 47341},
+						pos: position{line: 1647, col: 27, offset: 50912},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 27, offset: 47341},
+								pos:  position{line: 1647, col: 27, offset: 50912},
 								name: "Second",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 36, offset: 47350},
+								pos:  position{line: 1647, col: 36, offset: 50921},
 								name: "Month",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 44, offset: 47358},
+								pos:  position{line: 1647, col: 44, offset: 50929},
 								name: "Subseconds",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 57, offset: 47371},
+								pos:  position{line: 1647, col: 57, offset: 50942},
 								name: "Minute",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 66, offset: 47380},
+								pos:  position{line: 1647, col: 66, offset: 50951},
 								name: "Hour",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 73, offset: 47387},
+								pos:  position{line: 1647, col: 73, offset: 50958},
 								name: "Day",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 79, offset: 47393},
+								pos:  position{line: 1647, col: 79, offset: 50964},
 								name: "Week",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 86, offset: 47400},
+								pos:  position{line: 1647, col: 86, offset: 50971},
 								name: "Quarter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1535, col: 96, offset: 47410},
+								pos:  position{line: 1647, col: 96, offset: 50981},
 								name: "Year",
 							},
 						},
@@ -2714,37 +2826,37 @@ var g = &grammar{
 		},
 		{
 			name: "BinSpanLenOption",
-			pos:  position{line: 1539, col: 1, offset: 47446},
+			pos:  position{line: 1651, col: 1, offset: 51017},
 			expr: &actionExpr{
-				pos: position{line: 1539, col: 21, offset: 47466},
+				pos: position{line: 1651, col: 21, offset: 51037},
 				run: (*parser).callonBinSpanLenOption1,
 				expr: &seqExpr{
-					pos: position{line: 1539, col: 21, offset: 47466},
+					pos: position{line: 1651, col: 21, offset: 51037},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1539, col: 21, offset: 47466},
+							pos:   position{line: 1651, col: 21, offset: 51037},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1539, col: 29, offset: 47474},
+								pos: position{line: 1651, col: 29, offset: 51045},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1539, col: 29, offset: 47474},
+										pos:  position{line: 1651, col: 29, offset: 51045},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1539, col: 45, offset: 47490},
+										pos:  position{line: 1651, col: 45, offset: 51061},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1539, col: 62, offset: 47507},
+							pos:   position{line: 1651, col: 62, offset: 51078},
 							label: "timeScale",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1539, col: 72, offset: 47517},
+								pos: position{line: 1651, col: 72, offset: 51088},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1539, col: 73, offset: 47518},
+									pos:  position{line: 1651, col: 73, offset: 51089},
 									name: "AllTimeScale",
 								},
 							},
@@ -2755,28 +2867,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMinSpan",
-			pos:  position{line: 1598, col: 1, offset: 50209},
+			pos:  position{line: 1710, col: 1, offset: 53780},
 			expr: &actionExpr{
-				pos: position{line: 1598, col: 21, offset: 50229},
+				pos: position{line: 1710, col: 21, offset: 53800},
 				run: (*parser).callonBinOptionMinSpan1,
 				expr: &seqExpr{
-					pos: position{line: 1598, col: 21, offset: 50229},
+					pos: position{line: 1710, col: 21, offset: 53800},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1598, col: 21, offset: 50229},
+							pos:        position{line: 1710, col: 21, offset: 53800},
 							val:        "minspan",
 							ignoreCase: false,
 							want:       "\"minspan\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1598, col: 31, offset: 50239},
+							pos:  position{line: 1710, col: 31, offset: 53810},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1598, col: 37, offset: 50245},
+							pos:   position{line: 1710, col: 37, offset: 53816},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1598, col: 48, offset: 50256},
+								pos:  position{line: 1710, col: 48, offset: 53827},
 								name: "BinSpanLenOption",
 							},
 						},
@@ -2786,28 +2898,28 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionMaxBins",
-			pos:  position{line: 1609, col: 1, offset: 50497},
+			pos:  position{line: 1721, col: 1, offset: 54068},
 			expr: &actionExpr{
-				pos: position{line: 1609, col: 21, offset: 50517},
+				pos: position{line: 1721, col: 21, offset: 54088},
 				run: (*parser).callonBinOptionMaxBins1,
 				expr: &seqExpr{
-					pos: position{line: 1609, col: 21, offset: 50517},
+					pos: position{line: 1721, col: 21, offset: 54088},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1609, col: 21, offset: 50517},
+							pos:        position{line: 1721, col: 21, offset: 54088},
 							val:        "bins",
 							ignoreCase: false,
 							want:       "\"bins\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1609, col: 28, offset: 50524},
+							pos:  position{line: 1721, col: 28, offset: 54095},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1609, col: 34, offset: 50530},
+							pos:   position{line: 1721, col: 34, offset: 54101},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1609, col: 43, offset: 50539},
+								pos:  position{line: 1721, col: 43, offset: 54110},
 								name: "IntegerAsString",
 							},
 						},
@@ -2817,31 +2929,31 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionAlignTime",
-			pos:  position{line: 1630, col: 1, offset: 51118},
+			pos:  position{line: 1742, col: 1, offset: 54689},
 			expr: &choiceExpr{
-				pos: position{line: 1630, col: 23, offset: 51140},
+				pos: position{line: 1742, col: 23, offset: 54711},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1630, col: 23, offset: 51140},
+						pos: position{line: 1742, col: 23, offset: 54711},
 						run: (*parser).callonBinOptionAlignTime2,
 						expr: &seqExpr{
-							pos: position{line: 1630, col: 23, offset: 51140},
+							pos: position{line: 1742, col: 23, offset: 54711},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1630, col: 23, offset: 51140},
+									pos:        position{line: 1742, col: 23, offset: 54711},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1630, col: 35, offset: 51152},
+									pos:  position{line: 1742, col: 35, offset: 54723},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1630, col: 41, offset: 51158},
+									pos:   position{line: 1742, col: 41, offset: 54729},
 									label: "utcEpoch",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1630, col: 51, offset: 51168},
+										pos:  position{line: 1742, col: 51, offset: 54739},
 										name: "PositiveIntegerAsString",
 									},
 								},
@@ -2849,33 +2961,33 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1644, col: 3, offset: 51587},
+						pos: position{line: 1756, col: 3, offset: 55158},
 						run: (*parser).callonBinOptionAlignTime8,
 						expr: &seqExpr{
-							pos: position{line: 1644, col: 3, offset: 51587},
+							pos: position{line: 1756, col: 3, offset: 55158},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1644, col: 3, offset: 51587},
+									pos:        position{line: 1756, col: 3, offset: 55158},
 									val:        "aligntime",
 									ignoreCase: false,
 									want:       "\"aligntime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1644, col: 15, offset: 51599},
+									pos:  position{line: 1756, col: 15, offset: 55170},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1644, col: 21, offset: 51605},
+									pos:   position{line: 1756, col: 21, offset: 55176},
 									label: "timestamp",
 									expr: &choiceExpr{
-										pos: position{line: 1644, col: 32, offset: 51616},
+										pos: position{line: 1756, col: 32, offset: 55187},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 1644, col: 32, offset: 51616},
+												pos:  position{line: 1756, col: 32, offset: 55187},
 												name: "AbsoluteTimestamp",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 1644, col: 52, offset: 51636},
+												pos:  position{line: 1756, col: 52, offset: 55207},
 												name: "RelativeTimestamp",
 											},
 										},
@@ -2889,35 +3001,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionStart",
-			pos:  position{line: 1664, col: 1, offset: 52105},
+			pos:  position{line: 1776, col: 1, offset: 55676},
 			expr: &actionExpr{
-				pos: position{line: 1664, col: 19, offset: 52123},
+				pos: position{line: 1776, col: 19, offset: 55694},
 				run: (*parser).callonBinOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 1664, col: 19, offset: 52123},
+					pos: position{line: 1776, col: 19, offset: 55694},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1664, col: 19, offset: 52123},
+							pos:        position{line: 1776, col: 19, offset: 55694},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1664, col: 27, offset: 52131},
+							pos:  position{line: 1776, col: 27, offset: 55702},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1664, col: 33, offset: 52137},
+							pos:   position{line: 1776, col: 33, offset: 55708},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1664, col: 41, offset: 52145},
+								pos: position{line: 1776, col: 41, offset: 55716},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1664, col: 41, offset: 52145},
+										pos:  position{line: 1776, col: 41, offset: 55716},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1664, col: 57, offset: 52161},
+										pos:  position{line: 1776, col: 57, offset: 55732},
 										name: "IntegerAsString",
 									},
 								},
@@ -2929,35 +3041,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionEnd",
-			pos:  position{line: 1679, col: 1, offset: 52540},
+			pos:  position{line: 1791, col: 1, offset: 56111},
 			expr: &actionExpr{
-				pos: position{line: 1679, col: 17, offset: 52556},
+				pos: position{line: 1791, col: 17, offset: 56127},
 				run: (*parser).callonBinOptionEnd1,
 				expr: &seqExpr{
-					pos: position{line: 1679, col: 17, offset: 52556},
+					pos: position{line: 1791, col: 17, offset: 56127},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 1679, col: 17, offset: 52556},
+							pos:        position{line: 1791, col: 17, offset: 56127},
 							val:        "end",
 							ignoreCase: false,
 							want:       "\"end\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1679, col: 23, offset: 52562},
+							pos:  position{line: 1791, col: 23, offset: 56133},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1679, col: 29, offset: 52568},
+							pos:   position{line: 1791, col: 29, offset: 56139},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 1679, col: 37, offset: 52576},
+								pos: position{line: 1791, col: 37, offset: 56147},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1679, col: 37, offset: 52576},
+										pos:  position{line: 1791, col: 37, offset: 56147},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1679, col: 53, offset: 52592},
+										pos:  position{line: 1791, col: 53, offset: 56163},
 										name: "IntegerAsString",
 									},
 								},
@@ -2969,40 +3081,40 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptionSpan",
-			pos:  position{line: 1694, col: 1, offset: 52963},
+			pos:  position{line: 1806, col: 1, offset: 56534},
 			expr: &choiceExpr{
-				pos: position{line: 1694, col: 18, offset: 52980},
+				pos: position{line: 1806, col: 18, offset: 56551},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1694, col: 18, offset: 52980},
+						pos: position{line: 1806, col: 18, offset: 56551},
 						run: (*parser).callonBinOptionSpan2,
 						expr: &seqExpr{
-							pos: position{line: 1694, col: 18, offset: 52980},
+							pos: position{line: 1806, col: 18, offset: 56551},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1694, col: 18, offset: 52980},
+									pos:        position{line: 1806, col: 18, offset: 56551},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1694, col: 25, offset: 52987},
+									pos:  position{line: 1806, col: 25, offset: 56558},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1694, col: 31, offset: 52993},
+									pos:   position{line: 1806, col: 31, offset: 56564},
 									label: "num1",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1694, col: 36, offset: 52998},
+										pos: position{line: 1806, col: 36, offset: 56569},
 										expr: &choiceExpr{
-											pos: position{line: 1694, col: 37, offset: 52999},
+											pos: position{line: 1806, col: 37, offset: 56570},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1694, col: 37, offset: 52999},
+													pos:  position{line: 1806, col: 37, offset: 56570},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1694, col: 53, offset: 53015},
+													pos:  position{line: 1806, col: 53, offset: 56586},
 													name: "IntegerAsString",
 												},
 											},
@@ -3010,25 +3122,25 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 1694, col: 71, offset: 53033},
+									pos:        position{line: 1806, col: 71, offset: 56604},
 									val:        "log",
 									ignoreCase: false,
 									want:       "\"log\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 1694, col: 77, offset: 53039},
+									pos:   position{line: 1806, col: 77, offset: 56610},
 									label: "num2",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1694, col: 82, offset: 53044},
+										pos: position{line: 1806, col: 82, offset: 56615},
 										expr: &choiceExpr{
-											pos: position{line: 1694, col: 83, offset: 53045},
+											pos: position{line: 1806, col: 83, offset: 56616},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 1694, col: 83, offset: 53045},
+													pos:  position{line: 1806, col: 83, offset: 56616},
 													name: "FloatAsString",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 1694, col: 99, offset: 53061},
+													pos:  position{line: 1806, col: 99, offset: 56632},
 													name: "IntegerAsString",
 												},
 											},
@@ -3039,26 +3151,26 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1737, col: 3, offset: 54497},
+						pos: position{line: 1849, col: 3, offset: 58068},
 						run: (*parser).callonBinOptionSpan17,
 						expr: &seqExpr{
-							pos: position{line: 1737, col: 3, offset: 54497},
+							pos: position{line: 1849, col: 3, offset: 58068},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 1737, col: 3, offset: 54497},
+									pos:        position{line: 1849, col: 3, offset: 58068},
 									val:        "span",
 									ignoreCase: false,
 									want:       "\"span\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1737, col: 10, offset: 54504},
+									pos:  position{line: 1849, col: 10, offset: 58075},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1737, col: 16, offset: 54510},
+									pos:   position{line: 1849, col: 16, offset: 58081},
 									label: "spanLen",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1737, col: 24, offset: 54518},
+										pos:  position{line: 1849, col: 24, offset: 58089},
 										name: "BinSpanLenOption",
 									},
 								},
@@ -3070,38 +3182,38 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOption",
-			pos:  position{line: 1752, col: 1, offset: 54849},
+			pos:  position{line: 1864, col: 1, offset: 58420},
 			expr: &actionExpr{
-				pos: position{line: 1752, col: 17, offset: 54865},
+				pos: position{line: 1864, col: 17, offset: 58436},
 				run: (*parser).callonBinCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 1752, col: 17, offset: 54865},
+					pos:   position{line: 1864, col: 17, offset: 58436},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 1752, col: 25, offset: 54873},
+						pos: position{line: 1864, col: 25, offset: 58444},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 25, offset: 54873},
+								pos:  position{line: 1864, col: 25, offset: 58444},
 								name: "BinOptionAlignTime",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 46, offset: 54894},
+								pos:  position{line: 1864, col: 46, offset: 58465},
 								name: "BinOptionMinSpan",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 65, offset: 54913},
+								pos:  position{line: 1864, col: 65, offset: 58484},
 								name: "BinOptionMaxBins",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 84, offset: 54932},
+								pos:  position{line: 1864, col: 84, offset: 58503},
 								name: "BinOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 101, offset: 54949},
+								pos:  position{line: 1864, col: 101, offset: 58520},
 								name: "BinOptionEnd",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 1752, col: 116, offset: 54964},
+								pos:  position{line: 1864, col: 116, offset: 58535},
 								name: "BinOptionSpan",
 							},
 						},
@@ -3111,35 +3223,35 @@ var g = &grammar{
 		},
 		{
 			name: "BinCmdOptionsList",
-			pos:  position{line: 1756, col: 1, offset: 55007},
+			pos:  position{line: 1868, col: 1, offset: 58578},
 			expr: &actionExpr{
-				pos: position{line: 1756, col: 22, offset: 55028},
+				pos: position{line: 1868, col: 22, offset: 58599},
 				run: (*parser).callonBinCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 1756, col: 22, offset: 55028},
+					pos: position{line: 1868, col: 22, offset: 58599},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1756, col: 22, offset: 55028},
+							pos:   position{line: 1868, col: 22, offset: 58599},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1756, col: 29, offset: 55035},
+								pos:  position{line: 1868, col: 29, offset: 58606},
 								name: "BinCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1756, col: 42, offset: 55048},
+							pos:   position{line: 1868, col: 42, offset: 58619},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 1756, col: 48, offset: 55054},
+								pos: position{line: 1868, col: 48, offset: 58625},
 								expr: &seqExpr{
-									pos: position{line: 1756, col: 49, offset: 55055},
+									pos: position{line: 1868, col: 49, offset: 58626},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 1756, col: 49, offset: 55055},
+											pos:  position{line: 1868, col: 49, offset: 58626},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 1756, col: 55, offset: 55061},
+											pos:  position{line: 1868, col: 55, offset: 58632},
 											name: "BinCmdOption",
 										},
 									},
@@ -3152,51 +3264,51 @@ var g = &grammar{
 		},
 		{
 			name: "BinBlock",
-			pos:  position{line: 1802, col: 1, offset: 56545},
+			pos:  position{line: 1914, col: 1, offset: 60116},
 			expr: &choiceExpr{
-				pos: position{line: 1802, col: 13, offset: 56557},
+				pos: position{line: 1914, col: 13, offset: 60128},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1802, col: 13, offset: 56557},
+						pos: position{line: 1914, col: 13, offset: 60128},
 						run: (*parser).callonBinBlock2,
 						expr: &seqExpr{
-							pos: position{line: 1802, col: 13, offset: 56557},
+							pos: position{line: 1914, col: 13, offset: 60128},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1802, col: 13, offset: 56557},
+									pos:  position{line: 1914, col: 13, offset: 60128},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1802, col: 18, offset: 56562},
+									pos:  position{line: 1914, col: 18, offset: 60133},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1802, col: 26, offset: 56570},
+									pos:   position{line: 1914, col: 26, offset: 60141},
 									label: "binCmdOption",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1802, col: 40, offset: 56584},
+										pos:  position{line: 1914, col: 40, offset: 60155},
 										name: "BinCmdOptionsList",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1802, col: 59, offset: 56603},
+									pos:  position{line: 1914, col: 59, offset: 60174},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1802, col: 65, offset: 56609},
+									pos:   position{line: 1914, col: 65, offset: 60180},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1802, col: 71, offset: 56615},
+										pos:  position{line: 1914, col: 71, offset: 60186},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1802, col: 81, offset: 56625},
+									pos:   position{line: 1914, col: 81, offset: 60196},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1802, col: 94, offset: 56638},
+										pos: position{line: 1914, col: 94, offset: 60209},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1802, col: 95, offset: 56639},
+											pos:  position{line: 1914, col: 95, offset: 60210},
 											name: "AsField",
 										},
 									},
@@ -3205,34 +3317,34 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1829, col: 3, offset: 57465},
+						pos: position{line: 1941, col: 3, offset: 61036},
 						run: (*parser).callonBinBlock14,
 						expr: &seqExpr{
-							pos: position{line: 1829, col: 3, offset: 57465},
+							pos: position{line: 1941, col: 3, offset: 61036},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1829, col: 3, offset: 57465},
+									pos:  position{line: 1941, col: 3, offset: 61036},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1829, col: 8, offset: 57470},
+									pos:  position{line: 1941, col: 8, offset: 61041},
 									name: "CMD_BIN",
 								},
 								&labeledExpr{
-									pos:   position{line: 1829, col: 16, offset: 57478},
+									pos:   position{line: 1941, col: 16, offset: 61049},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1829, col: 22, offset: 57484},
+										pos:  position{line: 1941, col: 22, offset: 61055},
 										name: "FieldName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 1829, col: 32, offset: 57494},
+									pos:   position{line: 1941, col: 32, offset: 61065},
 									label: "newFieldName",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 1829, col: 45, offset: 57507},
+										pos: position{line: 1941, col: 45, offset: 61078},
 										expr: &ruleRefExpr{
-											pos:  position{line: 1829, col: 46, offset: 57508},
+											pos:  position{line: 1941, col: 46, offset: 61079},
 											name: "AsField",
 										},
 									},
@@ -3245,15 +3357,15 @@ var g = &grammar{
 		},
 		{
 			name: "BinOptions",
-			pos:  position{line: 1860, col: 1, offset: 58365},
+			pos:  position{line: 1972, col: 1, offset: 61936},
 			expr: &actionExpr{
-				pos: position{line: 1860, col: 15, offset: 58379},
+				pos: position{line: 1972, col: 15, offset: 61950},
 				run: (*parser).callonBinOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 1860, col: 15, offset: 58379},
+					pos:   position{line: 1972, col: 15, offset: 61950},
 					label: "spanOptions",
 					expr: &ruleRefExpr{
-						pos:  position{line: 1860, col: 27, offset: 58391},
+						pos:  position{line: 1972, col: 27, offset: 61962},
 						name: "SpanOptions",
 					},
 				},
@@ -3261,26 +3373,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanOptions",
-			pos:  position{line: 1868, col: 1, offset: 58616},
+			pos:  position{line: 1980, col: 1, offset: 62187},
 			expr: &actionExpr{
-				pos: position{line: 1868, col: 16, offset: 58631},
+				pos: position{line: 1980, col: 16, offset: 62202},
 				run: (*parser).callonSpanOptions1,
 				expr: &seqExpr{
-					pos: position{line: 1868, col: 16, offset: 58631},
+					pos: position{line: 1980, col: 16, offset: 62202},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 16, offset: 58631},
+							pos:  position{line: 1980, col: 16, offset: 62202},
 							name: "CMD_SPAN",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1868, col: 25, offset: 58640},
+							pos:  position{line: 1980, col: 25, offset: 62211},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1868, col: 31, offset: 58646},
+							pos:   position{line: 1980, col: 31, offset: 62217},
 							label: "spanLength",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1868, col: 42, offset: 58657},
+								pos:  position{line: 1980, col: 42, offset: 62228},
 								name: "SpanLength",
 							},
 						},
@@ -3290,26 +3402,26 @@ var g = &grammar{
 		},
 		{
 			name: "SpanLength",
-			pos:  position{line: 1875, col: 1, offset: 58803},
+			pos:  position{line: 1987, col: 1, offset: 62374},
 			expr: &actionExpr{
-				pos: position{line: 1875, col: 15, offset: 58817},
+				pos: position{line: 1987, col: 15, offset: 62388},
 				run: (*parser).callonSpanLength1,
 				expr: &seqExpr{
-					pos: position{line: 1875, col: 15, offset: 58817},
+					pos: position{line: 1987, col: 15, offset: 62388},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1875, col: 15, offset: 58817},
+							pos:   position{line: 1987, col: 15, offset: 62388},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1875, col: 24, offset: 58826},
+								pos:  position{line: 1987, col: 24, offset: 62397},
 								name: "IntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1875, col: 40, offset: 58842},
+							pos:   position{line: 1987, col: 40, offset: 62413},
 							label: "timeScale",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1875, col: 50, offset: 58852},
+								pos:  position{line: 1987, col: 50, offset: 62423},
 								name: "AllTimeScale",
 							},
 						},
@@ -3319,43 +3431,43 @@ var g = &grammar{
 		},
 		{
 			name: "LimitExpr",
-			pos:  position{line: 1892, col: 1, offset: 59401},
+			pos:  position{line: 2004, col: 1, offset: 62972},
 			expr: &actionExpr{
-				pos: position{line: 1892, col: 14, offset: 59414},
+				pos: position{line: 2004, col: 14, offset: 62985},
 				run: (*parser).callonLimitExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1892, col: 14, offset: 59414},
+					pos: position{line: 2004, col: 14, offset: 62985},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1892, col: 14, offset: 59414},
+							pos:  position{line: 2004, col: 14, offset: 62985},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 1892, col: 20, offset: 59420},
+							pos:        position{line: 2004, col: 20, offset: 62991},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1892, col: 28, offset: 59428},
+							pos:  position{line: 2004, col: 28, offset: 62999},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 1892, col: 34, offset: 59434},
+							pos:   position{line: 2004, col: 34, offset: 63005},
 							label: "sortBy",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1892, col: 41, offset: 59441},
+								pos: position{line: 2004, col: 41, offset: 63012},
 								expr: &choiceExpr{
-									pos: position{line: 1892, col: 42, offset: 59442},
+									pos: position{line: 2004, col: 42, offset: 63013},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 1892, col: 42, offset: 59442},
+											pos:        position{line: 2004, col: 42, offset: 63013},
 											val:        "top",
 											ignoreCase: false,
 											want:       "\"top\"",
 										},
 										&litMatcher{
-											pos:        position{line: 1892, col: 50, offset: 59450},
+											pos:        position{line: 2004, col: 50, offset: 63021},
 											val:        "bottom",
 											ignoreCase: false,
 											want:       "\"bottom\"",
@@ -3365,14 +3477,14 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 1892, col: 61, offset: 59461},
+							pos:  position{line: 2004, col: 61, offset: 63032},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1892, col: 76, offset: 59476},
+							pos:   position{line: 2004, col: 76, offset: 63047},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1892, col: 86, offset: 59486},
+								pos:  position{line: 2004, col: 86, offset: 63057},
 								name: "IntegerAsString",
 							},
 						},
@@ -3382,22 +3494,22 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticBlock",
-			pos:  position{line: 1916, col: 1, offset: 60067},
+			pos:  position{line: 2028, col: 1, offset: 63638},
 			expr: &actionExpr{
-				pos: position{line: 1916, col: 19, offset: 60085},
+				pos: position{line: 2028, col: 19, offset: 63656},
 				run: (*parser).callonStatisticBlock1,
 				expr: &seqExpr{
-					pos: position{line: 1916, col: 19, offset: 60085},
+					pos: position{line: 2028, col: 19, offset: 63656},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 1916, col: 19, offset: 60085},
+							pos:  position{line: 2028, col: 19, offset: 63656},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 1916, col: 24, offset: 60090},
+							pos:   position{line: 2028, col: 24, offset: 63661},
 							label: "statisticExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 1916, col: 38, offset: 60104},
+								pos:  position{line: 2028, col: 38, offset: 63675},
 								name: "StatisticExpr",
 							},
 						},
@@ -3407,76 +3519,76 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticExpr",
-			pos:  position{line: 1953, col: 1, offset: 61242},
+			pos:  position{line: 2065, col: 1, offset: 64813},
 			expr: &actionExpr{
-				pos: position{line: 1953, col: 18, offset: 61259},
+				pos: position{line: 2065, col: 18, offset: 64830},
 				run: (*parser).callonStatisticExpr1,
 				expr: &seqExpr{
-					pos: position{line: 1953, col: 18, offset: 61259},
+					pos: position{line: 2065, col: 18, offset: 64830},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 1953, col: 18, offset: 61259},
+							pos:   position{line: 2065, col: 18, offset: 64830},
 							label: "cmd",
 							expr: &choiceExpr{
-								pos: position{line: 1953, col: 23, offset: 61264},
+								pos: position{line: 2065, col: 23, offset: 64835},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 23, offset: 61264},
+										pos:  position{line: 2065, col: 23, offset: 64835},
 										name: "CMD_TOP",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 33, offset: 61274},
+										pos:  position{line: 2065, col: 33, offset: 64845},
 										name: "CMD_RARE",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1953, col: 43, offset: 61284},
+							pos:   position{line: 2065, col: 43, offset: 64855},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1953, col: 49, offset: 61290},
+								pos: position{line: 2065, col: 49, offset: 64861},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1953, col: 50, offset: 61291},
+									pos:  position{line: 2065, col: 50, offset: 64862},
 									name: "StatisticLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1953, col: 67, offset: 61308},
+							pos:   position{line: 2065, col: 67, offset: 64879},
 							label: "fieldList",
 							expr: &seqExpr{
-								pos: position{line: 1953, col: 78, offset: 61319},
+								pos: position{line: 2065, col: 78, offset: 64890},
 								exprs: []any{
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 78, offset: 61319},
+										pos:  position{line: 2065, col: 78, offset: 64890},
 										name: "SPACE",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 1953, col: 84, offset: 61325},
+										pos:  position{line: 2065, col: 84, offset: 64896},
 										name: "FieldNameList",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1953, col: 99, offset: 61340},
+							pos:   position{line: 2065, col: 99, offset: 64911},
 							label: "byClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1953, col: 108, offset: 61349},
+								pos: position{line: 2065, col: 108, offset: 64920},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1953, col: 109, offset: 61350},
+									pos:  position{line: 2065, col: 109, offset: 64921},
 									name: "ByClause",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 1953, col: 120, offset: 61361},
+							pos:   position{line: 2065, col: 120, offset: 64932},
 							label: "options",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 1953, col: 128, offset: 61369},
+								pos: position{line: 2065, col: 128, offset: 64940},
 								expr: &ruleRefExpr{
-									pos:  position{line: 1953, col: 129, offset: 61370},
+									pos:  position{line: 2065, col: 129, offset: 64941},
 									name: "StatisticOptions",
 								},
 							},
@@ -3487,25 +3599,25 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticLimit",
-			pos:  position{line: 1995, col: 1, offset: 62455},
+			pos:  position{line: 2107, col: 1, offset: 66026},
 			expr: &choiceExpr{
-				pos: position{line: 1995, col: 19, offset: 62473},
+				pos: position{line: 2107, col: 19, offset: 66044},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 1995, col: 19, offset: 62473},
+						pos: position{line: 2107, col: 19, offset: 66044},
 						run: (*parser).callonStatisticLimit2,
 						expr: &seqExpr{
-							pos: position{line: 1995, col: 19, offset: 62473},
+							pos: position{line: 2107, col: 19, offset: 66044},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1995, col: 19, offset: 62473},
+									pos:  position{line: 2107, col: 19, offset: 66044},
 									name: "SPACE",
 								},
 								&labeledExpr{
-									pos:   position{line: 1995, col: 25, offset: 62479},
+									pos:   position{line: 2107, col: 25, offset: 66050},
 									label: "number",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1995, col: 32, offset: 62486},
+										pos:  position{line: 2107, col: 32, offset: 66057},
 										name: "IntegerAsString",
 									},
 								},
@@ -3513,30 +3625,30 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 1998, col: 3, offset: 62540},
+						pos: position{line: 2110, col: 3, offset: 66111},
 						run: (*parser).callonStatisticLimit7,
 						expr: &seqExpr{
-							pos: position{line: 1998, col: 3, offset: 62540},
+							pos: position{line: 2110, col: 3, offset: 66111},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 1998, col: 3, offset: 62540},
+									pos:  position{line: 2110, col: 3, offset: 66111},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 1998, col: 9, offset: 62546},
+									pos:        position{line: 2110, col: 9, offset: 66117},
 									val:        "limit",
 									ignoreCase: false,
 									want:       "\"limit\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 1998, col: 17, offset: 62554},
+									pos:  position{line: 2110, col: 17, offset: 66125},
 									name: "EQUAL",
 								},
 								&labeledExpr{
-									pos:   position{line: 1998, col: 23, offset: 62560},
+									pos:   position{line: 2110, col: 23, offset: 66131},
 									label: "limit",
 									expr: &ruleRefExpr{
-										pos:  position{line: 1998, col: 30, offset: 62567},
+										pos:  position{line: 2110, col: 30, offset: 66138},
 										name: "IntegerAsString",
 									},
 								},
@@ -3548,17 +3660,17 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptions",
-			pos:  position{line: 2003, col: 1, offset: 62665},
+			pos:  position{line: 2115, col: 1, offset: 66236},
 			expr: &actionExpr{
-				pos: position{line: 2003, col: 21, offset: 62685},
+				pos: position{line: 2115, col: 21, offset: 66256},
 				run: (*parser).callonStatisticOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2003, col: 21, offset: 62685},
+					pos:   position{line: 2115, col: 21, offset: 66256},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2003, col: 28, offset: 62692},
+						pos: position{line: 2115, col: 28, offset: 66263},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2003, col: 29, offset: 62693},
+							pos:  position{line: 2115, col: 29, offset: 66264},
 							name: "StatisticOption",
 						},
 					},
@@ -3567,34 +3679,34 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOption",
-			pos:  position{line: 2052, col: 1, offset: 64255},
+			pos:  position{line: 2164, col: 1, offset: 67826},
 			expr: &actionExpr{
-				pos: position{line: 2052, col: 20, offset: 64274},
+				pos: position{line: 2164, col: 20, offset: 67845},
 				run: (*parser).callonStatisticOption1,
 				expr: &seqExpr{
-					pos: position{line: 2052, col: 20, offset: 64274},
+					pos: position{line: 2164, col: 20, offset: 67845},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2052, col: 20, offset: 64274},
+							pos:  position{line: 2164, col: 20, offset: 67845},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 26, offset: 64280},
+							pos:   position{line: 2164, col: 26, offset: 67851},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2052, col: 36, offset: 64290},
+								pos:  position{line: 2164, col: 36, offset: 67861},
 								name: "StatisticOptionCMD",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2052, col: 55, offset: 64309},
+							pos:  position{line: 2164, col: 55, offset: 67880},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2052, col: 61, offset: 64315},
+							pos:   position{line: 2164, col: 61, offset: 67886},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2052, col: 67, offset: 64321},
+								pos:  position{line: 2164, col: 67, offset: 67892},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -3604,48 +3716,48 @@ var g = &grammar{
 		},
 		{
 			name: "StatisticOptionCMD",
-			pos:  position{line: 2057, col: 1, offset: 64430},
+			pos:  position{line: 2169, col: 1, offset: 68001},
 			expr: &actionExpr{
-				pos: position{line: 2057, col: 23, offset: 64452},
+				pos: position{line: 2169, col: 23, offset: 68023},
 				run: (*parser).callonStatisticOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2057, col: 23, offset: 64452},
+					pos:   position{line: 2169, col: 23, offset: 68023},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2057, col: 31, offset: 64460},
+						pos: position{line: 2169, col: 31, offset: 68031},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2057, col: 31, offset: 64460},
+								pos:        position{line: 2169, col: 31, offset: 68031},
 								val:        "countfield",
 								ignoreCase: false,
 								want:       "\"countfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2057, col: 46, offset: 64475},
+								pos:        position{line: 2169, col: 46, offset: 68046},
 								val:        "showcount",
 								ignoreCase: false,
 								want:       "\"showcount\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2057, col: 60, offset: 64489},
+								pos:        position{line: 2169, col: 60, offset: 68060},
 								val:        "otherstr",
 								ignoreCase: false,
 								want:       "\"otherstr\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2057, col: 73, offset: 64502},
+								pos:        position{line: 2169, col: 73, offset: 68073},
 								val:        "useother",
 								ignoreCase: false,
 								want:       "\"useother\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2057, col: 85, offset: 64514},
+								pos:        position{line: 2169, col: 85, offset: 68085},
 								val:        "percentfield",
 								ignoreCase: false,
 								want:       "\"percentfield\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2057, col: 102, offset: 64531},
+								pos:        position{line: 2169, col: 102, offset: 68102},
 								val:        "showperc",
 								ignoreCase: false,
 								want:       "\"showperc\"",
@@ -3657,25 +3769,25 @@ var g = &grammar{
 		},
 		{
 			name: "ByClause",
-			pos:  position{line: 2065, col: 1, offset: 64718},
+			pos:  position{line: 2177, col: 1, offset: 68289},
 			expr: &choiceExpr{
-				pos: position{line: 2065, col: 13, offset: 64730},
+				pos: position{line: 2177, col: 13, offset: 68301},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2065, col: 13, offset: 64730},
+						pos: position{line: 2177, col: 13, offset: 68301},
 						run: (*parser).callonByClause2,
 						expr: &seqExpr{
-							pos: position{line: 2065, col: 13, offset: 64730},
+							pos: position{line: 2177, col: 13, offset: 68301},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 2065, col: 13, offset: 64730},
+									pos:  position{line: 2177, col: 13, offset: 68301},
 									name: "BY",
 								},
 								&labeledExpr{
-									pos:   position{line: 2065, col: 16, offset: 64733},
+									pos:   position{line: 2177, col: 16, offset: 68304},
 									label: "fieldList",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2065, col: 26, offset: 64743},
+										pos:  position{line: 2177, col: 26, offset: 68314},
 										name: "FieldNameList",
 									},
 								},
@@ -3683,13 +3795,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2068, col: 3, offset: 64800},
+						pos: position{line: 2180, col: 3, offset: 68371},
 						run: (*parser).callonByClause7,
 						expr: &labeledExpr{
-							pos:   position{line: 2068, col: 3, offset: 64800},
+							pos:   position{line: 2180, col: 3, offset: 68371},
 							label: "groupByBlock",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2068, col: 16, offset: 64813},
+								pos:  position{line: 2180, col: 16, offset: 68384},
 								name: "GroupbyBlock",
 							},
 						},
@@ -3699,26 +3811,26 @@ var g = &grammar{
 		},
 		{
 			name: "DedupBlock",
-			pos:  position{line: 2072, col: 1, offset: 64871},
+			pos:  position{line: 2184, col: 1, offset: 68442},
 			expr: &actionExpr{
-				pos: position{line: 2072, col: 15, offset: 64885},
+				pos: position{line: 2184, col: 15, offset: 68456},
 				run: (*parser).callonDedupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2072, col: 15, offset: 64885},
+					pos: position{line: 2184, col: 15, offset: 68456},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 15, offset: 64885},
+							pos:  position{line: 2184, col: 15, offset: 68456},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2072, col: 20, offset: 64890},
+							pos:  position{line: 2184, col: 20, offset: 68461},
 							name: "CMD_DEDUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 2072, col: 30, offset: 64900},
+							pos:   position{line: 2184, col: 30, offset: 68471},
 							label: "dedupExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2072, col: 40, offset: 64910},
+								pos:  position{line: 2184, col: 40, offset: 68481},
 								name: "DedupExpr",
 							},
 						},
@@ -3728,27 +3840,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupExpr",
-			pos:  position{line: 2118, col: 1, offset: 66239},
+			pos:  position{line: 2230, col: 1, offset: 69810},
 			expr: &actionExpr{
-				pos: position{line: 2118, col: 14, offset: 66252},
+				pos: position{line: 2230, col: 14, offset: 69823},
 				run: (*parser).callonDedupExpr1,
 				expr: &seqExpr{
-					pos: position{line: 2118, col: 14, offset: 66252},
+					pos: position{line: 2230, col: 14, offset: 69823},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2118, col: 14, offset: 66252},
+							pos:   position{line: 2230, col: 14, offset: 69823},
 							label: "limitArr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2118, col: 23, offset: 66261},
+								pos: position{line: 2230, col: 23, offset: 69832},
 								expr: &seqExpr{
-									pos: position{line: 2118, col: 24, offset: 66262},
+									pos: position{line: 2230, col: 24, offset: 69833},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2118, col: 24, offset: 66262},
+											pos:  position{line: 2230, col: 24, offset: 69833},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2118, col: 30, offset: 66268},
+											pos:  position{line: 2230, col: 30, offset: 69839},
 											name: "IntegerAsString",
 										},
 									},
@@ -3756,45 +3868,45 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2118, col: 48, offset: 66286},
+							pos:   position{line: 2230, col: 48, offset: 69857},
 							label: "options1",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2118, col: 57, offset: 66295},
+								pos: position{line: 2230, col: 57, offset: 69866},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2118, col: 58, offset: 66296},
+									pos:  position{line: 2230, col: 58, offset: 69867},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2118, col: 73, offset: 66311},
+							pos:   position{line: 2230, col: 73, offset: 69882},
 							label: "fieldList",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2118, col: 83, offset: 66321},
+								pos: position{line: 2230, col: 83, offset: 69892},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2118, col: 84, offset: 66322},
+									pos:  position{line: 2230, col: 84, offset: 69893},
 									name: "DedupFieldList",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2118, col: 101, offset: 66339},
+							pos:   position{line: 2230, col: 101, offset: 69910},
 							label: "options2",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2118, col: 110, offset: 66348},
+								pos: position{line: 2230, col: 110, offset: 69919},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2118, col: 111, offset: 66349},
+									pos:  position{line: 2230, col: 111, offset: 69920},
 									name: "DedupOptions",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2118, col: 126, offset: 66364},
+							pos:   position{line: 2230, col: 126, offset: 69935},
 							label: "sortByClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2118, col: 139, offset: 66377},
+								pos: position{line: 2230, col: 139, offset: 69948},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2118, col: 140, offset: 66378},
+									pos:  position{line: 2230, col: 140, offset: 69949},
 									name: "DedupSortByClause",
 								},
 							},
@@ -3805,27 +3917,27 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldName",
-			pos:  position{line: 2175, col: 1, offset: 68116},
+			pos:  position{line: 2287, col: 1, offset: 71687},
 			expr: &actionExpr{
-				pos: position{line: 2175, col: 19, offset: 68134},
+				pos: position{line: 2287, col: 19, offset: 71705},
 				run: (*parser).callonDedupFieldName1,
 				expr: &seqExpr{
-					pos: position{line: 2175, col: 19, offset: 68134},
+					pos: position{line: 2287, col: 19, offset: 71705},
 					exprs: []any{
 						&notExpr{
-							pos: position{line: 2175, col: 19, offset: 68134},
+							pos: position{line: 2287, col: 19, offset: 71705},
 							expr: &litMatcher{
-								pos:        position{line: 2175, col: 21, offset: 68136},
+								pos:        position{line: 2287, col: 21, offset: 71707},
 								val:        "sortby",
 								ignoreCase: false,
 								want:       "\"sortby\"",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2175, col: 31, offset: 68146},
+							pos:   position{line: 2287, col: 31, offset: 71717},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2175, col: 37, offset: 68152},
+								pos:  position{line: 2287, col: 37, offset: 71723},
 								name: "FieldName",
 							},
 						},
@@ -3835,48 +3947,48 @@ var g = &grammar{
 		},
 		{
 			name: "SpaceSeparatedFieldNameList",
-			pos:  position{line: 2181, col: 1, offset: 68291},
+			pos:  position{line: 2293, col: 1, offset: 71862},
 			expr: &actionExpr{
-				pos: position{line: 2181, col: 32, offset: 68322},
+				pos: position{line: 2293, col: 32, offset: 71893},
 				run: (*parser).callonSpaceSeparatedFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 2181, col: 32, offset: 68322},
+					pos: position{line: 2293, col: 32, offset: 71893},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2181, col: 32, offset: 68322},
+							pos:   position{line: 2293, col: 32, offset: 71893},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2181, col: 38, offset: 68328},
+								pos:  position{line: 2293, col: 38, offset: 71899},
 								name: "FieldName",
 							},
 						},
 						&notExpr{
-							pos: position{line: 2181, col: 48, offset: 68338},
+							pos: position{line: 2293, col: 48, offset: 71909},
 							expr: &ruleRefExpr{
-								pos:  position{line: 2181, col: 50, offset: 68340},
+								pos:  position{line: 2293, col: 50, offset: 71911},
 								name: "EQUAL",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2181, col: 57, offset: 68347},
+							pos:   position{line: 2293, col: 57, offset: 71918},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2181, col: 62, offset: 68352},
+								pos: position{line: 2293, col: 62, offset: 71923},
 								expr: &seqExpr{
-									pos: position{line: 2181, col: 63, offset: 68353},
+									pos: position{line: 2293, col: 63, offset: 71924},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2181, col: 63, offset: 68353},
+											pos:  position{line: 2293, col: 63, offset: 71924},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2181, col: 69, offset: 68359},
+											pos:  position{line: 2293, col: 69, offset: 71930},
 											name: "FieldName",
 										},
 										&notExpr{
-											pos: position{line: 2181, col: 79, offset: 68369},
+											pos: position{line: 2293, col: 79, offset: 71940},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2181, col: 81, offset: 68371},
+												pos:  position{line: 2293, col: 81, offset: 71942},
 												name: "EQUAL",
 											},
 										},
@@ -3890,45 +4002,45 @@ var g = &grammar{
 		},
 		{
 			name: "DedupFieldList",
-			pos:  position{line: 2192, col: 1, offset: 68646},
+			pos:  position{line: 2304, col: 1, offset: 72217},
 			expr: &actionExpr{
-				pos: position{line: 2192, col: 19, offset: 68664},
+				pos: position{line: 2304, col: 19, offset: 72235},
 				run: (*parser).callonDedupFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 2192, col: 19, offset: 68664},
+					pos: position{line: 2304, col: 19, offset: 72235},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2192, col: 19, offset: 68664},
+							pos:  position{line: 2304, col: 19, offset: 72235},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2192, col: 25, offset: 68670},
+							pos:   position{line: 2304, col: 25, offset: 72241},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2192, col: 31, offset: 68676},
+								pos:  position{line: 2304, col: 31, offset: 72247},
 								name: "DedupFieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2192, col: 46, offset: 68691},
+							pos:   position{line: 2304, col: 46, offset: 72262},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2192, col: 51, offset: 68696},
+								pos: position{line: 2304, col: 51, offset: 72267},
 								expr: &seqExpr{
-									pos: position{line: 2192, col: 52, offset: 68697},
+									pos: position{line: 2304, col: 52, offset: 72268},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2192, col: 52, offset: 68697},
+											pos:  position{line: 2304, col: 52, offset: 72268},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2192, col: 58, offset: 68703},
+											pos:  position{line: 2304, col: 58, offset: 72274},
 											name: "DedupFieldName",
 										},
 										&notExpr{
-											pos: position{line: 2192, col: 73, offset: 68718},
+											pos: position{line: 2304, col: 73, offset: 72289},
 											expr: &ruleRefExpr{
-												pos:  position{line: 2192, col: 74, offset: 68719},
+												pos:  position{line: 2304, col: 74, offset: 72290},
 												name: "EQUAL",
 											},
 										},
@@ -3942,17 +4054,17 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptions",
-			pos:  position{line: 2210, col: 1, offset: 69247},
+			pos:  position{line: 2322, col: 1, offset: 72818},
 			expr: &actionExpr{
-				pos: position{line: 2210, col: 17, offset: 69263},
+				pos: position{line: 2322, col: 17, offset: 72834},
 				run: (*parser).callonDedupOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 2210, col: 17, offset: 69263},
+					pos:   position{line: 2322, col: 17, offset: 72834},
 					label: "option",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 2210, col: 24, offset: 69270},
+						pos: position{line: 2322, col: 24, offset: 72841},
 						expr: &ruleRefExpr{
-							pos:  position{line: 2210, col: 25, offset: 69271},
+							pos:  position{line: 2322, col: 25, offset: 72842},
 							name: "DedupOption",
 						},
 					},
@@ -3961,36 +4073,36 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOption",
-			pos:  position{line: 2250, col: 1, offset: 70537},
+			pos:  position{line: 2362, col: 1, offset: 74108},
 			expr: &actionExpr{
-				pos: position{line: 2250, col: 16, offset: 70552},
+				pos: position{line: 2362, col: 16, offset: 74123},
 				run: (*parser).callonDedupOption1,
 				expr: &seqExpr{
-					pos: position{line: 2250, col: 16, offset: 70552},
+					pos: position{line: 2362, col: 16, offset: 74123},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2250, col: 16, offset: 70552},
+							pos:  position{line: 2362, col: 16, offset: 74123},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2250, col: 22, offset: 70558},
+							pos:   position{line: 2362, col: 22, offset: 74129},
 							label: "optionCMD",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2250, col: 32, offset: 70568},
+								pos:  position{line: 2362, col: 32, offset: 74139},
 								name: "DedupOptionCMD",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 2250, col: 47, offset: 70583},
+							pos:        position{line: 2362, col: 47, offset: 74154},
 							val:        "=",
 							ignoreCase: false,
 							want:       "\"=\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 2250, col: 51, offset: 70587},
+							pos:   position{line: 2362, col: 51, offset: 74158},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2250, col: 57, offset: 70593},
+								pos:  position{line: 2362, col: 57, offset: 74164},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -4000,30 +4112,30 @@ var g = &grammar{
 		},
 		{
 			name: "DedupOptionCMD",
-			pos:  position{line: 2255, col: 1, offset: 70702},
+			pos:  position{line: 2367, col: 1, offset: 74273},
 			expr: &actionExpr{
-				pos: position{line: 2255, col: 19, offset: 70720},
+				pos: position{line: 2367, col: 19, offset: 74291},
 				run: (*parser).callonDedupOptionCMD1,
 				expr: &labeledExpr{
-					pos:   position{line: 2255, col: 19, offset: 70720},
+					pos:   position{line: 2367, col: 19, offset: 74291},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 2255, col: 27, offset: 70728},
+						pos: position{line: 2367, col: 27, offset: 74299},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 2255, col: 27, offset: 70728},
+								pos:        position{line: 2367, col: 27, offset: 74299},
 								val:        "consecutive",
 								ignoreCase: false,
 								want:       "\"consecutive\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2255, col: 43, offset: 70744},
+								pos:        position{line: 2367, col: 43, offset: 74315},
 								val:        "keepempty",
 								ignoreCase: false,
 								want:       "\"keepempty\"",
 							},
 							&litMatcher{
-								pos:        position{line: 2255, col: 57, offset: 70758},
+								pos:        position{line: 2367, col: 57, offset: 74329},
 								val:        "keepevents",
 								ignoreCase: false,
 								want:       "\"keepevents\"",
@@ -4035,22 +4147,22 @@ var g = &grammar{
 		},
 		{
 			name: "DedupSortByClause",
-			pos:  position{line: 2263, col: 1, offset: 70943},
+			pos:  position{line: 2375, col: 1, offset: 74514},
 			expr: &actionExpr{
-				pos: position{line: 2263, col: 22, offset: 70964},
+				pos: position{line: 2375, col: 22, offset: 74535},
 				run: (*parser).callonDedupSortByClause1,
 				expr: &seqExpr{
-					pos: position{line: 2263, col: 22, offset: 70964},
+					pos: position{line: 2375, col: 22, offset: 74535},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2263, col: 22, offset: 70964},
+							pos:  position{line: 2375, col: 22, offset: 74535},
 							name: "CMD_DEDUP_SORTBY",
 						},
 						&labeledExpr{
-							pos:   position{line: 2263, col: 39, offset: 70981},
+							pos:   position{line: 2375, col: 39, offset: 74552},
 							label: "dedupSortEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2263, col: 53, offset: 70995},
+								pos:  position{line: 2375, col: 53, offset: 74566},
 								name: "SortElements",
 							},
 						},
@@ -4060,35 +4172,35 @@ var g = &grammar{
 		},
 		{
 			name: "SortElements",
-			pos:  position{line: 2268, col: 1, offset: 71103},
+			pos:  position{line: 2380, col: 1, offset: 74674},
 			expr: &actionExpr{
-				pos: position{line: 2268, col: 17, offset: 71119},
+				pos: position{line: 2380, col: 17, offset: 74690},
 				run: (*parser).callonSortElements1,
 				expr: &seqExpr{
-					pos: position{line: 2268, col: 17, offset: 71119},
+					pos: position{line: 2380, col: 17, offset: 74690},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2268, col: 17, offset: 71119},
+							pos:   position{line: 2380, col: 17, offset: 74690},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2268, col: 23, offset: 71125},
+								pos:  position{line: 2380, col: 23, offset: 74696},
 								name: "SingleSortElement",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2268, col: 41, offset: 71143},
+							pos:   position{line: 2380, col: 41, offset: 74714},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2268, col: 46, offset: 71148},
+								pos: position{line: 2380, col: 46, offset: 74719},
 								expr: &seqExpr{
-									pos: position{line: 2268, col: 47, offset: 71149},
+									pos: position{line: 2380, col: 47, offset: 74720},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2268, col: 47, offset: 71149},
+											pos:  position{line: 2380, col: 47, offset: 74720},
 											name: "SPACE_OR_COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2268, col: 62, offset: 71164},
+											pos:  position{line: 2380, col: 62, offset: 74735},
 											name: "SingleSortElement",
 										},
 									},
@@ -4101,22 +4213,22 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElement",
-			pos:  position{line: 2283, col: 1, offset: 71522},
+			pos:  position{line: 2395, col: 1, offset: 75093},
 			expr: &actionExpr{
-				pos: position{line: 2283, col: 22, offset: 71543},
+				pos: position{line: 2395, col: 22, offset: 75114},
 				run: (*parser).callonSingleSortElement1,
 				expr: &labeledExpr{
-					pos:   position{line: 2283, col: 22, offset: 71543},
+					pos:   position{line: 2395, col: 22, offset: 75114},
 					label: "element",
 					expr: &choiceExpr{
-						pos: position{line: 2283, col: 31, offset: 71552},
+						pos: position{line: 2395, col: 31, offset: 75123},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2283, col: 31, offset: 71552},
+								pos:  position{line: 2395, col: 31, offset: 75123},
 								name: "SingleSortElementWithCast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2283, col: 59, offset: 71580},
+								pos:  position{line: 2395, col: 59, offset: 75151},
 								name: "SingleSortElementWithoutCast",
 							},
 						},
@@ -4126,33 +4238,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithoutCast",
-			pos:  position{line: 2287, col: 1, offset: 71639},
+			pos:  position{line: 2399, col: 1, offset: 75210},
 			expr: &actionExpr{
-				pos: position{line: 2287, col: 33, offset: 71671},
+				pos: position{line: 2399, col: 33, offset: 75242},
 				run: (*parser).callonSingleSortElementWithoutCast1,
 				expr: &seqExpr{
-					pos: position{line: 2287, col: 33, offset: 71671},
+					pos: position{line: 2399, col: 33, offset: 75242},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2287, col: 33, offset: 71671},
+							pos:   position{line: 2399, col: 33, offset: 75242},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2287, col: 47, offset: 71685},
+								pos: position{line: 2399, col: 47, offset: 75256},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2287, col: 47, offset: 71685},
+										pos:        position{line: 2399, col: 47, offset: 75256},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2287, col: 53, offset: 71691},
+										pos:        position{line: 2399, col: 53, offset: 75262},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2287, col: 59, offset: 71697},
+										pos:        position{line: 2399, col: 59, offset: 75268},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4161,10 +4273,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2287, col: 63, offset: 71701},
+							pos:   position{line: 2399, col: 63, offset: 75272},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2287, col: 69, offset: 71707},
+								pos:  position{line: 2399, col: 69, offset: 75278},
 								name: "FieldName",
 							},
 						},
@@ -4174,33 +4286,33 @@ var g = &grammar{
 		},
 		{
 			name: "SingleSortElementWithCast",
-			pos:  position{line: 2302, col: 1, offset: 71982},
+			pos:  position{line: 2414, col: 1, offset: 75553},
 			expr: &actionExpr{
-				pos: position{line: 2302, col: 30, offset: 72011},
+				pos: position{line: 2414, col: 30, offset: 75582},
 				run: (*parser).callonSingleSortElementWithCast1,
 				expr: &seqExpr{
-					pos: position{line: 2302, col: 30, offset: 72011},
+					pos: position{line: 2414, col: 30, offset: 75582},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2302, col: 30, offset: 72011},
+							pos:   position{line: 2414, col: 30, offset: 75582},
 							label: "sortBySymbol",
 							expr: &choiceExpr{
-								pos: position{line: 2302, col: 44, offset: 72025},
+								pos: position{line: 2414, col: 44, offset: 75596},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2302, col: 44, offset: 72025},
+										pos:        position{line: 2414, col: 44, offset: 75596},
 										val:        "+",
 										ignoreCase: false,
 										want:       "\"+\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2302, col: 50, offset: 72031},
+										pos:        position{line: 2414, col: 50, offset: 75602},
 										val:        "-",
 										ignoreCase: false,
 										want:       "\"-\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2302, col: 56, offset: 72037},
+										pos:        position{line: 2414, col: 56, offset: 75608},
 										val:        "",
 										ignoreCase: false,
 										want:       "\"\"",
@@ -4209,31 +4321,31 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2302, col: 60, offset: 72041},
+							pos:   position{line: 2414, col: 60, offset: 75612},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 2302, col: 64, offset: 72045},
+								pos: position{line: 2414, col: 64, offset: 75616},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 2302, col: 64, offset: 72045},
+										pos:        position{line: 2414, col: 64, offset: 75616},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2302, col: 73, offset: 72054},
+										pos:        position{line: 2414, col: 73, offset: 75625},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2302, col: 81, offset: 72062},
+										pos:        position{line: 2414, col: 81, offset: 75633},
 										val:        "ip",
 										ignoreCase: false,
 										want:       "\"ip\"",
 									},
 									&litMatcher{
-										pos:        position{line: 2302, col: 88, offset: 72069},
+										pos:        position{line: 2414, col: 88, offset: 75640},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
@@ -4242,19 +4354,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2302, col: 95, offset: 72076},
+							pos:  position{line: 2414, col: 95, offset: 75647},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 2302, col: 103, offset: 72084},
+							pos:   position{line: 2414, col: 103, offset: 75655},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2302, col: 109, offset: 72090},
+								pos:  position{line: 2414, col: 109, offset: 75661},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2302, col: 119, offset: 72100},
+							pos:  position{line: 2414, col: 119, offset: 75671},
 							name: "R_PAREN",
 						},
 					},
@@ -4263,26 +4375,26 @@ var g = &grammar{
 		},
 		{
 			name: "RenameBlock",
-			pos:  position{line: 2322, col: 1, offset: 72525},
+			pos:  position{line: 2434, col: 1, offset: 76096},
 			expr: &actionExpr{
-				pos: position{line: 2322, col: 16, offset: 72540},
+				pos: position{line: 2434, col: 16, offset: 76111},
 				run: (*parser).callonRenameBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2322, col: 16, offset: 72540},
+					pos: position{line: 2434, col: 16, offset: 76111},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2322, col: 16, offset: 72540},
+							pos:  position{line: 2434, col: 16, offset: 76111},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2322, col: 21, offset: 72545},
+							pos:  position{line: 2434, col: 21, offset: 76116},
 							name: "CMD_RENAME",
 						},
 						&labeledExpr{
-							pos:   position{line: 2322, col: 32, offset: 72556},
+							pos:   position{line: 2434, col: 32, offset: 76127},
 							label: "renameExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2322, col: 43, offset: 72567},
+								pos:  position{line: 2434, col: 43, offset: 76138},
 								name: "RenameExpr",
 							},
 						},
@@ -4292,33 +4404,33 @@ var g = &grammar{
 		},
 		{
 			name: "RenameExpr",
-			pos:  position{line: 2345, col: 1, offset: 73231},
+			pos:  position{line: 2457, col: 1, offset: 76802},
 			expr: &choiceExpr{
-				pos: position{line: 2345, col: 15, offset: 73245},
+				pos: position{line: 2457, col: 15, offset: 76816},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2345, col: 15, offset: 73245},
+						pos: position{line: 2457, col: 15, offset: 76816},
 						run: (*parser).callonRenameExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2345, col: 15, offset: 73245},
+							pos: position{line: 2457, col: 15, offset: 76816},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2345, col: 15, offset: 73245},
+									pos:   position{line: 2457, col: 15, offset: 76816},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2345, col: 31, offset: 73261},
+										pos:  position{line: 2457, col: 31, offset: 76832},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2345, col: 41, offset: 73271},
+									pos:  position{line: 2457, col: 41, offset: 76842},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2345, col: 44, offset: 73274},
+									pos:   position{line: 2457, col: 44, offset: 76845},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2345, col: 55, offset: 73285},
+										pos:  position{line: 2457, col: 55, offset: 76856},
 										name: "QuotedString",
 									},
 								},
@@ -4326,28 +4438,28 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2356, col: 3, offset: 73604},
+						pos: position{line: 2468, col: 3, offset: 77175},
 						run: (*parser).callonRenameExpr9,
 						expr: &seqExpr{
-							pos: position{line: 2356, col: 3, offset: 73604},
+							pos: position{line: 2468, col: 3, offset: 77175},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2356, col: 3, offset: 73604},
+									pos:   position{line: 2468, col: 3, offset: 77175},
 									label: "originalPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2356, col: 19, offset: 73620},
+										pos:  position{line: 2468, col: 19, offset: 77191},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2356, col: 29, offset: 73630},
+									pos:  position{line: 2468, col: 29, offset: 77201},
 									name: "AS",
 								},
 								&labeledExpr{
-									pos:   position{line: 2356, col: 32, offset: 73633},
+									pos:   position{line: 2468, col: 32, offset: 77204},
 									label: "newPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2356, col: 43, offset: 73644},
+										pos:  position{line: 2468, col: 43, offset: 77215},
 										name: "RenamePattern",
 									},
 								},
@@ -4359,48 +4471,48 @@ var g = &grammar{
 		},
 		{
 			name: "RexBlock",
-			pos:  position{line: 2378, col: 1, offset: 74210},
+			pos:  position{line: 2490, col: 1, offset: 77781},
 			expr: &actionExpr{
-				pos: position{line: 2378, col: 13, offset: 74222},
+				pos: position{line: 2490, col: 13, offset: 77793},
 				run: (*parser).callonRexBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2378, col: 13, offset: 74222},
+					pos: position{line: 2490, col: 13, offset: 77793},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2378, col: 13, offset: 74222},
+							pos:  position{line: 2490, col: 13, offset: 77793},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2378, col: 18, offset: 74227},
+							pos:  position{line: 2490, col: 18, offset: 77798},
 							name: "CMD_REX",
 						},
 						&litMatcher{
-							pos:        position{line: 2378, col: 26, offset: 74235},
+							pos:        position{line: 2490, col: 26, offset: 77806},
 							val:        "field",
 							ignoreCase: false,
 							want:       "\"field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2378, col: 34, offset: 74243},
+							pos:  position{line: 2490, col: 34, offset: 77814},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2378, col: 40, offset: 74249},
+							pos:   position{line: 2490, col: 40, offset: 77820},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2378, col: 46, offset: 74255},
+								pos:  position{line: 2490, col: 46, offset: 77826},
 								name: "EvalFieldToRead",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2378, col: 62, offset: 74271},
+							pos:  position{line: 2490, col: 62, offset: 77842},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 2378, col: 68, offset: 74277},
+							pos:   position{line: 2490, col: 68, offset: 77848},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2378, col: 72, offset: 74281},
+								pos:  position{line: 2490, col: 72, offset: 77852},
 								name: "QuotedString",
 							},
 						},
@@ -4410,37 +4522,37 @@ var g = &grammar{
 		},
 		{
 			name: "SortBlock",
-			pos:  position{line: 2407, col: 1, offset: 75010},
+			pos:  position{line: 2519, col: 1, offset: 78581},
 			expr: &actionExpr{
-				pos: position{line: 2407, col: 14, offset: 75023},
+				pos: position{line: 2519, col: 14, offset: 78594},
 				run: (*parser).callonSortBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2407, col: 14, offset: 75023},
+					pos: position{line: 2519, col: 14, offset: 78594},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2407, col: 14, offset: 75023},
+							pos:  position{line: 2519, col: 14, offset: 78594},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2407, col: 19, offset: 75028},
+							pos:  position{line: 2519, col: 19, offset: 78599},
 							name: "CMD_SORT",
 						},
 						&labeledExpr{
-							pos:   position{line: 2407, col: 28, offset: 75037},
+							pos:   position{line: 2519, col: 28, offset: 78608},
 							label: "limit",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 2407, col: 34, offset: 75043},
+								pos: position{line: 2519, col: 34, offset: 78614},
 								expr: &ruleRefExpr{
-									pos:  position{line: 2407, col: 35, offset: 75044},
+									pos:  position{line: 2519, col: 35, offset: 78615},
 									name: "SortLimit",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2407, col: 47, offset: 75056},
+							pos:   position{line: 2519, col: 47, offset: 78627},
 							label: "sortByEles",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2407, col: 58, offset: 75067},
+								pos:  position{line: 2519, col: 58, offset: 78638},
 								name: "SortElements",
 							},
 						},
@@ -4450,41 +4562,41 @@ var g = &grammar{
 		},
 		{
 			name: "SortLimit",
-			pos:  position{line: 2445, col: 1, offset: 75946},
+			pos:  position{line: 2557, col: 1, offset: 79517},
 			expr: &actionExpr{
-				pos: position{line: 2445, col: 14, offset: 75959},
+				pos: position{line: 2557, col: 14, offset: 79530},
 				run: (*parser).callonSortLimit1,
 				expr: &seqExpr{
-					pos: position{line: 2445, col: 14, offset: 75959},
+					pos: position{line: 2557, col: 14, offset: 79530},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 2445, col: 14, offset: 75959},
+							pos: position{line: 2557, col: 14, offset: 79530},
 							expr: &seqExpr{
-								pos: position{line: 2445, col: 15, offset: 75960},
+								pos: position{line: 2557, col: 15, offset: 79531},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 2445, col: 15, offset: 75960},
+										pos:        position{line: 2557, col: 15, offset: 79531},
 										val:        "limit",
 										ignoreCase: false,
 										want:       "\"limit\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 2445, col: 23, offset: 75968},
+										pos:  position{line: 2557, col: 23, offset: 79539},
 										name: "EQUAL",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2445, col: 31, offset: 75976},
+							pos:   position{line: 2557, col: 31, offset: 79547},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2445, col: 40, offset: 75985},
+								pos:  position{line: 2557, col: 40, offset: 79556},
 								name: "IntegerAsString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2445, col: 56, offset: 76001},
+							pos:  position{line: 2557, col: 56, offset: 79572},
 							name: "SPACE",
 						},
 					},
@@ -4493,43 +4605,43 @@ var g = &grammar{
 		},
 		{
 			name: "EvalBlock",
-			pos:  position{line: 2459, col: 1, offset: 76300},
+			pos:  position{line: 2571, col: 1, offset: 79871},
 			expr: &actionExpr{
-				pos: position{line: 2459, col: 14, offset: 76313},
+				pos: position{line: 2571, col: 14, offset: 79884},
 				run: (*parser).callonEvalBlock1,
 				expr: &seqExpr{
-					pos: position{line: 2459, col: 14, offset: 76313},
+					pos: position{line: 2571, col: 14, offset: 79884},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 2459, col: 14, offset: 76313},
+							pos:  position{line: 2571, col: 14, offset: 79884},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2459, col: 19, offset: 76318},
+							pos:  position{line: 2571, col: 19, offset: 79889},
 							name: "CMD_EVAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2459, col: 28, offset: 76327},
+							pos:   position{line: 2571, col: 28, offset: 79898},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2459, col: 34, offset: 76333},
+								pos:  position{line: 2571, col: 34, offset: 79904},
 								name: "SingleEval",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 2459, col: 45, offset: 76344},
+							pos:   position{line: 2571, col: 45, offset: 79915},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 2459, col: 50, offset: 76349},
+								pos: position{line: 2571, col: 50, offset: 79920},
 								expr: &seqExpr{
-									pos: position{line: 2459, col: 51, offset: 76350},
+									pos: position{line: 2571, col: 51, offset: 79921},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 2459, col: 51, offset: 76350},
+											pos:  position{line: 2571, col: 51, offset: 79921},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 2459, col: 57, offset: 76356},
+											pos:  position{line: 2571, col: 57, offset: 79927},
 											name: "SingleEval",
 										},
 									},
@@ -4542,30 +4654,30 @@ var g = &grammar{
 		},
 		{
 			name: "SingleEval",
-			pos:  position{line: 2494, col: 1, offset: 77589},
+			pos:  position{line: 2606, col: 1, offset: 81160},
 			expr: &actionExpr{
-				pos: position{line: 2494, col: 15, offset: 77603},
+				pos: position{line: 2606, col: 15, offset: 81174},
 				run: (*parser).callonSingleEval1,
 				expr: &seqExpr{
-					pos: position{line: 2494, col: 15, offset: 77603},
+					pos: position{line: 2606, col: 15, offset: 81174},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2494, col: 15, offset: 77603},
+							pos:   position{line: 2606, col: 15, offset: 81174},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2494, col: 21, offset: 77609},
+								pos:  position{line: 2606, col: 21, offset: 81180},
 								name: "FieldName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2494, col: 31, offset: 77619},
+							pos:  position{line: 2606, col: 31, offset: 81190},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 2494, col: 37, offset: 77625},
+							pos:   position{line: 2606, col: 37, offset: 81196},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2494, col: 42, offset: 77630},
+								pos:  position{line: 2606, col: 42, offset: 81201},
 								name: "EvalExpression",
 							},
 						},
@@ -4575,15 +4687,15 @@ var g = &grammar{
 		},
 		{
 			name: "EvalExpression",
-			pos:  position{line: 2507, col: 1, offset: 78031},
+			pos:  position{line: 2619, col: 1, offset: 81602},
 			expr: &actionExpr{
-				pos: position{line: 2507, col: 19, offset: 78049},
+				pos: position{line: 2619, col: 19, offset: 81620},
 				run: (*parser).callonEvalExpression1,
 				expr: &labeledExpr{
-					pos:   position{line: 2507, col: 19, offset: 78049},
+					pos:   position{line: 2619, col: 19, offset: 81620},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2507, col: 25, offset: 78055},
+						pos:  position{line: 2619, col: 25, offset: 81626},
 						name: "ValueExpr",
 					},
 				},
@@ -4591,85 +4703,85 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionExpr",
-			pos:  position{line: 2519, col: 1, offset: 78443},
+			pos:  position{line: 2631, col: 1, offset: 82014},
 			expr: &choiceExpr{
-				pos: position{line: 2519, col: 18, offset: 78460},
+				pos: position{line: 2631, col: 18, offset: 82031},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2519, col: 18, offset: 78460},
+						pos: position{line: 2631, col: 18, offset: 82031},
 						run: (*parser).callonConditionExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2519, col: 18, offset: 78460},
+							pos: position{line: 2631, col: 18, offset: 82031},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2519, col: 18, offset: 78460},
+									pos:        position{line: 2631, col: 18, offset: 82031},
 									val:        "if",
 									ignoreCase: false,
 									want:       "\"if\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2519, col: 23, offset: 78465},
+									pos:  position{line: 2631, col: 23, offset: 82036},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2519, col: 31, offset: 78473},
+									pos:   position{line: 2631, col: 31, offset: 82044},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2519, col: 41, offset: 78483},
+										pos:  position{line: 2631, col: 41, offset: 82054},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2519, col: 50, offset: 78492},
+									pos:  position{line: 2631, col: 50, offset: 82063},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2519, col: 56, offset: 78498},
+									pos:   position{line: 2631, col: 56, offset: 82069},
 									label: "trueValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2519, col: 66, offset: 78508},
+										pos:  position{line: 2631, col: 66, offset: 82079},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2519, col: 76, offset: 78518},
+									pos:  position{line: 2631, col: 76, offset: 82089},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2519, col: 82, offset: 78524},
+									pos:   position{line: 2631, col: 82, offset: 82095},
 									label: "falseValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2519, col: 93, offset: 78535},
+										pos:  position{line: 2631, col: 93, offset: 82106},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2519, col: 103, offset: 78545},
+									pos:  position{line: 2631, col: 103, offset: 82116},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2530, col: 3, offset: 78796},
+						pos: position{line: 2642, col: 3, offset: 82367},
 						run: (*parser).callonConditionExpr15,
 						expr: &seqExpr{
-							pos: position{line: 2530, col: 3, offset: 78796},
+							pos: position{line: 2642, col: 3, offset: 82367},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2530, col: 3, offset: 78796},
+									pos:   position{line: 2642, col: 3, offset: 82367},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2530, col: 11, offset: 78804},
+										pos: position{line: 2642, col: 11, offset: 82375},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2530, col: 11, offset: 78804},
+												pos:        position{line: 2642, col: 11, offset: 82375},
 												val:        "case",
 												ignoreCase: false,
 												want:       "\"case\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2530, col: 20, offset: 78813},
+												pos:        position{line: 2642, col: 20, offset: 82384},
 												val:        "validate",
 												ignoreCase: false,
 												want:       "\"validate\"",
@@ -4678,31 +4790,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2530, col: 32, offset: 78825},
+									pos:  position{line: 2642, col: 32, offset: 82396},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2530, col: 40, offset: 78833},
+									pos:   position{line: 2642, col: 40, offset: 82404},
 									label: "pair",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2530, col: 45, offset: 78838},
+										pos:  position{line: 2642, col: 45, offset: 82409},
 										name: "ConditionValuePair",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2530, col: 64, offset: 78857},
+									pos:   position{line: 2642, col: 64, offset: 82428},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2530, col: 69, offset: 78862},
+										pos: position{line: 2642, col: 69, offset: 82433},
 										expr: &seqExpr{
-											pos: position{line: 2530, col: 70, offset: 78863},
+											pos: position{line: 2642, col: 70, offset: 82434},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2530, col: 70, offset: 78863},
+													pos:  position{line: 2642, col: 70, offset: 82434},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2530, col: 76, offset: 78869},
+													pos:  position{line: 2642, col: 76, offset: 82440},
 													name: "ConditionValuePair",
 												},
 											},
@@ -4710,50 +4822,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2530, col: 97, offset: 78890},
+									pos:  position{line: 2642, col: 97, offset: 82461},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2553, col: 3, offset: 79494},
+						pos: position{line: 2665, col: 3, offset: 83065},
 						run: (*parser).callonConditionExpr30,
 						expr: &seqExpr{
-							pos: position{line: 2553, col: 3, offset: 79494},
+							pos: position{line: 2665, col: 3, offset: 83065},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2553, col: 3, offset: 79494},
+									pos:        position{line: 2665, col: 3, offset: 83065},
 									val:        "coalesce",
 									ignoreCase: false,
 									want:       "\"coalesce\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2553, col: 14, offset: 79505},
+									pos:  position{line: 2665, col: 14, offset: 83076},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2553, col: 22, offset: 79513},
+									pos:   position{line: 2665, col: 22, offset: 83084},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2553, col: 32, offset: 79523},
+										pos:  position{line: 2665, col: 32, offset: 83094},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2553, col: 42, offset: 79533},
+									pos:   position{line: 2665, col: 42, offset: 83104},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2553, col: 47, offset: 79538},
+										pos: position{line: 2665, col: 47, offset: 83109},
 										expr: &seqExpr{
-											pos: position{line: 2553, col: 48, offset: 79539},
+											pos: position{line: 2665, col: 48, offset: 83110},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2553, col: 48, offset: 79539},
+													pos:  position{line: 2665, col: 48, offset: 83110},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2553, col: 54, offset: 79545},
+													pos:  position{line: 2665, col: 54, offset: 83116},
 													name: "ValueExpr",
 												},
 											},
@@ -4761,73 +4873,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2553, col: 66, offset: 79557},
+									pos:  position{line: 2665, col: 66, offset: 83128},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2570, col: 3, offset: 79976},
+						pos: position{line: 2682, col: 3, offset: 83547},
 						run: (*parser).callonConditionExpr42,
 						expr: &seqExpr{
-							pos: position{line: 2570, col: 3, offset: 79976},
+							pos: position{line: 2682, col: 3, offset: 83547},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2570, col: 3, offset: 79976},
+									pos:        position{line: 2682, col: 3, offset: 83547},
 									val:        "nullif",
 									ignoreCase: false,
 									want:       "\"nullif\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2570, col: 12, offset: 79985},
+									pos:  position{line: 2682, col: 12, offset: 83556},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2570, col: 20, offset: 79993},
+									pos:   position{line: 2682, col: 20, offset: 83564},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2570, col: 30, offset: 80003},
+										pos:  position{line: 2682, col: 30, offset: 83574},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2570, col: 40, offset: 80013},
+									pos:  position{line: 2682, col: 40, offset: 83584},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2570, col: 46, offset: 80019},
+									pos:   position{line: 2682, col: 46, offset: 83590},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2570, col: 57, offset: 80030},
+										pos:  position{line: 2682, col: 57, offset: 83601},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2570, col: 67, offset: 80040},
+									pos:  position{line: 2682, col: 67, offset: 83611},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2582, col: 3, offset: 80320},
+						pos: position{line: 2694, col: 3, offset: 83891},
 						run: (*parser).callonConditionExpr52,
 						expr: &seqExpr{
-							pos: position{line: 2582, col: 3, offset: 80320},
+							pos: position{line: 2694, col: 3, offset: 83891},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2582, col: 3, offset: 80320},
+									pos:        position{line: 2694, col: 3, offset: 83891},
 									val:        "null",
 									ignoreCase: false,
 									want:       "\"null\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2582, col: 10, offset: 80327},
+									pos:  position{line: 2694, col: 10, offset: 83898},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2582, col: 18, offset: 80335},
+									pos:  position{line: 2694, col: 18, offset: 83906},
 									name: "R_PAREN",
 								},
 							},
@@ -4838,30 +4950,30 @@ var g = &grammar{
 		},
 		{
 			name: "ConditionValuePair",
-			pos:  position{line: 2589, col: 1, offset: 80432},
+			pos:  position{line: 2701, col: 1, offset: 84003},
 			expr: &actionExpr{
-				pos: position{line: 2589, col: 23, offset: 80454},
+				pos: position{line: 2701, col: 23, offset: 84025},
 				run: (*parser).callonConditionValuePair1,
 				expr: &seqExpr{
-					pos: position{line: 2589, col: 23, offset: 80454},
+					pos: position{line: 2701, col: 23, offset: 84025},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 2589, col: 23, offset: 80454},
+							pos:   position{line: 2701, col: 23, offset: 84025},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2589, col: 33, offset: 80464},
+								pos:  position{line: 2701, col: 33, offset: 84035},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 2589, col: 42, offset: 80473},
+							pos:  position{line: 2701, col: 42, offset: 84044},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 2589, col: 48, offset: 80479},
+							pos:   position{line: 2701, col: 48, offset: 84050},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 2589, col: 54, offset: 80485},
+								pos:  position{line: 2701, col: 54, offset: 84056},
 								name: "ValueExpr",
 							},
 						},
@@ -4871,15 +4983,15 @@ var g = &grammar{
 		},
 		{
 			name: "StringExprAsValueExpr",
-			pos:  position{line: 2597, col: 1, offset: 80690},
+			pos:  position{line: 2709, col: 1, offset: 84261},
 			expr: &actionExpr{
-				pos: position{line: 2597, col: 26, offset: 80715},
+				pos: position{line: 2709, col: 26, offset: 84286},
 				run: (*parser).callonStringExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2597, col: 26, offset: 80715},
+					pos:   position{line: 2709, col: 26, offset: 84286},
 					label: "stringExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2597, col: 37, offset: 80726},
+						pos:  position{line: 2709, col: 37, offset: 84297},
 						name: "StringExpr",
 					},
 				},
@@ -4887,15 +4999,15 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExprAsValueExpr",
-			pos:  position{line: 2607, col: 1, offset: 80935},
+			pos:  position{line: 2719, col: 1, offset: 84506},
 			expr: &actionExpr{
-				pos: position{line: 2607, col: 30, offset: 80964},
+				pos: position{line: 2719, col: 30, offset: 84535},
 				run: (*parser).callonMultiValueExprAsValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2607, col: 30, offset: 80964},
+					pos:   position{line: 2719, col: 30, offset: 84535},
 					label: "multiValueExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 2607, col: 45, offset: 80979},
+						pos:  position{line: 2719, col: 45, offset: 84550},
 						name: "MultiValueExpr",
 					},
 				},
@@ -4903,22 +5015,22 @@ var g = &grammar{
 		},
 		{
 			name: "StringOrMultiValueExpr",
-			pos:  position{line: 2616, col: 1, offset: 81185},
+			pos:  position{line: 2728, col: 1, offset: 84756},
 			expr: &actionExpr{
-				pos: position{line: 2616, col: 27, offset: 81211},
+				pos: position{line: 2728, col: 27, offset: 84782},
 				run: (*parser).callonStringOrMultiValueExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 2616, col: 27, offset: 81211},
+					pos:   position{line: 2728, col: 27, offset: 84782},
 					label: "strOrMVExpr",
 					expr: &choiceExpr{
-						pos: position{line: 2616, col: 40, offset: 81224},
+						pos: position{line: 2728, col: 40, offset: 84795},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 2616, col: 40, offset: 81224},
+								pos:  position{line: 2728, col: 40, offset: 84795},
 								name: "MultiValueExprAsValueExpr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 2616, col: 68, offset: 81252},
+								pos:  position{line: 2728, col: 68, offset: 84823},
 								name: "StringExprAsValueExpr",
 							},
 						},
@@ -4928,182 +5040,182 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueExpr",
-			pos:  position{line: 2620, col: 1, offset: 81329},
+			pos:  position{line: 2732, col: 1, offset: 84900},
 			expr: &choiceExpr{
-				pos: position{line: 2620, col: 19, offset: 81347},
+				pos: position{line: 2732, col: 19, offset: 84918},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2620, col: 19, offset: 81347},
+						pos: position{line: 2732, col: 19, offset: 84918},
 						run: (*parser).callonMultiValueExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2620, col: 20, offset: 81348},
+							pos: position{line: 2732, col: 20, offset: 84919},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2620, col: 20, offset: 81348},
+									pos:   position{line: 2732, col: 20, offset: 84919},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2620, col: 28, offset: 81356},
+										pos:        position{line: 2732, col: 28, offset: 84927},
 										val:        "split",
 										ignoreCase: false,
 										want:       "\"split\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2620, col: 37, offset: 81365},
+									pos:  position{line: 2732, col: 37, offset: 84936},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2620, col: 45, offset: 81373},
+									pos:   position{line: 2732, col: 45, offset: 84944},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2620, col: 56, offset: 81384},
+										pos:  position{line: 2732, col: 56, offset: 84955},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2620, col: 67, offset: 81395},
+									pos:  position{line: 2732, col: 67, offset: 84966},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2620, col: 73, offset: 81401},
+									pos:   position{line: 2732, col: 73, offset: 84972},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2620, col: 79, offset: 81407},
+										pos:  position{line: 2732, col: 79, offset: 84978},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2620, col: 90, offset: 81418},
+									pos:  position{line: 2732, col: 90, offset: 84989},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2632, col: 3, offset: 81779},
+						pos: position{line: 2744, col: 3, offset: 85350},
 						run: (*parser).callonMultiValueExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2632, col: 4, offset: 81780},
+							pos: position{line: 2744, col: 4, offset: 85351},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2632, col: 4, offset: 81780},
+									pos:   position{line: 2744, col: 4, offset: 85351},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2632, col: 12, offset: 81788},
+										pos:        position{line: 2744, col: 12, offset: 85359},
 										val:        "spath",
 										ignoreCase: false,
 										want:       "\"spath\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 21, offset: 81797},
+									pos:  position{line: 2744, col: 21, offset: 85368},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2632, col: 29, offset: 81805},
+									pos:   position{line: 2744, col: 29, offset: 85376},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2632, col: 35, offset: 81811},
+										pos:  position{line: 2744, col: 35, offset: 85382},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 46, offset: 81822},
+									pos:  position{line: 2744, col: 46, offset: 85393},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2632, col: 52, offset: 81828},
+									pos:   position{line: 2744, col: 52, offset: 85399},
 									label: "path",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2632, col: 57, offset: 81833},
+										pos:  position{line: 2744, col: 57, offset: 85404},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2632, col: 68, offset: 81844},
+									pos:  position{line: 2744, col: 68, offset: 85415},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2644, col: 3, offset: 82199},
+						pos: position{line: 2756, col: 3, offset: 85770},
 						run: (*parser).callonMultiValueExpr24,
 						expr: &seqExpr{
-							pos: position{line: 2644, col: 4, offset: 82200},
+							pos: position{line: 2756, col: 4, offset: 85771},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2644, col: 4, offset: 82200},
+									pos:   position{line: 2756, col: 4, offset: 85771},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2644, col: 12, offset: 82208},
+										pos:        position{line: 2756, col: 12, offset: 85779},
 										val:        "mvindex",
 										ignoreCase: false,
 										want:       "\"mvindex\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2644, col: 23, offset: 82219},
+									pos:  position{line: 2756, col: 23, offset: 85790},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2644, col: 31, offset: 82227},
+									pos:   position{line: 2756, col: 31, offset: 85798},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2644, col: 46, offset: 82242},
+										pos:  position{line: 2756, col: 46, offset: 85813},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2644, col: 61, offset: 82257},
+									pos:  position{line: 2756, col: 61, offset: 85828},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2644, col: 67, offset: 82263},
+									pos:   position{line: 2756, col: 67, offset: 85834},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2644, col: 78, offset: 82274},
+										pos:  position{line: 2756, col: 78, offset: 85845},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2644, col: 90, offset: 82286},
+									pos:   position{line: 2756, col: 90, offset: 85857},
 									label: "endIndex",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2644, col: 99, offset: 82295},
+										pos: position{line: 2756, col: 99, offset: 85866},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2644, col: 100, offset: 82296},
+											pos:  position{line: 2756, col: 100, offset: 85867},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2644, col: 119, offset: 82315},
+									pos:  position{line: 2756, col: 119, offset: 85886},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2660, col: 3, offset: 82877},
+						pos: position{line: 2772, col: 3, offset: 86448},
 						run: (*parser).callonMultiValueExpr38,
 						expr: &seqExpr{
-							pos: position{line: 2660, col: 4, offset: 82878},
+							pos: position{line: 2772, col: 4, offset: 86449},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2660, col: 4, offset: 82878},
+									pos:   position{line: 2772, col: 4, offset: 86449},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2660, col: 12, offset: 82886},
+										pos: position{line: 2772, col: 12, offset: 86457},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2660, col: 12, offset: 82886},
+												pos:        position{line: 2772, col: 12, offset: 86457},
 												val:        "mvdedup",
 												ignoreCase: false,
 												want:       "\"mvdedup\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2660, col: 24, offset: 82898},
+												pos:        position{line: 2772, col: 24, offset: 86469},
 												val:        "mvsort",
 												ignoreCase: false,
 												want:       "\"mvsort\"",
@@ -5112,222 +5224,222 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2660, col: 34, offset: 82908},
+									pos:  position{line: 2772, col: 34, offset: 86479},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2660, col: 42, offset: 82916},
+									pos:   position{line: 2772, col: 42, offset: 86487},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2660, col: 57, offset: 82931},
+										pos:  position{line: 2772, col: 57, offset: 86502},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2660, col: 72, offset: 82946},
+									pos:  position{line: 2772, col: 72, offset: 86517},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2672, col: 3, offset: 83294},
+						pos: position{line: 2784, col: 3, offset: 86865},
 						run: (*parser).callonMultiValueExpr48,
 						expr: &seqExpr{
-							pos: position{line: 2672, col: 4, offset: 83295},
+							pos: position{line: 2784, col: 4, offset: 86866},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2672, col: 4, offset: 83295},
+									pos:   position{line: 2784, col: 4, offset: 86866},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2672, col: 12, offset: 83303},
+										pos:        position{line: 2784, col: 12, offset: 86874},
 										val:        "mvfilter",
 										ignoreCase: false,
 										want:       "\"mvfilter\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 24, offset: 83315},
+									pos:  position{line: 2784, col: 24, offset: 86886},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2672, col: 32, offset: 83323},
+									pos:   position{line: 2784, col: 32, offset: 86894},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2672, col: 42, offset: 83333},
+										pos:  position{line: 2784, col: 42, offset: 86904},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2672, col: 51, offset: 83342},
+									pos:  position{line: 2784, col: 51, offset: 86913},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2685, col: 3, offset: 83689},
+						pos: position{line: 2797, col: 3, offset: 87260},
 						run: (*parser).callonMultiValueExpr56,
 						expr: &seqExpr{
-							pos: position{line: 2685, col: 4, offset: 83690},
+							pos: position{line: 2797, col: 4, offset: 87261},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2685, col: 4, offset: 83690},
+									pos:   position{line: 2797, col: 4, offset: 87261},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2685, col: 12, offset: 83698},
+										pos:        position{line: 2797, col: 12, offset: 87269},
 										val:        "mvmap",
 										ignoreCase: false,
 										want:       "\"mvmap\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 21, offset: 83707},
+									pos:  position{line: 2797, col: 21, offset: 87278},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 29, offset: 83715},
+									pos:   position{line: 2797, col: 29, offset: 87286},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 44, offset: 83730},
+										pos:  position{line: 2797, col: 44, offset: 87301},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 59, offset: 83745},
+									pos:  position{line: 2797, col: 59, offset: 87316},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2685, col: 65, offset: 83751},
+									pos:   position{line: 2797, col: 65, offset: 87322},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2685, col: 70, offset: 83756},
+										pos:  position{line: 2797, col: 70, offset: 87327},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2685, col: 80, offset: 83766},
+									pos:  position{line: 2797, col: 80, offset: 87337},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2698, col: 3, offset: 84188},
+						pos: position{line: 2810, col: 3, offset: 87759},
 						run: (*parser).callonMultiValueExpr67,
 						expr: &seqExpr{
-							pos: position{line: 2698, col: 4, offset: 84189},
+							pos: position{line: 2810, col: 4, offset: 87760},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2698, col: 4, offset: 84189},
+									pos:   position{line: 2810, col: 4, offset: 87760},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2698, col: 12, offset: 84197},
+										pos:        position{line: 2810, col: 12, offset: 87768},
 										val:        "mvrange",
 										ignoreCase: false,
 										want:       "\"mvrange\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2698, col: 23, offset: 84208},
+									pos:  position{line: 2810, col: 23, offset: 87779},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2698, col: 31, offset: 84216},
+									pos:   position{line: 2810, col: 31, offset: 87787},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2698, col: 42, offset: 84227},
+										pos:  position{line: 2810, col: 42, offset: 87798},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2698, col: 54, offset: 84239},
+									pos:  position{line: 2810, col: 54, offset: 87810},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2698, col: 60, offset: 84245},
+									pos:   position{line: 2810, col: 60, offset: 87816},
 									label: "endIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2698, col: 69, offset: 84254},
+										pos:  position{line: 2810, col: 69, offset: 87825},
 										name: "NumericExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2698, col: 81, offset: 84266},
+									pos:  position{line: 2810, col: 81, offset: 87837},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2698, col: 87, offset: 84272},
+									pos:   position{line: 2810, col: 87, offset: 87843},
 									label: "stringExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2698, col: 98, offset: 84283},
+										pos: position{line: 2810, col: 98, offset: 87854},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2698, col: 99, offset: 84284},
+											pos:  position{line: 2810, col: 99, offset: 87855},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2698, col: 112, offset: 84297},
+									pos:  position{line: 2810, col: 112, offset: 87868},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2711, col: 3, offset: 84748},
+						pos: position{line: 2823, col: 3, offset: 88319},
 						run: (*parser).callonMultiValueExpr82,
 						expr: &seqExpr{
-							pos: position{line: 2711, col: 4, offset: 84749},
+							pos: position{line: 2823, col: 4, offset: 88320},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2711, col: 4, offset: 84749},
+									pos:   position{line: 2823, col: 4, offset: 88320},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2711, col: 12, offset: 84757},
+										pos:        position{line: 2823, col: 12, offset: 88328},
 										val:        "mvzip",
 										ignoreCase: false,
 										want:       "\"mvzip\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2711, col: 21, offset: 84766},
+									pos:  position{line: 2823, col: 21, offset: 88337},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2711, col: 29, offset: 84774},
+									pos:   position{line: 2823, col: 29, offset: 88345},
 									label: "mvLeft",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2711, col: 36, offset: 84781},
+										pos:  position{line: 2823, col: 36, offset: 88352},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2711, col: 51, offset: 84796},
+									pos:  position{line: 2823, col: 51, offset: 88367},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2711, col: 57, offset: 84802},
+									pos:   position{line: 2823, col: 57, offset: 88373},
 									label: "mvRight",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2711, col: 65, offset: 84810},
+										pos:  position{line: 2823, col: 65, offset: 88381},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2711, col: 80, offset: 84825},
+									pos:   position{line: 2823, col: 80, offset: 88396},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2711, col: 85, offset: 84830},
+										pos: position{line: 2823, col: 85, offset: 88401},
 										expr: &seqExpr{
-											pos: position{line: 2711, col: 86, offset: 84831},
+											pos: position{line: 2823, col: 86, offset: 88402},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2711, col: 86, offset: 84831},
+													pos:  position{line: 2823, col: 86, offset: 88402},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2711, col: 92, offset: 84837},
+													pos:  position{line: 2823, col: 92, offset: 88408},
 													name: "StringExpr",
 												},
 											},
@@ -5335,63 +5447,63 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2711, col: 105, offset: 84850},
+									pos:  position{line: 2823, col: 105, offset: 88421},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2728, col: 3, offset: 85378},
+						pos: position{line: 2840, col: 3, offset: 88949},
 						run: (*parser).callonMultiValueExpr98,
 						expr: &seqExpr{
-							pos: position{line: 2728, col: 4, offset: 85379},
+							pos: position{line: 2840, col: 4, offset: 88950},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2728, col: 4, offset: 85379},
+									pos:   position{line: 2840, col: 4, offset: 88950},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2728, col: 12, offset: 85387},
+										pos:        position{line: 2840, col: 12, offset: 88958},
 										val:        "mv_to_json_array",
 										ignoreCase: false,
 										want:       "\"mv_to_json_array\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 32, offset: 85407},
+									pos:  position{line: 2840, col: 32, offset: 88978},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2728, col: 40, offset: 85415},
+									pos:   position{line: 2840, col: 40, offset: 88986},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2728, col: 55, offset: 85430},
+										pos:  position{line: 2840, col: 55, offset: 89001},
 										name: "MultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2728, col: 70, offset: 85445},
+									pos:   position{line: 2840, col: 70, offset: 89016},
 									label: "rest",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2728, col: 75, offset: 85450},
+										pos: position{line: 2840, col: 75, offset: 89021},
 										expr: &seqExpr{
-											pos: position{line: 2728, col: 76, offset: 85451},
+											pos: position{line: 2840, col: 76, offset: 89022},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2728, col: 76, offset: 85451},
+													pos:  position{line: 2840, col: 76, offset: 89022},
 													name: "COMMA",
 												},
 												&choiceExpr{
-													pos: position{line: 2728, col: 83, offset: 85458},
+													pos: position{line: 2840, col: 83, offset: 89029},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2728, col: 83, offset: 85458},
+															pos:        position{line: 2840, col: 83, offset: 89029},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2728, col: 92, offset: 85467},
+															pos:        position{line: 2840, col: 92, offset: 89038},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -5399,7 +5511,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2728, col: 101, offset: 85476},
+													pos:        position{line: 2840, col: 101, offset: 89047},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -5409,54 +5521,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2728, col: 108, offset: 85483},
+									pos:  position{line: 2840, col: 108, offset: 89054},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2753, col: 3, offset: 86186},
+						pos: position{line: 2865, col: 3, offset: 89757},
 						run: (*parser).callonMultiValueExpr114,
 						expr: &seqExpr{
-							pos: position{line: 2753, col: 4, offset: 86187},
+							pos: position{line: 2865, col: 4, offset: 89758},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2753, col: 4, offset: 86187},
+									pos:   position{line: 2865, col: 4, offset: 89758},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2753, col: 12, offset: 86195},
+										pos:        position{line: 2865, col: 12, offset: 89766},
 										val:        "mvappend",
 										ignoreCase: false,
 										want:       "\"mvappend\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2753, col: 24, offset: 86207},
+									pos:  position{line: 2865, col: 24, offset: 89778},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2753, col: 32, offset: 86215},
+									pos:   position{line: 2865, col: 32, offset: 89786},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2753, col: 41, offset: 86224},
+										pos:  position{line: 2865, col: 41, offset: 89795},
 										name: "StringOrMultiValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2753, col: 64, offset: 86247},
+									pos:   position{line: 2865, col: 64, offset: 89818},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2753, col: 69, offset: 86252},
+										pos: position{line: 2865, col: 69, offset: 89823},
 										expr: &seqExpr{
-											pos: position{line: 2753, col: 70, offset: 86253},
+											pos: position{line: 2865, col: 70, offset: 89824},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2753, col: 70, offset: 86253},
+													pos:  position{line: 2865, col: 70, offset: 89824},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2753, col: 76, offset: 86259},
+													pos:  position{line: 2865, col: 76, offset: 89830},
 													name: "StringOrMultiValueExpr",
 												},
 											},
@@ -5464,57 +5576,57 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2753, col: 101, offset: 86284},
+									pos:  position{line: 2865, col: 101, offset: 89855},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2773, col: 3, offset: 86872},
+						pos: position{line: 2885, col: 3, offset: 90443},
 						run: (*parser).callonMultiValueExpr127,
 						expr: &seqExpr{
-							pos: position{line: 2773, col: 3, offset: 86872},
+							pos: position{line: 2885, col: 3, offset: 90443},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2773, col: 3, offset: 86872},
+									pos:   position{line: 2885, col: 3, offset: 90443},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2773, col: 9, offset: 86878},
+										pos:  position{line: 2885, col: 9, offset: 90449},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 2773, col: 25, offset: 86894},
+									pos: position{line: 2885, col: 25, offset: 90465},
 									expr: &choiceExpr{
-										pos: position{line: 2773, col: 27, offset: 86896},
+										pos: position{line: 2885, col: 27, offset: 90467},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 27, offset: 86896},
+												pos:  position{line: 2885, col: 27, offset: 90467},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 36, offset: 86905},
+												pos:  position{line: 2885, col: 36, offset: 90476},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 46, offset: 86915},
+												pos:  position{line: 2885, col: 46, offset: 90486},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 54, offset: 86923},
+												pos:  position{line: 2885, col: 54, offset: 90494},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 62, offset: 86931},
+												pos:  position{line: 2885, col: 62, offset: 90502},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 2773, col: 70, offset: 86939},
+												pos:  position{line: 2885, col: 70, offset: 90510},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 2773, col: 84, offset: 86953},
+												pos:        position{line: 2885, col: 84, offset: 90524},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -5530,36 +5642,36 @@ var g = &grammar{
 		},
 		{
 			name: "TextExpr",
-			pos:  position{line: 2785, col: 1, offset: 87348},
+			pos:  position{line: 2897, col: 1, offset: 90919},
 			expr: &choiceExpr{
-				pos: position{line: 2785, col: 13, offset: 87360},
+				pos: position{line: 2897, col: 13, offset: 90931},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 2785, col: 13, offset: 87360},
+						pos: position{line: 2897, col: 13, offset: 90931},
 						run: (*parser).callonTextExpr2,
 						expr: &seqExpr{
-							pos: position{line: 2785, col: 14, offset: 87361},
+							pos: position{line: 2897, col: 14, offset: 90932},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2785, col: 14, offset: 87361},
+									pos:   position{line: 2897, col: 14, offset: 90932},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2785, col: 22, offset: 87369},
+										pos: position{line: 2897, col: 22, offset: 90940},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2785, col: 22, offset: 87369},
+												pos:        position{line: 2897, col: 22, offset: 90940},
 												val:        "lower",
 												ignoreCase: false,
 												want:       "\"lower\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2785, col: 32, offset: 87379},
+												pos:        position{line: 2897, col: 32, offset: 90950},
 												val:        "upper",
 												ignoreCase: false,
 												want:       "\"upper\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2785, col: 42, offset: 87389},
+												pos:        position{line: 2897, col: 42, offset: 90960},
 												val:        "urldecode",
 												ignoreCase: false,
 												want:       "\"urldecode\"",
@@ -5568,44 +5680,44 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 55, offset: 87402},
+									pos:  position{line: 2897, col: 55, offset: 90973},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2785, col: 63, offset: 87410},
+									pos:   position{line: 2897, col: 63, offset: 90981},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2785, col: 74, offset: 87421},
+										pos:  position{line: 2897, col: 74, offset: 90992},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2785, col: 85, offset: 87432},
+									pos:  position{line: 2897, col: 85, offset: 91003},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2797, col: 3, offset: 87746},
+						pos: position{line: 2909, col: 3, offset: 91317},
 						run: (*parser).callonTextExpr13,
 						expr: &seqExpr{
-							pos: position{line: 2797, col: 4, offset: 87747},
+							pos: position{line: 2909, col: 4, offset: 91318},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2797, col: 4, offset: 87747},
+									pos:   position{line: 2909, col: 4, offset: 91318},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2797, col: 12, offset: 87755},
+										pos: position{line: 2909, col: 12, offset: 91326},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2797, col: 12, offset: 87755},
+												pos:        position{line: 2909, col: 12, offset: 91326},
 												val:        "max",
 												ignoreCase: false,
 												want:       "\"max\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2797, col: 20, offset: 87763},
+												pos:        position{line: 2909, col: 20, offset: 91334},
 												val:        "min",
 												ignoreCase: false,
 												want:       "\"min\"",
@@ -5614,31 +5726,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 27, offset: 87770},
+									pos:  position{line: 2909, col: 27, offset: 91341},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 35, offset: 87778},
+									pos:   position{line: 2909, col: 35, offset: 91349},
 									label: "firstVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2797, col: 44, offset: 87787},
+										pos:  position{line: 2909, col: 44, offset: 91358},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2797, col: 55, offset: 87798},
+									pos:   position{line: 2909, col: 55, offset: 91369},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2797, col: 60, offset: 87803},
+										pos: position{line: 2909, col: 60, offset: 91374},
 										expr: &seqExpr{
-											pos: position{line: 2797, col: 61, offset: 87804},
+											pos: position{line: 2909, col: 61, offset: 91375},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2797, col: 61, offset: 87804},
+													pos:  position{line: 2909, col: 61, offset: 91375},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2797, col: 67, offset: 87810},
+													pos:  position{line: 2909, col: 67, offset: 91381},
 													name: "StringExpr",
 												},
 											},
@@ -5646,195 +5758,195 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2797, col: 80, offset: 87823},
+									pos:  position{line: 2909, col: 80, offset: 91394},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2819, col: 3, offset: 88423},
+						pos: position{line: 2931, col: 3, offset: 91994},
 						run: (*parser).callonTextExpr28,
 						expr: &seqExpr{
-							pos: position{line: 2819, col: 4, offset: 88424},
+							pos: position{line: 2931, col: 4, offset: 91995},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2819, col: 4, offset: 88424},
+									pos:   position{line: 2931, col: 4, offset: 91995},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2819, col: 12, offset: 88432},
+										pos:        position{line: 2931, col: 12, offset: 92003},
 										val:        "mvcount",
 										ignoreCase: false,
 										want:       "\"mvcount\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2819, col: 23, offset: 88443},
+									pos:  position{line: 2931, col: 23, offset: 92014},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2819, col: 31, offset: 88451},
+									pos:   position{line: 2931, col: 31, offset: 92022},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2819, col: 46, offset: 88466},
+										pos:  position{line: 2931, col: 46, offset: 92037},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2819, col: 61, offset: 88481},
+									pos:  position{line: 2931, col: 61, offset: 92052},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2830, col: 3, offset: 88783},
+						pos: position{line: 2942, col: 3, offset: 92354},
 						run: (*parser).callonTextExpr36,
 						expr: &seqExpr{
-							pos: position{line: 2830, col: 4, offset: 88784},
+							pos: position{line: 2942, col: 4, offset: 92355},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2830, col: 4, offset: 88784},
+									pos:   position{line: 2942, col: 4, offset: 92355},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2830, col: 12, offset: 88792},
+										pos:        position{line: 2942, col: 12, offset: 92363},
 										val:        "mvjoin",
 										ignoreCase: false,
 										want:       "\"mvjoin\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 22, offset: 88802},
+									pos:  position{line: 2942, col: 22, offset: 92373},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2830, col: 30, offset: 88810},
+									pos:   position{line: 2942, col: 30, offset: 92381},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2830, col: 45, offset: 88825},
+										pos:  position{line: 2942, col: 45, offset: 92396},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 60, offset: 88840},
+									pos:  position{line: 2942, col: 60, offset: 92411},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2830, col: 66, offset: 88846},
+									pos:   position{line: 2942, col: 66, offset: 92417},
 									label: "delim",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2830, col: 72, offset: 88852},
+										pos:  position{line: 2942, col: 72, offset: 92423},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2830, col: 83, offset: 88863},
+									pos:  position{line: 2942, col: 83, offset: 92434},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2842, col: 3, offset: 89213},
+						pos: position{line: 2954, col: 3, offset: 92784},
 						run: (*parser).callonTextExpr47,
 						expr: &seqExpr{
-							pos: position{line: 2842, col: 4, offset: 89214},
+							pos: position{line: 2954, col: 4, offset: 92785},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2842, col: 4, offset: 89214},
+									pos:   position{line: 2954, col: 4, offset: 92785},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2842, col: 12, offset: 89222},
+										pos:        position{line: 2954, col: 12, offset: 92793},
 										val:        "mvfind",
 										ignoreCase: false,
 										want:       "\"mvfind\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 22, offset: 89232},
+									pos:  position{line: 2954, col: 22, offset: 92803},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2842, col: 30, offset: 89240},
+									pos:   position{line: 2954, col: 30, offset: 92811},
 									label: "multiValueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2842, col: 45, offset: 89255},
+										pos:  position{line: 2954, col: 45, offset: 92826},
 										name: "MultiValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 60, offset: 89270},
+									pos:  position{line: 2954, col: 60, offset: 92841},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2842, col: 66, offset: 89276},
+									pos:   position{line: 2954, col: 66, offset: 92847},
 									label: "regexPattern",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2842, col: 79, offset: 89289},
+										pos:  position{line: 2954, col: 79, offset: 92860},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2842, col: 90, offset: 89300},
+									pos:  position{line: 2954, col: 90, offset: 92871},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2866, col: 3, offset: 89966},
+						pos: position{line: 2978, col: 3, offset: 93537},
 						run: (*parser).callonTextExpr58,
 						expr: &seqExpr{
-							pos: position{line: 2866, col: 4, offset: 89967},
+							pos: position{line: 2978, col: 4, offset: 93538},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2866, col: 4, offset: 89967},
+									pos:   position{line: 2978, col: 4, offset: 93538},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 2866, col: 12, offset: 89975},
+										pos:        position{line: 2978, col: 12, offset: 93546},
 										val:        "substr",
 										ignoreCase: false,
 										want:       "\"substr\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2866, col: 22, offset: 89985},
+									pos:  position{line: 2978, col: 22, offset: 93556},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2866, col: 30, offset: 89993},
+									pos:   position{line: 2978, col: 30, offset: 93564},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2866, col: 41, offset: 90004},
+										pos:  position{line: 2978, col: 41, offset: 93575},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2866, col: 52, offset: 90015},
+									pos:  position{line: 2978, col: 52, offset: 93586},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2866, col: 58, offset: 90021},
+									pos:   position{line: 2978, col: 58, offset: 93592},
 									label: "startIndex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2866, col: 69, offset: 90032},
+										pos:  position{line: 2978, col: 69, offset: 93603},
 										name: "NumericExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2866, col: 81, offset: 90044},
+									pos:   position{line: 2978, col: 81, offset: 93615},
 									label: "lengthParam",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2866, col: 93, offset: 90056},
+										pos: position{line: 2978, col: 93, offset: 93627},
 										expr: &seqExpr{
-											pos: position{line: 2866, col: 94, offset: 90057},
+											pos: position{line: 2978, col: 94, offset: 93628},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2866, col: 94, offset: 90057},
+													pos:  position{line: 2978, col: 94, offset: 93628},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2866, col: 100, offset: 90063},
+													pos:  position{line: 2978, col: 100, offset: 93634},
 													name: "NumericExpr",
 												},
 											},
@@ -5842,50 +5954,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2866, col: 114, offset: 90077},
+									pos:  position{line: 2978, col: 114, offset: 93648},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2891, col: 3, offset: 90907},
+						pos: position{line: 3003, col: 3, offset: 94478},
 						run: (*parser).callonTextExpr74,
 						expr: &seqExpr{
-							pos: position{line: 2891, col: 3, offset: 90907},
+							pos: position{line: 3003, col: 3, offset: 94478},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2891, col: 3, offset: 90907},
+									pos:        position{line: 3003, col: 3, offset: 94478},
 									val:        "tostring",
 									ignoreCase: false,
 									want:       "\"tostring\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2891, col: 14, offset: 90918},
+									pos:  position{line: 3003, col: 14, offset: 94489},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2891, col: 22, offset: 90926},
+									pos:   position{line: 3003, col: 22, offset: 94497},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2891, col: 28, offset: 90932},
+										pos:  position{line: 3003, col: 28, offset: 94503},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2891, col: 38, offset: 90942},
+									pos:   position{line: 3003, col: 38, offset: 94513},
 									label: "format",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2891, col: 45, offset: 90949},
+										pos: position{line: 3003, col: 45, offset: 94520},
 										expr: &seqExpr{
-											pos: position{line: 2891, col: 46, offset: 90950},
+											pos: position{line: 3003, col: 46, offset: 94521},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2891, col: 46, offset: 90950},
+													pos:  position{line: 3003, col: 46, offset: 94521},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2891, col: 52, offset: 90956},
+													pos:  position{line: 3003, col: 52, offset: 94527},
 													name: "StringExpr",
 												},
 											},
@@ -5893,38 +6005,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2891, col: 65, offset: 90969},
+									pos:  position{line: 3003, col: 65, offset: 94540},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2904, col: 3, offset: 91337},
+						pos: position{line: 3016, col: 3, offset: 94908},
 						run: (*parser).callonTextExpr86,
 						expr: &seqExpr{
-							pos: position{line: 2904, col: 4, offset: 91338},
+							pos: position{line: 3016, col: 4, offset: 94909},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 2904, col: 4, offset: 91338},
+									pos:   position{line: 3016, col: 4, offset: 94909},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 2904, col: 12, offset: 91346},
+										pos: position{line: 3016, col: 12, offset: 94917},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 2904, col: 12, offset: 91346},
+												pos:        position{line: 3016, col: 12, offset: 94917},
 												val:        "ltrim",
 												ignoreCase: false,
 												want:       "\"ltrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2904, col: 22, offset: 91356},
+												pos:        position{line: 3016, col: 22, offset: 94927},
 												val:        "rtrim",
 												ignoreCase: false,
 												want:       "\"rtrim\"",
 											},
 											&litMatcher{
-												pos:        position{line: 2904, col: 32, offset: 91366},
+												pos:        position{line: 3016, col: 32, offset: 94937},
 												val:        "trim",
 												ignoreCase: false,
 												want:       "\"trim\"",
@@ -5933,171 +6045,171 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2904, col: 40, offset: 91374},
+									pos:  position{line: 3016, col: 40, offset: 94945},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2904, col: 48, offset: 91382},
+									pos:   position{line: 3016, col: 48, offset: 94953},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2904, col: 54, offset: 91388},
+										pos:  position{line: 3016, col: 54, offset: 94959},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2904, col: 66, offset: 91400},
+									pos:   position{line: 3016, col: 66, offset: 94971},
 									label: "strToRemoveExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2904, col: 82, offset: 91416},
+										pos: position{line: 3016, col: 82, offset: 94987},
 										expr: &ruleRefExpr{
-											pos:  position{line: 2904, col: 83, offset: 91417},
+											pos:  position{line: 3016, col: 83, offset: 94988},
 											name: "StrToRemoveExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2904, col: 101, offset: 91435},
+									pos:  position{line: 3016, col: 101, offset: 95006},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2923, col: 3, offset: 91875},
+						pos: position{line: 3035, col: 3, offset: 95446},
 						run: (*parser).callonTextExpr100,
 						expr: &seqExpr{
-							pos: position{line: 2923, col: 3, offset: 91875},
+							pos: position{line: 3035, col: 3, offset: 95446},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2923, col: 3, offset: 91875},
+									pos:        position{line: 3035, col: 3, offset: 95446},
 									val:        "ipmask",
 									ignoreCase: false,
 									want:       "\"ipmask\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2923, col: 12, offset: 91884},
+									pos:  position{line: 3035, col: 12, offset: 95455},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2923, col: 20, offset: 91892},
+									pos:   position{line: 3035, col: 20, offset: 95463},
 									label: "mask",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2923, col: 25, offset: 91897},
+										pos:  position{line: 3035, col: 25, offset: 95468},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2923, col: 36, offset: 91908},
+									pos:  position{line: 3035, col: 36, offset: 95479},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2923, col: 42, offset: 91914},
+									pos:   position{line: 3035, col: 42, offset: 95485},
 									label: "ip",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2923, col: 45, offset: 91917},
+										pos:  position{line: 3035, col: 45, offset: 95488},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2923, col: 55, offset: 91927},
+									pos:  position{line: 3035, col: 55, offset: 95498},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2930, col: 3, offset: 92085},
+						pos: position{line: 3042, col: 3, offset: 95656},
 						run: (*parser).callonTextExpr110,
 						expr: &seqExpr{
-							pos: position{line: 2930, col: 3, offset: 92085},
+							pos: position{line: 3042, col: 3, offset: 95656},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2930, col: 3, offset: 92085},
+									pos:        position{line: 3042, col: 3, offset: 95656},
 									val:        "object_to_array",
 									ignoreCase: false,
 									want:       "\"object_to_array\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 21, offset: 92103},
+									pos:  position{line: 3042, col: 21, offset: 95674},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 29, offset: 92111},
+									pos:   position{line: 3042, col: 29, offset: 95682},
 									label: "obj",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 33, offset: 92115},
+										pos:  position{line: 3042, col: 33, offset: 95686},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 43, offset: 92125},
+									pos:  position{line: 3042, col: 43, offset: 95696},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 49, offset: 92131},
+									pos:   position{line: 3042, col: 49, offset: 95702},
 									label: "key",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 53, offset: 92135},
+										pos:  position{line: 3042, col: 53, offset: 95706},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 66, offset: 92148},
+									pos:  position{line: 3042, col: 66, offset: 95719},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 2930, col: 72, offset: 92154},
+									pos:   position{line: 3042, col: 72, offset: 95725},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2930, col: 78, offset: 92160},
+										pos:  position{line: 3042, col: 78, offset: 95731},
 										name: "QuotedString",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2930, col: 91, offset: 92173},
+									pos:  position{line: 3042, col: 91, offset: 95744},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2941, col: 3, offset: 92481},
+						pos: position{line: 3053, col: 3, offset: 96052},
 						run: (*parser).callonTextExpr123,
 						expr: &seqExpr{
-							pos: position{line: 2941, col: 3, offset: 92481},
+							pos: position{line: 3053, col: 3, offset: 96052},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2941, col: 3, offset: 92481},
+									pos:        position{line: 3053, col: 3, offset: 96052},
 									val:        "printf",
 									ignoreCase: false,
 									want:       "\"printf\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2941, col: 12, offset: 92490},
+									pos:  position{line: 3053, col: 12, offset: 96061},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2941, col: 20, offset: 92498},
+									pos:   position{line: 3053, col: 20, offset: 96069},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2941, col: 27, offset: 92505},
+										pos:  position{line: 3053, col: 27, offset: 96076},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2941, col: 38, offset: 92516},
+									pos:   position{line: 3053, col: 38, offset: 96087},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 2941, col: 43, offset: 92521},
+										pos: position{line: 3053, col: 43, offset: 96092},
 										expr: &seqExpr{
-											pos: position{line: 2941, col: 44, offset: 92522},
+											pos: position{line: 3053, col: 44, offset: 96093},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2941, col: 44, offset: 92522},
+													pos:  position{line: 3053, col: 44, offset: 96093},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2941, col: 50, offset: 92528},
+													pos:  position{line: 3053, col: 50, offset: 96099},
 													name: "StringExpr",
 												},
 											},
@@ -6105,47 +6217,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2941, col: 63, offset: 92541},
+									pos:  position{line: 3053, col: 63, offset: 96112},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2959, col: 3, offset: 93008},
+						pos: position{line: 3071, col: 3, offset: 96579},
 						run: (*parser).callonTextExpr135,
 						expr: &seqExpr{
-							pos: position{line: 2959, col: 3, offset: 93008},
+							pos: position{line: 3071, col: 3, offset: 96579},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2959, col: 3, offset: 93008},
+									pos:        position{line: 3071, col: 3, offset: 96579},
 									val:        "tojson",
 									ignoreCase: false,
 									want:       "\"tojson\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2959, col: 12, offset: 93017},
+									pos:  position{line: 3071, col: 12, offset: 96588},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2959, col: 20, offset: 93025},
+									pos:   position{line: 3071, col: 20, offset: 96596},
 									label: "containInternalFields",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2959, col: 42, offset: 93047},
+										pos: position{line: 3071, col: 42, offset: 96618},
 										expr: &seqExpr{
-											pos: position{line: 2959, col: 43, offset: 93048},
+											pos: position{line: 3071, col: 43, offset: 96619},
 											exprs: []any{
 												&choiceExpr{
-													pos: position{line: 2959, col: 44, offset: 93049},
+													pos: position{line: 3071, col: 44, offset: 96620},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2959, col: 44, offset: 93049},
+															pos:        position{line: 3071, col: 44, offset: 96620},
 															val:        "true",
 															ignoreCase: false,
 															want:       "\"true\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2959, col: 53, offset: 93058},
+															pos:        position{line: 3071, col: 53, offset: 96629},
 															val:        "false",
 															ignoreCase: false,
 															want:       "\"false\"",
@@ -6153,7 +6265,7 @@ var g = &grammar{
 													},
 												},
 												&litMatcher{
-													pos:        position{line: 2959, col: 62, offset: 93067},
+													pos:        position{line: 3071, col: 62, offset: 96638},
 													val:        "()",
 													ignoreCase: false,
 													want:       "\"()\"",
@@ -6163,56 +6275,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2959, col: 69, offset: 93074},
+									pos:  position{line: 3071, col: 69, offset: 96645},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 2981, col: 3, offset: 93671},
+						pos: position{line: 3093, col: 3, offset: 97242},
 						run: (*parser).callonTextExpr147,
 						expr: &seqExpr{
-							pos: position{line: 2981, col: 3, offset: 93671},
+							pos: position{line: 3093, col: 3, offset: 97242},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 2981, col: 3, offset: 93671},
+									pos:        position{line: 3093, col: 3, offset: 97242},
 									val:        "cluster",
 									ignoreCase: false,
 									want:       "\"cluster\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 13, offset: 93681},
+									pos:  position{line: 3093, col: 13, offset: 97252},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 21, offset: 93689},
+									pos:   position{line: 3093, col: 21, offset: 97260},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 2981, col: 27, offset: 93695},
+										pos:  position{line: 3093, col: 27, offset: 97266},
 										name: "EvalFieldToRead",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 43, offset: 93711},
+									pos:   position{line: 3093, col: 43, offset: 97282},
 									label: "threshold",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2981, col: 53, offset: 93721},
+										pos: position{line: 3093, col: 53, offset: 97292},
 										expr: &seqExpr{
-											pos: position{line: 2981, col: 54, offset: 93722},
+											pos: position{line: 3093, col: 54, offset: 97293},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 54, offset: 93722},
+													pos:  position{line: 3093, col: 54, offset: 97293},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2981, col: 60, offset: 93728},
+													pos:        position{line: 3093, col: 60, offset: 97299},
 													val:        "threshold:",
 													ignoreCase: false,
 													want:       "\"threshold:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 73, offset: 93741},
+													pos:  position{line: 3093, col: 73, offset: 97312},
 													name: "FloatAsString",
 												},
 											},
@@ -6220,40 +6332,40 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 89, offset: 93757},
+									pos:   position{line: 3093, col: 89, offset: 97328},
 									label: "match",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2981, col: 95, offset: 93763},
+										pos: position{line: 3093, col: 95, offset: 97334},
 										expr: &seqExpr{
-											pos: position{line: 2981, col: 96, offset: 93764},
+											pos: position{line: 3093, col: 96, offset: 97335},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 96, offset: 93764},
+													pos:  position{line: 3093, col: 96, offset: 97335},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2981, col: 102, offset: 93770},
+													pos:        position{line: 3093, col: 102, offset: 97341},
 													val:        "match:",
 													ignoreCase: false,
 													want:       "\"match:\"",
 												},
 												&choiceExpr{
-													pos: position{line: 2981, col: 112, offset: 93780},
+													pos: position{line: 3093, col: 112, offset: 97351},
 													alternatives: []any{
 														&litMatcher{
-															pos:        position{line: 2981, col: 112, offset: 93780},
+															pos:        position{line: 3093, col: 112, offset: 97351},
 															val:        "termlist",
 															ignoreCase: false,
 															want:       "\"termlist\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2981, col: 125, offset: 93793},
+															pos:        position{line: 3093, col: 125, offset: 97364},
 															val:        "termset",
 															ignoreCase: false,
 															want:       "\"termset\"",
 														},
 														&litMatcher{
-															pos:        position{line: 2981, col: 137, offset: 93805},
+															pos:        position{line: 3093, col: 137, offset: 97376},
 															val:        "ngramset",
 															ignoreCase: false,
 															want:       "\"ngramset\"",
@@ -6265,25 +6377,25 @@ var g = &grammar{
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 2981, col: 151, offset: 93819},
+									pos:   position{line: 3093, col: 151, offset: 97390},
 									label: "delims",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 2981, col: 158, offset: 93826},
+										pos: position{line: 3093, col: 158, offset: 97397},
 										expr: &seqExpr{
-											pos: position{line: 2981, col: 159, offset: 93827},
+											pos: position{line: 3093, col: 159, offset: 97398},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 159, offset: 93827},
+													pos:  position{line: 3093, col: 159, offset: 97398},
 													name: "COMMA",
 												},
 												&litMatcher{
-													pos:        position{line: 2981, col: 165, offset: 93833},
+													pos:        position{line: 3093, col: 165, offset: 97404},
 													val:        "delims:",
 													ignoreCase: false,
 													want:       "\"delims:\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 2981, col: 175, offset: 93843},
+													pos:  position{line: 3093, col: 175, offset: 97414},
 													name: "QuotedString",
 												},
 											},
@@ -6291,213 +6403,213 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 2981, col: 190, offset: 93858},
+									pos:  position{line: 3093, col: 190, offset: 97429},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3021, col: 3, offset: 94853},
+						pos: position{line: 3133, col: 3, offset: 98424},
 						run: (*parser).callonTextExpr175,
 						expr: &seqExpr{
-							pos: position{line: 3021, col: 3, offset: 94853},
+							pos: position{line: 3133, col: 3, offset: 98424},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3021, col: 3, offset: 94853},
+									pos:        position{line: 3133, col: 3, offset: 98424},
 									val:        "getfields",
 									ignoreCase: false,
 									want:       "\"getfields\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3021, col: 15, offset: 94865},
+									pos:  position{line: 3133, col: 15, offset: 98436},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3021, col: 23, offset: 94873},
+									pos:   position{line: 3133, col: 23, offset: 98444},
 									label: "filter",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3021, col: 30, offset: 94880},
+										pos: position{line: 3133, col: 30, offset: 98451},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3021, col: 31, offset: 94881},
+											pos:  position{line: 3133, col: 31, offset: 98452},
 											name: "StringExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3021, col: 44, offset: 94894},
+									pos:  position{line: 3133, col: 44, offset: 98465},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3032, col: 3, offset: 95085},
+						pos: position{line: 3144, col: 3, offset: 98656},
 						run: (*parser).callonTextExpr183,
 						expr: &seqExpr{
-							pos: position{line: 3032, col: 3, offset: 95085},
+							pos: position{line: 3144, col: 3, offset: 98656},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3032, col: 3, offset: 95085},
+									pos:        position{line: 3144, col: 3, offset: 98656},
 									val:        "typeof",
 									ignoreCase: false,
 									want:       "\"typeof\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3032, col: 12, offset: 95094},
+									pos:  position{line: 3144, col: 12, offset: 98665},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3032, col: 20, offset: 95102},
+									pos:   position{line: 3144, col: 20, offset: 98673},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3032, col: 30, offset: 95112},
+										pos:  position{line: 3144, col: 30, offset: 98683},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3032, col: 40, offset: 95122},
+									pos:  position{line: 3144, col: 40, offset: 98693},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3038, col: 3, offset: 95245},
+						pos: position{line: 3150, col: 3, offset: 98816},
 						run: (*parser).callonTextExpr190,
 						expr: &seqExpr{
-							pos: position{line: 3038, col: 3, offset: 95245},
+							pos: position{line: 3150, col: 3, offset: 98816},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3038, col: 3, offset: 95245},
+									pos:        position{line: 3150, col: 3, offset: 98816},
 									val:        "replace",
 									ignoreCase: false,
 									want:       "\"replace\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3038, col: 13, offset: 95255},
+									pos:  position{line: 3150, col: 13, offset: 98826},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3038, col: 21, offset: 95263},
+									pos:   position{line: 3150, col: 21, offset: 98834},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3038, col: 25, offset: 95267},
+										pos:  position{line: 3150, col: 25, offset: 98838},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3038, col: 35, offset: 95277},
+									pos:  position{line: 3150, col: 35, offset: 98848},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3038, col: 41, offset: 95283},
+									pos:   position{line: 3150, col: 41, offset: 98854},
 									label: "regex",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3038, col: 47, offset: 95289},
+										pos:  position{line: 3150, col: 47, offset: 98860},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3038, col: 58, offset: 95300},
+									pos:  position{line: 3150, col: 58, offset: 98871},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3038, col: 64, offset: 95306},
+									pos:   position{line: 3150, col: 64, offset: 98877},
 									label: "replacement",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3038, col: 76, offset: 95318},
+										pos:  position{line: 3150, col: 76, offset: 98889},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3038, col: 87, offset: 95329},
+									pos:  position{line: 3150, col: 87, offset: 98900},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3045, col: 3, offset: 95553},
+						pos: position{line: 3157, col: 3, offset: 99124},
 						run: (*parser).callonTextExpr203,
 						expr: &seqExpr{
-							pos: position{line: 3045, col: 3, offset: 95553},
+							pos: position{line: 3157, col: 3, offset: 99124},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3045, col: 3, offset: 95553},
+									pos:        position{line: 3157, col: 3, offset: 99124},
 									val:        "strftime",
 									ignoreCase: false,
 									want:       "\"strftime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 14, offset: 95564},
+									pos:  position{line: 3157, col: 14, offset: 99135},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 22, offset: 95572},
+									pos:   position{line: 3157, col: 22, offset: 99143},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 26, offset: 95576},
+										pos:  position{line: 3157, col: 26, offset: 99147},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 36, offset: 95586},
+									pos:  position{line: 3157, col: 36, offset: 99157},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3045, col: 42, offset: 95592},
+									pos:   position{line: 3157, col: 42, offset: 99163},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3045, col: 49, offset: 95599},
+										pos:  position{line: 3157, col: 49, offset: 99170},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3045, col: 60, offset: 95610},
+									pos:  position{line: 3157, col: 60, offset: 99181},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3053, col: 3, offset: 95774},
+						pos: position{line: 3165, col: 3, offset: 99345},
 						run: (*parser).callonTextExpr213,
 						expr: &seqExpr{
-							pos: position{line: 3053, col: 3, offset: 95774},
+							pos: position{line: 3165, col: 3, offset: 99345},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3053, col: 3, offset: 95774},
+									pos:        position{line: 3165, col: 3, offset: 99345},
 									val:        "strptime",
 									ignoreCase: false,
 									want:       "\"strptime\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3053, col: 14, offset: 95785},
+									pos:  position{line: 3165, col: 14, offset: 99356},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3053, col: 22, offset: 95793},
+									pos:   position{line: 3165, col: 22, offset: 99364},
 									label: "val",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3053, col: 26, offset: 95797},
+										pos:  position{line: 3165, col: 26, offset: 99368},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3053, col: 36, offset: 95807},
+									pos:  position{line: 3165, col: 36, offset: 99378},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3053, col: 42, offset: 95813},
+									pos:   position{line: 3165, col: 42, offset: 99384},
 									label: "format",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3053, col: 49, offset: 95820},
+										pos:  position{line: 3165, col: 49, offset: 99391},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3053, col: 60, offset: 95831},
+									pos:  position{line: 3165, col: 60, offset: 99402},
 									name: "R_PAREN",
 								},
 							},
@@ -6508,15 +6620,15 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedPathString",
-			pos:  position{line: 3061, col: 1, offset: 95993},
+			pos:  position{line: 3173, col: 1, offset: 99564},
 			expr: &actionExpr{
-				pos: position{line: 3061, col: 21, offset: 96013},
+				pos: position{line: 3173, col: 21, offset: 99584},
 				run: (*parser).callonQuotedPathString1,
 				expr: &labeledExpr{
-					pos:   position{line: 3061, col: 21, offset: 96013},
+					pos:   position{line: 3173, col: 21, offset: 99584},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3061, col: 25, offset: 96017},
+						pos:  position{line: 3173, col: 25, offset: 99588},
 						name: "QuotedString",
 					},
 				},
@@ -6524,15 +6636,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedPathValue",
-			pos:  position{line: 3068, col: 1, offset: 96144},
+			pos:  position{line: 3180, col: 1, offset: 99715},
 			expr: &actionExpr{
-				pos: position{line: 3068, col: 22, offset: 96165},
+				pos: position{line: 3180, col: 22, offset: 99736},
 				run: (*parser).callonUnquotedPathValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 3068, col: 22, offset: 96165},
+					pos:   position{line: 3180, col: 22, offset: 99736},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3068, col: 26, offset: 96169},
+						pos:  position{line: 3180, col: 26, offset: 99740},
 						name: "UnquotedString",
 					},
 				},
@@ -6540,22 +6652,22 @@ var g = &grammar{
 		},
 		{
 			name: "StrToRemoveExpr",
-			pos:  position{line: 3075, col: 1, offset: 96297},
+			pos:  position{line: 3187, col: 1, offset: 99868},
 			expr: &actionExpr{
-				pos: position{line: 3075, col: 20, offset: 96316},
+				pos: position{line: 3187, col: 20, offset: 99887},
 				run: (*parser).callonStrToRemoveExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3075, col: 20, offset: 96316},
+					pos: position{line: 3187, col: 20, offset: 99887},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3075, col: 20, offset: 96316},
+							pos:  position{line: 3187, col: 20, offset: 99887},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3075, col: 26, offset: 96322},
+							pos:   position{line: 3187, col: 26, offset: 99893},
 							label: "strToRemove",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3075, col: 38, offset: 96334},
+								pos:  position{line: 3187, col: 38, offset: 99905},
 								name: "String",
 							},
 						},
@@ -6565,27 +6677,27 @@ var g = &grammar{
 		},
 		{
 			name: "EvalFieldToRead",
-			pos:  position{line: 3081, col: 1, offset: 96519},
+			pos:  position{line: 3193, col: 1, offset: 100090},
 			expr: &choiceExpr{
-				pos: position{line: 3081, col: 20, offset: 96538},
+				pos: position{line: 3193, col: 20, offset: 100109},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3081, col: 20, offset: 96538},
+						pos: position{line: 3193, col: 20, offset: 100109},
 						run: (*parser).callonEvalFieldToRead2,
 						expr: &seqExpr{
-							pos: position{line: 3081, col: 20, offset: 96538},
+							pos: position{line: 3193, col: 20, offset: 100109},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 3081, col: 20, offset: 96538},
+									pos:        position{line: 3193, col: 20, offset: 100109},
 									val:        "[a-zA-Z]",
 									ranges:     []rune{'a', 'z', 'A', 'Z'},
 									ignoreCase: false,
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 3081, col: 28, offset: 96546},
+									pos: position{line: 3193, col: 28, offset: 100117},
 									expr: &charClassMatcher{
-										pos:        position{line: 3081, col: 28, offset: 96546},
+										pos:        position{line: 3193, col: 28, offset: 100117},
 										val:        "[_a-zA-Z0-9]",
 										chars:      []rune{'_'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -6594,9 +6706,9 @@ var g = &grammar{
 									},
 								},
 								&notExpr{
-									pos: position{line: 3081, col: 42, offset: 96560},
+									pos: position{line: 3193, col: 42, offset: 100131},
 									expr: &litMatcher{
-										pos:        position{line: 3081, col: 44, offset: 96562},
+										pos:        position{line: 3193, col: 44, offset: 100133},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -6606,27 +6718,27 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3084, col: 3, offset: 96604},
+						pos: position{line: 3196, col: 3, offset: 100175},
 						run: (*parser).callonEvalFieldToRead9,
 						expr: &seqExpr{
-							pos: position{line: 3084, col: 3, offset: 96604},
+							pos: position{line: 3196, col: 3, offset: 100175},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3084, col: 3, offset: 96604},
+									pos:        position{line: 3196, col: 3, offset: 100175},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 3084, col: 7, offset: 96608},
+									pos:   position{line: 3196, col: 7, offset: 100179},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3084, col: 13, offset: 96614},
+										pos:  position{line: 3196, col: 13, offset: 100185},
 										name: "FieldName",
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 3084, col: 23, offset: 96624},
+									pos:        position{line: 3196, col: 23, offset: 100195},
 									val:        "'",
 									ignoreCase: false,
 									want:       "\"'\"",
@@ -6639,26 +6751,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereBlock",
-			pos:  position{line: 3089, col: 1, offset: 96692},
+			pos:  position{line: 3201, col: 1, offset: 100263},
 			expr: &actionExpr{
-				pos: position{line: 3089, col: 15, offset: 96706},
+				pos: position{line: 3201, col: 15, offset: 100277},
 				run: (*parser).callonWhereBlock1,
 				expr: &seqExpr{
-					pos: position{line: 3089, col: 15, offset: 96706},
+					pos: position{line: 3201, col: 15, offset: 100277},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3089, col: 15, offset: 96706},
+							pos:  position{line: 3201, col: 15, offset: 100277},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3089, col: 20, offset: 96711},
+							pos:  position{line: 3201, col: 20, offset: 100282},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 3089, col: 30, offset: 96721},
+							pos:   position{line: 3201, col: 30, offset: 100292},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3089, col: 40, offset: 96731},
+								pos:  position{line: 3201, col: 40, offset: 100302},
 								name: "BoolExpr",
 							},
 						},
@@ -6668,15 +6780,15 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExpr",
-			pos:  position{line: 3102, col: 1, offset: 97074},
+			pos:  position{line: 3214, col: 1, offset: 100645},
 			expr: &actionExpr{
-				pos: position{line: 3102, col: 13, offset: 97086},
+				pos: position{line: 3214, col: 13, offset: 100657},
 				run: (*parser).callonBoolExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3102, col: 13, offset: 97086},
+					pos:   position{line: 3214, col: 13, offset: 100657},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3102, col: 18, offset: 97091},
+						pos:  position{line: 3214, col: 18, offset: 100662},
 						name: "BoolExprLevel4",
 					},
 				},
@@ -6684,35 +6796,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel4",
-			pos:  position{line: 3107, col: 1, offset: 97161},
+			pos:  position{line: 3219, col: 1, offset: 100732},
 			expr: &actionExpr{
-				pos: position{line: 3107, col: 19, offset: 97179},
+				pos: position{line: 3219, col: 19, offset: 100750},
 				run: (*parser).callonBoolExprLevel41,
 				expr: &seqExpr{
-					pos: position{line: 3107, col: 19, offset: 97179},
+					pos: position{line: 3219, col: 19, offset: 100750},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3107, col: 19, offset: 97179},
+							pos:   position{line: 3219, col: 19, offset: 100750},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3107, col: 25, offset: 97185},
+								pos:  position{line: 3219, col: 25, offset: 100756},
 								name: "BoolExprLevel3",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3107, col: 40, offset: 97200},
+							pos:   position{line: 3219, col: 40, offset: 100771},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3107, col: 45, offset: 97205},
+								pos: position{line: 3219, col: 45, offset: 100776},
 								expr: &seqExpr{
-									pos: position{line: 3107, col: 46, offset: 97206},
+									pos: position{line: 3219, col: 46, offset: 100777},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3107, col: 46, offset: 97206},
+											pos:  position{line: 3219, col: 46, offset: 100777},
 											name: "OR",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3107, col: 49, offset: 97209},
+											pos:  position{line: 3219, col: 49, offset: 100780},
 											name: "BoolExprLevel3",
 										},
 									},
@@ -6725,35 +6837,35 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel3",
-			pos:  position{line: 3127, col: 1, offset: 97647},
+			pos:  position{line: 3239, col: 1, offset: 101218},
 			expr: &actionExpr{
-				pos: position{line: 3127, col: 19, offset: 97665},
+				pos: position{line: 3239, col: 19, offset: 101236},
 				run: (*parser).callonBoolExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3127, col: 19, offset: 97665},
+					pos: position{line: 3239, col: 19, offset: 101236},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3127, col: 19, offset: 97665},
+							pos:   position{line: 3239, col: 19, offset: 101236},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3127, col: 25, offset: 97671},
+								pos:  position{line: 3239, col: 25, offset: 101242},
 								name: "BoolExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3127, col: 40, offset: 97686},
+							pos:   position{line: 3239, col: 40, offset: 101257},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3127, col: 45, offset: 97691},
+								pos: position{line: 3239, col: 45, offset: 101262},
 								expr: &seqExpr{
-									pos: position{line: 3127, col: 46, offset: 97692},
+									pos: position{line: 3239, col: 46, offset: 101263},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3127, col: 46, offset: 97692},
+											pos:  position{line: 3239, col: 46, offset: 101263},
 											name: "AND",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3127, col: 50, offset: 97696},
+											pos:  position{line: 3239, col: 50, offset: 101267},
 											name: "BoolExprLevel2",
 										},
 									},
@@ -6766,47 +6878,47 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel2",
-			pos:  position{line: 3147, col: 1, offset: 98135},
+			pos:  position{line: 3259, col: 1, offset: 101706},
 			expr: &choiceExpr{
-				pos: position{line: 3147, col: 19, offset: 98153},
+				pos: position{line: 3259, col: 19, offset: 101724},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3147, col: 19, offset: 98153},
+						pos: position{line: 3259, col: 19, offset: 101724},
 						run: (*parser).callonBoolExprLevel22,
 						expr: &seqExpr{
-							pos: position{line: 3147, col: 19, offset: 98153},
+							pos: position{line: 3259, col: 19, offset: 101724},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 19, offset: 98153},
+									pos:  position{line: 3259, col: 19, offset: 101724},
 									name: "NOT",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 23, offset: 98157},
+									pos:  position{line: 3259, col: 23, offset: 101728},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3147, col: 31, offset: 98165},
+									pos:   position{line: 3259, col: 31, offset: 101736},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3147, col: 37, offset: 98171},
+										pos:  position{line: 3259, col: 37, offset: 101742},
 										name: "BoolExprLevel1",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3147, col: 52, offset: 98186},
+									pos:  position{line: 3259, col: 52, offset: 101757},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3157, col: 3, offset: 98389},
+						pos: position{line: 3269, col: 3, offset: 101960},
 						run: (*parser).callonBoolExprLevel29,
 						expr: &labeledExpr{
-							pos:   position{line: 3157, col: 3, offset: 98389},
+							pos:   position{line: 3269, col: 3, offset: 101960},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3157, col: 9, offset: 98395},
+								pos:  position{line: 3269, col: 9, offset: 101966},
 								name: "BoolExprLevel1",
 							},
 						},
@@ -6816,50 +6928,50 @@ var g = &grammar{
 		},
 		{
 			name: "BoolExprLevel1",
-			pos:  position{line: 3162, col: 1, offset: 98466},
+			pos:  position{line: 3274, col: 1, offset: 102037},
 			expr: &choiceExpr{
-				pos: position{line: 3162, col: 19, offset: 98484},
+				pos: position{line: 3274, col: 19, offset: 102055},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3162, col: 19, offset: 98484},
+						pos: position{line: 3274, col: 19, offset: 102055},
 						run: (*parser).callonBoolExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3162, col: 19, offset: 98484},
+							pos: position{line: 3274, col: 19, offset: 102055},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 19, offset: 98484},
+									pos:  position{line: 3274, col: 19, offset: 102055},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3162, col: 27, offset: 98492},
+									pos:   position{line: 3274, col: 27, offset: 102063},
 									label: "first",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3162, col: 33, offset: 98498},
+										pos:  position{line: 3274, col: 33, offset: 102069},
 										name: "BoolExprLevel4",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3162, col: 48, offset: 98513},
+									pos:  position{line: 3274, col: 48, offset: 102084},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3165, col: 3, offset: 98549},
+						pos: position{line: 3277, col: 3, offset: 102120},
 						run: (*parser).callonBoolExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3165, col: 3, offset: 98549},
+							pos:   position{line: 3277, col: 3, offset: 102120},
 							label: "expr",
 							expr: &choiceExpr{
-								pos: position{line: 3165, col: 10, offset: 98556},
+								pos: position{line: 3277, col: 10, offset: 102127},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3165, col: 10, offset: 98556},
+										pos:  position{line: 3277, col: 10, offset: 102127},
 										name: "EvalComparisonExpr",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3165, col: 31, offset: 98577},
+										pos:  position{line: 3277, col: 31, offset: 102148},
 										name: "BoolComparisonExpr",
 									},
 								},
@@ -6871,72 +6983,72 @@ var g = &grammar{
 		},
 		{
 			name: "EvalComparisonExpr",
-			pos:  position{line: 3170, col: 1, offset: 98697},
+			pos:  position{line: 3282, col: 1, offset: 102268},
 			expr: &choiceExpr{
-				pos: position{line: 3170, col: 23, offset: 98719},
+				pos: position{line: 3282, col: 23, offset: 102290},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3170, col: 23, offset: 98719},
+						pos: position{line: 3282, col: 23, offset: 102290},
 						run: (*parser).callonEvalComparisonExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3170, col: 24, offset: 98720},
+							pos: position{line: 3282, col: 24, offset: 102291},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3170, col: 24, offset: 98720},
+									pos:   position{line: 3282, col: 24, offset: 102291},
 									label: "op",
 									expr: &choiceExpr{
-										pos: position{line: 3170, col: 28, offset: 98724},
+										pos: position{line: 3282, col: 28, offset: 102295},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3170, col: 28, offset: 98724},
+												pos:        position{line: 3282, col: 28, offset: 102295},
 												val:        "isbool",
 												ignoreCase: false,
 												want:       "\"isbool\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 39, offset: 98735},
+												pos:        position{line: 3282, col: 39, offset: 102306},
 												val:        "isint",
 												ignoreCase: false,
 												want:       "\"isint\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 49, offset: 98745},
+												pos:        position{line: 3282, col: 49, offset: 102316},
 												val:        "isstr",
 												ignoreCase: false,
 												want:       "\"isstr\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 59, offset: 98755},
+												pos:        position{line: 3282, col: 59, offset: 102326},
 												val:        "isnull",
 												ignoreCase: false,
 												want:       "\"isnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 70, offset: 98766},
+												pos:        position{line: 3282, col: 70, offset: 102337},
 												val:        "isnotnull",
 												ignoreCase: false,
 												want:       "\"isnotnull\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 84, offset: 98780},
+												pos:        position{line: 3282, col: 84, offset: 102351},
 												val:        "isnum",
 												ignoreCase: false,
 												want:       "\"isnum\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 94, offset: 98790},
+												pos:        position{line: 3282, col: 94, offset: 102361},
 												val:        "searchmatch",
 												ignoreCase: false,
 												want:       "\"searchmatch\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 110, offset: 98806},
+												pos:        position{line: 3282, col: 110, offset: 102377},
 												val:        "ismv",
 												ignoreCase: false,
 												want:       "\"ismv\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3170, col: 119, offset: 98815},
+												pos:        position{line: 3282, col: 119, offset: 102386},
 												val:        "isobject",
 												ignoreCase: false,
 												want:       "\"isobject\"",
@@ -6945,56 +7057,56 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3170, col: 131, offset: 98827},
+									pos:  position{line: 3282, col: 131, offset: 102398},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3170, col: 139, offset: 98835},
+									pos:   position{line: 3282, col: 139, offset: 102406},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3170, col: 145, offset: 98841},
+										pos:  position{line: 3282, col: 145, offset: 102412},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3170, col: 155, offset: 98851},
+									pos:  position{line: 3282, col: 155, offset: 102422},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3200, col: 3, offset: 99722},
+						pos: position{line: 3312, col: 3, offset: 103293},
 						run: (*parser).callonEvalComparisonExpr19,
 						expr: &seqExpr{
-							pos: position{line: 3200, col: 3, offset: 99722},
+							pos: position{line: 3312, col: 3, offset: 103293},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3200, col: 3, offset: 99722},
+									pos:   position{line: 3312, col: 3, offset: 103293},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3200, col: 11, offset: 99730},
+										pos: position{line: 3312, col: 11, offset: 103301},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3200, col: 11, offset: 99730},
+												pos:        position{line: 3312, col: 11, offset: 103301},
 												val:        "like",
 												ignoreCase: false,
 												want:       "\"like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3200, col: 20, offset: 99739},
+												pos:        position{line: 3312, col: 20, offset: 103310},
 												val:        "Like",
 												ignoreCase: false,
 												want:       "\"Like\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3200, col: 29, offset: 99748},
+												pos:        position{line: 3312, col: 29, offset: 103319},
 												val:        "match",
 												ignoreCase: false,
 												want:       "\"match\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3200, col: 39, offset: 99758},
+												pos:        position{line: 3312, col: 39, offset: 103329},
 												val:        "cidrmatch",
 												ignoreCase: false,
 												want:       "\"cidrmatch\"",
@@ -7003,86 +7115,86 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3200, col: 52, offset: 99771},
+									pos:  position{line: 3312, col: 52, offset: 103342},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3200, col: 60, offset: 99779},
+									pos:   position{line: 3312, col: 60, offset: 103350},
 									label: "leftValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3200, col: 70, offset: 99789},
+										pos:  position{line: 3312, col: 70, offset: 103360},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3200, col: 80, offset: 99799},
+									pos:  position{line: 3312, col: 80, offset: 103370},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3200, col: 86, offset: 99805},
+									pos:   position{line: 3312, col: 86, offset: 103376},
 									label: "rightValue",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3200, col: 97, offset: 99816},
+										pos:  position{line: 3312, col: 97, offset: 103387},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3200, col: 107, offset: 99826},
+									pos:  position{line: 3312, col: 107, offset: 103397},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3213, col: 3, offset: 100196},
+						pos: position{line: 3325, col: 3, offset: 103767},
 						run: (*parser).callonEvalComparisonExpr34,
 						expr: &seqExpr{
-							pos: position{line: 3213, col: 3, offset: 100196},
+							pos: position{line: 3325, col: 3, offset: 103767},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3213, col: 3, offset: 100196},
+									pos:   position{line: 3325, col: 3, offset: 103767},
 									label: "left",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3213, col: 8, offset: 100201},
+										pos:  position{line: 3325, col: 8, offset: 103772},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3213, col: 18, offset: 100211},
+									pos:  position{line: 3325, col: 18, offset: 103782},
 									name: "SPACE",
 								},
 								&litMatcher{
-									pos:        position{line: 3213, col: 24, offset: 100217},
+									pos:        position{line: 3325, col: 24, offset: 103788},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3213, col: 29, offset: 100222},
+									pos:  position{line: 3325, col: 29, offset: 103793},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3213, col: 37, offset: 100230},
+									pos:   position{line: 3325, col: 37, offset: 103801},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3213, col: 50, offset: 100243},
+										pos:  position{line: 3325, col: 50, offset: 103814},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3213, col: 60, offset: 100253},
+									pos:   position{line: 3325, col: 60, offset: 103824},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3213, col: 65, offset: 100258},
+										pos: position{line: 3325, col: 65, offset: 103829},
 										expr: &seqExpr{
-											pos: position{line: 3213, col: 66, offset: 100259},
+											pos: position{line: 3325, col: 66, offset: 103830},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 66, offset: 100259},
+													pos:  position{line: 3325, col: 66, offset: 103830},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3213, col: 72, offset: 100265},
+													pos:  position{line: 3325, col: 72, offset: 103836},
 													name: "ValueExpr",
 												},
 											},
@@ -7090,50 +7202,50 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3213, col: 84, offset: 100277},
+									pos:  position{line: 3325, col: 84, offset: 103848},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3232, col: 3, offset: 100828},
+						pos: position{line: 3344, col: 3, offset: 104399},
 						run: (*parser).callonEvalComparisonExpr49,
 						expr: &seqExpr{
-							pos: position{line: 3232, col: 3, offset: 100828},
+							pos: position{line: 3344, col: 3, offset: 104399},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3232, col: 3, offset: 100828},
+									pos:        position{line: 3344, col: 3, offset: 104399},
 									val:        "in",
 									ignoreCase: false,
 									want:       "\"in\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3232, col: 8, offset: 100833},
+									pos:  position{line: 3344, col: 8, offset: 104404},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3232, col: 16, offset: 100841},
+									pos:   position{line: 3344, col: 16, offset: 104412},
 									label: "valueToJudge",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3232, col: 29, offset: 100854},
+										pos:  position{line: 3344, col: 29, offset: 104425},
 										name: "ValueExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3232, col: 39, offset: 100864},
+									pos:   position{line: 3344, col: 39, offset: 104435},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3232, col: 44, offset: 100869},
+										pos: position{line: 3344, col: 44, offset: 104440},
 										expr: &seqExpr{
-											pos: position{line: 3232, col: 45, offset: 100870},
+											pos: position{line: 3344, col: 45, offset: 104441},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3232, col: 45, offset: 100870},
+													pos:  position{line: 3344, col: 45, offset: 104441},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3232, col: 51, offset: 100876},
+													pos:  position{line: 3344, col: 51, offset: 104447},
 													name: "ValueExpr",
 												},
 											},
@@ -7141,7 +7253,7 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3232, col: 63, offset: 100888},
+									pos:  position{line: 3344, col: 63, offset: 104459},
 									name: "R_PAREN",
 								},
 							},
@@ -7152,34 +7264,34 @@ var g = &grammar{
 		},
 		{
 			name: "BoolComparisonExpr",
-			pos:  position{line: 3250, col: 1, offset: 101309},
+			pos:  position{line: 3362, col: 1, offset: 104880},
 			expr: &actionExpr{
-				pos: position{line: 3250, col: 23, offset: 101331},
+				pos: position{line: 3362, col: 23, offset: 104902},
 				run: (*parser).callonBoolComparisonExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3250, col: 23, offset: 101331},
+					pos: position{line: 3362, col: 23, offset: 104902},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3250, col: 23, offset: 101331},
+							pos:   position{line: 3362, col: 23, offset: 104902},
 							label: "left",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3250, col: 28, offset: 101336},
+								pos:  position{line: 3362, col: 28, offset: 104907},
 								name: "ValueExpr",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3250, col: 38, offset: 101346},
+							pos:   position{line: 3362, col: 38, offset: 104917},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3250, col: 41, offset: 101349},
+								pos:  position{line: 3362, col: 41, offset: 104920},
 								name: "EqualityOrInequality",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3250, col: 62, offset: 101370},
+							pos:   position{line: 3362, col: 62, offset: 104941},
 							label: "right",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3250, col: 68, offset: 101376},
+								pos:  position{line: 3362, col: 68, offset: 104947},
 								name: "ValueExpr",
 							},
 						},
@@ -7189,141 +7301,141 @@ var g = &grammar{
 		},
 		{
 			name: "ValueExpr",
-			pos:  position{line: 3268, col: 1, offset: 101970},
+			pos:  position{line: 3380, col: 1, offset: 105541},
 			expr: &choiceExpr{
-				pos: position{line: 3268, col: 14, offset: 101983},
+				pos: position{line: 3380, col: 14, offset: 105554},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3268, col: 14, offset: 101983},
+						pos: position{line: 3380, col: 14, offset: 105554},
 						run: (*parser).callonValueExpr2,
 						expr: &labeledExpr{
-							pos:   position{line: 3268, col: 14, offset: 101983},
+							pos:   position{line: 3380, col: 14, offset: 105554},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3268, col: 24, offset: 101993},
+								pos:  position{line: 3380, col: 24, offset: 105564},
 								name: "ConditionExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3277, col: 3, offset: 102183},
+						pos: position{line: 3389, col: 3, offset: 105754},
 						run: (*parser).callonValueExpr5,
 						expr: &seqExpr{
-							pos: position{line: 3277, col: 3, offset: 102183},
+							pos: position{line: 3389, col: 3, offset: 105754},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3277, col: 3, offset: 102183},
+									pos:  position{line: 3389, col: 3, offset: 105754},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3277, col: 12, offset: 102192},
+									pos:   position{line: 3389, col: 12, offset: 105763},
 									label: "condition",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3277, col: 22, offset: 102202},
+										pos:  position{line: 3389, col: 22, offset: 105773},
 										name: "ConditionExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3277, col: 37, offset: 102217},
+									pos:  position{line: 3389, col: 37, offset: 105788},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3286, col: 3, offset: 102401},
+						pos: position{line: 3398, col: 3, offset: 105972},
 						run: (*parser).callonValueExpr11,
 						expr: &labeledExpr{
-							pos:   position{line: 3286, col: 3, offset: 102401},
+							pos:   position{line: 3398, col: 3, offset: 105972},
 							label: "numeric",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3286, col: 11, offset: 102409},
+								pos:  position{line: 3398, col: 11, offset: 105980},
 								name: "NumericExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3295, col: 3, offset: 102589},
+						pos: position{line: 3407, col: 3, offset: 106160},
 						run: (*parser).callonValueExpr14,
 						expr: &labeledExpr{
-							pos:   position{line: 3295, col: 3, offset: 102589},
+							pos:   position{line: 3407, col: 3, offset: 106160},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3295, col: 7, offset: 102593},
+								pos:  position{line: 3407, col: 7, offset: 106164},
 								name: "StringExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3304, col: 3, offset: 102765},
+						pos: position{line: 3416, col: 3, offset: 106336},
 						run: (*parser).callonValueExpr17,
 						expr: &seqExpr{
-							pos: position{line: 3304, col: 3, offset: 102765},
+							pos: position{line: 3416, col: 3, offset: 106336},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3304, col: 3, offset: 102765},
+									pos:  position{line: 3416, col: 3, offset: 106336},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3304, col: 12, offset: 102774},
+									pos:   position{line: 3416, col: 12, offset: 106345},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3304, col: 16, offset: 102778},
+										pos:  position{line: 3416, col: 16, offset: 106349},
 										name: "StringExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3304, col: 28, offset: 102790},
+									pos:  position{line: 3416, col: 28, offset: 106361},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3313, col: 3, offset: 102959},
+						pos: position{line: 3425, col: 3, offset: 106530},
 						run: (*parser).callonValueExpr23,
 						expr: &seqExpr{
-							pos: position{line: 3313, col: 3, offset: 102959},
+							pos: position{line: 3425, col: 3, offset: 106530},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 3, offset: 102959},
+									pos:  position{line: 3425, col: 3, offset: 106530},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3313, col: 11, offset: 102967},
+									pos:   position{line: 3425, col: 11, offset: 106538},
 									label: "boolean",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3313, col: 19, offset: 102975},
+										pos:  position{line: 3425, col: 19, offset: 106546},
 										name: "BoolExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3313, col: 28, offset: 102984},
+									pos:  position{line: 3425, col: 28, offset: 106555},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3322, col: 3, offset: 103156},
+						pos: position{line: 3434, col: 3, offset: 106727},
 						run: (*parser).callonValueExpr29,
 						expr: &labeledExpr{
-							pos:   position{line: 3322, col: 3, offset: 103156},
+							pos:   position{line: 3434, col: 3, offset: 106727},
 							label: "multiValueExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3322, col: 18, offset: 103171},
+								pos:  position{line: 3434, col: 18, offset: 106742},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3331, col: 3, offset: 103369},
+						pos: position{line: 3443, col: 3, offset: 106940},
 						run: (*parser).callonValueExpr32,
 						expr: &labeledExpr{
-							pos:   position{line: 3331, col: 3, offset: 103369},
+							pos:   position{line: 3443, col: 3, offset: 106940},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3331, col: 12, offset: 103378},
+								pos:  position{line: 3443, col: 12, offset: 106949},
 								name: "JsonExpr",
 							},
 						},
@@ -7333,28 +7445,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringExpr",
-			pos:  position{line: 3340, col: 1, offset: 103545},
+			pos:  position{line: 3452, col: 1, offset: 107116},
 			expr: &choiceExpr{
-				pos: position{line: 3340, col: 15, offset: 103559},
+				pos: position{line: 3452, col: 15, offset: 107130},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3340, col: 15, offset: 103559},
+						pos: position{line: 3452, col: 15, offset: 107130},
 						run: (*parser).callonStringExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3340, col: 15, offset: 103559},
+							pos: position{line: 3452, col: 15, offset: 107130},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3340, col: 15, offset: 103559},
+									pos:   position{line: 3452, col: 15, offset: 107130},
 									label: "text",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3340, col: 20, offset: 103564},
+										pos:  position{line: 3452, col: 20, offset: 107135},
 										name: "TextExpr",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3340, col: 29, offset: 103573},
+									pos: position{line: 3452, col: 29, offset: 107144},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3340, col: 31, offset: 103575},
+										pos:  position{line: 3452, col: 31, offset: 107146},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7362,23 +7474,23 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3348, col: 3, offset: 103745},
+						pos: position{line: 3460, col: 3, offset: 107316},
 						run: (*parser).callonStringExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3348, col: 3, offset: 103745},
+							pos: position{line: 3460, col: 3, offset: 107316},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3348, col: 3, offset: 103745},
+									pos:   position{line: 3460, col: 3, offset: 107316},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3348, col: 7, offset: 103749},
+										pos:  position{line: 3460, col: 7, offset: 107320},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3348, col: 20, offset: 103762},
+									pos: position{line: 3460, col: 20, offset: 107333},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3348, col: 22, offset: 103764},
+										pos:  position{line: 3460, col: 22, offset: 107335},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -7386,50 +7498,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3356, col: 3, offset: 103929},
+						pos: position{line: 3468, col: 3, offset: 107500},
 						run: (*parser).callonStringExpr14,
 						expr: &seqExpr{
-							pos: position{line: 3356, col: 3, offset: 103929},
+							pos: position{line: 3468, col: 3, offset: 107500},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3356, col: 3, offset: 103929},
+									pos:   position{line: 3468, col: 3, offset: 107500},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3356, col: 9, offset: 103935},
+										pos:  position{line: 3468, col: 9, offset: 107506},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3356, col: 25, offset: 103951},
+									pos: position{line: 3468, col: 25, offset: 107522},
 									expr: &choiceExpr{
-										pos: position{line: 3356, col: 27, offset: 103953},
+										pos: position{line: 3468, col: 27, offset: 107524},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 27, offset: 103953},
+												pos:  position{line: 3468, col: 27, offset: 107524},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 36, offset: 103962},
+												pos:  position{line: 3468, col: 36, offset: 107533},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 46, offset: 103972},
+												pos:  position{line: 3468, col: 46, offset: 107543},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 54, offset: 103980},
+												pos:  position{line: 3468, col: 54, offset: 107551},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 62, offset: 103988},
+												pos:  position{line: 3468, col: 62, offset: 107559},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3356, col: 70, offset: 103996},
+												pos:  position{line: 3468, col: 70, offset: 107567},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3356, col: 84, offset: 104010},
+												pos:        position{line: 3468, col: 84, offset: 107581},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -7441,13 +7553,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3364, col: 3, offset: 104160},
+						pos: position{line: 3476, col: 3, offset: 107731},
 						run: (*parser).callonStringExpr27,
 						expr: &labeledExpr{
-							pos:   position{line: 3364, col: 3, offset: 104160},
+							pos:   position{line: 3476, col: 3, offset: 107731},
 							label: "concat",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3364, col: 10, offset: 104167},
+								pos:  position{line: 3476, col: 10, offset: 107738},
 								name: "ConcatExpr",
 							},
 						},
@@ -7457,35 +7569,35 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatExpr",
-			pos:  position{line: 3374, col: 1, offset: 104373},
+			pos:  position{line: 3486, col: 1, offset: 107944},
 			expr: &actionExpr{
-				pos: position{line: 3374, col: 15, offset: 104387},
+				pos: position{line: 3486, col: 15, offset: 107958},
 				run: (*parser).callonConcatExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3374, col: 15, offset: 104387},
+					pos: position{line: 3486, col: 15, offset: 107958},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3374, col: 15, offset: 104387},
+							pos:   position{line: 3486, col: 15, offset: 107958},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3374, col: 21, offset: 104393},
+								pos:  position{line: 3486, col: 21, offset: 107964},
 								name: "ConcatAtom",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3374, col: 32, offset: 104404},
+							pos:   position{line: 3486, col: 32, offset: 107975},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3374, col: 37, offset: 104409},
+								pos: position{line: 3486, col: 37, offset: 107980},
 								expr: &seqExpr{
-									pos: position{line: 3374, col: 38, offset: 104410},
+									pos: position{line: 3486, col: 38, offset: 107981},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 3374, col: 38, offset: 104410},
+											pos:  position{line: 3486, col: 38, offset: 107981},
 											name: "EVAL_CONCAT",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3374, col: 50, offset: 104422},
+											pos:  position{line: 3486, col: 50, offset: 107993},
 											name: "ConcatAtom",
 										},
 									},
@@ -7493,28 +7605,28 @@ var g = &grammar{
 							},
 						},
 						&notExpr{
-							pos: position{line: 3374, col: 63, offset: 104435},
+							pos: position{line: 3486, col: 63, offset: 108006},
 							expr: &choiceExpr{
-								pos: position{line: 3374, col: 65, offset: 104437},
+								pos: position{line: 3486, col: 65, offset: 108008},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3374, col: 65, offset: 104437},
+										pos:  position{line: 3486, col: 65, offset: 108008},
 										name: "OpPlus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3374, col: 74, offset: 104446},
+										pos:  position{line: 3486, col: 74, offset: 108017},
 										name: "OpMinus",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3374, col: 84, offset: 104456},
+										pos:  position{line: 3486, col: 84, offset: 108027},
 										name: "OpMul",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3374, col: 92, offset: 104464},
+										pos:  position{line: 3486, col: 92, offset: 108035},
 										name: "OpDiv",
 									},
 									&litMatcher{
-										pos:        position{line: 3374, col: 100, offset: 104472},
+										pos:        position{line: 3486, col: 100, offset: 108043},
 										val:        "(",
 										ignoreCase: false,
 										want:       "\"(\"",
@@ -7528,54 +7640,54 @@ var g = &grammar{
 		},
 		{
 			name: "ConcatAtom",
-			pos:  position{line: 3392, col: 1, offset: 104878},
+			pos:  position{line: 3504, col: 1, offset: 108449},
 			expr: &choiceExpr{
-				pos: position{line: 3392, col: 15, offset: 104892},
+				pos: position{line: 3504, col: 15, offset: 108463},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3392, col: 15, offset: 104892},
+						pos: position{line: 3504, col: 15, offset: 108463},
 						run: (*parser).callonConcatAtom2,
 						expr: &labeledExpr{
-							pos:   position{line: 3392, col: 15, offset: 104892},
+							pos:   position{line: 3504, col: 15, offset: 108463},
 							label: "text",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3392, col: 20, offset: 104897},
+								pos:  position{line: 3504, col: 20, offset: 108468},
 								name: "TextExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3401, col: 3, offset: 105061},
+						pos: position{line: 3513, col: 3, offset: 108632},
 						run: (*parser).callonConcatAtom5,
 						expr: &labeledExpr{
-							pos:   position{line: 3401, col: 3, offset: 105061},
+							pos:   position{line: 3513, col: 3, offset: 108632},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3401, col: 7, offset: 105065},
+								pos:  position{line: 3513, col: 7, offset: 108636},
 								name: "QuotedString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3409, col: 3, offset: 105204},
+						pos: position{line: 3521, col: 3, offset: 108775},
 						run: (*parser).callonConcatAtom8,
 						expr: &labeledExpr{
-							pos:   position{line: 3409, col: 3, offset: 105204},
+							pos:   position{line: 3521, col: 3, offset: 108775},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3409, col: 10, offset: 105211},
+								pos:  position{line: 3521, col: 10, offset: 108782},
 								name: "NumberAsString",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3417, col: 3, offset: 105350},
+						pos: position{line: 3529, col: 3, offset: 108921},
 						run: (*parser).callonConcatAtom11,
 						expr: &labeledExpr{
-							pos:   position{line: 3417, col: 3, offset: 105350},
+							pos:   position{line: 3529, col: 3, offset: 108921},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3417, col: 9, offset: 105356},
+								pos:  position{line: 3529, col: 9, offset: 108927},
 								name: "EvalFieldToRead",
 							},
 						},
@@ -7585,32 +7697,32 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExpr",
-			pos:  position{line: 3427, col: 1, offset: 105525},
+			pos:  position{line: 3539, col: 1, offset: 109096},
 			expr: &actionExpr{
-				pos: position{line: 3427, col: 16, offset: 105540},
+				pos: position{line: 3539, col: 16, offset: 109111},
 				run: (*parser).callonNumericExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3427, col: 16, offset: 105540},
+					pos: position{line: 3539, col: 16, offset: 109111},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3427, col: 16, offset: 105540},
+							pos:   position{line: 3539, col: 16, offset: 109111},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3427, col: 21, offset: 105545},
+								pos:  position{line: 3539, col: 21, offset: 109116},
 								name: "NumericExprLevel3",
 							},
 						},
 						&notExpr{
-							pos: position{line: 3427, col: 39, offset: 105563},
+							pos: position{line: 3539, col: 39, offset: 109134},
 							expr: &choiceExpr{
-								pos: position{line: 3427, col: 41, offset: 105565},
+								pos: position{line: 3539, col: 41, offset: 109136},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 3427, col: 41, offset: 105565},
+										pos:  position{line: 3539, col: 41, offset: 109136},
 										name: "EVAL_CONCAT",
 									},
 									&litMatcher{
-										pos:        position{line: 3427, col: 55, offset: 105579},
+										pos:        position{line: 3539, col: 55, offset: 109150},
 										val:        "\"",
 										ignoreCase: false,
 										want:       "\"\\\"\"",
@@ -7624,44 +7736,44 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel3",
-			pos:  position{line: 3432, col: 1, offset: 105644},
+			pos:  position{line: 3544, col: 1, offset: 109215},
 			expr: &actionExpr{
-				pos: position{line: 3432, col: 22, offset: 105665},
+				pos: position{line: 3544, col: 22, offset: 109236},
 				run: (*parser).callonNumericExprLevel31,
 				expr: &seqExpr{
-					pos: position{line: 3432, col: 22, offset: 105665},
+					pos: position{line: 3544, col: 22, offset: 109236},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3432, col: 22, offset: 105665},
+							pos:   position{line: 3544, col: 22, offset: 109236},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3432, col: 28, offset: 105671},
+								pos:  position{line: 3544, col: 28, offset: 109242},
 								name: "NumericExprLevel2",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3432, col: 46, offset: 105689},
+							pos:   position{line: 3544, col: 46, offset: 109260},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3432, col: 51, offset: 105694},
+								pos: position{line: 3544, col: 51, offset: 109265},
 								expr: &seqExpr{
-									pos: position{line: 3432, col: 52, offset: 105695},
+									pos: position{line: 3544, col: 52, offset: 109266},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3432, col: 53, offset: 105696},
+											pos: position{line: 3544, col: 53, offset: 109267},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3432, col: 53, offset: 105696},
+													pos:  position{line: 3544, col: 53, offset: 109267},
 													name: "OpPlus",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3432, col: 62, offset: 105705},
+													pos:  position{line: 3544, col: 62, offset: 109276},
 													name: "OpMinus",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3432, col: 71, offset: 105714},
+											pos:  position{line: 3544, col: 71, offset: 109285},
 											name: "NumericExprLevel2",
 										},
 									},
@@ -7674,48 +7786,48 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel2",
-			pos:  position{line: 3453, col: 1, offset: 106215},
+			pos:  position{line: 3565, col: 1, offset: 109786},
 			expr: &actionExpr{
-				pos: position{line: 3453, col: 22, offset: 106236},
+				pos: position{line: 3565, col: 22, offset: 109807},
 				run: (*parser).callonNumericExprLevel21,
 				expr: &seqExpr{
-					pos: position{line: 3453, col: 22, offset: 106236},
+					pos: position{line: 3565, col: 22, offset: 109807},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 3453, col: 22, offset: 106236},
+							pos:   position{line: 3565, col: 22, offset: 109807},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3453, col: 28, offset: 106242},
+								pos:  position{line: 3565, col: 28, offset: 109813},
 								name: "NumericExprLevel1",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 3453, col: 46, offset: 106260},
+							pos:   position{line: 3565, col: 46, offset: 109831},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 3453, col: 51, offset: 106265},
+								pos: position{line: 3565, col: 51, offset: 109836},
 								expr: &seqExpr{
-									pos: position{line: 3453, col: 52, offset: 106266},
+									pos: position{line: 3565, col: 52, offset: 109837},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 3453, col: 53, offset: 106267},
+											pos: position{line: 3565, col: 53, offset: 109838},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3453, col: 53, offset: 106267},
+													pos:  position{line: 3565, col: 53, offset: 109838},
 													name: "OpMul",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3453, col: 61, offset: 106275},
+													pos:  position{line: 3565, col: 61, offset: 109846},
 													name: "OpDiv",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3453, col: 69, offset: 106283},
+													pos:  position{line: 3565, col: 69, offset: 109854},
 													name: "OpMod",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 3453, col: 76, offset: 106290},
+											pos:  position{line: 3565, col: 76, offset: 109861},
 											name: "NumericExprLevel1",
 										},
 									},
@@ -7728,22 +7840,22 @@ var g = &grammar{
 		},
 		{
 			name: "NumericParamExpr",
-			pos:  position{line: 3473, col: 1, offset: 106759},
+			pos:  position{line: 3585, col: 1, offset: 110330},
 			expr: &actionExpr{
-				pos: position{line: 3473, col: 21, offset: 106779},
+				pos: position{line: 3585, col: 21, offset: 110350},
 				run: (*parser).callonNumericParamExpr1,
 				expr: &seqExpr{
-					pos: position{line: 3473, col: 21, offset: 106779},
+					pos: position{line: 3585, col: 21, offset: 110350},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 3473, col: 21, offset: 106779},
+							pos:  position{line: 3585, col: 21, offset: 110350},
 							name: "COMMA",
 						},
 						&labeledExpr{
-							pos:   position{line: 3473, col: 27, offset: 106785},
+							pos:   position{line: 3585, col: 27, offset: 110356},
 							label: "expr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3473, col: 32, offset: 106790},
+								pos:  position{line: 3585, col: 32, offset: 110361},
 								name: "NumericExprLevel3",
 							},
 						},
@@ -7753,67 +7865,67 @@ var g = &grammar{
 		},
 		{
 			name: "NumericExprLevel1",
-			pos:  position{line: 3483, col: 1, offset: 107034},
+			pos:  position{line: 3595, col: 1, offset: 110605},
 			expr: &choiceExpr{
-				pos: position{line: 3483, col: 22, offset: 107055},
+				pos: position{line: 3595, col: 22, offset: 110626},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3483, col: 22, offset: 107055},
+						pos: position{line: 3595, col: 22, offset: 110626},
 						run: (*parser).callonNumericExprLevel12,
 						expr: &seqExpr{
-							pos: position{line: 3483, col: 22, offset: 107055},
+							pos: position{line: 3595, col: 22, offset: 110626},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 3483, col: 22, offset: 107055},
+									pos:  position{line: 3595, col: 22, offset: 110626},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3483, col: 30, offset: 107063},
+									pos:   position{line: 3595, col: 30, offset: 110634},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3483, col: 35, offset: 107068},
+										pos:  position{line: 3595, col: 35, offset: 110639},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3483, col: 53, offset: 107086},
+									pos:  position{line: 3595, col: 53, offset: 110657},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3486, col: 3, offset: 107121},
+						pos: position{line: 3598, col: 3, offset: 110692},
 						run: (*parser).callonNumericExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3486, col: 3, offset: 107121},
+							pos:   position{line: 3598, col: 3, offset: 110692},
 							label: "numericEvalExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3486, col: 20, offset: 107138},
+								pos:  position{line: 3598, col: 20, offset: 110709},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3489, col: 3, offset: 107192},
+						pos: position{line: 3601, col: 3, offset: 110763},
 						run: (*parser).callonNumericExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3489, col: 3, offset: 107192},
+							pos:   position{line: 3601, col: 3, offset: 110763},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3489, col: 9, offset: 107198},
+								pos:  position{line: 3601, col: 9, offset: 110769},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3499, col: 3, offset: 107417},
+						pos: position{line: 3611, col: 3, offset: 110988},
 						run: (*parser).callonNumericExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3499, col: 3, offset: 107417},
+							pos:   position{line: 3611, col: 3, offset: 110988},
 							label: "number",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3499, col: 10, offset: 107424},
+								pos:  position{line: 3611, col: 10, offset: 110995},
 								name: "NumberAsString",
 							},
 						},
@@ -7823,144 +7935,144 @@ var g = &grammar{
 		},
 		{
 			name: "NumericEvalExpr",
-			pos:  position{line: 3512, col: 1, offset: 107802},
+			pos:  position{line: 3624, col: 1, offset: 111373},
 			expr: &choiceExpr{
-				pos: position{line: 3512, col: 20, offset: 107821},
+				pos: position{line: 3624, col: 20, offset: 111392},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3512, col: 20, offset: 107821},
+						pos: position{line: 3624, col: 20, offset: 111392},
 						run: (*parser).callonNumericEvalExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3512, col: 21, offset: 107822},
+							pos: position{line: 3624, col: 21, offset: 111393},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3512, col: 21, offset: 107822},
+									pos:   position{line: 3624, col: 21, offset: 111393},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3512, col: 29, offset: 107830},
+										pos: position{line: 3624, col: 29, offset: 111401},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3512, col: 29, offset: 107830},
+												pos:        position{line: 3624, col: 29, offset: 111401},
 												val:        "abs",
 												ignoreCase: false,
 												want:       "\"abs\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 37, offset: 107838},
+												pos:        position{line: 3624, col: 37, offset: 111409},
 												val:        "ceil",
 												ignoreCase: false,
 												want:       "\"ceil\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 46, offset: 107847},
+												pos:        position{line: 3624, col: 46, offset: 111418},
 												val:        "ceiling",
 												ignoreCase: false,
 												want:       "\"ceiling\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 58, offset: 107859},
+												pos:        position{line: 3624, col: 58, offset: 111430},
 												val:        "sqrt",
 												ignoreCase: false,
 												want:       "\"sqrt\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 67, offset: 107868},
+												pos:        position{line: 3624, col: 67, offset: 111439},
 												val:        "exact",
 												ignoreCase: false,
 												want:       "\"exact\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 77, offset: 107878},
+												pos:        position{line: 3624, col: 77, offset: 111449},
 												val:        "exp",
 												ignoreCase: false,
 												want:       "\"exp\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 85, offset: 107886},
+												pos:        position{line: 3624, col: 85, offset: 111457},
 												val:        "floor",
 												ignoreCase: false,
 												want:       "\"floor\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 95, offset: 107896},
+												pos:        position{line: 3624, col: 95, offset: 111467},
 												val:        "ln",
 												ignoreCase: false,
 												want:       "\"ln\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 102, offset: 107903},
+												pos:        position{line: 3624, col: 102, offset: 111474},
 												val:        "sigfig",
 												ignoreCase: false,
 												want:       "\"sigfig\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 113, offset: 107914},
+												pos:        position{line: 3624, col: 113, offset: 111485},
 												val:        "acosh",
 												ignoreCase: false,
 												want:       "\"acosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 123, offset: 107924},
+												pos:        position{line: 3624, col: 123, offset: 111495},
 												val:        "acos",
 												ignoreCase: false,
 												want:       "\"acos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 132, offset: 107933},
+												pos:        position{line: 3624, col: 132, offset: 111504},
 												val:        "asinh",
 												ignoreCase: false,
 												want:       "\"asinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 142, offset: 107943},
+												pos:        position{line: 3624, col: 142, offset: 111514},
 												val:        "asin",
 												ignoreCase: false,
 												want:       "\"asin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 151, offset: 107952},
+												pos:        position{line: 3624, col: 151, offset: 111523},
 												val:        "atanh",
 												ignoreCase: false,
 												want:       "\"atanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 161, offset: 107962},
+												pos:        position{line: 3624, col: 161, offset: 111533},
 												val:        "atan",
 												ignoreCase: false,
 												want:       "\"atan\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 170, offset: 107971},
+												pos:        position{line: 3624, col: 170, offset: 111542},
 												val:        "cosh",
 												ignoreCase: false,
 												want:       "\"cosh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 179, offset: 107980},
+												pos:        position{line: 3624, col: 179, offset: 111551},
 												val:        "cos",
 												ignoreCase: false,
 												want:       "\"cos\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 187, offset: 107988},
+												pos:        position{line: 3624, col: 187, offset: 111559},
 												val:        "sinh",
 												ignoreCase: false,
 												want:       "\"sinh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 196, offset: 107997},
+												pos:        position{line: 3624, col: 196, offset: 111568},
 												val:        "sin",
 												ignoreCase: false,
 												want:       "\"sin\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 204, offset: 108005},
+												pos:        position{line: 3624, col: 204, offset: 111576},
 												val:        "tanh",
 												ignoreCase: false,
 												want:       "\"tanh\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3512, col: 213, offset: 108014},
+												pos:        position{line: 3624, col: 213, offset: 111585},
 												val:        "tan",
 												ignoreCase: false,
 												want:       "\"tan\"",
@@ -7969,102 +8081,102 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3512, col: 220, offset: 108021},
+									pos:  position{line: 3624, col: 220, offset: 111592},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3512, col: 228, offset: 108029},
+									pos:   position{line: 3624, col: 228, offset: 111600},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3512, col: 234, offset: 108035},
+										pos:  position{line: 3624, col: 234, offset: 111606},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3512, col: 253, offset: 108054},
+									pos:  position{line: 3624, col: 253, offset: 111625},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3532, col: 3, offset: 108566},
+						pos: position{line: 3644, col: 3, offset: 112137},
 						run: (*parser).callonNumericEvalExpr31,
 						expr: &seqExpr{
-							pos: position{line: 3532, col: 3, offset: 108566},
+							pos: position{line: 3644, col: 3, offset: 112137},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3532, col: 3, offset: 108566},
+									pos:   position{line: 3644, col: 3, offset: 112137},
 									label: "roundExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3532, col: 13, offset: 108576},
+										pos:        position{line: 3644, col: 13, offset: 112147},
 										val:        "round",
 										ignoreCase: false,
 										want:       "\"round\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3532, col: 21, offset: 108584},
+									pos:  position{line: 3644, col: 21, offset: 112155},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3532, col: 29, offset: 108592},
+									pos:   position{line: 3644, col: 29, offset: 112163},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3532, col: 35, offset: 108598},
+										pos:  position{line: 3644, col: 35, offset: 112169},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3532, col: 54, offset: 108617},
+									pos:   position{line: 3644, col: 54, offset: 112188},
 									label: "roundPrecision",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3532, col: 69, offset: 108632},
+										pos: position{line: 3644, col: 69, offset: 112203},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3532, col: 70, offset: 108633},
+											pos:  position{line: 3644, col: 70, offset: 112204},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3532, col: 89, offset: 108652},
+									pos:  position{line: 3644, col: 89, offset: 112223},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3553, col: 3, offset: 109270},
+						pos: position{line: 3665, col: 3, offset: 112841},
 						run: (*parser).callonNumericEvalExpr42,
 						expr: &seqExpr{
-							pos: position{line: 3553, col: 4, offset: 109271},
+							pos: position{line: 3665, col: 4, offset: 112842},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3553, col: 4, offset: 109271},
+									pos:   position{line: 3665, col: 4, offset: 112842},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3553, col: 12, offset: 109279},
+										pos: position{line: 3665, col: 12, offset: 112850},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3553, col: 12, offset: 109279},
+												pos:        position{line: 3665, col: 12, offset: 112850},
 												val:        "now",
 												ignoreCase: false,
 												want:       "\"now\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3553, col: 20, offset: 109287},
+												pos:        position{line: 3665, col: 20, offset: 112858},
 												val:        "pi",
 												ignoreCase: false,
 												want:       "\"pi\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3553, col: 27, offset: 109294},
+												pos:        position{line: 3665, col: 27, offset: 112865},
 												val:        "random",
 												ignoreCase: false,
 												want:       "\"random\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3553, col: 38, offset: 109305},
+												pos:        position{line: 3665, col: 38, offset: 112876},
 												val:        "time",
 												ignoreCase: false,
 												want:       "\"time\"",
@@ -8073,54 +8185,54 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3553, col: 46, offset: 109313},
+									pos:  position{line: 3665, col: 46, offset: 112884},
 									name: "L_PAREN",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3553, col: 54, offset: 109321},
+									pos:  position{line: 3665, col: 54, offset: 112892},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3566, col: 3, offset: 109607},
+						pos: position{line: 3678, col: 3, offset: 113178},
 						run: (*parser).callonNumericEvalExpr52,
 						expr: &seqExpr{
-							pos: position{line: 3566, col: 3, offset: 109607},
+							pos: position{line: 3678, col: 3, offset: 113178},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 3566, col: 3, offset: 109607},
+									pos:        position{line: 3678, col: 3, offset: 113178},
 									val:        "tonumber",
 									ignoreCase: false,
 									want:       "\"tonumber\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 14, offset: 109618},
+									pos:  position{line: 3678, col: 14, offset: 113189},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3566, col: 22, offset: 109626},
+									pos:   position{line: 3678, col: 22, offset: 113197},
 									label: "stringExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3566, col: 33, offset: 109637},
+										pos:  position{line: 3678, col: 33, offset: 113208},
 										name: "StringExpr",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3566, col: 44, offset: 109648},
+									pos:   position{line: 3678, col: 44, offset: 113219},
 									label: "baseExpr",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3566, col: 53, offset: 109657},
+										pos: position{line: 3678, col: 53, offset: 113228},
 										expr: &seqExpr{
-											pos: position{line: 3566, col: 54, offset: 109658},
+											pos: position{line: 3678, col: 54, offset: 113229},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3566, col: 54, offset: 109658},
+													pos:  position{line: 3678, col: 54, offset: 113229},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3566, col: 60, offset: 109664},
+													pos:  position{line: 3678, col: 60, offset: 113235},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8128,38 +8240,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3566, col: 80, offset: 109684},
+									pos:  position{line: 3678, col: 80, offset: 113255},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3594, col: 3, offset: 110527},
+						pos: position{line: 3706, col: 3, offset: 114098},
 						run: (*parser).callonNumericEvalExpr64,
 						expr: &seqExpr{
-							pos: position{line: 3594, col: 4, offset: 110528},
+							pos: position{line: 3706, col: 4, offset: 114099},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3594, col: 4, offset: 110528},
+									pos:   position{line: 3706, col: 4, offset: 114099},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3594, col: 12, offset: 110536},
+										pos: position{line: 3706, col: 12, offset: 114107},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3594, col: 12, offset: 110536},
+												pos:        position{line: 3706, col: 12, offset: 114107},
 												val:        "bit_and",
 												ignoreCase: false,
 												want:       "\"bit_and\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3594, col: 24, offset: 110548},
+												pos:        position{line: 3706, col: 24, offset: 114119},
 												val:        "bit_or",
 												ignoreCase: false,
 												want:       "\"bit_or\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3594, col: 35, offset: 110559},
+												pos:        position{line: 3706, col: 35, offset: 114130},
 												val:        "bit_xor",
 												ignoreCase: false,
 												want:       "\"bit_xor\"",
@@ -8168,43 +8280,43 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3594, col: 46, offset: 110570},
+									pos:  position{line: 3706, col: 46, offset: 114141},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3594, col: 54, offset: 110578},
+									pos:   position{line: 3706, col: 54, offset: 114149},
 									label: "firstArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3594, col: 63, offset: 110587},
+										pos:  position{line: 3706, col: 63, offset: 114158},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3594, col: 81, offset: 110605},
+									pos:  position{line: 3706, col: 81, offset: 114176},
 									name: "COMMA",
 								},
 								&labeledExpr{
-									pos:   position{line: 3594, col: 87, offset: 110611},
+									pos:   position{line: 3706, col: 87, offset: 114182},
 									label: "secondArg",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3594, col: 97, offset: 110621},
+										pos:  position{line: 3706, col: 97, offset: 114192},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3594, col: 115, offset: 110639},
+									pos:   position{line: 3706, col: 115, offset: 114210},
 									label: "rest",
 									expr: &zeroOrMoreExpr{
-										pos: position{line: 3594, col: 120, offset: 110644},
+										pos: position{line: 3706, col: 120, offset: 114215},
 										expr: &seqExpr{
-											pos: position{line: 3594, col: 121, offset: 110645},
+											pos: position{line: 3706, col: 121, offset: 114216},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3594, col: 121, offset: 110645},
+													pos:  position{line: 3706, col: 121, offset: 114216},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3594, col: 127, offset: 110651},
+													pos:  position{line: 3706, col: 127, offset: 114222},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8212,38 +8324,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3594, col: 147, offset: 110671},
+									pos:  position{line: 3706, col: 147, offset: 114242},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3630, col: 3, offset: 111768},
+						pos: position{line: 3742, col: 3, offset: 115339},
 						run: (*parser).callonNumericEvalExpr83,
 						expr: &seqExpr{
-							pos: position{line: 3630, col: 4, offset: 111769},
+							pos: position{line: 3742, col: 4, offset: 115340},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3630, col: 4, offset: 111769},
+									pos:   position{line: 3742, col: 4, offset: 115340},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3630, col: 12, offset: 111777},
+										pos: position{line: 3742, col: 12, offset: 115348},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3630, col: 12, offset: 111777},
+												pos:        position{line: 3742, col: 12, offset: 115348},
 												val:        "bit_not",
 												ignoreCase: false,
 												want:       "\"bit_not\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3630, col: 24, offset: 111789},
+												pos:        position{line: 3742, col: 24, offset: 115360},
 												val:        "bit_shift_left",
 												ignoreCase: false,
 												want:       "\"bit_shift_left\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3630, col: 43, offset: 111808},
+												pos:        position{line: 3742, col: 43, offset: 115379},
 												val:        "bit_shift_right",
 												ignoreCase: false,
 												want:       "\"bit_shift_right\"",
@@ -8252,31 +8364,31 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3630, col: 62, offset: 111827},
+									pos:  position{line: 3742, col: 62, offset: 115398},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3630, col: 70, offset: 111835},
+									pos:   position{line: 3742, col: 70, offset: 115406},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3630, col: 75, offset: 111840},
+										pos:  position{line: 3742, col: 75, offset: 115411},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3630, col: 93, offset: 111858},
+									pos:   position{line: 3742, col: 93, offset: 115429},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3630, col: 99, offset: 111864},
+										pos: position{line: 3742, col: 99, offset: 115435},
 										expr: &seqExpr{
-											pos: position{line: 3630, col: 100, offset: 111865},
+											pos: position{line: 3742, col: 100, offset: 115436},
 											exprs: []any{
 												&ruleRefExpr{
-													pos:  position{line: 3630, col: 100, offset: 111865},
+													pos:  position{line: 3742, col: 100, offset: 115436},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 3630, col: 106, offset: 111871},
+													pos:  position{line: 3742, col: 106, offset: 115442},
 													name: "NumericExprLevel3",
 												},
 											},
@@ -8284,73 +8396,73 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3630, col: 126, offset: 111891},
+									pos:  position{line: 3742, col: 126, offset: 115462},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3657, col: 3, offset: 112815},
+						pos: position{line: 3769, col: 3, offset: 116386},
 						run: (*parser).callonNumericEvalExpr99,
 						expr: &seqExpr{
-							pos: position{line: 3657, col: 3, offset: 112815},
+							pos: position{line: 3769, col: 3, offset: 116386},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3657, col: 3, offset: 112815},
+									pos:   position{line: 3769, col: 3, offset: 116386},
 									label: "lenExpr",
 									expr: &litMatcher{
-										pos:        position{line: 3657, col: 12, offset: 112824},
+										pos:        position{line: 3769, col: 12, offset: 116395},
 										val:        "len",
 										ignoreCase: false,
 										want:       "\"len\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3657, col: 18, offset: 112830},
+									pos:  position{line: 3769, col: 18, offset: 116401},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3657, col: 26, offset: 112838},
+									pos:   position{line: 3769, col: 26, offset: 116409},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3657, col: 31, offset: 112843},
+										pos:  position{line: 3769, col: 31, offset: 116414},
 										name: "LenExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3657, col: 39, offset: 112851},
+									pos:  position{line: 3769, col: 39, offset: 116422},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3660, col: 3, offset: 112886},
+						pos: position{line: 3772, col: 3, offset: 116457},
 						run: (*parser).callonNumericEvalExpr107,
 						expr: &seqExpr{
-							pos: position{line: 3660, col: 4, offset: 112887},
+							pos: position{line: 3772, col: 4, offset: 116458},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3660, col: 4, offset: 112887},
+									pos:   position{line: 3772, col: 4, offset: 116458},
 									label: "opName",
 									expr: &choiceExpr{
-										pos: position{line: 3660, col: 12, offset: 112895},
+										pos: position{line: 3772, col: 12, offset: 116466},
 										alternatives: []any{
 											&litMatcher{
-												pos:        position{line: 3660, col: 12, offset: 112895},
+												pos:        position{line: 3772, col: 12, offset: 116466},
 												val:        "pow",
 												ignoreCase: false,
 												want:       "\"pow\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3660, col: 20, offset: 112903},
+												pos:        position{line: 3772, col: 20, offset: 116474},
 												val:        "atan2",
 												ignoreCase: false,
 												want:       "\"atan2\"",
 											},
 											&litMatcher{
-												pos:        position{line: 3660, col: 30, offset: 112913},
+												pos:        position{line: 3772, col: 30, offset: 116484},
 												val:        "hypot",
 												ignoreCase: false,
 												want:       "\"hypot\"",
@@ -8359,128 +8471,128 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3660, col: 39, offset: 112922},
+									pos:  position{line: 3772, col: 39, offset: 116493},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3660, col: 47, offset: 112930},
+									pos:   position{line: 3772, col: 47, offset: 116501},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3660, col: 53, offset: 112936},
+										pos:  position{line: 3772, col: 53, offset: 116507},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3660, col: 72, offset: 112955},
+									pos:   position{line: 3772, col: 72, offset: 116526},
 									label: "param",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3660, col: 79, offset: 112962},
+										pos:  position{line: 3772, col: 79, offset: 116533},
 										name: "NumericParamExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3660, col: 97, offset: 112980},
+									pos:  position{line: 3772, col: 97, offset: 116551},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3690, col: 3, offset: 113819},
+						pos: position{line: 3802, col: 3, offset: 117390},
 						run: (*parser).callonNumericEvalExpr120,
 						expr: &seqExpr{
-							pos: position{line: 3690, col: 4, offset: 113820},
+							pos: position{line: 3802, col: 4, offset: 117391},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3690, col: 4, offset: 113820},
+									pos:   position{line: 3802, col: 4, offset: 117391},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3690, col: 11, offset: 113827},
+										pos:        position{line: 3802, col: 11, offset: 117398},
 										val:        "log",
 										ignoreCase: false,
 										want:       "\"log\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3690, col: 17, offset: 113833},
+									pos:  position{line: 3802, col: 17, offset: 117404},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3690, col: 25, offset: 113841},
+									pos:   position{line: 3802, col: 25, offset: 117412},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3690, col: 31, offset: 113847},
+										pos:  position{line: 3802, col: 31, offset: 117418},
 										name: "NumericExprLevel3",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 3690, col: 50, offset: 113866},
+									pos:   position{line: 3802, col: 50, offset: 117437},
 									label: "param",
 									expr: &zeroOrOneExpr{
-										pos: position{line: 3690, col: 56, offset: 113872},
+										pos: position{line: 3802, col: 56, offset: 117443},
 										expr: &ruleRefExpr{
-											pos:  position{line: 3690, col: 57, offset: 113873},
+											pos:  position{line: 3802, col: 57, offset: 117444},
 											name: "NumericParamExpr",
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3690, col: 76, offset: 113892},
+									pos:  position{line: 3802, col: 76, offset: 117463},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3719, col: 3, offset: 114665},
+						pos: position{line: 3831, col: 3, offset: 118236},
 						run: (*parser).callonNumericEvalExpr131,
 						expr: &seqExpr{
-							pos: position{line: 3719, col: 3, offset: 114665},
+							pos: position{line: 3831, col: 3, offset: 118236},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3719, col: 3, offset: 114665},
+									pos:   position{line: 3831, col: 3, offset: 118236},
 									label: "opName",
 									expr: &litMatcher{
-										pos:        position{line: 3719, col: 11, offset: 114673},
+										pos:        position{line: 3831, col: 11, offset: 118244},
 										val:        "relative_time",
 										ignoreCase: false,
 										want:       "\"relative_time\"",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 28, offset: 114690},
+									pos:  position{line: 3831, col: 28, offset: 118261},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 3719, col: 36, offset: 114698},
+									pos:   position{line: 3831, col: 36, offset: 118269},
 									label: "expr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3719, col: 42, offset: 114704},
+										pos:  position{line: 3831, col: 42, offset: 118275},
 										name: "NumericExprLevel3",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 61, offset: 114723},
+									pos:  position{line: 3831, col: 61, offset: 118294},
 									name: "COMMA",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 67, offset: 114729},
+									pos:  position{line: 3831, col: 67, offset: 118300},
 									name: "QUOTE",
 								},
 								&labeledExpr{
-									pos:   position{line: 3719, col: 73, offset: 114735},
+									pos:   position{line: 3831, col: 73, offset: 118306},
 									label: "specifier",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3719, col: 84, offset: 114746},
+										pos:  position{line: 3831, col: 84, offset: 118317},
 										name: "RelativeTimeCommandTimestampFormat",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 120, offset: 114782},
+									pos:  position{line: 3831, col: 120, offset: 118353},
 									name: "QUOTE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 3719, col: 126, offset: 114788},
+									pos:  position{line: 3831, col: 126, offset: 118359},
 									name: "R_PAREN",
 								},
 							},
@@ -8491,103 +8603,103 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExprLevel1",
-			pos:  position{line: 3736, col: 1, offset: 115318},
+			pos:  position{line: 3848, col: 1, offset: 118889},
 			expr: &choiceExpr{
-				pos: position{line: 3736, col: 19, offset: 115336},
+				pos: position{line: 3848, col: 19, offset: 118907},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3736, col: 19, offset: 115336},
+						pos: position{line: 3848, col: 19, offset: 118907},
 						run: (*parser).callonJsonExprLevel12,
 						expr: &labeledExpr{
-							pos:   position{line: 3736, col: 19, offset: 115336},
+							pos:   position{line: 3848, col: 19, offset: 118907},
 							label: "jsonExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3736, col: 28, offset: 115345},
+								pos:  position{line: 3848, col: 28, offset: 118916},
 								name: "JsonExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3739, col: 3, offset: 115385},
+						pos: position{line: 3851, col: 3, offset: 118956},
 						run: (*parser).callonJsonExprLevel15,
 						expr: &labeledExpr{
-							pos:   position{line: 3739, col: 3, offset: 115385},
+							pos:   position{line: 3851, col: 3, offset: 118956},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3739, col: 9, offset: 115391},
+								pos:  position{line: 3851, col: 9, offset: 118962},
 								name: "EvalFieldToRead",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3753, col: 3, offset: 115737},
+						pos: position{line: 3865, col: 3, offset: 119308},
 						run: (*parser).callonJsonExprLevel18,
 						expr: &labeledExpr{
-							pos:   position{line: 3753, col: 3, offset: 115737},
+							pos:   position{line: 3865, col: 3, offset: 119308},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3753, col: 9, offset: 115743},
+								pos:  position{line: 3865, col: 9, offset: 119314},
 								name: "NumericEvalExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3767, col: 3, offset: 116107},
+						pos: position{line: 3879, col: 3, offset: 119678},
 						run: (*parser).callonJsonExprLevel111,
 						expr: &labeledExpr{
-							pos:   position{line: 3767, col: 3, offset: 116107},
+							pos:   position{line: 3879, col: 3, offset: 119678},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3767, col: 9, offset: 116113},
+								pos:  position{line: 3879, col: 9, offset: 119684},
 								name: "NumericExprLevel3",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3781, col: 3, offset: 116479},
+						pos: position{line: 3893, col: 3, offset: 120050},
 						run: (*parser).callonJsonExprLevel114,
 						expr: &labeledExpr{
-							pos:   position{line: 3781, col: 3, offset: 116479},
+							pos:   position{line: 3893, col: 3, offset: 120050},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3781, col: 9, offset: 116485},
+								pos:  position{line: 3893, col: 9, offset: 120056},
 								name: "MultiValueExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3795, col: 3, offset: 116862},
+						pos: position{line: 3907, col: 3, offset: 120433},
 						run: (*parser).callonJsonExprLevel117,
 						expr: &labeledExpr{
-							pos:   position{line: 3795, col: 3, offset: 116862},
+							pos:   position{line: 3907, col: 3, offset: 120433},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3795, col: 9, offset: 116868},
+								pos:  position{line: 3907, col: 9, offset: 120439},
 								name: "BoolExpr",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3809, col: 3, offset: 117223},
+						pos: position{line: 3921, col: 3, offset: 120794},
 						run: (*parser).callonJsonExprLevel120,
 						expr: &labeledExpr{
-							pos:   position{line: 3809, col: 3, offset: 117223},
+							pos:   position{line: 3921, col: 3, offset: 120794},
 							label: "value",
 							expr: &seqExpr{
-								pos: position{line: 3809, col: 10, offset: 117230},
+								pos: position{line: 3921, col: 10, offset: 120801},
 								exprs: []any{
 									&litMatcher{
-										pos:        position{line: 3809, col: 10, offset: 117230},
+										pos:        position{line: 3921, col: 10, offset: 120801},
 										val:        "null",
 										ignoreCase: false,
 										want:       "\"null\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3809, col: 17, offset: 117237},
+										pos:  position{line: 3921, col: 17, offset: 120808},
 										name: "L_PAREN",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 3809, col: 25, offset: 117245},
+										pos:  position{line: 3921, col: 25, offset: 120816},
 										name: "R_PAREN",
 									},
 								},
@@ -8595,13 +8707,13 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3819, col: 3, offset: 117440},
+						pos: position{line: 3931, col: 3, offset: 121011},
 						run: (*parser).callonJsonExprLevel126,
 						expr: &labeledExpr{
-							pos:   position{line: 3819, col: 3, offset: 117440},
+							pos:   position{line: 3931, col: 3, offset: 121011},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3819, col: 9, offset: 117446},
+								pos:  position{line: 3931, col: 9, offset: 121017},
 								name: "StringExpr",
 							},
 						},
@@ -8611,74 +8723,201 @@ var g = &grammar{
 		},
 		{
 			name: "JsonExpr",
-			pos:  position{line: 3834, col: 1, offset: 117809},
-			expr: &actionExpr{
-				pos: position{line: 3834, col: 13, offset: 117821},
-				run: (*parser).callonJsonExpr1,
-				expr: &seqExpr{
-					pos: position{line: 3834, col: 13, offset: 117821},
-					exprs: []any{
-						&litMatcher{
-							pos:        position{line: 3834, col: 13, offset: 117821},
-							val:        "json_object",
-							ignoreCase: false,
-							want:       "\"json_object\"",
-						},
-						&ruleRefExpr{
-							pos:  position{line: 3834, col: 27, offset: 117835},
-							name: "L_PAREN",
-						},
-						&labeledExpr{
-							pos:   position{line: 3834, col: 35, offset: 117843},
-							label: "firstKey",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3834, col: 45, offset: 117853},
-								name: "JsonExprLevel1",
-							},
-						},
-						&ruleRefExpr{
-							pos:  position{line: 3834, col: 61, offset: 117869},
-							name: "COMMA",
-						},
-						&labeledExpr{
-							pos:   position{line: 3834, col: 67, offset: 117875},
-							label: "firstValue",
-							expr: &ruleRefExpr{
-								pos:  position{line: 3834, col: 79, offset: 117887},
-								name: "JsonExprLevel1",
-							},
-						},
-						&labeledExpr{
-							pos:   position{line: 3834, col: 95, offset: 117903},
-							label: "rest",
-							expr: &zeroOrMoreExpr{
-								pos: position{line: 3834, col: 100, offset: 117908},
-								expr: &seqExpr{
-									pos: position{line: 3834, col: 101, offset: 117909},
-									exprs: []any{
-										&ruleRefExpr{
-											pos:  position{line: 3834, col: 101, offset: 117909},
-											name: "COMMA",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 3834, col: 107, offset: 117915},
-											name: "JsonExprLevel1",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 3834, col: 122, offset: 117930},
-											name: "COMMA",
-										},
-										&ruleRefExpr{
-											pos:  position{line: 3834, col: 128, offset: 117936},
-											name: "JsonExprLevel1",
+			pos:  position{line: 3946, col: 1, offset: 121380},
+			expr: &choiceExpr{
+				pos: position{line: 3946, col: 13, offset: 121392},
+				alternatives: []any{
+					&actionExpr{
+						pos: position{line: 3946, col: 13, offset: 121392},
+						run: (*parser).callonJsonExpr2,
+						expr: &seqExpr{
+							pos: position{line: 3946, col: 13, offset: 121392},
+							exprs: []any{
+								&litMatcher{
+									pos:        position{line: 3946, col: 13, offset: 121392},
+									val:        "json_object",
+									ignoreCase: false,
+									want:       "\"json_object\"",
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3946, col: 27, offset: 121406},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 3946, col: 35, offset: 121414},
+									label: "firstKey",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3946, col: 45, offset: 121424},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3946, col: 61, offset: 121440},
+									name: "COMMA",
+								},
+								&labeledExpr{
+									pos:   position{line: 3946, col: 67, offset: 121446},
+									label: "firstValue",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3946, col: 79, offset: 121458},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 3946, col: 95, offset: 121474},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 3946, col: 100, offset: 121479},
+										expr: &seqExpr{
+											pos: position{line: 3946, col: 101, offset: 121480},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 3946, col: 101, offset: 121480},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3946, col: 107, offset: 121486},
+													name: "JsonExprLevel1",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3946, col: 122, offset: 121501},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3946, col: 128, offset: 121507},
+													name: "JsonExprLevel1",
+												},
+											},
 										},
 									},
 								},
+								&ruleRefExpr{
+									pos:  position{line: 3946, col: 145, offset: 121524},
+									name: "R_PAREN",
+								},
 							},
 						},
-						&ruleRefExpr{
-							pos:  position{line: 3834, col: 145, offset: 117953},
-							name: "R_PAREN",
+					},
+					&actionExpr{
+						pos: position{line: 3954, col: 3, offset: 121704},
+						run: (*parser).callonJsonExpr19,
+						expr: &seqExpr{
+							pos: position{line: 3954, col: 3, offset: 121704},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 3954, col: 3, offset: 121704},
+									label: "opName",
+									expr: &litMatcher{
+										pos:        position{line: 3954, col: 10, offset: 121711},
+										val:        "json",
+										ignoreCase: false,
+										want:       "\"json\"",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3954, col: 17, offset: 121718},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 3954, col: 25, offset: 121726},
+									label: "value",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3954, col: 31, offset: 121732},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3954, col: 46, offset: 121747},
+									name: "R_PAREN",
+								},
+							},
+						},
+					},
+					&actionExpr{
+						pos: position{line: 3972, col: 3, offset: 122236},
+						run: (*parser).callonJsonExpr27,
+						expr: &seqExpr{
+							pos: position{line: 3972, col: 3, offset: 122236},
+							exprs: []any{
+								&labeledExpr{
+									pos:   position{line: 3972, col: 3, offset: 122236},
+									label: "opName",
+									expr: &litMatcher{
+										pos:        position{line: 3972, col: 10, offset: 122243},
+										val:        "json_append",
+										ignoreCase: false,
+										want:       "\"json_append\"",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3972, col: 24, offset: 122257},
+									name: "L_PAREN",
+								},
+								&labeledExpr{
+									pos:   position{line: 3972, col: 32, offset: 122265},
+									label: "json",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3972, col: 37, offset: 122270},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3972, col: 52, offset: 122285},
+									name: "COMMA",
+								},
+								&labeledExpr{
+									pos:   position{line: 3972, col: 58, offset: 122291},
+									label: "path",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3972, col: 63, offset: 122296},
+										name: "JsonExprLevel1",
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3972, col: 78, offset: 122311},
+									name: "COMMA",
+								},
+								&labeledExpr{
+									pos:   position{line: 3972, col: 84, offset: 122317},
+									label: "value",
+									expr: &ruleRefExpr{
+										pos:  position{line: 3972, col: 90, offset: 122323},
+										name: "JsonExprLevel1",
+									},
+								},
+								&labeledExpr{
+									pos:   position{line: 3972, col: 105, offset: 122338},
+									label: "rest",
+									expr: &zeroOrMoreExpr{
+										pos: position{line: 3972, col: 110, offset: 122343},
+										expr: &seqExpr{
+											pos: position{line: 3972, col: 111, offset: 122344},
+											exprs: []any{
+												&ruleRefExpr{
+													pos:  position{line: 3972, col: 111, offset: 122344},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3972, col: 117, offset: 122350},
+													name: "JsonExprLevel1",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3972, col: 132, offset: 122365},
+													name: "COMMA",
+												},
+												&ruleRefExpr{
+													pos:  position{line: 3972, col: 138, offset: 122371},
+													name: "JsonExprLevel1",
+												},
+											},
+										},
+									},
+								},
+								&ruleRefExpr{
+									pos:  position{line: 3972, col: 155, offset: 122388},
+									name: "R_PAREN",
+								},
+							},
 						},
 					},
 				},
@@ -8686,28 +8925,28 @@ var g = &grammar{
 		},
 		{
 			name: "LenExpr",
-			pos:  position{line: 3927, col: 1, offset: 120957},
+			pos:  position{line: 4001, col: 1, offset: 123476},
 			expr: &choiceExpr{
-				pos: position{line: 3927, col: 12, offset: 120968},
+				pos: position{line: 4001, col: 12, offset: 123487},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 3927, col: 12, offset: 120968},
+						pos: position{line: 4001, col: 12, offset: 123487},
 						run: (*parser).callonLenExpr2,
 						expr: &seqExpr{
-							pos: position{line: 3927, col: 12, offset: 120968},
+							pos: position{line: 4001, col: 12, offset: 123487},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3927, col: 12, offset: 120968},
+									pos:   position{line: 4001, col: 12, offset: 123487},
 									label: "str",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3927, col: 16, offset: 120972},
+										pos:  position{line: 4001, col: 16, offset: 123491},
 										name: "QuotedString",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3927, col: 29, offset: 120985},
+									pos: position{line: 4001, col: 29, offset: 123504},
 									expr: &ruleRefExpr{
-										pos:  position{line: 3927, col: 31, offset: 120987},
+										pos:  position{line: 4001, col: 31, offset: 123506},
 										name: "EVAL_CONCAT",
 									},
 								},
@@ -8715,50 +8954,50 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 3943, col: 3, offset: 121362},
+						pos: position{line: 4017, col: 3, offset: 123881},
 						run: (*parser).callonLenExpr8,
 						expr: &seqExpr{
-							pos: position{line: 3943, col: 3, offset: 121362},
+							pos: position{line: 4017, col: 3, offset: 123881},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 3943, col: 3, offset: 121362},
+									pos:   position{line: 4017, col: 3, offset: 123881},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 3943, col: 9, offset: 121368},
+										pos:  position{line: 4017, col: 9, offset: 123887},
 										name: "EvalFieldToRead",
 									},
 								},
 								&notExpr{
-									pos: position{line: 3943, col: 25, offset: 121384},
+									pos: position{line: 4017, col: 25, offset: 123903},
 									expr: &choiceExpr{
-										pos: position{line: 3943, col: 27, offset: 121386},
+										pos: position{line: 4017, col: 27, offset: 123905},
 										alternatives: []any{
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 27, offset: 121386},
+												pos:  position{line: 4017, col: 27, offset: 123905},
 												name: "OpPlus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 36, offset: 121395},
+												pos:  position{line: 4017, col: 36, offset: 123914},
 												name: "OpMinus",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 46, offset: 121405},
+												pos:  position{line: 4017, col: 46, offset: 123924},
 												name: "OpMul",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 54, offset: 121413},
+												pos:  position{line: 4017, col: 54, offset: 123932},
 												name: "OpDiv",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 62, offset: 121421},
+												pos:  position{line: 4017, col: 62, offset: 123940},
 												name: "OpMod",
 											},
 											&ruleRefExpr{
-												pos:  position{line: 3943, col: 70, offset: 121429},
+												pos:  position{line: 4017, col: 70, offset: 123948},
 												name: "EVAL_CONCAT",
 											},
 											&litMatcher{
-												pos:        position{line: 3943, col: 84, offset: 121443},
+												pos:        position{line: 4017, col: 84, offset: 123962},
 												val:        "(",
 												ignoreCase: false,
 												want:       "\"(\"",
@@ -8774,28 +9013,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionNull",
-			pos:  position{line: 3960, col: 1, offset: 121794},
+			pos:  position{line: 4034, col: 1, offset: 124313},
 			expr: &actionExpr{
-				pos: position{line: 3960, col: 19, offset: 121812},
+				pos: position{line: 4034, col: 19, offset: 124331},
 				run: (*parser).callonHeadOptionNull1,
 				expr: &seqExpr{
-					pos: position{line: 3960, col: 19, offset: 121812},
+					pos: position{line: 4034, col: 19, offset: 124331},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3960, col: 19, offset: 121812},
+							pos:        position{line: 4034, col: 19, offset: 124331},
 							val:        "null",
 							ignoreCase: false,
 							want:       "\"null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3960, col: 26, offset: 121819},
+							pos:  position{line: 4034, col: 26, offset: 124338},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3960, col: 32, offset: 121825},
+							pos:   position{line: 4034, col: 32, offset: 124344},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3960, col: 40, offset: 121833},
+								pos:  position{line: 4034, col: 40, offset: 124352},
 								name: "Boolean",
 							},
 						},
@@ -8805,28 +9044,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionKeeplast",
-			pos:  position{line: 3971, col: 1, offset: 122022},
+			pos:  position{line: 4045, col: 1, offset: 124541},
 			expr: &actionExpr{
-				pos: position{line: 3971, col: 23, offset: 122044},
+				pos: position{line: 4045, col: 23, offset: 124563},
 				run: (*parser).callonHeadOptionKeeplast1,
 				expr: &seqExpr{
-					pos: position{line: 3971, col: 23, offset: 122044},
+					pos: position{line: 4045, col: 23, offset: 124563},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3971, col: 23, offset: 122044},
+							pos:        position{line: 4045, col: 23, offset: 124563},
 							val:        "keeplast",
 							ignoreCase: false,
 							want:       "\"keeplast\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3971, col: 34, offset: 122055},
+							pos:  position{line: 4045, col: 34, offset: 124574},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3971, col: 40, offset: 122061},
+							pos:   position{line: 4045, col: 40, offset: 124580},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3971, col: 48, offset: 122069},
+								pos:  position{line: 4045, col: 48, offset: 124588},
 								name: "Boolean",
 							},
 						},
@@ -8836,28 +9075,28 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionLimit",
-			pos:  position{line: 3982, col: 1, offset: 122266},
+			pos:  position{line: 4056, col: 1, offset: 124785},
 			expr: &actionExpr{
-				pos: position{line: 3982, col: 20, offset: 122285},
+				pos: position{line: 4056, col: 20, offset: 124804},
 				run: (*parser).callonHeadOptionLimit1,
 				expr: &seqExpr{
-					pos: position{line: 3982, col: 20, offset: 122285},
+					pos: position{line: 4056, col: 20, offset: 124804},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 3982, col: 20, offset: 122285},
+							pos:        position{line: 4056, col: 20, offset: 124804},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 3982, col: 28, offset: 122293},
+							pos:  position{line: 4056, col: 28, offset: 124812},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 3982, col: 34, offset: 122299},
+							pos:   position{line: 4056, col: 34, offset: 124818},
 							label: "intAsStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 3982, col: 43, offset: 122308},
+								pos:  position{line: 4056, col: 43, offset: 124827},
 								name: "IntegerAsString",
 							},
 						},
@@ -8867,15 +9106,15 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionExpr",
-			pos:  position{line: 3997, col: 1, offset: 122670},
+			pos:  position{line: 4071, col: 1, offset: 125189},
 			expr: &actionExpr{
-				pos: position{line: 3997, col: 19, offset: 122688},
+				pos: position{line: 4071, col: 19, offset: 125207},
 				run: (*parser).callonHeadOptionExpr1,
 				expr: &labeledExpr{
-					pos:   position{line: 3997, col: 19, offset: 122688},
+					pos:   position{line: 4071, col: 19, offset: 125207},
 					label: "boolExpr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 3997, col: 28, offset: 122697},
+						pos:  position{line: 4071, col: 28, offset: 125216},
 						name: "BoolExpr",
 					},
 				},
@@ -8883,30 +9122,30 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOption",
-			pos:  position{line: 4008, col: 1, offset: 122909},
+			pos:  position{line: 4082, col: 1, offset: 125428},
 			expr: &actionExpr{
-				pos: position{line: 4008, col: 15, offset: 122923},
+				pos: position{line: 4082, col: 15, offset: 125442},
 				run: (*parser).callonHeadOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4008, col: 15, offset: 122923},
+					pos:   position{line: 4082, col: 15, offset: 125442},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4008, col: 23, offset: 122931},
+						pos: position{line: 4082, col: 23, offset: 125450},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4008, col: 23, offset: 122931},
+								pos:  position{line: 4082, col: 23, offset: 125450},
 								name: "HeadOptionKeeplast",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4008, col: 44, offset: 122952},
+								pos:  position{line: 4082, col: 44, offset: 125471},
 								name: "HeadOptionNull",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4008, col: 61, offset: 122969},
+								pos:  position{line: 4082, col: 61, offset: 125488},
 								name: "HeadOptionLimit",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4008, col: 79, offset: 122987},
+								pos:  position{line: 4082, col: 79, offset: 125506},
 								name: "HeadOptionExpr",
 							},
 						},
@@ -8916,35 +9155,35 @@ var g = &grammar{
 		},
 		{
 			name: "HeadOptionList",
-			pos:  position{line: 4012, col: 1, offset: 123031},
+			pos:  position{line: 4086, col: 1, offset: 125550},
 			expr: &actionExpr{
-				pos: position{line: 4012, col: 19, offset: 123049},
+				pos: position{line: 4086, col: 19, offset: 125568},
 				run: (*parser).callonHeadOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 4012, col: 19, offset: 123049},
+					pos: position{line: 4086, col: 19, offset: 125568},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4012, col: 19, offset: 123049},
+							pos:   position{line: 4086, col: 19, offset: 125568},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4012, col: 26, offset: 123056},
+								pos:  position{line: 4086, col: 26, offset: 125575},
 								name: "HeadOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4012, col: 37, offset: 123067},
+							pos:   position{line: 4086, col: 37, offset: 125586},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4012, col: 43, offset: 123073},
+								pos: position{line: 4086, col: 43, offset: 125592},
 								expr: &seqExpr{
-									pos: position{line: 4012, col: 44, offset: 123074},
+									pos: position{line: 4086, col: 44, offset: 125593},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4012, col: 44, offset: 123074},
+											pos:  position{line: 4086, col: 44, offset: 125593},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4012, col: 50, offset: 123080},
+											pos:  position{line: 4086, col: 50, offset: 125599},
 											name: "HeadOption",
 										},
 									},
@@ -8957,29 +9196,29 @@ var g = &grammar{
 		},
 		{
 			name: "HeadBlock",
-			pos:  position{line: 4069, col: 1, offset: 124880},
+			pos:  position{line: 4143, col: 1, offset: 127399},
 			expr: &choiceExpr{
-				pos: position{line: 4069, col: 14, offset: 124893},
+				pos: position{line: 4143, col: 14, offset: 127412},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4069, col: 14, offset: 124893},
+						pos: position{line: 4143, col: 14, offset: 127412},
 						run: (*parser).callonHeadBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4069, col: 14, offset: 124893},
+							pos: position{line: 4143, col: 14, offset: 127412},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4069, col: 14, offset: 124893},
+									pos:  position{line: 4143, col: 14, offset: 127412},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4069, col: 19, offset: 124898},
+									pos:  position{line: 4143, col: 19, offset: 127417},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4069, col: 28, offset: 124907},
+									pos:   position{line: 4143, col: 28, offset: 127426},
 									label: "headExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4069, col: 37, offset: 124916},
+										pos:  position{line: 4143, col: 37, offset: 127435},
 										name: "HeadOptionList",
 									},
 								},
@@ -8987,24 +9226,24 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4080, col: 3, offset: 125235},
+						pos: position{line: 4154, col: 3, offset: 127754},
 						run: (*parser).callonHeadBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4080, col: 3, offset: 125235},
+							pos: position{line: 4154, col: 3, offset: 127754},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4080, col: 3, offset: 125235},
+									pos:  position{line: 4154, col: 3, offset: 127754},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4080, col: 8, offset: 125240},
+									pos:  position{line: 4154, col: 8, offset: 127759},
 									name: "CMD_HEAD",
 								},
 								&labeledExpr{
-									pos:   position{line: 4080, col: 17, offset: 125249},
+									pos:   position{line: 4154, col: 17, offset: 127768},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4080, col: 26, offset: 125258},
+										pos:  position{line: 4154, col: 26, offset: 127777},
 										name: "IntegerAsString",
 									},
 								},
@@ -9012,17 +9251,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4100, col: 3, offset: 125775},
+						pos: position{line: 4174, col: 3, offset: 128294},
 						run: (*parser).callonHeadBlock14,
 						expr: &seqExpr{
-							pos: position{line: 4100, col: 3, offset: 125775},
+							pos: position{line: 4174, col: 3, offset: 128294},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4100, col: 3, offset: 125775},
+									pos:  position{line: 4174, col: 3, offset: 128294},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4100, col: 8, offset: 125780},
+									pos:  position{line: 4174, col: 8, offset: 128299},
 									name: "CMD_HEAD_NO_SPACE",
 								},
 							},
@@ -9033,29 +9272,29 @@ var g = &grammar{
 		},
 		{
 			name: "TailBlock",
-			pos:  position{line: 4118, col: 1, offset: 126250},
+			pos:  position{line: 4192, col: 1, offset: 128769},
 			expr: &choiceExpr{
-				pos: position{line: 4118, col: 14, offset: 126263},
+				pos: position{line: 4192, col: 14, offset: 128782},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4118, col: 14, offset: 126263},
+						pos: position{line: 4192, col: 14, offset: 128782},
 						run: (*parser).callonTailBlock2,
 						expr: &seqExpr{
-							pos: position{line: 4118, col: 14, offset: 126263},
+							pos: position{line: 4192, col: 14, offset: 128782},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4118, col: 14, offset: 126263},
+									pos:  position{line: 4192, col: 14, offset: 128782},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4118, col: 19, offset: 126268},
+									pos:  position{line: 4192, col: 19, offset: 128787},
 									name: "CMD_TAIL",
 								},
 								&labeledExpr{
-									pos:   position{line: 4118, col: 28, offset: 126277},
+									pos:   position{line: 4192, col: 28, offset: 128796},
 									label: "intAsStr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4118, col: 37, offset: 126286},
+										pos:  position{line: 4192, col: 37, offset: 128805},
 										name: "IntegerAsString",
 									},
 								},
@@ -9063,17 +9302,17 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4139, col: 3, offset: 126860},
+						pos: position{line: 4213, col: 3, offset: 129379},
 						run: (*parser).callonTailBlock8,
 						expr: &seqExpr{
-							pos: position{line: 4139, col: 3, offset: 126860},
+							pos: position{line: 4213, col: 3, offset: 129379},
 							exprs: []any{
 								&ruleRefExpr{
-									pos:  position{line: 4139, col: 3, offset: 126860},
+									pos:  position{line: 4213, col: 3, offset: 129379},
 									name: "PIPE",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4139, col: 8, offset: 126865},
+									pos:  position{line: 4213, col: 8, offset: 129384},
 									name: "CMD_TAIL_NO_SPACE",
 								},
 							},
@@ -9084,44 +9323,44 @@ var g = &grammar{
 		},
 		{
 			name: "AggregationList",
-			pos:  position{line: 4160, col: 1, offset: 127483},
+			pos:  position{line: 4234, col: 1, offset: 130002},
 			expr: &actionExpr{
-				pos: position{line: 4160, col: 20, offset: 127502},
+				pos: position{line: 4234, col: 20, offset: 130021},
 				run: (*parser).callonAggregationList1,
 				expr: &seqExpr{
-					pos: position{line: 4160, col: 20, offset: 127502},
+					pos: position{line: 4234, col: 20, offset: 130021},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4160, col: 20, offset: 127502},
+							pos:   position{line: 4234, col: 20, offset: 130021},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4160, col: 26, offset: 127508},
+								pos:  position{line: 4234, col: 26, offset: 130027},
 								name: "Aggregator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4160, col: 37, offset: 127519},
+							pos:   position{line: 4234, col: 37, offset: 130038},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4160, col: 42, offset: 127524},
+								pos: position{line: 4234, col: 42, offset: 130043},
 								expr: &seqExpr{
-									pos: position{line: 4160, col: 43, offset: 127525},
+									pos: position{line: 4234, col: 43, offset: 130044},
 									exprs: []any{
 										&choiceExpr{
-											pos: position{line: 4160, col: 44, offset: 127526},
+											pos: position{line: 4234, col: 44, offset: 130045},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4160, col: 44, offset: 127526},
+													pos:  position{line: 4234, col: 44, offset: 130045},
 													name: "COMMA",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4160, col: 52, offset: 127534},
+													pos:  position{line: 4234, col: 52, offset: 130053},
 													name: "SPACE",
 												},
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4160, col: 59, offset: 127541},
+											pos:  position{line: 4234, col: 59, offset: 130060},
 											name: "Aggregator",
 										},
 									},
@@ -9134,28 +9373,28 @@ var g = &grammar{
 		},
 		{
 			name: "Aggregator",
-			pos:  position{line: 4177, col: 1, offset: 128044},
+			pos:  position{line: 4251, col: 1, offset: 130563},
 			expr: &actionExpr{
-				pos: position{line: 4177, col: 15, offset: 128058},
+				pos: position{line: 4251, col: 15, offset: 130577},
 				run: (*parser).callonAggregator1,
 				expr: &seqExpr{
-					pos: position{line: 4177, col: 15, offset: 128058},
+					pos: position{line: 4251, col: 15, offset: 130577},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4177, col: 15, offset: 128058},
+							pos:   position{line: 4251, col: 15, offset: 130577},
 							label: "aggFunc",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4177, col: 23, offset: 128066},
+								pos:  position{line: 4251, col: 23, offset: 130585},
 								name: "AggFunction",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4177, col: 35, offset: 128078},
+							pos:   position{line: 4251, col: 35, offset: 130597},
 							label: "asField",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4177, col: 43, offset: 128086},
+								pos: position{line: 4251, col: 43, offset: 130605},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4177, col: 43, offset: 128086},
+									pos:  position{line: 4251, col: 43, offset: 130605},
 									name: "AsField",
 								},
 							},
@@ -9166,26 +9405,26 @@ var g = &grammar{
 		},
 		{
 			name: "AggFunction",
-			pos:  position{line: 4193, col: 1, offset: 128927},
+			pos:  position{line: 4267, col: 1, offset: 131446},
 			expr: &actionExpr{
-				pos: position{line: 4193, col: 16, offset: 128942},
+				pos: position{line: 4267, col: 16, offset: 131461},
 				run: (*parser).callonAggFunction1,
 				expr: &labeledExpr{
-					pos:   position{line: 4193, col: 16, offset: 128942},
+					pos:   position{line: 4267, col: 16, offset: 131461},
 					label: "agg",
 					expr: &choiceExpr{
-						pos: position{line: 4193, col: 21, offset: 128947},
+						pos: position{line: 4267, col: 21, offset: 131466},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4193, col: 21, offset: 128947},
+								pos:  position{line: 4267, col: 21, offset: 131466},
 								name: "AggCount",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4193, col: 32, offset: 128958},
+								pos:  position{line: 4267, col: 32, offset: 131477},
 								name: "AggPercCommon",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4193, col: 48, offset: 128974},
+								pos:  position{line: 4267, col: 48, offset: 131493},
 								name: "AggCommon",
 							},
 						},
@@ -9195,165 +9434,165 @@ var g = &grammar{
 		},
 		{
 			name: "CommonAggName",
-			pos:  position{line: 4198, col: 1, offset: 129142},
+			pos:  position{line: 4272, col: 1, offset: 131661},
 			expr: &actionExpr{
-				pos: position{line: 4198, col: 18, offset: 129159},
+				pos: position{line: 4272, col: 18, offset: 131678},
 				run: (*parser).callonCommonAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4198, col: 19, offset: 129160},
+					pos: position{line: 4272, col: 19, offset: 131679},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4198, col: 19, offset: 129160},
+							pos:        position{line: 4272, col: 19, offset: 131679},
 							val:        "values",
 							ignoreCase: false,
 							want:       "\"values\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 30, offset: 129171},
+							pos:        position{line: 4272, col: 30, offset: 131690},
 							val:        "varp",
 							ignoreCase: false,
 							want:       "\"varp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 39, offset: 129180},
+							pos:        position{line: 4272, col: 39, offset: 131699},
 							val:        "var",
 							ignoreCase: false,
 							want:       "\"var\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 47, offset: 129188},
+							pos:        position{line: 4272, col: 47, offset: 131707},
 							val:        "sumsq",
 							ignoreCase: false,
 							want:       "\"sumsq\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 57, offset: 129198},
+							pos:        position{line: 4272, col: 57, offset: 131717},
 							val:        "sum",
 							ignoreCase: false,
 							want:       "\"sum\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 65, offset: 129206},
+							pos:        position{line: 4272, col: 65, offset: 131725},
 							val:        "stdevp",
 							ignoreCase: false,
 							want:       "\"stdevp\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 76, offset: 129217},
+							pos:        position{line: 4272, col: 76, offset: 131736},
 							val:        "stdev",
 							ignoreCase: false,
 							want:       "\"stdev\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 86, offset: 129227},
+							pos:        position{line: 4272, col: 86, offset: 131746},
 							val:        "rate",
 							ignoreCase: false,
 							want:       "\"rate\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 95, offset: 129236},
+							pos:        position{line: 4272, col: 95, offset: 131755},
 							val:        "range",
 							ignoreCase: false,
 							want:       "\"range\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 105, offset: 129246},
+							pos:        position{line: 4272, col: 105, offset: 131765},
 							val:        "mode",
 							ignoreCase: false,
 							want:       "\"mode\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 114, offset: 129255},
+							pos:        position{line: 4272, col: 114, offset: 131774},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 122, offset: 129263},
+							pos:        position{line: 4272, col: 122, offset: 131782},
 							val:        "median",
 							ignoreCase: false,
 							want:       "\"median\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 133, offset: 129274},
+							pos:        position{line: 4272, col: 133, offset: 131793},
 							val:        "mean",
 							ignoreCase: false,
 							want:       "\"mean\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4198, col: 142, offset: 129283},
+							pos:        position{line: 4272, col: 142, offset: 131802},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 1, offset: 129292},
+							pos:        position{line: 4273, col: 1, offset: 131811},
 							val:        "list",
 							ignoreCase: false,
 							want:       "\"list\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 10, offset: 129301},
+							pos:        position{line: 4273, col: 10, offset: 131820},
 							val:        "latest_time",
 							ignoreCase: false,
 							want:       "\"latest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 26, offset: 129317},
+							pos:        position{line: 4273, col: 26, offset: 131836},
 							val:        "latest",
 							ignoreCase: false,
 							want:       "\"latest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 37, offset: 129328},
+							pos:        position{line: 4273, col: 37, offset: 131847},
 							val:        "last",
 							ignoreCase: false,
 							want:       "\"last\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 46, offset: 129337},
+							pos:        position{line: 4273, col: 46, offset: 131856},
 							val:        "first",
 							ignoreCase: false,
 							want:       "\"first\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 56, offset: 129347},
+							pos:        position{line: 4273, col: 56, offset: 131866},
 							val:        "estdc_error",
 							ignoreCase: false,
 							want:       "\"estdc_error\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 72, offset: 129363},
+							pos:        position{line: 4273, col: 72, offset: 131882},
 							val:        "estdc",
 							ignoreCase: false,
 							want:       "\"estdc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 82, offset: 129373},
+							pos:        position{line: 4273, col: 82, offset: 131892},
 							val:        "earliest_time",
 							ignoreCase: false,
 							want:       "\"earliest_time\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 100, offset: 129391},
+							pos:        position{line: 4273, col: 100, offset: 131910},
 							val:        "earliest",
 							ignoreCase: false,
 							want:       "\"earliest\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 113, offset: 129404},
+							pos:        position{line: 4273, col: 113, offset: 131923},
 							val:        "distinct_count",
 							ignoreCase: false,
 							want:       "\"distinct_count\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 132, offset: 129423},
+							pos:        position{line: 4273, col: 132, offset: 131942},
 							val:        "dc",
 							ignoreCase: false,
 							want:       "\"dc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4199, col: 139, offset: 129430},
+							pos:        position{line: 4273, col: 139, offset: 131949},
 							val:        "avg",
 							ignoreCase: false,
 							want:       "\"avg\"",
@@ -9364,33 +9603,33 @@ var g = &grammar{
 		},
 		{
 			name: "CommonPercAggName",
-			pos:  position{line: 4203, col: 1, offset: 129473},
+			pos:  position{line: 4277, col: 1, offset: 131992},
 			expr: &actionExpr{
-				pos: position{line: 4203, col: 22, offset: 129494},
+				pos: position{line: 4277, col: 22, offset: 132013},
 				run: (*parser).callonCommonPercAggName1,
 				expr: &choiceExpr{
-					pos: position{line: 4203, col: 23, offset: 129495},
+					pos: position{line: 4277, col: 23, offset: 132014},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4203, col: 23, offset: 129495},
+							pos:        position{line: 4277, col: 23, offset: 132014},
 							val:        "upperperc",
 							ignoreCase: false,
 							want:       "\"upperperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4203, col: 37, offset: 129509},
+							pos:        position{line: 4277, col: 37, offset: 132028},
 							val:        "exactperc",
 							ignoreCase: false,
 							want:       "\"exactperc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4203, col: 51, offset: 129523},
+							pos:        position{line: 4277, col: 51, offset: 132042},
 							val:        "perc",
 							ignoreCase: false,
 							want:       "\"perc\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4203, col: 60, offset: 129532},
+							pos:        position{line: 4277, col: 60, offset: 132051},
 							val:        "p",
 							ignoreCase: false,
 							want:       "\"p\"",
@@ -9401,29 +9640,29 @@ var g = &grammar{
 		},
 		{
 			name: "AsField",
-			pos:  position{line: 4207, col: 1, offset: 129573},
+			pos:  position{line: 4281, col: 1, offset: 132092},
 			expr: &actionExpr{
-				pos: position{line: 4207, col: 12, offset: 129584},
+				pos: position{line: 4281, col: 12, offset: 132103},
 				run: (*parser).callonAsField1,
 				expr: &seqExpr{
-					pos: position{line: 4207, col: 12, offset: 129584},
+					pos: position{line: 4281, col: 12, offset: 132103},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4207, col: 12, offset: 129584},
+							pos:  position{line: 4281, col: 12, offset: 132103},
 							name: "AS",
 						},
 						&labeledExpr{
-							pos:   position{line: 4207, col: 15, offset: 129587},
+							pos:   position{line: 4281, col: 15, offset: 132106},
 							label: "field",
 							expr: &choiceExpr{
-								pos: position{line: 4207, col: 23, offset: 129595},
+								pos: position{line: 4281, col: 23, offset: 132114},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4207, col: 23, offset: 129595},
+										pos:  position{line: 4281, col: 23, offset: 132114},
 										name: "FieldName",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4207, col: 35, offset: 129607},
+										pos:  position{line: 4281, col: 35, offset: 132126},
 										name: "String",
 									},
 								},
@@ -9435,27 +9674,27 @@ var g = &grammar{
 		},
 		{
 			name: "AggCount",
-			pos:  position{line: 4221, col: 1, offset: 129936},
+			pos:  position{line: 4295, col: 1, offset: 132455},
 			expr: &choiceExpr{
-				pos: position{line: 4221, col: 13, offset: 129948},
+				pos: position{line: 4295, col: 13, offset: 132467},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4221, col: 13, offset: 129948},
+						pos: position{line: 4295, col: 13, offset: 132467},
 						run: (*parser).callonAggCount2,
 						expr: &seqExpr{
-							pos: position{line: 4221, col: 13, offset: 129948},
+							pos: position{line: 4295, col: 13, offset: 132467},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4221, col: 14, offset: 129949},
+									pos: position{line: 4295, col: 14, offset: 132468},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4221, col: 14, offset: 129949},
+											pos:        position{line: 4295, col: 14, offset: 132468},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4221, col: 24, offset: 129959},
+											pos:        position{line: 4295, col: 24, offset: 132478},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9463,47 +9702,47 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4221, col: 29, offset: 129964},
+									pos:  position{line: 4295, col: 29, offset: 132483},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4221, col: 37, offset: 129972},
+									pos:        position{line: 4295, col: 37, offset: 132491},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4221, col: 44, offset: 129979},
+									pos:   position{line: 4295, col: 44, offset: 132498},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4221, col: 54, offset: 129989},
+										pos:  position{line: 4295, col: 54, offset: 132508},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4221, col: 64, offset: 129999},
+									pos:  position{line: 4295, col: 64, offset: 132518},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4231, col: 3, offset: 130228},
+						pos: position{line: 4305, col: 3, offset: 132747},
 						run: (*parser).callonAggCount12,
 						expr: &seqExpr{
-							pos: position{line: 4231, col: 3, offset: 130228},
+							pos: position{line: 4305, col: 3, offset: 132747},
 							exprs: []any{
 								&choiceExpr{
-									pos: position{line: 4231, col: 4, offset: 130229},
+									pos: position{line: 4305, col: 4, offset: 132748},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4231, col: 4, offset: 130229},
+											pos:        position{line: 4305, col: 4, offset: 132748},
 											val:        "count",
 											ignoreCase: false,
 											want:       "\"count\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4231, col: 14, offset: 130239},
+											pos:        position{line: 4305, col: 14, offset: 132758},
 											val:        "c",
 											ignoreCase: false,
 											want:       "\"c\"",
@@ -9511,38 +9750,38 @@ var g = &grammar{
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4231, col: 19, offset: 130244},
+									pos:  position{line: 4305, col: 19, offset: 132763},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4231, col: 27, offset: 130252},
+									pos:   position{line: 4305, col: 27, offset: 132771},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4231, col: 33, offset: 130258},
+										pos:  position{line: 4305, col: 33, offset: 132777},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4231, col: 43, offset: 130268},
+									pos:  position{line: 4305, col: 43, offset: 132787},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4238, col: 5, offset: 130420},
+						pos: position{line: 4312, col: 5, offset: 132939},
 						run: (*parser).callonAggCount21,
 						expr: &choiceExpr{
-							pos: position{line: 4238, col: 6, offset: 130421},
+							pos: position{line: 4312, col: 6, offset: 132940},
 							alternatives: []any{
 								&litMatcher{
-									pos:        position{line: 4238, col: 6, offset: 130421},
+									pos:        position{line: 4312, col: 6, offset: 132940},
 									val:        "count",
 									ignoreCase: false,
 									want:       "\"count\"",
 								},
 								&litMatcher{
-									pos:        position{line: 4238, col: 16, offset: 130431},
+									pos:        position{line: 4312, col: 16, offset: 132950},
 									val:        "c",
 									ignoreCase: false,
 									want:       "\"c\"",
@@ -9555,77 +9794,77 @@ var g = &grammar{
 		},
 		{
 			name: "AggCommon",
-			pos:  position{line: 4247, col: 1, offset: 130568},
+			pos:  position{line: 4321, col: 1, offset: 133087},
 			expr: &choiceExpr{
-				pos: position{line: 4247, col: 14, offset: 130581},
+				pos: position{line: 4321, col: 14, offset: 133100},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4247, col: 14, offset: 130581},
+						pos: position{line: 4321, col: 14, offset: 133100},
 						run: (*parser).callonAggCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4247, col: 14, offset: 130581},
+							pos: position{line: 4321, col: 14, offset: 133100},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4247, col: 14, offset: 130581},
+									pos:   position{line: 4321, col: 14, offset: 133100},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4247, col: 22, offset: 130589},
+										pos:  position{line: 4321, col: 22, offset: 133108},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4247, col: 36, offset: 130603},
+									pos:  position{line: 4321, col: 36, offset: 133122},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4247, col: 44, offset: 130611},
+									pos:        position{line: 4321, col: 44, offset: 133130},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4247, col: 51, offset: 130618},
+									pos:   position{line: 4321, col: 51, offset: 133137},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4247, col: 61, offset: 130628},
+										pos:  position{line: 4321, col: 61, offset: 133147},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4247, col: 71, offset: 130638},
+									pos:  position{line: 4321, col: 71, offset: 133157},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4262, col: 3, offset: 131049},
+						pos: position{line: 4336, col: 3, offset: 133568},
 						run: (*parser).callonAggCommon11,
 						expr: &seqExpr{
-							pos: position{line: 4262, col: 3, offset: 131049},
+							pos: position{line: 4336, col: 3, offset: 133568},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4262, col: 3, offset: 131049},
+									pos:   position{line: 4336, col: 3, offset: 133568},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4262, col: 11, offset: 131057},
+										pos:  position{line: 4336, col: 11, offset: 133576},
 										name: "CommonAggName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4262, col: 25, offset: 131071},
+									pos:  position{line: 4336, col: 25, offset: 133590},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4262, col: 33, offset: 131079},
+									pos:   position{line: 4336, col: 33, offset: 133598},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4262, col: 39, offset: 131085},
+										pos:  position{line: 4336, col: 39, offset: 133604},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4262, col: 49, offset: 131095},
+									pos:  position{line: 4336, col: 49, offset: 133614},
 									name: "R_PAREN",
 								},
 							},
@@ -9636,22 +9875,22 @@ var g = &grammar{
 		},
 		{
 			name: "PercentileVal",
-			pos:  position{line: 4292, col: 1, offset: 132076},
+			pos:  position{line: 4366, col: 1, offset: 134595},
 			expr: &actionExpr{
-				pos: position{line: 4292, col: 18, offset: 132093},
+				pos: position{line: 4366, col: 18, offset: 134612},
 				run: (*parser).callonPercentileVal1,
 				expr: &labeledExpr{
-					pos:   position{line: 4292, col: 18, offset: 132093},
+					pos:   position{line: 4366, col: 18, offset: 134612},
 					label: "numStr",
 					expr: &choiceExpr{
-						pos: position{line: 4292, col: 26, offset: 132101},
+						pos: position{line: 4366, col: 26, offset: 134620},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4292, col: 26, offset: 132101},
+								pos:  position{line: 4366, col: 26, offset: 134620},
 								name: "FloatAsString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4292, col: 42, offset: 132117},
+								pos:  position{line: 4366, col: 42, offset: 134636},
 								name: "IntegerAsString",
 							},
 						},
@@ -9661,161 +9900,161 @@ var g = &grammar{
 		},
 		{
 			name: "AggPercCommon",
-			pos:  position{line: 4304, col: 1, offset: 132484},
+			pos:  position{line: 4378, col: 1, offset: 135003},
 			expr: &choiceExpr{
-				pos: position{line: 4304, col: 18, offset: 132501},
+				pos: position{line: 4378, col: 18, offset: 135020},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4304, col: 18, offset: 132501},
+						pos: position{line: 4378, col: 18, offset: 135020},
 						run: (*parser).callonAggPercCommon2,
 						expr: &seqExpr{
-							pos: position{line: 4304, col: 18, offset: 132501},
+							pos: position{line: 4378, col: 18, offset: 135020},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4304, col: 18, offset: 132501},
+									pos:   position{line: 4378, col: 18, offset: 135020},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4304, col: 26, offset: 132509},
+										pos:  position{line: 4378, col: 26, offset: 135028},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4304, col: 44, offset: 132527},
+									pos:   position{line: 4378, col: 44, offset: 135046},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4304, col: 58, offset: 132541},
+										pos:  position{line: 4378, col: 58, offset: 135060},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4304, col: 72, offset: 132555},
+									pos:  position{line: 4378, col: 72, offset: 135074},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4304, col: 80, offset: 132563},
+									pos:        position{line: 4378, col: 80, offset: 135082},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4304, col: 87, offset: 132570},
+									pos:   position{line: 4378, col: 87, offset: 135089},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4304, col: 97, offset: 132580},
+										pos:  position{line: 4378, col: 97, offset: 135099},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4304, col: 107, offset: 132590},
+									pos:  position{line: 4378, col: 107, offset: 135109},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4320, col: 3, offset: 133114},
+						pos: position{line: 4394, col: 3, offset: 135633},
 						run: (*parser).callonAggPercCommon13,
 						expr: &seqExpr{
-							pos: position{line: 4320, col: 3, offset: 133114},
+							pos: position{line: 4394, col: 3, offset: 135633},
 							exprs: []any{
 								&labeledExpr{
-									pos:   position{line: 4320, col: 3, offset: 133114},
+									pos:   position{line: 4394, col: 3, offset: 135633},
 									label: "aggName",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4320, col: 11, offset: 133122},
+										pos:  position{line: 4394, col: 11, offset: 135641},
 										name: "CommonPercAggName",
 									},
 								},
 								&labeledExpr{
-									pos:   position{line: 4320, col: 29, offset: 133140},
+									pos:   position{line: 4394, col: 29, offset: 135659},
 									label: "percentileVal",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4320, col: 43, offset: 133154},
+										pos:  position{line: 4394, col: 43, offset: 135673},
 										name: "PercentileVal",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4320, col: 57, offset: 133168},
+									pos:  position{line: 4394, col: 57, offset: 135687},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4320, col: 65, offset: 133176},
+									pos:   position{line: 4394, col: 65, offset: 135695},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4320, col: 71, offset: 133182},
+										pos:  position{line: 4394, col: 71, offset: 135701},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4320, col: 81, offset: 133192},
+									pos:  position{line: 4394, col: 81, offset: 135711},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4335, col: 3, offset: 133672},
+						pos: position{line: 4409, col: 3, offset: 136191},
 						run: (*parser).callonAggPercCommon23,
 						expr: &seqExpr{
-							pos: position{line: 4335, col: 3, offset: 133672},
+							pos: position{line: 4409, col: 3, offset: 136191},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4335, col: 4, offset: 133673},
+									pos:        position{line: 4409, col: 4, offset: 136192},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4335, col: 14, offset: 133683},
+									pos:  position{line: 4409, col: 14, offset: 136202},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4335, col: 22, offset: 133691},
+									pos:   position{line: 4409, col: 22, offset: 136210},
 									label: "field",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4335, col: 28, offset: 133697},
+										pos:  position{line: 4409, col: 28, offset: 136216},
 										name: "FieldName",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4335, col: 38, offset: 133707},
+									pos:  position{line: 4409, col: 38, offset: 136226},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4350, col: 3, offset: 134094},
+						pos: position{line: 4424, col: 3, offset: 136613},
 						run: (*parser).callonAggPercCommon30,
 						expr: &seqExpr{
-							pos: position{line: 4350, col: 3, offset: 134094},
+							pos: position{line: 4424, col: 3, offset: 136613},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4350, col: 4, offset: 134095},
+									pos:        position{line: 4424, col: 4, offset: 136614},
 									val:        "median",
 									ignoreCase: false,
 									want:       "\"median\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4350, col: 14, offset: 134105},
+									pos:  position{line: 4424, col: 14, offset: 136624},
 									name: "L_PAREN",
 								},
 								&litMatcher{
-									pos:        position{line: 4350, col: 22, offset: 134113},
+									pos:        position{line: 4424, col: 22, offset: 136632},
 									val:        "eval",
 									ignoreCase: false,
 									want:       "\"eval\"",
 								},
 								&labeledExpr{
-									pos:   position{line: 4350, col: 29, offset: 134120},
+									pos:   position{line: 4424, col: 29, offset: 136639},
 									label: "valueExpr",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4350, col: 39, offset: 134130},
+										pos:  position{line: 4424, col: 39, offset: 136649},
 										name: "ValueExpr",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4350, col: 49, offset: 134140},
+									pos:  position{line: 4424, col: 49, offset: 136659},
 									name: "R_PAREN",
 								},
 							},
@@ -9826,22 +10065,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithNumberValue",
-			pos:  position{line: 4368, col: 1, offset: 134571},
+			pos:  position{line: 4442, col: 1, offset: 137090},
 			expr: &actionExpr{
-				pos: position{line: 4368, col: 25, offset: 134595},
+				pos: position{line: 4442, col: 25, offset: 137114},
 				run: (*parser).callonFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4368, col: 25, offset: 134595},
+					pos:   position{line: 4442, col: 25, offset: 137114},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4368, col: 39, offset: 134609},
+						pos: position{line: 4442, col: 39, offset: 137128},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4368, col: 39, offset: 134609},
+								pos:  position{line: 4442, col: 39, offset: 137128},
 								name: "NamedFieldWithNumberValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4368, col: 67, offset: 134637},
+								pos:  position{line: 4442, col: 67, offset: 137156},
 								name: "UnnamedFieldWithNumberValue",
 							},
 						},
@@ -9851,43 +10090,43 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithNumberValue",
-			pos:  position{line: 4372, col: 1, offset: 134700},
+			pos:  position{line: 4446, col: 1, offset: 137219},
 			expr: &actionExpr{
-				pos: position{line: 4372, col: 30, offset: 134729},
+				pos: position{line: 4446, col: 30, offset: 137248},
 				run: (*parser).callonNamedFieldWithNumberValue1,
 				expr: &seqExpr{
-					pos: position{line: 4372, col: 30, offset: 134729},
+					pos: position{line: 4446, col: 30, offset: 137248},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4372, col: 30, offset: 134729},
+							pos:   position{line: 4446, col: 30, offset: 137248},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4372, col: 34, offset: 134733},
+								pos:  position{line: 4446, col: 34, offset: 137252},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4372, col: 44, offset: 134743},
+							pos:   position{line: 4446, col: 44, offset: 137262},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4372, col: 48, offset: 134747},
+								pos: position{line: 4446, col: 48, offset: 137266},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4372, col: 48, offset: 134747},
+										pos:  position{line: 4446, col: 48, offset: 137266},
 										name: "EqualityOperator",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4372, col: 67, offset: 134766},
+										pos:  position{line: 4446, col: 67, offset: 137285},
 										name: "InequalityOperator",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4372, col: 87, offset: 134786},
+							pos:   position{line: 4446, col: 87, offset: 137305},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4372, col: 93, offset: 134792},
+								pos:  position{line: 4446, col: 93, offset: 137311},
 								name: "Number",
 							},
 						},
@@ -9897,15 +10136,15 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithNumberValue",
-			pos:  position{line: 4385, col: 1, offset: 135026},
+			pos:  position{line: 4459, col: 1, offset: 137545},
 			expr: &actionExpr{
-				pos: position{line: 4385, col: 32, offset: 135057},
+				pos: position{line: 4459, col: 32, offset: 137576},
 				run: (*parser).callonUnnamedFieldWithNumberValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4385, col: 32, offset: 135057},
+					pos:   position{line: 4459, col: 32, offset: 137576},
 					label: "value",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4385, col: 38, offset: 135063},
+						pos:  position{line: 4459, col: 38, offset: 137582},
 						name: "Number",
 					},
 				},
@@ -9913,34 +10152,34 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithBooleanValue",
-			pos:  position{line: 4398, col: 1, offset: 135280},
+			pos:  position{line: 4472, col: 1, offset: 137799},
 			expr: &actionExpr{
-				pos: position{line: 4398, col: 26, offset: 135305},
+				pos: position{line: 4472, col: 26, offset: 137824},
 				run: (*parser).callonFieldWithBooleanValue1,
 				expr: &seqExpr{
-					pos: position{line: 4398, col: 26, offset: 135305},
+					pos: position{line: 4472, col: 26, offset: 137824},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4398, col: 26, offset: 135305},
+							pos:   position{line: 4472, col: 26, offset: 137824},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4398, col: 30, offset: 135309},
+								pos:  position{line: 4472, col: 30, offset: 137828},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4398, col: 40, offset: 135319},
+							pos:   position{line: 4472, col: 40, offset: 137838},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4398, col: 43, offset: 135322},
+								pos:  position{line: 4472, col: 43, offset: 137841},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4398, col: 60, offset: 135339},
+							pos:   position{line: 4472, col: 60, offset: 137858},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4398, col: 66, offset: 135345},
+								pos:  position{line: 4472, col: 66, offset: 137864},
 								name: "Boolean",
 							},
 						},
@@ -9950,22 +10189,22 @@ var g = &grammar{
 		},
 		{
 			name: "FieldWithStringValue",
-			pos:  position{line: 4411, col: 1, offset: 135580},
+			pos:  position{line: 4485, col: 1, offset: 138099},
 			expr: &actionExpr{
-				pos: position{line: 4411, col: 25, offset: 135604},
+				pos: position{line: 4485, col: 25, offset: 138123},
 				run: (*parser).callonFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4411, col: 25, offset: 135604},
+					pos:   position{line: 4485, col: 25, offset: 138123},
 					label: "keyValuePair",
 					expr: &choiceExpr{
-						pos: position{line: 4411, col: 39, offset: 135618},
+						pos: position{line: 4485, col: 39, offset: 138137},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4411, col: 39, offset: 135618},
+								pos:  position{line: 4485, col: 39, offset: 138137},
 								name: "NamedFieldWithStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4411, col: 67, offset: 135646},
+								pos:  position{line: 4485, col: 67, offset: 138165},
 								name: "UnnamedFieldWithStringValue",
 							},
 						},
@@ -9975,41 +10214,41 @@ var g = &grammar{
 		},
 		{
 			name: "NamedFieldWithStringValue",
-			pos:  position{line: 4415, col: 1, offset: 135709},
+			pos:  position{line: 4489, col: 1, offset: 138228},
 			expr: &actionExpr{
-				pos: position{line: 4415, col: 30, offset: 135738},
+				pos: position{line: 4489, col: 30, offset: 138257},
 				run: (*parser).callonNamedFieldWithStringValue1,
 				expr: &seqExpr{
-					pos: position{line: 4415, col: 30, offset: 135738},
+					pos: position{line: 4489, col: 30, offset: 138257},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4415, col: 30, offset: 135738},
+							pos:   position{line: 4489, col: 30, offset: 138257},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4415, col: 34, offset: 135742},
+								pos:  position{line: 4489, col: 34, offset: 138261},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4415, col: 44, offset: 135752},
+							pos:   position{line: 4489, col: 44, offset: 138271},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4415, col: 47, offset: 135755},
+								pos:  position{line: 4489, col: 47, offset: 138274},
 								name: "EqualityOperator",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4415, col: 64, offset: 135772},
+							pos:   position{line: 4489, col: 64, offset: 138291},
 							label: "stringSearchReq",
 							expr: &choiceExpr{
-								pos: position{line: 4415, col: 81, offset: 135789},
+								pos: position{line: 4489, col: 81, offset: 138308},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4415, col: 81, offset: 135789},
+										pos:  position{line: 4489, col: 81, offset: 138308},
 										name: "CaseSensitiveString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4415, col: 103, offset: 135811},
+										pos:  position{line: 4489, col: 103, offset: 138330},
 										name: "CaseInsensitiveString",
 									},
 								},
@@ -10021,22 +10260,22 @@ var g = &grammar{
 		},
 		{
 			name: "UnnamedFieldWithStringValue",
-			pos:  position{line: 4431, col: 1, offset: 136243},
+			pos:  position{line: 4505, col: 1, offset: 138762},
 			expr: &actionExpr{
-				pos: position{line: 4431, col: 32, offset: 136274},
+				pos: position{line: 4505, col: 32, offset: 138793},
 				run: (*parser).callonUnnamedFieldWithStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 4431, col: 32, offset: 136274},
+					pos:   position{line: 4505, col: 32, offset: 138793},
 					label: "stringSearchReq",
 					expr: &choiceExpr{
-						pos: position{line: 4431, col: 49, offset: 136291},
+						pos: position{line: 4505, col: 49, offset: 138810},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4431, col: 49, offset: 136291},
+								pos:  position{line: 4505, col: 49, offset: 138810},
 								name: "CaseSensitiveString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4431, col: 71, offset: 136313},
+								pos:  position{line: 4505, col: 71, offset: 138832},
 								name: "CaseInsensitiveString",
 							},
 						},
@@ -10046,33 +10285,33 @@ var g = &grammar{
 		},
 		{
 			name: "CaseSensitiveString",
-			pos:  position{line: 4448, col: 1, offset: 136824},
+			pos:  position{line: 4522, col: 1, offset: 139343},
 			expr: &actionExpr{
-				pos: position{line: 4448, col: 24, offset: 136847},
+				pos: position{line: 4522, col: 24, offset: 139366},
 				run: (*parser).callonCaseSensitiveString1,
 				expr: &seqExpr{
-					pos: position{line: 4448, col: 24, offset: 136847},
+					pos: position{line: 4522, col: 24, offset: 139366},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4448, col: 24, offset: 136847},
+							pos:        position{line: 4522, col: 24, offset: 139366},
 							val:        "CASE",
 							ignoreCase: false,
 							want:       "\"CASE\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4448, col: 31, offset: 136854},
+							pos:  position{line: 4522, col: 31, offset: 139373},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 4448, col: 39, offset: 136862},
+							pos:   position{line: 4522, col: 39, offset: 139381},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4448, col: 45, offset: 136868},
+								pos:  position{line: 4522, col: 45, offset: 139387},
 								name: "String",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4448, col: 52, offset: 136875},
+							pos:  position{line: 4522, col: 52, offset: 139394},
 							name: "R_PAREN",
 						},
 					},
@@ -10081,49 +10320,49 @@ var g = &grammar{
 		},
 		{
 			name: "CaseInsensitiveString",
-			pos:  position{line: 4457, col: 1, offset: 137112},
+			pos:  position{line: 4531, col: 1, offset: 139631},
 			expr: &choiceExpr{
-				pos: position{line: 4457, col: 26, offset: 137137},
+				pos: position{line: 4531, col: 26, offset: 139656},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4457, col: 26, offset: 137137},
+						pos: position{line: 4531, col: 26, offset: 139656},
 						run: (*parser).callonCaseInsensitiveString2,
 						expr: &seqExpr{
-							pos: position{line: 4457, col: 26, offset: 137137},
+							pos: position{line: 4531, col: 26, offset: 139656},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 4457, col: 26, offset: 137137},
+									pos:        position{line: 4531, col: 26, offset: 139656},
 									val:        "TERM",
 									ignoreCase: false,
 									want:       "\"TERM\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4457, col: 33, offset: 137144},
+									pos:  position{line: 4531, col: 33, offset: 139663},
 									name: "L_PAREN",
 								},
 								&labeledExpr{
-									pos:   position{line: 4457, col: 41, offset: 137152},
+									pos:   position{line: 4531, col: 41, offset: 139671},
 									label: "value",
 									expr: &ruleRefExpr{
-										pos:  position{line: 4457, col: 47, offset: 137158},
+										pos:  position{line: 4531, col: 47, offset: 139677},
 										name: "String",
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 4457, col: 54, offset: 137165},
+									pos:  position{line: 4531, col: 54, offset: 139684},
 									name: "R_PAREN",
 								},
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4466, col: 3, offset: 137355},
+						pos: position{line: 4540, col: 3, offset: 139874},
 						run: (*parser).callonCaseInsensitiveString9,
 						expr: &labeledExpr{
-							pos:   position{line: 4466, col: 3, offset: 137355},
+							pos:   position{line: 4540, col: 3, offset: 139874},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4466, col: 9, offset: 137361},
+								pos:  position{line: 4540, col: 9, offset: 139880},
 								name: "String",
 							},
 						},
@@ -10133,35 +10372,35 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameList",
-			pos:  position{line: 4476, col: 1, offset: 137641},
+			pos:  position{line: 4550, col: 1, offset: 140160},
 			expr: &actionExpr{
-				pos: position{line: 4476, col: 18, offset: 137658},
+				pos: position{line: 4550, col: 18, offset: 140177},
 				run: (*parser).callonFieldNameList1,
 				expr: &seqExpr{
-					pos: position{line: 4476, col: 18, offset: 137658},
+					pos: position{line: 4550, col: 18, offset: 140177},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4476, col: 18, offset: 137658},
+							pos:   position{line: 4550, col: 18, offset: 140177},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4476, col: 24, offset: 137664},
+								pos:  position{line: 4550, col: 24, offset: 140183},
 								name: "FieldName",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4476, col: 34, offset: 137674},
+							pos:   position{line: 4550, col: 34, offset: 140193},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4476, col: 39, offset: 137679},
+								pos: position{line: 4550, col: 39, offset: 140198},
 								expr: &seqExpr{
-									pos: position{line: 4476, col: 40, offset: 137680},
+									pos: position{line: 4550, col: 40, offset: 140199},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4476, col: 40, offset: 137680},
+											pos:  position{line: 4550, col: 40, offset: 140199},
 											name: "COMMA",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4476, col: 46, offset: 137686},
+											pos:  position{line: 4550, col: 46, offset: 140205},
 											name: "FieldName",
 										},
 									},
@@ -10174,16 +10413,16 @@ var g = &grammar{
 		},
 		{
 			name: "TimeModifiers",
-			pos:  position{line: 4493, col: 1, offset: 138181},
+			pos:  position{line: 4567, col: 1, offset: 140700},
 			expr: &choiceExpr{
-				pos: position{line: 4493, col: 18, offset: 138198},
+				pos: position{line: 4567, col: 18, offset: 140717},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 4493, col: 18, offset: 138198},
+						pos:  position{line: 4567, col: 18, offset: 140717},
 						name: "EarliestAndLatest",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 4493, col: 38, offset: 138218},
+						pos:  position{line: 4567, col: 38, offset: 140737},
 						name: "EarliestOnly",
 					},
 				},
@@ -10191,62 +10430,62 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestAndLatest",
-			pos:  position{line: 4495, col: 1, offset: 138232},
+			pos:  position{line: 4569, col: 1, offset: 140751},
 			expr: &actionExpr{
-				pos: position{line: 4495, col: 22, offset: 138253},
+				pos: position{line: 4569, col: 22, offset: 140772},
 				run: (*parser).callonEarliestAndLatest1,
 				expr: &seqExpr{
-					pos: position{line: 4495, col: 22, offset: 138253},
+					pos: position{line: 4569, col: 22, offset: 140772},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4495, col: 22, offset: 138253},
+							pos:  position{line: 4569, col: 22, offset: 140772},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4495, col: 35, offset: 138266},
+							pos:  position{line: 4569, col: 35, offset: 140785},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4495, col: 41, offset: 138272},
+							pos:   position{line: 4569, col: 41, offset: 140791},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4495, col: 55, offset: 138286},
+								pos: position{line: 4569, col: 55, offset: 140805},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4495, col: 55, offset: 138286},
+										pos:  position{line: 4569, col: 55, offset: 140805},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4495, col: 75, offset: 138306},
+										pos:  position{line: 4569, col: 75, offset: 140825},
 										name: "RelativeTimestamp",
 									},
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4495, col: 94, offset: 138325},
+							pos:  position{line: 4569, col: 94, offset: 140844},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4495, col: 100, offset: 138331},
+							pos:  position{line: 4569, col: 100, offset: 140850},
 							name: "CMD_LATEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4495, col: 111, offset: 138342},
+							pos:  position{line: 4569, col: 111, offset: 140861},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4495, col: 117, offset: 138348},
+							pos:   position{line: 4569, col: 117, offset: 140867},
 							label: "latestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4495, col: 129, offset: 138360},
+								pos: position{line: 4569, col: 129, offset: 140879},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4495, col: 129, offset: 138360},
+										pos:  position{line: 4569, col: 129, offset: 140879},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4495, col: 149, offset: 138380},
+										pos:  position{line: 4569, col: 149, offset: 140899},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10258,33 +10497,33 @@ var g = &grammar{
 		},
 		{
 			name: "EarliestOnly",
-			pos:  position{line: 4536, col: 1, offset: 139519},
+			pos:  position{line: 4610, col: 1, offset: 142038},
 			expr: &actionExpr{
-				pos: position{line: 4536, col: 17, offset: 139535},
+				pos: position{line: 4610, col: 17, offset: 142054},
 				run: (*parser).callonEarliestOnly1,
 				expr: &seqExpr{
-					pos: position{line: 4536, col: 17, offset: 139535},
+					pos: position{line: 4610, col: 17, offset: 142054},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4536, col: 17, offset: 139535},
+							pos:  position{line: 4610, col: 17, offset: 142054},
 							name: "CMD_EARLIEST",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4536, col: 30, offset: 139548},
+							pos:  position{line: 4610, col: 30, offset: 142067},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4536, col: 36, offset: 139554},
+							pos:   position{line: 4610, col: 36, offset: 142073},
 							label: "earliestTime",
 							expr: &choiceExpr{
-								pos: position{line: 4536, col: 50, offset: 139568},
+								pos: position{line: 4610, col: 50, offset: 142087},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4536, col: 50, offset: 139568},
+										pos:  position{line: 4610, col: 50, offset: 142087},
 										name: "AbsoluteTimestamp",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4536, col: 70, offset: 139588},
+										pos:  position{line: 4610, col: 70, offset: 142107},
 										name: "RelativeTimestamp",
 									},
 								},
@@ -10296,24 +10535,24 @@ var g = &grammar{
 		},
 		{
 			name: "RelIntegerAsString",
-			pos:  position{line: 4564, col: 1, offset: 140296},
+			pos:  position{line: 4638, col: 1, offset: 142815},
 			expr: &actionExpr{
-				pos: position{line: 4564, col: 23, offset: 140318},
+				pos: position{line: 4638, col: 23, offset: 142837},
 				run: (*parser).callonRelIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4564, col: 23, offset: 140318},
+					pos: position{line: 4638, col: 23, offset: 142837},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4564, col: 23, offset: 140318},
+							pos:        position{line: 4638, col: 23, offset: 142837},
 							val:        "[-+]",
 							chars:      []rune{'-', '+'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4564, col: 27, offset: 140322},
+							pos: position{line: 4638, col: 27, offset: 142841},
 							expr: &charClassMatcher{
-								pos:        position{line: 4564, col: 27, offset: 140322},
+								pos:        position{line: 4638, col: 27, offset: 142841},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -10326,21 +10565,21 @@ var g = &grammar{
 		},
 		{
 			name: "WeekSnap",
-			pos:  position{line: 4568, col: 1, offset: 140365},
+			pos:  position{line: 4642, col: 1, offset: 142884},
 			expr: &actionExpr{
-				pos: position{line: 4568, col: 13, offset: 140377},
+				pos: position{line: 4642, col: 13, offset: 142896},
 				run: (*parser).callonWeekSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4568, col: 14, offset: 140378},
+					pos: position{line: 4642, col: 14, offset: 142897},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4568, col: 14, offset: 140378},
+							pos:        position{line: 4642, col: 14, offset: 142897},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4568, col: 17, offset: 140381},
+							pos:        position{line: 4642, col: 17, offset: 142900},
 							val:        "[0-7]",
 							ranges:     []rune{'0', '7'},
 							ignoreCase: false,
@@ -10352,15 +10591,15 @@ var g = &grammar{
 		},
 		{
 			name: "RelTimeUnit",
-			pos:  position{line: 4572, col: 1, offset: 140424},
+			pos:  position{line: 4646, col: 1, offset: 142943},
 			expr: &actionExpr{
-				pos: position{line: 4572, col: 16, offset: 140439},
+				pos: position{line: 4646, col: 16, offset: 142958},
 				run: (*parser).callonRelTimeUnit1,
 				expr: &labeledExpr{
-					pos:   position{line: 4572, col: 16, offset: 140439},
+					pos:   position{line: 4646, col: 16, offset: 142958},
 					label: "timeUnit",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4572, col: 26, offset: 140449},
+						pos:  position{line: 4646, col: 26, offset: 142968},
 						name: "AllTimeScale",
 					},
 				},
@@ -10368,31 +10607,31 @@ var g = &grammar{
 		},
 		{
 			name: "Snap",
-			pos:  position{line: 4579, col: 1, offset: 140676},
+			pos:  position{line: 4653, col: 1, offset: 143195},
 			expr: &actionExpr{
-				pos: position{line: 4579, col: 9, offset: 140684},
+				pos: position{line: 4653, col: 9, offset: 143203},
 				run: (*parser).callonSnap1,
 				expr: &seqExpr{
-					pos: position{line: 4579, col: 9, offset: 140684},
+					pos: position{line: 4653, col: 9, offset: 143203},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4579, col: 9, offset: 140684},
+							pos:        position{line: 4653, col: 9, offset: 143203},
 							val:        "@",
 							ignoreCase: false,
 							want:       "\"@\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4579, col: 13, offset: 140688},
+							pos:   position{line: 4653, col: 13, offset: 143207},
 							label: "snap",
 							expr: &choiceExpr{
-								pos: position{line: 4579, col: 19, offset: 140694},
+								pos: position{line: 4653, col: 19, offset: 143213},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4579, col: 19, offset: 140694},
+										pos:  position{line: 4653, col: 19, offset: 143213},
 										name: "WeekSnap",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4579, col: 30, offset: 140705},
+										pos:  position{line: 4653, col: 30, offset: 143224},
 										name: "RelTimeUnit",
 									},
 								},
@@ -10404,26 +10643,26 @@ var g = &grammar{
 		},
 		{
 			name: "Offset",
-			pos:  position{line: 4583, col: 1, offset: 140753},
+			pos:  position{line: 4657, col: 1, offset: 143272},
 			expr: &actionExpr{
-				pos: position{line: 4583, col: 11, offset: 140763},
+				pos: position{line: 4657, col: 11, offset: 143282},
 				run: (*parser).callonOffset1,
 				expr: &seqExpr{
-					pos: position{line: 4583, col: 11, offset: 140763},
+					pos: position{line: 4657, col: 11, offset: 143282},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4583, col: 11, offset: 140763},
+							pos:   position{line: 4657, col: 11, offset: 143282},
 							label: "off",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4583, col: 16, offset: 140768},
+								pos:  position{line: 4657, col: 16, offset: 143287},
 								name: "RelIntegerAsString",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4583, col: 36, offset: 140788},
+							pos:   position{line: 4657, col: 36, offset: 143307},
 							label: "tuOff",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4583, col: 43, offset: 140795},
+								pos:  position{line: 4657, col: 43, offset: 143314},
 								name: "RelTimeUnit",
 							},
 						},
@@ -10433,44 +10672,44 @@ var g = &grammar{
 		},
 		{
 			name: "ChainedRelativeTimestamp",
-			pos:  position{line: 4611, col: 1, offset: 141534},
+			pos:  position{line: 4685, col: 1, offset: 144053},
 			expr: &actionExpr{
-				pos: position{line: 4611, col: 29, offset: 141562},
+				pos: position{line: 4685, col: 29, offset: 144081},
 				run: (*parser).callonChainedRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4611, col: 29, offset: 141562},
+					pos: position{line: 4685, col: 29, offset: 144081},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4611, col: 29, offset: 141562},
+							pos:   position{line: 4685, col: 29, offset: 144081},
 							label: "first",
 							expr: &choiceExpr{
-								pos: position{line: 4611, col: 36, offset: 141569},
+								pos: position{line: 4685, col: 36, offset: 144088},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4611, col: 36, offset: 141569},
+										pos:  position{line: 4685, col: 36, offset: 144088},
 										name: "Offset",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4611, col: 45, offset: 141578},
+										pos:  position{line: 4685, col: 45, offset: 144097},
 										name: "Snap",
 									},
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4611, col: 51, offset: 141584},
+							pos:   position{line: 4685, col: 51, offset: 144103},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4611, col: 57, offset: 141590},
+								pos: position{line: 4685, col: 57, offset: 144109},
 								expr: &choiceExpr{
-									pos: position{line: 4611, col: 58, offset: 141591},
+									pos: position{line: 4685, col: 58, offset: 144110},
 									alternatives: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4611, col: 58, offset: 141591},
+											pos:  position{line: 4685, col: 58, offset: 144110},
 											name: "Offset",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4611, col: 67, offset: 141600},
+											pos:  position{line: 4685, col: 67, offset: 144119},
 											name: "Snap",
 										},
 									},
@@ -10483,29 +10722,29 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimestamp",
-			pos:  position{line: 4658, col: 1, offset: 143032},
+			pos:  position{line: 4732, col: 1, offset: 145551},
 			expr: &actionExpr{
-				pos: position{line: 4658, col: 22, offset: 143053},
+				pos: position{line: 4732, col: 22, offset: 145572},
 				run: (*parser).callonRelativeTimestamp1,
 				expr: &seqExpr{
-					pos: position{line: 4658, col: 22, offset: 143053},
+					pos: position{line: 4732, col: 22, offset: 145572},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4658, col: 22, offset: 143053},
+							pos:   position{line: 4732, col: 22, offset: 145572},
 							label: "defaultTime",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4658, col: 34, offset: 143065},
+								pos: position{line: 4732, col: 34, offset: 145584},
 								expr: &choiceExpr{
-									pos: position{line: 4658, col: 35, offset: 143066},
+									pos: position{line: 4732, col: 35, offset: 145585},
 									alternatives: []any{
 										&litMatcher{
-											pos:        position{line: 4658, col: 35, offset: 143066},
+											pos:        position{line: 4732, col: 35, offset: 145585},
 											val:        "now",
 											ignoreCase: false,
 											want:       "\"now\"",
 										},
 										&litMatcher{
-											pos:        position{line: 4658, col: 43, offset: 143074},
+											pos:        position{line: 4732, col: 43, offset: 145593},
 											val:        "1",
 											ignoreCase: false,
 											want:       "\"1\"",
@@ -10515,12 +10754,12 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4658, col: 49, offset: 143080},
+							pos:   position{line: 4732, col: 49, offset: 145599},
 							label: "chained",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4658, col: 57, offset: 143088},
+								pos: position{line: 4732, col: 57, offset: 145607},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4658, col: 58, offset: 143089},
+									pos:  position{line: 4732, col: 58, offset: 145608},
 									name: "ChainedRelativeTimestamp",
 								},
 							},
@@ -10531,31 +10770,31 @@ var g = &grammar{
 		},
 		{
 			name: "RelativeTimeCommandTimestampFormat",
-			pos:  position{line: 4683, col: 1, offset: 143772},
+			pos:  position{line: 4757, col: 1, offset: 146291},
 			expr: &actionExpr{
-				pos: position{line: 4683, col: 39, offset: 143810},
+				pos: position{line: 4757, col: 39, offset: 146329},
 				run: (*parser).callonRelativeTimeCommandTimestampFormat1,
 				expr: &seqExpr{
-					pos: position{line: 4683, col: 39, offset: 143810},
+					pos: position{line: 4757, col: 39, offset: 146329},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4683, col: 39, offset: 143810},
+							pos:   position{line: 4757, col: 39, offset: 146329},
 							label: "offset",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4683, col: 46, offset: 143817},
+								pos: position{line: 4757, col: 46, offset: 146336},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4683, col: 47, offset: 143818},
+									pos:  position{line: 4757, col: 47, offset: 146337},
 									name: "Offset",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4683, col: 56, offset: 143827},
+							pos:   position{line: 4757, col: 56, offset: 146346},
 							label: "snapParam",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 4683, col: 66, offset: 143837},
+								pos: position{line: 4757, col: 66, offset: 146356},
 								expr: &ruleRefExpr{
-									pos:  position{line: 4683, col: 67, offset: 143838},
+									pos:  position{line: 4757, col: 67, offset: 146357},
 									name: "Snap",
 								},
 							},
@@ -10566,136 +10805,136 @@ var g = &grammar{
 		},
 		{
 			name: "FullTimeStamp",
-			pos:  position{line: 4710, col: 1, offset: 144468},
+			pos:  position{line: 4784, col: 1, offset: 146987},
 			expr: &actionExpr{
-				pos: position{line: 4710, col: 18, offset: 144485},
+				pos: position{line: 4784, col: 18, offset: 147004},
 				run: (*parser).callonFullTimeStamp1,
 				expr: &seqExpr{
-					pos: position{line: 4710, col: 18, offset: 144485},
+					pos: position{line: 4784, col: 18, offset: 147004},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 18, offset: 144485},
+							pos:        position{line: 4784, col: 18, offset: 147004},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 23, offset: 144490},
+							pos:        position{line: 4784, col: 23, offset: 147009},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4710, col: 29, offset: 144496},
+							pos:        position{line: 4784, col: 29, offset: 147015},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 33, offset: 144500},
+							pos:        position{line: 4784, col: 33, offset: 147019},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 38, offset: 144505},
+							pos:        position{line: 4784, col: 38, offset: 147024},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4710, col: 44, offset: 144511},
+							pos:        position{line: 4784, col: 44, offset: 147030},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 48, offset: 144515},
+							pos:        position{line: 4784, col: 48, offset: 147034},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 53, offset: 144520},
+							pos:        position{line: 4784, col: 53, offset: 147039},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 58, offset: 144525},
+							pos:        position{line: 4784, col: 58, offset: 147044},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 63, offset: 144530},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&litMatcher{
-							pos:        position{line: 4710, col: 69, offset: 144536},
-							val:        ":",
-							ignoreCase: false,
-							want:       "\":\"",
-						},
-						&charClassMatcher{
-							pos:        position{line: 4710, col: 73, offset: 144540},
-							val:        "[0-9]",
-							ranges:     []rune{'0', '9'},
-							ignoreCase: false,
-							inverted:   false,
-						},
-						&charClassMatcher{
-							pos:        position{line: 4710, col: 78, offset: 144545},
+							pos:        position{line: 4784, col: 63, offset: 147049},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4710, col: 84, offset: 144551},
+							pos:        position{line: 4784, col: 69, offset: 147055},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 88, offset: 144555},
+							pos:        position{line: 4784, col: 73, offset: 147059},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 93, offset: 144560},
+							pos:        position{line: 4784, col: 78, offset: 147064},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&litMatcher{
-							pos:        position{line: 4710, col: 99, offset: 144566},
+							pos:        position{line: 4784, col: 84, offset: 147070},
 							val:        ":",
 							ignoreCase: false,
 							want:       "\":\"",
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 103, offset: 144570},
+							pos:        position{line: 4784, col: 88, offset: 147074},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
 							inverted:   false,
 						},
 						&charClassMatcher{
-							pos:        position{line: 4710, col: 108, offset: 144575},
+							pos:        position{line: 4784, col: 93, offset: 147079},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&litMatcher{
+							pos:        position{line: 4784, col: 99, offset: 147085},
+							val:        ":",
+							ignoreCase: false,
+							want:       "\":\"",
+						},
+						&charClassMatcher{
+							pos:        position{line: 4784, col: 103, offset: 147089},
+							val:        "[0-9]",
+							ranges:     []rune{'0', '9'},
+							ignoreCase: false,
+							inverted:   false,
+						},
+						&charClassMatcher{
+							pos:        position{line: 4784, col: 108, offset: 147094},
 							val:        "[0-9]",
 							ranges:     []rune{'0', '9'},
 							ignoreCase: false,
@@ -10707,15 +10946,15 @@ var g = &grammar{
 		},
 		{
 			name: "AbsoluteTimestamp",
-			pos:  position{line: 4714, col: 1, offset: 144617},
+			pos:  position{line: 4788, col: 1, offset: 147136},
 			expr: &actionExpr{
-				pos: position{line: 4714, col: 22, offset: 144638},
+				pos: position{line: 4788, col: 22, offset: 147157},
 				run: (*parser).callonAbsoluteTimestamp1,
 				expr: &labeledExpr{
-					pos:   position{line: 4714, col: 22, offset: 144638},
+					pos:   position{line: 4788, col: 22, offset: 147157},
 					label: "timestamp",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4714, col: 32, offset: 144648},
+						pos:  position{line: 4788, col: 32, offset: 147167},
 						name: "FullTimeStamp",
 					},
 				},
@@ -10723,18 +10962,18 @@ var g = &grammar{
 		},
 		{
 			name: "FieldName",
-			pos:  position{line: 4725, col: 1, offset: 145091},
+			pos:  position{line: 4799, col: 1, offset: 147610},
 			expr: &choiceExpr{
-				pos: position{line: 4725, col: 14, offset: 145104},
+				pos: position{line: 4799, col: 14, offset: 147623},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4725, col: 14, offset: 145104},
+						pos: position{line: 4799, col: 14, offset: 147623},
 						run: (*parser).callonFieldName2,
 						expr: &seqExpr{
-							pos: position{line: 4725, col: 14, offset: 145104},
+							pos: position{line: 4799, col: 14, offset: 147623},
 							exprs: []any{
 								&charClassMatcher{
-									pos:        position{line: 4725, col: 14, offset: 145104},
+									pos:        position{line: 4799, col: 14, offset: 147623},
 									val:        "[-/a-zA-Z0-9:*]",
 									chars:      []rune{'-', '/', ':', '*'},
 									ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10742,9 +10981,9 @@ var g = &grammar{
 									inverted:   false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 4725, col: 29, offset: 145119},
+									pos: position{line: 4799, col: 29, offset: 147638},
 									expr: &charClassMatcher{
-										pos:        position{line: 4725, col: 29, offset: 145119},
+										pos:        position{line: 4799, col: 29, offset: 147638},
 										val:        "[-/a-zA-Z0-9:_.*]",
 										chars:      []rune{'-', '/', ':', '_', '.', '*'},
 										ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10756,10 +10995,10 @@ var g = &grammar{
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4728, col: 3, offset: 145175},
+						pos: position{line: 4802, col: 3, offset: 147694},
 						run: (*parser).callonFieldName7,
 						expr: &ruleRefExpr{
-							pos:  position{line: 4728, col: 3, offset: 145175},
+							pos:  position{line: 4802, col: 3, offset: 147694},
 							name: "QuotedString",
 						},
 					},
@@ -10768,15 +11007,15 @@ var g = &grammar{
 		},
 		{
 			name: "FieldNameStartWith_",
-			pos:  position{line: 4732, col: 1, offset: 145238},
+			pos:  position{line: 4806, col: 1, offset: 147757},
 			expr: &actionExpr{
-				pos: position{line: 4732, col: 24, offset: 145261},
+				pos: position{line: 4806, col: 24, offset: 147780},
 				run: (*parser).callonFieldNameStartWith_1,
 				expr: &seqExpr{
-					pos: position{line: 4732, col: 24, offset: 145261},
+					pos: position{line: 4806, col: 24, offset: 147780},
 					exprs: []any{
 						&charClassMatcher{
-							pos:        position{line: 4732, col: 24, offset: 145261},
+							pos:        position{line: 4806, col: 24, offset: 147780},
 							val:        "[a-zA-Z0-9:_.*]",
 							chars:      []rune{':', '_', '.', '*'},
 							ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10784,9 +11023,9 @@ var g = &grammar{
 							inverted:   false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4732, col: 39, offset: 145276},
+							pos: position{line: 4806, col: 39, offset: 147795},
 							expr: &charClassMatcher{
-								pos:        position{line: 4732, col: 39, offset: 145276},
+								pos:        position{line: 4806, col: 39, offset: 147795},
 								val:        "[a-zA-Z0-9:_.*]",
 								chars:      []rune{':', '_', '.', '*'},
 								ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10800,22 +11039,22 @@ var g = &grammar{
 		},
 		{
 			name: "String",
-			pos:  position{line: 4736, col: 1, offset: 145329},
+			pos:  position{line: 4810, col: 1, offset: 147848},
 			expr: &actionExpr{
-				pos: position{line: 4736, col: 11, offset: 145339},
+				pos: position{line: 4810, col: 11, offset: 147858},
 				run: (*parser).callonString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4736, col: 11, offset: 145339},
+					pos:   position{line: 4810, col: 11, offset: 147858},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4736, col: 16, offset: 145344},
+						pos: position{line: 4810, col: 16, offset: 147863},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4736, col: 16, offset: 145344},
+								pos:  position{line: 4810, col: 16, offset: 147863},
 								name: "QuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4736, col: 31, offset: 145359},
+								pos:  position{line: 4810, col: 31, offset: 147878},
 								name: "UnquotedString",
 							},
 						},
@@ -10825,38 +11064,38 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedString",
-			pos:  position{line: 4740, col: 1, offset: 145400},
+			pos:  position{line: 4814, col: 1, offset: 147919},
 			expr: &actionExpr{
-				pos: position{line: 4740, col: 17, offset: 145416},
+				pos: position{line: 4814, col: 17, offset: 147935},
 				run: (*parser).callonQuotedString1,
 				expr: &seqExpr{
-					pos: position{line: 4740, col: 17, offset: 145416},
+					pos: position{line: 4814, col: 17, offset: 147935},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4740, col: 17, offset: 145416},
+							pos:        position{line: 4814, col: 17, offset: 147935},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4740, col: 21, offset: 145420},
+							pos: position{line: 4814, col: 21, offset: 147939},
 							expr: &choiceExpr{
-								pos: position{line: 4740, col: 22, offset: 145421},
+								pos: position{line: 4814, col: 22, offset: 147940},
 								alternatives: []any{
 									&seqExpr{
-										pos: position{line: 4740, col: 22, offset: 145421},
+										pos: position{line: 4814, col: 22, offset: 147940},
 										exprs: []any{
 											&notExpr{
-												pos: position{line: 4740, col: 22, offset: 145421},
+												pos: position{line: 4814, col: 22, offset: 147940},
 												expr: &litMatcher{
-													pos:        position{line: 4740, col: 23, offset: 145422},
+													pos:        position{line: 4814, col: 23, offset: 147941},
 													val:        "\\",
 													ignoreCase: false,
 													want:       "\"\\\\\"",
 												},
 											},
 											&charClassMatcher{
-												pos:        position{line: 4740, col: 28, offset: 145427},
+												pos:        position{line: 4814, col: 28, offset: 147946},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -10865,16 +11104,16 @@ var g = &grammar{
 										},
 									},
 									&seqExpr{
-										pos: position{line: 4740, col: 35, offset: 145434},
+										pos: position{line: 4814, col: 35, offset: 147953},
 										exprs: []any{
 											&litMatcher{
-												pos:        position{line: 4740, col: 35, offset: 145434},
+												pos:        position{line: 4814, col: 35, offset: 147953},
 												val:        "\\",
 												ignoreCase: false,
 												want:       "\"\\\\\"",
 											},
 											&anyMatcher{
-												line: 4740, col: 40, offset: 145439,
+												line: 4814, col: 40, offset: 147958,
 											},
 										},
 									},
@@ -10882,7 +11121,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4740, col: 44, offset: 145443},
+							pos:        position{line: 4814, col: 44, offset: 147962},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -10893,48 +11132,48 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedString",
-			pos:  position{line: 4745, col: 1, offset: 145554},
+			pos:  position{line: 4819, col: 1, offset: 148073},
 			expr: &actionExpr{
-				pos: position{line: 4745, col: 19, offset: 145572},
+				pos: position{line: 4819, col: 19, offset: 148091},
 				run: (*parser).callonUnquotedString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4745, col: 19, offset: 145572},
+					pos: position{line: 4819, col: 19, offset: 148091},
 					expr: &choiceExpr{
-						pos: position{line: 4745, col: 20, offset: 145573},
+						pos: position{line: 4819, col: 20, offset: 148092},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 4745, col: 20, offset: 145573},
+								pos:        position{line: 4819, col: 20, offset: 148092},
 								val:        "*",
 								ignoreCase: false,
 								want:       "\"*\"",
 							},
 							&seqExpr{
-								pos: position{line: 4745, col: 27, offset: 145580},
+								pos: position{line: 4819, col: 27, offset: 148099},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4745, col: 27, offset: 145580},
+										pos: position{line: 4819, col: 27, offset: 148099},
 										expr: &choiceExpr{
-											pos: position{line: 4745, col: 29, offset: 145582},
+											pos: position{line: 4819, col: 29, offset: 148101},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4745, col: 29, offset: 145582},
+													pos:  position{line: 4819, col: 29, offset: 148101},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4745, col: 43, offset: 145596},
+													pos:        position{line: 4819, col: 43, offset: 148115},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4745, col: 49, offset: 145602},
+													pos:  position{line: 4819, col: 49, offset: 148121},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4745, col: 54, offset: 145607,
+										line: 4819, col: 54, offset: 148126,
 									},
 								},
 							},
@@ -10945,12 +11184,12 @@ var g = &grammar{
 		},
 		{
 			name: "AllowedChar",
-			pos:  position{line: 4752, col: 1, offset: 145722},
+			pos:  position{line: 4826, col: 1, offset: 148241},
 			expr: &choiceExpr{
-				pos: position{line: 4752, col: 16, offset: 145737},
+				pos: position{line: 4826, col: 16, offset: 148256},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 4752, col: 16, offset: 145737},
+						pos:        position{line: 4826, col: 16, offset: 148256},
 						val:        "[a-zA-Z0-9:_{}@.]",
 						chars:      []rune{':', '_', '{', '}', '@', '.'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -10958,18 +11197,18 @@ var g = &grammar{
 						inverted:   false,
 					},
 					&seqExpr{
-						pos: position{line: 4752, col: 37, offset: 145758},
+						pos: position{line: 4826, col: 37, offset: 148277},
 						exprs: []any{
 							&litMatcher{
-								pos:        position{line: 4752, col: 37, offset: 145758},
+								pos:        position{line: 4826, col: 37, offset: 148277},
 								val:        "{",
 								ignoreCase: false,
 								want:       "\"{\"",
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 4752, col: 41, offset: 145762},
+								pos: position{line: 4826, col: 41, offset: 148281},
 								expr: &charClassMatcher{
-									pos:        position{line: 4752, col: 41, offset: 145762},
+									pos:        position{line: 4826, col: 41, offset: 148281},
 									val:        "[0-9]",
 									ranges:     []rune{'0', '9'},
 									ignoreCase: false,
@@ -10977,7 +11216,7 @@ var g = &grammar{
 								},
 							},
 							&litMatcher{
-								pos:        position{line: 4752, col: 48, offset: 145769},
+								pos:        position{line: 4826, col: 48, offset: 148288},
 								val:        "}",
 								ignoreCase: false,
 								want:       "\"}\"",
@@ -10989,46 +11228,46 @@ var g = &grammar{
 		},
 		{
 			name: "UnquotedStringWithTemplateWildCard",
-			pos:  position{line: 4754, col: 1, offset: 145775},
+			pos:  position{line: 4828, col: 1, offset: 148294},
 			expr: &actionExpr{
-				pos: position{line: 4754, col: 39, offset: 145813},
+				pos: position{line: 4828, col: 39, offset: 148332},
 				run: (*parser).callonUnquotedStringWithTemplateWildCard1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4754, col: 39, offset: 145813},
+					pos: position{line: 4828, col: 39, offset: 148332},
 					expr: &choiceExpr{
-						pos: position{line: 4754, col: 40, offset: 145814},
+						pos: position{line: 4828, col: 40, offset: 148333},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4754, col: 40, offset: 145814},
+								pos:  position{line: 4828, col: 40, offset: 148333},
 								name: "AllowedChar",
 							},
 							&seqExpr{
-								pos: position{line: 4754, col: 54, offset: 145828},
+								pos: position{line: 4828, col: 54, offset: 148347},
 								exprs: []any{
 									&notExpr{
-										pos: position{line: 4754, col: 54, offset: 145828},
+										pos: position{line: 4828, col: 54, offset: 148347},
 										expr: &choiceExpr{
-											pos: position{line: 4754, col: 56, offset: 145830},
+											pos: position{line: 4828, col: 56, offset: 148349},
 											alternatives: []any{
 												&ruleRefExpr{
-													pos:  position{line: 4754, col: 56, offset: 145830},
+													pos:  position{line: 4828, col: 56, offset: 148349},
 													name: "MAJOR_BREAK",
 												},
 												&litMatcher{
-													pos:        position{line: 4754, col: 70, offset: 145844},
+													pos:        position{line: 4828, col: 70, offset: 148363},
 													val:        "|",
 													ignoreCase: false,
 													want:       "\"|\"",
 												},
 												&ruleRefExpr{
-													pos:  position{line: 4754, col: 76, offset: 145850},
+													pos:  position{line: 4828, col: 76, offset: 148369},
 													name: "EOF",
 												},
 											},
 										},
 									},
 									&anyMatcher{
-										line: 4754, col: 81, offset: 145855,
+										line: 4828, col: 81, offset: 148374,
 									},
 								},
 							},
@@ -11039,21 +11278,21 @@ var g = &grammar{
 		},
 		{
 			name: "Boolean",
-			pos:  position{line: 4758, col: 1, offset: 145895},
+			pos:  position{line: 4832, col: 1, offset: 148414},
 			expr: &actionExpr{
-				pos: position{line: 4758, col: 12, offset: 145906},
+				pos: position{line: 4832, col: 12, offset: 148425},
 				run: (*parser).callonBoolean1,
 				expr: &choiceExpr{
-					pos: position{line: 4758, col: 13, offset: 145907},
+					pos: position{line: 4832, col: 13, offset: 148426},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4758, col: 13, offset: 145907},
+							pos:        position{line: 4832, col: 13, offset: 148426},
 							val:        "true",
 							ignoreCase: false,
 							want:       "\"true\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4758, col: 22, offset: 145916},
+							pos:        position{line: 4832, col: 22, offset: 148435},
 							val:        "false",
 							ignoreCase: false,
 							want:       "\"false\"",
@@ -11064,14 +11303,14 @@ var g = &grammar{
 		},
 		{
 			name: "RenamePattern",
-			pos:  position{line: 4764, col: 1, offset: 146070},
+			pos:  position{line: 4838, col: 1, offset: 148589},
 			expr: &actionExpr{
-				pos: position{line: 4764, col: 18, offset: 146087},
+				pos: position{line: 4838, col: 18, offset: 148606},
 				run: (*parser).callonRenamePattern1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4764, col: 18, offset: 146087},
+					pos: position{line: 4838, col: 18, offset: 148606},
 					expr: &charClassMatcher{
-						pos:        position{line: 4764, col: 18, offset: 146087},
+						pos:        position{line: 4838, col: 18, offset: 148606},
 						val:        "[a-zA-Z0-9_*]",
 						chars:      []rune{'_', '*'},
 						ranges:     []rune{'a', 'z', 'A', 'Z', '0', '9'},
@@ -11083,15 +11322,15 @@ var g = &grammar{
 		},
 		{
 			name: "Number",
-			pos:  position{line: 4768, col: 1, offset: 146138},
+			pos:  position{line: 4842, col: 1, offset: 148657},
 			expr: &actionExpr{
-				pos: position{line: 4768, col: 11, offset: 146148},
+				pos: position{line: 4842, col: 11, offset: 148667},
 				run: (*parser).callonNumber1,
 				expr: &labeledExpr{
-					pos:   position{line: 4768, col: 11, offset: 146148},
+					pos:   position{line: 4842, col: 11, offset: 148667},
 					label: "number",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4768, col: 18, offset: 146155},
+						pos:  position{line: 4842, col: 18, offset: 148674},
 						name: "NumberAsString",
 					},
 				},
@@ -11099,59 +11338,59 @@ var g = &grammar{
 		},
 		{
 			name: "NumberAsString",
-			pos:  position{line: 4774, col: 1, offset: 146344},
+			pos:  position{line: 4848, col: 1, offset: 148863},
 			expr: &actionExpr{
-				pos: position{line: 4774, col: 19, offset: 146362},
+				pos: position{line: 4848, col: 19, offset: 148881},
 				run: (*parser).callonNumberAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4774, col: 19, offset: 146362},
+					pos: position{line: 4848, col: 19, offset: 148881},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4774, col: 19, offset: 146362},
+							pos:   position{line: 4848, col: 19, offset: 148881},
 							label: "number",
 							expr: &choiceExpr{
-								pos: position{line: 4774, col: 27, offset: 146370},
+								pos: position{line: 4848, col: 27, offset: 148889},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4774, col: 27, offset: 146370},
+										pos:  position{line: 4848, col: 27, offset: 148889},
 										name: "FloatAsString",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4774, col: 43, offset: 146386},
+										pos:  position{line: 4848, col: 43, offset: 148905},
 										name: "IntegerAsString",
 									},
 								},
 							},
 						},
 						&andExpr{
-							pos: position{line: 4774, col: 60, offset: 146403},
+							pos: position{line: 4848, col: 60, offset: 148922},
 							expr: &choiceExpr{
-								pos: position{line: 4774, col: 62, offset: 146405},
+								pos: position{line: 4848, col: 62, offset: 148924},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 4774, col: 62, offset: 146405},
+										pos:  position{line: 4848, col: 62, offset: 148924},
 										name: "SPACE",
 									},
 									&litMatcher{
-										pos:        position{line: 4774, col: 70, offset: 146413},
+										pos:        position{line: 4848, col: 70, offset: 148932},
 										val:        "|",
 										ignoreCase: false,
 										want:       "\"|\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4774, col: 76, offset: 146419},
+										pos:        position{line: 4848, col: 76, offset: 148938},
 										val:        ")",
 										ignoreCase: false,
 										want:       "\")\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4774, col: 82, offset: 146425},
+										pos:        position{line: 4848, col: 82, offset: 148944},
 										val:        ",",
 										ignoreCase: false,
 										want:       "\",\"",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 4774, col: 88, offset: 146431},
+										pos:  position{line: 4848, col: 88, offset: 148950},
 										name: "EOF",
 									},
 								},
@@ -11163,17 +11402,17 @@ var g = &grammar{
 		},
 		{
 			name: "FloatAsString",
-			pos:  position{line: 4780, col: 1, offset: 146560},
+			pos:  position{line: 4854, col: 1, offset: 149079},
 			expr: &actionExpr{
-				pos: position{line: 4780, col: 18, offset: 146577},
+				pos: position{line: 4854, col: 18, offset: 149096},
 				run: (*parser).callonFloatAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4780, col: 18, offset: 146577},
+					pos: position{line: 4854, col: 18, offset: 149096},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4780, col: 18, offset: 146577},
+							pos: position{line: 4854, col: 18, offset: 149096},
 							expr: &charClassMatcher{
-								pos:        position{line: 4780, col: 18, offset: 146577},
+								pos:        position{line: 4854, col: 18, offset: 149096},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11181,9 +11420,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 4780, col: 24, offset: 146583},
+							pos: position{line: 4854, col: 24, offset: 149102},
 							expr: &charClassMatcher{
-								pos:        position{line: 4780, col: 24, offset: 146583},
+								pos:        position{line: 4854, col: 24, offset: 149102},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11191,15 +11430,15 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4780, col: 31, offset: 146590},
+							pos:        position{line: 4854, col: 31, offset: 149109},
 							val:        ".",
 							ignoreCase: false,
 							want:       "\".\"",
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4780, col: 35, offset: 146594},
+							pos: position{line: 4854, col: 35, offset: 149113},
 							expr: &charClassMatcher{
-								pos:        position{line: 4780, col: 35, offset: 146594},
+								pos:        position{line: 4854, col: 35, offset: 149113},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11212,17 +11451,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntegerAsString",
-			pos:  position{line: 4785, col: 1, offset: 146689},
+			pos:  position{line: 4859, col: 1, offset: 149208},
 			expr: &actionExpr{
-				pos: position{line: 4785, col: 20, offset: 146708},
+				pos: position{line: 4859, col: 20, offset: 149227},
 				run: (*parser).callonIntegerAsString1,
 				expr: &seqExpr{
-					pos: position{line: 4785, col: 20, offset: 146708},
+					pos: position{line: 4859, col: 20, offset: 149227},
 					exprs: []any{
 						&zeroOrOneExpr{
-							pos: position{line: 4785, col: 20, offset: 146708},
+							pos: position{line: 4859, col: 20, offset: 149227},
 							expr: &charClassMatcher{
-								pos:        position{line: 4785, col: 20, offset: 146708},
+								pos:        position{line: 4859, col: 20, offset: 149227},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -11230,9 +11469,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 4785, col: 26, offset: 146714},
+							pos: position{line: 4859, col: 26, offset: 149233},
 							expr: &charClassMatcher{
-								pos:        position{line: 4785, col: 26, offset: 146714},
+								pos:        position{line: 4859, col: 26, offset: 149233},
 								val:        "[0-9]",
 								ranges:     []rune{'0', '9'},
 								ignoreCase: false,
@@ -11245,14 +11484,14 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveIntegerAsString",
-			pos:  position{line: 4789, col: 1, offset: 146757},
+			pos:  position{line: 4863, col: 1, offset: 149276},
 			expr: &actionExpr{
-				pos: position{line: 4789, col: 28, offset: 146784},
+				pos: position{line: 4863, col: 28, offset: 149303},
 				run: (*parser).callonPositiveIntegerAsString1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 4789, col: 28, offset: 146784},
+					pos: position{line: 4863, col: 28, offset: 149303},
 					expr: &charClassMatcher{
-						pos:        position{line: 4789, col: 28, offset: 146784},
+						pos:        position{line: 4863, col: 28, offset: 149303},
 						val:        "[0-9]",
 						ranges:     []rune{'0', '9'},
 						ignoreCase: false,
@@ -11263,15 +11502,15 @@ var g = &grammar{
 		},
 		{
 			name: "PositiveInteger",
-			pos:  position{line: 4793, col: 1, offset: 146827},
+			pos:  position{line: 4867, col: 1, offset: 149346},
 			expr: &actionExpr{
-				pos: position{line: 4793, col: 20, offset: 146846},
+				pos: position{line: 4867, col: 20, offset: 149365},
 				run: (*parser).callonPositiveInteger1,
 				expr: &labeledExpr{
-					pos:   position{line: 4793, col: 20, offset: 146846},
+					pos:   position{line: 4867, col: 20, offset: 149365},
 					label: "intStr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4793, col: 27, offset: 146853},
+						pos:  position{line: 4867, col: 27, offset: 149372},
 						name: "PositiveIntegerAsString",
 					},
 				},
@@ -11279,37 +11518,37 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOperator",
-			pos:  position{line: 4801, col: 1, offset: 147100},
+			pos:  position{line: 4875, col: 1, offset: 149619},
 			expr: &actionExpr{
-				pos: position{line: 4801, col: 21, offset: 147120},
+				pos: position{line: 4875, col: 21, offset: 149639},
 				run: (*parser).callonEqualityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4801, col: 21, offset: 147120},
+					pos: position{line: 4875, col: 21, offset: 149639},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4801, col: 21, offset: 147120},
+							pos:  position{line: 4875, col: 21, offset: 149639},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4801, col: 36, offset: 147135},
+							pos:   position{line: 4875, col: 36, offset: 149654},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4801, col: 40, offset: 147139},
+								pos: position{line: 4875, col: 40, offset: 149658},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4801, col: 40, offset: 147139},
+										pos:        position{line: 4875, col: 40, offset: 149658},
 										val:        "==",
 										ignoreCase: false,
 										want:       "\"==\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4801, col: 47, offset: 147146},
+										pos:        position{line: 4875, col: 47, offset: 149665},
 										val:        "=",
 										ignoreCase: false,
 										want:       "\"=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4801, col: 53, offset: 147152},
+										pos:        position{line: 4875, col: 53, offset: 149671},
 										val:        "!=",
 										ignoreCase: false,
 										want:       "\"!=\"",
@@ -11318,7 +11557,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4801, col: 59, offset: 147158},
+							pos:  position{line: 4875, col: 59, offset: 149677},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11327,43 +11566,43 @@ var g = &grammar{
 		},
 		{
 			name: "InequalityOperator",
-			pos:  position{line: 4812, col: 1, offset: 147388},
+			pos:  position{line: 4886, col: 1, offset: 149907},
 			expr: &actionExpr{
-				pos: position{line: 4812, col: 23, offset: 147410},
+				pos: position{line: 4886, col: 23, offset: 149929},
 				run: (*parser).callonInequalityOperator1,
 				expr: &seqExpr{
-					pos: position{line: 4812, col: 23, offset: 147410},
+					pos: position{line: 4886, col: 23, offset: 149929},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4812, col: 23, offset: 147410},
+							pos:  position{line: 4886, col: 23, offset: 149929},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 4812, col: 38, offset: 147425},
+							pos:   position{line: 4886, col: 38, offset: 149944},
 							label: "op",
 							expr: &choiceExpr{
-								pos: position{line: 4812, col: 42, offset: 147429},
+								pos: position{line: 4886, col: 42, offset: 149948},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 4812, col: 42, offset: 147429},
+										pos:        position{line: 4886, col: 42, offset: 149948},
 										val:        "<=",
 										ignoreCase: false,
 										want:       "\"<=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4812, col: 49, offset: 147436},
+										pos:        position{line: 4886, col: 49, offset: 149955},
 										val:        "<",
 										ignoreCase: false,
 										want:       "\"<\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4812, col: 55, offset: 147442},
+										pos:        position{line: 4886, col: 55, offset: 149961},
 										val:        ">=",
 										ignoreCase: false,
 										want:       "\">=\"",
 									},
 									&litMatcher{
-										pos:        position{line: 4812, col: 62, offset: 147449},
+										pos:        position{line: 4886, col: 62, offset: 149968},
 										val:        ">",
 										ignoreCase: false,
 										want:       "\">\"",
@@ -11372,7 +11611,7 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4812, col: 67, offset: 147454},
+							pos:  position{line: 4886, col: 67, offset: 149973},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11381,30 +11620,30 @@ var g = &grammar{
 		},
 		{
 			name: "EqualityOrInequality",
-			pos:  position{line: 4820, col: 1, offset: 147637},
+			pos:  position{line: 4894, col: 1, offset: 150156},
 			expr: &choiceExpr{
-				pos: position{line: 4820, col: 25, offset: 147661},
+				pos: position{line: 4894, col: 25, offset: 150180},
 				alternatives: []any{
 					&actionExpr{
-						pos: position{line: 4820, col: 25, offset: 147661},
+						pos: position{line: 4894, col: 25, offset: 150180},
 						run: (*parser).callonEqualityOrInequality2,
 						expr: &labeledExpr{
-							pos:   position{line: 4820, col: 25, offset: 147661},
+							pos:   position{line: 4894, col: 25, offset: 150180},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4820, col: 28, offset: 147664},
+								pos:  position{line: 4894, col: 28, offset: 150183},
 								name: "EqualityOperator",
 							},
 						},
 					},
 					&actionExpr{
-						pos: position{line: 4823, col: 3, offset: 147706},
+						pos: position{line: 4897, col: 3, offset: 150225},
 						run: (*parser).callonEqualityOrInequality5,
 						expr: &labeledExpr{
-							pos:   position{line: 4823, col: 3, offset: 147706},
+							pos:   position{line: 4897, col: 3, offset: 150225},
 							label: "op",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4823, col: 6, offset: 147709},
+								pos:  position{line: 4897, col: 6, offset: 150228},
 								name: "InequalityOperator",
 							},
 						},
@@ -11414,25 +11653,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpPlus",
-			pos:  position{line: 4827, col: 1, offset: 147752},
+			pos:  position{line: 4901, col: 1, offset: 150271},
 			expr: &actionExpr{
-				pos: position{line: 4827, col: 11, offset: 147762},
+				pos: position{line: 4901, col: 11, offset: 150281},
 				run: (*parser).callonOpPlus1,
 				expr: &seqExpr{
-					pos: position{line: 4827, col: 11, offset: 147762},
+					pos: position{line: 4901, col: 11, offset: 150281},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4827, col: 11, offset: 147762},
+							pos:  position{line: 4901, col: 11, offset: 150281},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4827, col: 26, offset: 147777},
+							pos:        position{line: 4901, col: 26, offset: 150296},
 							val:        "+",
 							ignoreCase: false,
 							want:       "\"+\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4827, col: 30, offset: 147781},
+							pos:  position{line: 4901, col: 30, offset: 150300},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11441,25 +11680,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMinus",
-			pos:  position{line: 4831, col: 1, offset: 147821},
+			pos:  position{line: 4905, col: 1, offset: 150340},
 			expr: &actionExpr{
-				pos: position{line: 4831, col: 12, offset: 147832},
+				pos: position{line: 4905, col: 12, offset: 150351},
 				run: (*parser).callonOpMinus1,
 				expr: &seqExpr{
-					pos: position{line: 4831, col: 12, offset: 147832},
+					pos: position{line: 4905, col: 12, offset: 150351},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4831, col: 12, offset: 147832},
+							pos:  position{line: 4905, col: 12, offset: 150351},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4831, col: 27, offset: 147847},
+							pos:        position{line: 4905, col: 27, offset: 150366},
 							val:        "-",
 							ignoreCase: false,
 							want:       "\"-\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4831, col: 31, offset: 147851},
+							pos:  position{line: 4905, col: 31, offset: 150370},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11468,25 +11707,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMul",
-			pos:  position{line: 4835, col: 1, offset: 147891},
+			pos:  position{line: 4909, col: 1, offset: 150410},
 			expr: &actionExpr{
-				pos: position{line: 4835, col: 10, offset: 147900},
+				pos: position{line: 4909, col: 10, offset: 150419},
 				run: (*parser).callonOpMul1,
 				expr: &seqExpr{
-					pos: position{line: 4835, col: 10, offset: 147900},
+					pos: position{line: 4909, col: 10, offset: 150419},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4835, col: 10, offset: 147900},
+							pos:  position{line: 4909, col: 10, offset: 150419},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4835, col: 25, offset: 147915},
+							pos:        position{line: 4909, col: 25, offset: 150434},
 							val:        "*",
 							ignoreCase: false,
 							want:       "\"*\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4835, col: 29, offset: 147919},
+							pos:  position{line: 4909, col: 29, offset: 150438},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11495,25 +11734,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpDiv",
-			pos:  position{line: 4839, col: 1, offset: 147959},
+			pos:  position{line: 4913, col: 1, offset: 150478},
 			expr: &actionExpr{
-				pos: position{line: 4839, col: 10, offset: 147968},
+				pos: position{line: 4913, col: 10, offset: 150487},
 				run: (*parser).callonOpDiv1,
 				expr: &seqExpr{
-					pos: position{line: 4839, col: 10, offset: 147968},
+					pos: position{line: 4913, col: 10, offset: 150487},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4839, col: 10, offset: 147968},
+							pos:  position{line: 4913, col: 10, offset: 150487},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4839, col: 25, offset: 147983},
+							pos:        position{line: 4913, col: 25, offset: 150502},
 							val:        "/",
 							ignoreCase: false,
 							want:       "\"/\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4839, col: 29, offset: 147987},
+							pos:  position{line: 4913, col: 29, offset: 150506},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11522,25 +11761,25 @@ var g = &grammar{
 		},
 		{
 			name: "OpMod",
-			pos:  position{line: 4843, col: 1, offset: 148027},
+			pos:  position{line: 4917, col: 1, offset: 150546},
 			expr: &actionExpr{
-				pos: position{line: 4843, col: 10, offset: 148036},
+				pos: position{line: 4917, col: 10, offset: 150555},
 				run: (*parser).callonOpMod1,
 				expr: &seqExpr{
-					pos: position{line: 4843, col: 10, offset: 148036},
+					pos: position{line: 4917, col: 10, offset: 150555},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4843, col: 10, offset: 148036},
+							pos:  position{line: 4917, col: 10, offset: 150555},
 							name: "EMPTY_OR_SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 4843, col: 25, offset: 148051},
+							pos:        position{line: 4917, col: 25, offset: 150570},
 							val:        "%",
 							ignoreCase: false,
 							want:       "\"%\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4843, col: 29, offset: 148055},
+							pos:  position{line: 4917, col: 29, offset: 150574},
 							name: "EMPTY_OR_SPACE",
 						},
 					},
@@ -11549,39 +11788,39 @@ var g = &grammar{
 		},
 		{
 			name: "Second",
-			pos:  position{line: 4848, col: 1, offset: 148119},
+			pos:  position{line: 4922, col: 1, offset: 150638},
 			expr: &actionExpr{
-				pos: position{line: 4848, col: 11, offset: 148129},
+				pos: position{line: 4922, col: 11, offset: 150648},
 				run: (*parser).callonSecond1,
 				expr: &choiceExpr{
-					pos: position{line: 4848, col: 12, offset: 148130},
+					pos: position{line: 4922, col: 12, offset: 150649},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4848, col: 12, offset: 148130},
+							pos:        position{line: 4922, col: 12, offset: 150649},
 							val:        "seconds",
 							ignoreCase: false,
 							want:       "\"seconds\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4848, col: 24, offset: 148142},
+							pos:        position{line: 4922, col: 24, offset: 150661},
 							val:        "second",
 							ignoreCase: false,
 							want:       "\"second\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4848, col: 35, offset: 148153},
+							pos:        position{line: 4922, col: 35, offset: 150672},
 							val:        "secs",
 							ignoreCase: false,
 							want:       "\"secs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4848, col: 44, offset: 148162},
+							pos:        position{line: 4922, col: 44, offset: 150681},
 							val:        "sec",
 							ignoreCase: false,
 							want:       "\"sec\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4848, col: 52, offset: 148170},
+							pos:        position{line: 4922, col: 52, offset: 150689},
 							val:        "s",
 							ignoreCase: false,
 							want:       "\"s\"",
@@ -11592,39 +11831,39 @@ var g = &grammar{
 		},
 		{
 			name: "Minute",
-			pos:  position{line: 4852, col: 1, offset: 148212},
+			pos:  position{line: 4926, col: 1, offset: 150731},
 			expr: &actionExpr{
-				pos: position{line: 4852, col: 11, offset: 148222},
+				pos: position{line: 4926, col: 11, offset: 150741},
 				run: (*parser).callonMinute1,
 				expr: &choiceExpr{
-					pos: position{line: 4852, col: 12, offset: 148223},
+					pos: position{line: 4926, col: 12, offset: 150742},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4852, col: 12, offset: 148223},
+							pos:        position{line: 4926, col: 12, offset: 150742},
 							val:        "minutes",
 							ignoreCase: false,
 							want:       "\"minutes\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4852, col: 24, offset: 148235},
+							pos:        position{line: 4926, col: 24, offset: 150754},
 							val:        "minute",
 							ignoreCase: false,
 							want:       "\"minute\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4852, col: 35, offset: 148246},
+							pos:        position{line: 4926, col: 35, offset: 150765},
 							val:        "mins",
 							ignoreCase: false,
 							want:       "\"mins\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4852, col: 44, offset: 148255},
+							pos:        position{line: 4926, col: 44, offset: 150774},
 							val:        "min",
 							ignoreCase: false,
 							want:       "\"min\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4852, col: 52, offset: 148263},
+							pos:        position{line: 4926, col: 52, offset: 150782},
 							val:        "m",
 							ignoreCase: false,
 							want:       "\"m\"",
@@ -11635,39 +11874,39 @@ var g = &grammar{
 		},
 		{
 			name: "Hour",
-			pos:  position{line: 4856, col: 1, offset: 148305},
+			pos:  position{line: 4930, col: 1, offset: 150824},
 			expr: &actionExpr{
-				pos: position{line: 4856, col: 9, offset: 148313},
+				pos: position{line: 4930, col: 9, offset: 150832},
 				run: (*parser).callonHour1,
 				expr: &choiceExpr{
-					pos: position{line: 4856, col: 10, offset: 148314},
+					pos: position{line: 4930, col: 10, offset: 150833},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4856, col: 10, offset: 148314},
+							pos:        position{line: 4930, col: 10, offset: 150833},
 							val:        "hours",
 							ignoreCase: false,
 							want:       "\"hours\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 20, offset: 148324},
+							pos:        position{line: 4930, col: 20, offset: 150843},
 							val:        "hour",
 							ignoreCase: false,
 							want:       "\"hour\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 29, offset: 148333},
+							pos:        position{line: 4930, col: 29, offset: 150852},
 							val:        "hrs",
 							ignoreCase: false,
 							want:       "\"hrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 37, offset: 148341},
+							pos:        position{line: 4930, col: 37, offset: 150860},
 							val:        "hr",
 							ignoreCase: false,
 							want:       "\"hr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4856, col: 44, offset: 148348},
+							pos:        position{line: 4930, col: 44, offset: 150867},
 							val:        "h",
 							ignoreCase: false,
 							want:       "\"h\"",
@@ -11678,27 +11917,27 @@ var g = &grammar{
 		},
 		{
 			name: "Day",
-			pos:  position{line: 4860, col: 1, offset: 148388},
+			pos:  position{line: 4934, col: 1, offset: 150907},
 			expr: &actionExpr{
-				pos: position{line: 4860, col: 8, offset: 148395},
+				pos: position{line: 4934, col: 8, offset: 150914},
 				run: (*parser).callonDay1,
 				expr: &choiceExpr{
-					pos: position{line: 4860, col: 9, offset: 148396},
+					pos: position{line: 4934, col: 9, offset: 150915},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4860, col: 9, offset: 148396},
+							pos:        position{line: 4934, col: 9, offset: 150915},
 							val:        "days",
 							ignoreCase: false,
 							want:       "\"days\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4860, col: 18, offset: 148405},
+							pos:        position{line: 4934, col: 18, offset: 150924},
 							val:        "day",
 							ignoreCase: false,
 							want:       "\"day\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4860, col: 26, offset: 148413},
+							pos:        position{line: 4934, col: 26, offset: 150932},
 							val:        "d",
 							ignoreCase: false,
 							want:       "\"d\"",
@@ -11709,27 +11948,27 @@ var g = &grammar{
 		},
 		{
 			name: "Week",
-			pos:  position{line: 4864, col: 1, offset: 148452},
+			pos:  position{line: 4938, col: 1, offset: 150971},
 			expr: &actionExpr{
-				pos: position{line: 4864, col: 9, offset: 148460},
+				pos: position{line: 4938, col: 9, offset: 150979},
 				run: (*parser).callonWeek1,
 				expr: &choiceExpr{
-					pos: position{line: 4864, col: 10, offset: 148461},
+					pos: position{line: 4938, col: 10, offset: 150980},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4864, col: 10, offset: 148461},
+							pos:        position{line: 4938, col: 10, offset: 150980},
 							val:        "weeks",
 							ignoreCase: false,
 							want:       "\"weeks\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4864, col: 20, offset: 148471},
+							pos:        position{line: 4938, col: 20, offset: 150990},
 							val:        "week",
 							ignoreCase: false,
 							want:       "\"week\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4864, col: 29, offset: 148480},
+							pos:        position{line: 4938, col: 29, offset: 150999},
 							val:        "w",
 							ignoreCase: false,
 							want:       "\"w\"",
@@ -11740,27 +11979,27 @@ var g = &grammar{
 		},
 		{
 			name: "Month",
-			pos:  position{line: 4868, col: 1, offset: 148520},
+			pos:  position{line: 4942, col: 1, offset: 151039},
 			expr: &actionExpr{
-				pos: position{line: 4868, col: 10, offset: 148529},
+				pos: position{line: 4942, col: 10, offset: 151048},
 				run: (*parser).callonMonth1,
 				expr: &choiceExpr{
-					pos: position{line: 4868, col: 11, offset: 148530},
+					pos: position{line: 4942, col: 11, offset: 151049},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4868, col: 11, offset: 148530},
+							pos:        position{line: 4942, col: 11, offset: 151049},
 							val:        "months",
 							ignoreCase: false,
 							want:       "\"months\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4868, col: 22, offset: 148541},
+							pos:        position{line: 4942, col: 22, offset: 151060},
 							val:        "month",
 							ignoreCase: false,
 							want:       "\"month\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4868, col: 32, offset: 148551},
+							pos:        position{line: 4942, col: 32, offset: 151070},
 							val:        "mon",
 							ignoreCase: false,
 							want:       "\"mon\"",
@@ -11771,39 +12010,39 @@ var g = &grammar{
 		},
 		{
 			name: "Quarter",
-			pos:  position{line: 4872, col: 1, offset: 148594},
+			pos:  position{line: 4946, col: 1, offset: 151113},
 			expr: &actionExpr{
-				pos: position{line: 4872, col: 12, offset: 148605},
+				pos: position{line: 4946, col: 12, offset: 151124},
 				run: (*parser).callonQuarter1,
 				expr: &choiceExpr{
-					pos: position{line: 4872, col: 13, offset: 148606},
+					pos: position{line: 4946, col: 13, offset: 151125},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4872, col: 13, offset: 148606},
+							pos:        position{line: 4946, col: 13, offset: 151125},
 							val:        "quarters",
 							ignoreCase: false,
 							want:       "\"quarters\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4872, col: 26, offset: 148619},
+							pos:        position{line: 4946, col: 26, offset: 151138},
 							val:        "quarter",
 							ignoreCase: false,
 							want:       "\"quarter\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4872, col: 38, offset: 148631},
+							pos:        position{line: 4946, col: 38, offset: 151150},
 							val:        "qtrs",
 							ignoreCase: false,
 							want:       "\"qtrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4872, col: 47, offset: 148640},
+							pos:        position{line: 4946, col: 47, offset: 151159},
 							val:        "qtr",
 							ignoreCase: false,
 							want:       "\"qtr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4872, col: 55, offset: 148648},
+							pos:        position{line: 4946, col: 55, offset: 151167},
 							val:        "q",
 							ignoreCase: false,
 							want:       "\"q\"",
@@ -11814,39 +12053,39 @@ var g = &grammar{
 		},
 		{
 			name: "Year",
-			pos:  position{line: 4876, col: 1, offset: 148691},
+			pos:  position{line: 4950, col: 1, offset: 151210},
 			expr: &actionExpr{
-				pos: position{line: 4876, col: 9, offset: 148699},
+				pos: position{line: 4950, col: 9, offset: 151218},
 				run: (*parser).callonYear1,
 				expr: &choiceExpr{
-					pos: position{line: 4876, col: 10, offset: 148700},
+					pos: position{line: 4950, col: 10, offset: 151219},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4876, col: 10, offset: 148700},
+							pos:        position{line: 4950, col: 10, offset: 151219},
 							val:        "years",
 							ignoreCase: false,
 							want:       "\"years\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4876, col: 20, offset: 148710},
+							pos:        position{line: 4950, col: 20, offset: 151229},
 							val:        "year",
 							ignoreCase: false,
 							want:       "\"year\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4876, col: 29, offset: 148719},
+							pos:        position{line: 4950, col: 29, offset: 151238},
 							val:        "yrs",
 							ignoreCase: false,
 							want:       "\"yrs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4876, col: 37, offset: 148727},
+							pos:        position{line: 4950, col: 37, offset: 151246},
 							val:        "yr",
 							ignoreCase: false,
 							want:       "\"yr\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4876, col: 44, offset: 148734},
+							pos:        position{line: 4950, col: 44, offset: 151253},
 							val:        "y",
 							ignoreCase: false,
 							want:       "\"y\"",
@@ -11857,33 +12096,33 @@ var g = &grammar{
 		},
 		{
 			name: "Subseconds",
-			pos:  position{line: 4881, col: 1, offset: 148866},
+			pos:  position{line: 4955, col: 1, offset: 151385},
 			expr: &actionExpr{
-				pos: position{line: 4881, col: 15, offset: 148880},
+				pos: position{line: 4955, col: 15, offset: 151399},
 				run: (*parser).callonSubseconds1,
 				expr: &choiceExpr{
-					pos: position{line: 4881, col: 16, offset: 148881},
+					pos: position{line: 4955, col: 16, offset: 151400},
 					alternatives: []any{
 						&litMatcher{
-							pos:        position{line: 4881, col: 16, offset: 148881},
+							pos:        position{line: 4955, col: 16, offset: 151400},
 							val:        "us",
 							ignoreCase: false,
 							want:       "\"us\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4881, col: 23, offset: 148888},
+							pos:        position{line: 4955, col: 23, offset: 151407},
 							val:        "ms",
 							ignoreCase: false,
 							want:       "\"ms\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4881, col: 30, offset: 148895},
+							pos:        position{line: 4955, col: 30, offset: 151414},
 							val:        "cs",
 							ignoreCase: false,
 							want:       "\"cs\"",
 						},
 						&litMatcher{
-							pos:        position{line: 4881, col: 37, offset: 148902},
+							pos:        position{line: 4955, col: 37, offset: 151421},
 							val:        "ds",
 							ignoreCase: false,
 							want:       "\"ds\"",
@@ -11894,26 +12133,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionBlock",
-			pos:  position{line: 4890, col: 1, offset: 149126},
+			pos:  position{line: 4964, col: 1, offset: 151645},
 			expr: &actionExpr{
-				pos: position{line: 4890, col: 21, offset: 149146},
+				pos: position{line: 4964, col: 21, offset: 151665},
 				run: (*parser).callonTransactionBlock1,
 				expr: &seqExpr{
-					pos: position{line: 4890, col: 21, offset: 149146},
+					pos: position{line: 4964, col: 21, offset: 151665},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 4890, col: 21, offset: 149146},
+							pos:  position{line: 4964, col: 21, offset: 151665},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4890, col: 26, offset: 149151},
+							pos:  position{line: 4964, col: 26, offset: 151670},
 							name: "CMD_TRANSACTION",
 						},
 						&labeledExpr{
-							pos:   position{line: 4890, col: 42, offset: 149167},
+							pos:   position{line: 4964, col: 42, offset: 151686},
 							label: "txnOptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4890, col: 53, offset: 149178},
+								pos:  position{line: 4964, col: 53, offset: 151697},
 								name: "TransactionOptions",
 							},
 						},
@@ -11923,17 +12162,17 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionOptions",
-			pos:  position{line: 4900, col: 1, offset: 149553},
+			pos:  position{line: 4974, col: 1, offset: 152072},
 			expr: &actionExpr{
-				pos: position{line: 4900, col: 23, offset: 149575},
+				pos: position{line: 4974, col: 23, offset: 152094},
 				run: (*parser).callonTransactionOptions1,
 				expr: &labeledExpr{
-					pos:   position{line: 4900, col: 23, offset: 149575},
+					pos:   position{line: 4974, col: 23, offset: 152094},
 					label: "txnOptions",
 					expr: &zeroOrOneExpr{
-						pos: position{line: 4900, col: 34, offset: 149586},
+						pos: position{line: 4974, col: 34, offset: 152105},
 						expr: &ruleRefExpr{
-							pos:  position{line: 4900, col: 34, offset: 149586},
+							pos:  position{line: 4974, col: 34, offset: 152105},
 							name: "TransactionDefinitionOptionsList",
 						},
 					},
@@ -11942,35 +12181,35 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOptionsList",
-			pos:  position{line: 4915, col: 1, offset: 149977},
+			pos:  position{line: 4989, col: 1, offset: 152496},
 			expr: &actionExpr{
-				pos: position{line: 4915, col: 37, offset: 150013},
+				pos: position{line: 4989, col: 37, offset: 152532},
 				run: (*parser).callonTransactionDefinitionOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 4915, col: 37, offset: 150013},
+					pos: position{line: 4989, col: 37, offset: 152532},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 4915, col: 37, offset: 150013},
+							pos:   position{line: 4989, col: 37, offset: 152532},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4915, col: 43, offset: 150019},
+								pos:  position{line: 4989, col: 43, offset: 152538},
 								name: "TransactionDefinitionOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 4915, col: 71, offset: 150047},
+							pos:   position{line: 4989, col: 71, offset: 152566},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 4915, col: 76, offset: 150052},
+								pos: position{line: 4989, col: 76, offset: 152571},
 								expr: &seqExpr{
-									pos: position{line: 4915, col: 77, offset: 150053},
+									pos: position{line: 4989, col: 77, offset: 152572},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 4915, col: 77, offset: 150053},
+											pos:  position{line: 4989, col: 77, offset: 152572},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 4915, col: 83, offset: 150059},
+											pos:  position{line: 4989, col: 83, offset: 152578},
 											name: "TransactionDefinitionOption",
 										},
 									},
@@ -11983,26 +12222,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionDefinitionOption",
-			pos:  position{line: 4950, col: 1, offset: 151048},
+			pos:  position{line: 5024, col: 1, offset: 153567},
 			expr: &actionExpr{
-				pos: position{line: 4950, col: 32, offset: 151079},
+				pos: position{line: 5024, col: 32, offset: 153598},
 				run: (*parser).callonTransactionDefinitionOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 4950, col: 32, offset: 151079},
+					pos:   position{line: 5024, col: 32, offset: 153598},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 4950, col: 40, offset: 151087},
+						pos: position{line: 5024, col: 40, offset: 153606},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4950, col: 40, offset: 151087},
+								pos:  position{line: 5024, col: 40, offset: 153606},
 								name: "TransactionSpaceSeparatedFieldList",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4950, col: 77, offset: 151124},
+								pos:  position{line: 5024, col: 77, offset: 153643},
 								name: "StartsWithOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4950, col: 96, offset: 151143},
+								pos:  position{line: 5024, col: 96, offset: 153662},
 								name: "EndsWithOption",
 							},
 						},
@@ -12012,15 +12251,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSpaceSeparatedFieldList",
-			pos:  position{line: 4954, col: 1, offset: 151187},
+			pos:  position{line: 5028, col: 1, offset: 153706},
 			expr: &actionExpr{
-				pos: position{line: 4954, col: 39, offset: 151225},
+				pos: position{line: 5028, col: 39, offset: 153744},
 				run: (*parser).callonTransactionSpaceSeparatedFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 4954, col: 39, offset: 151225},
+					pos:   position{line: 5028, col: 39, offset: 153744},
 					label: "fields",
 					expr: &ruleRefExpr{
-						pos:  position{line: 4954, col: 46, offset: 151232},
+						pos:  position{line: 5028, col: 46, offset: 153751},
 						name: "SpaceSeparatedFieldNameList",
 					},
 				},
@@ -12028,28 +12267,28 @@ var g = &grammar{
 		},
 		{
 			name: "StartsWithOption",
-			pos:  position{line: 4965, col: 1, offset: 151448},
+			pos:  position{line: 5039, col: 1, offset: 153967},
 			expr: &actionExpr{
-				pos: position{line: 4965, col: 21, offset: 151468},
+				pos: position{line: 5039, col: 21, offset: 153987},
 				run: (*parser).callonStartsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4965, col: 21, offset: 151468},
+					pos: position{line: 5039, col: 21, offset: 153987},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4965, col: 21, offset: 151468},
+							pos:        position{line: 5039, col: 21, offset: 153987},
 							val:        "startswith",
 							ignoreCase: false,
 							want:       "\"startswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4965, col: 34, offset: 151481},
+							pos:  position{line: 5039, col: 34, offset: 154000},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4965, col: 40, offset: 151487},
+							pos:   position{line: 5039, col: 40, offset: 154006},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4965, col: 48, offset: 151495},
+								pos:  position{line: 5039, col: 48, offset: 154014},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12059,28 +12298,28 @@ var g = &grammar{
 		},
 		{
 			name: "EndsWithOption",
-			pos:  position{line: 4975, col: 1, offset: 151733},
+			pos:  position{line: 5049, col: 1, offset: 154252},
 			expr: &actionExpr{
-				pos: position{line: 4975, col: 19, offset: 151751},
+				pos: position{line: 5049, col: 19, offset: 154270},
 				run: (*parser).callonEndsWithOption1,
 				expr: &seqExpr{
-					pos: position{line: 4975, col: 19, offset: 151751},
+					pos: position{line: 5049, col: 19, offset: 154270},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4975, col: 19, offset: 151751},
+							pos:        position{line: 5049, col: 19, offset: 154270},
 							val:        "endswith",
 							ignoreCase: false,
 							want:       "\"endswith\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 4975, col: 30, offset: 151762},
+							pos:  position{line: 5049, col: 30, offset: 154281},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 4975, col: 36, offset: 151768},
+							pos:   position{line: 5049, col: 36, offset: 154287},
 							label: "strExpr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4975, col: 44, offset: 151776},
+								pos:  position{line: 5049, col: 44, offset: 154295},
 								name: "TransactionFilterString",
 							},
 						},
@@ -12090,26 +12329,26 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionFilterString",
-			pos:  position{line: 4986, col: 1, offset: 152045},
+			pos:  position{line: 5060, col: 1, offset: 154564},
 			expr: &actionExpr{
-				pos: position{line: 4986, col: 28, offset: 152072},
+				pos: position{line: 5060, col: 28, offset: 154591},
 				run: (*parser).callonTransactionFilterString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4986, col: 28, offset: 152072},
+					pos:   position{line: 5060, col: 28, offset: 154591},
 					label: "strExpr",
 					expr: &choiceExpr{
-						pos: position{line: 4986, col: 37, offset: 152081},
+						pos: position{line: 5060, col: 37, offset: 154600},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4986, col: 37, offset: 152081},
+								pos:  position{line: 5060, col: 37, offset: 154600},
 								name: "TransactionQuotedString",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4986, col: 63, offset: 152107},
+								pos:  position{line: 5060, col: 63, offset: 154626},
 								name: "TransactionEval",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4986, col: 81, offset: 152125},
+								pos:  position{line: 5060, col: 81, offset: 154644},
 								name: "TransactionSearch",
 							},
 						},
@@ -12119,22 +12358,22 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedString",
-			pos:  position{line: 4990, col: 1, offset: 152173},
+			pos:  position{line: 5064, col: 1, offset: 154692},
 			expr: &actionExpr{
-				pos: position{line: 4990, col: 28, offset: 152200},
+				pos: position{line: 5064, col: 28, offset: 154719},
 				run: (*parser).callonTransactionQuotedString1,
 				expr: &labeledExpr{
-					pos:   position{line: 4990, col: 28, offset: 152200},
+					pos:   position{line: 5064, col: 28, offset: 154719},
 					label: "str",
 					expr: &choiceExpr{
-						pos: position{line: 4990, col: 33, offset: 152205},
+						pos: position{line: 5064, col: 33, offset: 154724},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 4990, col: 33, offset: 152205},
+								pos:  position{line: 5064, col: 33, offset: 154724},
 								name: "TransactionQuotedStringValue",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 4990, col: 64, offset: 152236},
+								pos:  position{line: 5064, col: 64, offset: 154755},
 								name: "TransactionQuotedStringSearchExpr",
 							},
 						},
@@ -12144,29 +12383,29 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringSearchExpr",
-			pos:  position{line: 4994, col: 1, offset: 152296},
+			pos:  position{line: 5068, col: 1, offset: 154815},
 			expr: &actionExpr{
-				pos: position{line: 4994, col: 38, offset: 152333},
+				pos: position{line: 5068, col: 38, offset: 154852},
 				run: (*parser).callonTransactionQuotedStringSearchExpr1,
 				expr: &seqExpr{
-					pos: position{line: 4994, col: 38, offset: 152333},
+					pos: position{line: 5068, col: 38, offset: 154852},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 4994, col: 38, offset: 152333},
+							pos:        position{line: 5068, col: 38, offset: 154852},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&labeledExpr{
-							pos:   position{line: 4994, col: 42, offset: 152337},
+							pos:   position{line: 5068, col: 42, offset: 154856},
 							label: "searchClause",
 							expr: &ruleRefExpr{
-								pos:  position{line: 4994, col: 55, offset: 152350},
+								pos:  position{line: 5068, col: 55, offset: 154869},
 								name: "ClauseLevel4",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 4994, col: 68, offset: 152363},
+							pos:        position{line: 5068, col: 68, offset: 154882},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12177,23 +12416,23 @@ var g = &grammar{
 		},
 		{
 			name: "QuotedStringNoOp",
-			pos:  position{line: 5002, col: 1, offset: 152502},
+			pos:  position{line: 5076, col: 1, offset: 155021},
 			expr: &actionExpr{
-				pos: position{line: 5002, col: 21, offset: 152522},
+				pos: position{line: 5076, col: 21, offset: 155041},
 				run: (*parser).callonQuotedStringNoOp1,
 				expr: &seqExpr{
-					pos: position{line: 5002, col: 21, offset: 152522},
+					pos: position{line: 5076, col: 21, offset: 155041},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5002, col: 21, offset: 152522},
+							pos:        position{line: 5076, col: 21, offset: 155041},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 5002, col: 25, offset: 152526},
+							pos: position{line: 5076, col: 25, offset: 155045},
 							expr: &charClassMatcher{
-								pos:        position{line: 5002, col: 25, offset: 152526},
+								pos:        position{line: 5076, col: 25, offset: 155045},
 								val:        "[^\" !(OR / AND)]",
 								chars:      []rune{'"', ' ', '!', '(', 'O', 'R', ' ', '/', ' ', 'A', 'N', 'D', ')'},
 								ignoreCase: false,
@@ -12201,7 +12440,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5002, col: 44, offset: 152545},
+							pos:        position{line: 5076, col: 44, offset: 155064},
 							val:        "\"",
 							ignoreCase: false,
 							want:       "\"\\\"\"",
@@ -12212,15 +12451,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionQuotedStringValue",
-			pos:  position{line: 5007, col: 1, offset: 152656},
+			pos:  position{line: 5081, col: 1, offset: 155175},
 			expr: &actionExpr{
-				pos: position{line: 5007, col: 33, offset: 152688},
+				pos: position{line: 5081, col: 33, offset: 155207},
 				run: (*parser).callonTransactionQuotedStringValue1,
 				expr: &labeledExpr{
-					pos:   position{line: 5007, col: 33, offset: 152688},
+					pos:   position{line: 5081, col: 33, offset: 155207},
 					label: "str",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5007, col: 37, offset: 152692},
+						pos:  position{line: 5081, col: 37, offset: 155211},
 						name: "QuotedStringNoOp",
 					},
 				},
@@ -12228,15 +12467,15 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionSearch",
-			pos:  position{line: 5015, col: 1, offset: 152847},
+			pos:  position{line: 5089, col: 1, offset: 155366},
 			expr: &actionExpr{
-				pos: position{line: 5015, col: 22, offset: 152868},
+				pos: position{line: 5089, col: 22, offset: 155387},
 				run: (*parser).callonTransactionSearch1,
 				expr: &labeledExpr{
-					pos:   position{line: 5015, col: 22, offset: 152868},
+					pos:   position{line: 5089, col: 22, offset: 155387},
 					label: "expr",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5015, col: 27, offset: 152873},
+						pos:  position{line: 5089, col: 27, offset: 155392},
 						name: "ClauseLevel1",
 					},
 				},
@@ -12244,37 +12483,37 @@ var g = &grammar{
 		},
 		{
 			name: "TransactionEval",
-			pos:  position{line: 5025, col: 1, offset: 153045},
+			pos:  position{line: 5099, col: 1, offset: 155564},
 			expr: &actionExpr{
-				pos: position{line: 5025, col: 20, offset: 153064},
+				pos: position{line: 5099, col: 20, offset: 155583},
 				run: (*parser).callonTransactionEval1,
 				expr: &seqExpr{
-					pos: position{line: 5025, col: 20, offset: 153064},
+					pos: position{line: 5099, col: 20, offset: 155583},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5025, col: 20, offset: 153064},
+							pos:        position{line: 5099, col: 20, offset: 155583},
 							val:        "eval",
 							ignoreCase: false,
 							want:       "\"eval\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5025, col: 27, offset: 153071},
+							pos:  position{line: 5099, col: 27, offset: 155590},
 							name: "EMPTY_OR_SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5025, col: 42, offset: 153086},
+							pos:  position{line: 5099, col: 42, offset: 155605},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5025, col: 50, offset: 153094},
+							pos:   position{line: 5099, col: 50, offset: 155613},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5025, col: 60, offset: 153104},
+								pos:  position{line: 5099, col: 60, offset: 155623},
 								name: "BoolExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5025, col: 69, offset: 153113},
+							pos:  position{line: 5099, col: 69, offset: 155632},
 							name: "R_PAREN",
 						},
 					},
@@ -12283,22 +12522,22 @@ var g = &grammar{
 		},
 		{
 			name: "MultiValueBlock",
-			pos:  position{line: 5035, col: 1, offset: 153416},
+			pos:  position{line: 5109, col: 1, offset: 155935},
 			expr: &actionExpr{
-				pos: position{line: 5035, col: 20, offset: 153435},
+				pos: position{line: 5109, col: 20, offset: 155954},
 				run: (*parser).callonMultiValueBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5035, col: 20, offset: 153435},
+					pos: position{line: 5109, col: 20, offset: 155954},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5035, col: 20, offset: 153435},
+							pos:  position{line: 5109, col: 20, offset: 155954},
 							name: "PIPE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5035, col: 25, offset: 153440},
+							pos:   position{line: 5109, col: 25, offset: 155959},
 							label: "mvQueryAggNode",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5035, col: 42, offset: 153457},
+								pos:  position{line: 5109, col: 42, offset: 155976},
 								name: "MakeMVBlock",
 							},
 						},
@@ -12308,41 +12547,41 @@ var g = &grammar{
 		},
 		{
 			name: "MakeMVBlock",
-			pos:  position{line: 5039, col: 1, offset: 153506},
+			pos:  position{line: 5113, col: 1, offset: 156025},
 			expr: &actionExpr{
-				pos: position{line: 5039, col: 16, offset: 153521},
+				pos: position{line: 5113, col: 16, offset: 156040},
 				run: (*parser).callonMakeMVBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5039, col: 16, offset: 153521},
+					pos: position{line: 5113, col: 16, offset: 156040},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 16, offset: 153521},
+							pos:  position{line: 5113, col: 16, offset: 156040},
 							name: "CMD_MAKEMV",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 27, offset: 153532},
+							pos:  position{line: 5113, col: 27, offset: 156051},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5039, col: 33, offset: 153538},
+							pos:   position{line: 5113, col: 33, offset: 156057},
 							label: "mvColOptionExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5039, col: 50, offset: 153555},
+								pos: position{line: 5113, col: 50, offset: 156074},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5039, col: 50, offset: 153555},
+									pos:  position{line: 5113, col: 50, offset: 156074},
 									name: "MVBlockOptionsList",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5039, col: 70, offset: 153575},
+							pos:  position{line: 5113, col: 70, offset: 156094},
 							name: "EMPTY_OR_SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5039, col: 85, offset: 153590},
+							pos:   position{line: 5113, col: 85, offset: 156109},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5039, col: 91, offset: 153596},
+								pos:  position{line: 5113, col: 91, offset: 156115},
 								name: "FieldName",
 							},
 						},
@@ -12352,35 +12591,35 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOptionsList",
-			pos:  position{line: 5068, col: 1, offset: 154367},
+			pos:  position{line: 5142, col: 1, offset: 156886},
 			expr: &actionExpr{
-				pos: position{line: 5068, col: 23, offset: 154389},
+				pos: position{line: 5142, col: 23, offset: 156908},
 				run: (*parser).callonMVBlockOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5068, col: 23, offset: 154389},
+					pos: position{line: 5142, col: 23, offset: 156908},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5068, col: 23, offset: 154389},
+							pos:   position{line: 5142, col: 23, offset: 156908},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5068, col: 31, offset: 154397},
+								pos:  position{line: 5142, col: 31, offset: 156916},
 								name: "MVBlockOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5068, col: 46, offset: 154412},
+							pos:   position{line: 5142, col: 46, offset: 156931},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5068, col: 52, offset: 154418},
+								pos: position{line: 5142, col: 52, offset: 156937},
 								expr: &seqExpr{
-									pos: position{line: 5068, col: 53, offset: 154419},
+									pos: position{line: 5142, col: 53, offset: 156938},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5068, col: 53, offset: 154419},
+											pos:  position{line: 5142, col: 53, offset: 156938},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5068, col: 59, offset: 154425},
+											pos:  position{line: 5142, col: 59, offset: 156944},
 											name: "MVBlockOption",
 										},
 									},
@@ -12393,26 +12632,26 @@ var g = &grammar{
 		},
 		{
 			name: "MVBlockOption",
-			pos:  position{line: 5102, col: 1, offset: 155481},
+			pos:  position{line: 5176, col: 1, offset: 158000},
 			expr: &actionExpr{
-				pos: position{line: 5102, col: 18, offset: 155498},
+				pos: position{line: 5176, col: 18, offset: 158017},
 				run: (*parser).callonMVBlockOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5102, col: 18, offset: 155498},
+					pos:   position{line: 5176, col: 18, offset: 158017},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5102, col: 27, offset: 155507},
+						pos: position{line: 5176, col: 27, offset: 158026},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5102, col: 27, offset: 155507},
+								pos:  position{line: 5176, col: 27, offset: 158026},
 								name: "DelimOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5102, col: 41, offset: 155521},
+								pos:  position{line: 5176, col: 41, offset: 158040},
 								name: "AllowEmptyOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5102, col: 60, offset: 155540},
+								pos:  position{line: 5176, col: 60, offset: 158059},
 								name: "SetSvOption",
 							},
 						},
@@ -12422,22 +12661,22 @@ var g = &grammar{
 		},
 		{
 			name: "DelimOption",
-			pos:  position{line: 5106, col: 1, offset: 155581},
+			pos:  position{line: 5180, col: 1, offset: 158100},
 			expr: &actionExpr{
-				pos: position{line: 5106, col: 16, offset: 155596},
+				pos: position{line: 5180, col: 16, offset: 158115},
 				run: (*parser).callonDelimOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5106, col: 16, offset: 155596},
+					pos:   position{line: 5180, col: 16, offset: 158115},
 					label: "delimExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5106, col: 28, offset: 155608},
+						pos: position{line: 5180, col: 28, offset: 158127},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5106, col: 28, offset: 155608},
+								pos:  position{line: 5180, col: 28, offset: 158127},
 								name: "StringDelimiter",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5106, col: 46, offset: 155626},
+								pos:  position{line: 5180, col: 46, offset: 158145},
 								name: "RegexDelimiter",
 							},
 						},
@@ -12447,28 +12686,28 @@ var g = &grammar{
 		},
 		{
 			name: "StringDelimiter",
-			pos:  position{line: 5110, col: 1, offset: 155673},
+			pos:  position{line: 5184, col: 1, offset: 158192},
 			expr: &actionExpr{
-				pos: position{line: 5110, col: 20, offset: 155692},
+				pos: position{line: 5184, col: 20, offset: 158211},
 				run: (*parser).callonStringDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5110, col: 20, offset: 155692},
+					pos: position{line: 5184, col: 20, offset: 158211},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5110, col: 20, offset: 155692},
+							pos:        position{line: 5184, col: 20, offset: 158211},
 							val:        "delim",
 							ignoreCase: false,
 							want:       "\"delim\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5110, col: 28, offset: 155700},
+							pos:  position{line: 5184, col: 28, offset: 158219},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5110, col: 34, offset: 155706},
+							pos:   position{line: 5184, col: 34, offset: 158225},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5110, col: 38, offset: 155710},
+								pos:  position{line: 5184, col: 38, offset: 158229},
 								name: "QuotedString",
 							},
 						},
@@ -12478,28 +12717,28 @@ var g = &grammar{
 		},
 		{
 			name: "RegexDelimiter",
-			pos:  position{line: 5121, col: 1, offset: 155961},
+			pos:  position{line: 5195, col: 1, offset: 158480},
 			expr: &actionExpr{
-				pos: position{line: 5121, col: 19, offset: 155979},
+				pos: position{line: 5195, col: 19, offset: 158498},
 				run: (*parser).callonRegexDelimiter1,
 				expr: &seqExpr{
-					pos: position{line: 5121, col: 19, offset: 155979},
+					pos: position{line: 5195, col: 19, offset: 158498},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5121, col: 19, offset: 155979},
+							pos:        position{line: 5195, col: 19, offset: 158498},
 							val:        "tokenizer",
 							ignoreCase: false,
 							want:       "\"tokenizer\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5121, col: 31, offset: 155991},
+							pos:  position{line: 5195, col: 31, offset: 158510},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5121, col: 37, offset: 155997},
+							pos:   position{line: 5195, col: 37, offset: 158516},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5121, col: 41, offset: 156001},
+								pos:  position{line: 5195, col: 41, offset: 158520},
 								name: "QuotedString",
 							},
 						},
@@ -12509,28 +12748,28 @@ var g = &grammar{
 		},
 		{
 			name: "AllowEmptyOption",
-			pos:  position{line: 5139, col: 1, offset: 156472},
+			pos:  position{line: 5213, col: 1, offset: 158991},
 			expr: &actionExpr{
-				pos: position{line: 5139, col: 21, offset: 156492},
+				pos: position{line: 5213, col: 21, offset: 159011},
 				run: (*parser).callonAllowEmptyOption1,
 				expr: &seqExpr{
-					pos: position{line: 5139, col: 21, offset: 156492},
+					pos: position{line: 5213, col: 21, offset: 159011},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5139, col: 21, offset: 156492},
+							pos:        position{line: 5213, col: 21, offset: 159011},
 							val:        "allowempty",
 							ignoreCase: false,
 							want:       "\"allowempty\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5139, col: 34, offset: 156505},
+							pos:  position{line: 5213, col: 34, offset: 159024},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5139, col: 40, offset: 156511},
+							pos:   position{line: 5213, col: 40, offset: 159030},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5139, col: 48, offset: 156519},
+								pos:  position{line: 5213, col: 48, offset: 159038},
 								name: "Boolean",
 							},
 						},
@@ -12540,28 +12779,28 @@ var g = &grammar{
 		},
 		{
 			name: "SetSvOption",
-			pos:  position{line: 5151, col: 1, offset: 156759},
+			pos:  position{line: 5225, col: 1, offset: 159278},
 			expr: &actionExpr{
-				pos: position{line: 5151, col: 16, offset: 156774},
+				pos: position{line: 5225, col: 16, offset: 159293},
 				run: (*parser).callonSetSvOption1,
 				expr: &seqExpr{
-					pos: position{line: 5151, col: 16, offset: 156774},
+					pos: position{line: 5225, col: 16, offset: 159293},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5151, col: 16, offset: 156774},
+							pos:        position{line: 5225, col: 16, offset: 159293},
 							val:        "setsv",
 							ignoreCase: false,
 							want:       "\"setsv\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5151, col: 24, offset: 156782},
+							pos:  position{line: 5225, col: 24, offset: 159301},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5151, col: 30, offset: 156788},
+							pos:   position{line: 5225, col: 30, offset: 159307},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5151, col: 38, offset: 156796},
+								pos:  position{line: 5225, col: 38, offset: 159315},
 								name: "Boolean",
 							},
 						},
@@ -12571,28 +12810,28 @@ var g = &grammar{
 		},
 		{
 			name: "SPathBlock",
-			pos:  position{line: 5163, col: 1, offset: 157061},
+			pos:  position{line: 5237, col: 1, offset: 159580},
 			expr: &actionExpr{
-				pos: position{line: 5163, col: 15, offset: 157075},
+				pos: position{line: 5237, col: 15, offset: 159594},
 				run: (*parser).callonSPathBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5163, col: 15, offset: 157075},
+					pos: position{line: 5237, col: 15, offset: 159594},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5163, col: 15, offset: 157075},
+							pos:  position{line: 5237, col: 15, offset: 159594},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5163, col: 20, offset: 157080},
+							pos:  position{line: 5237, col: 20, offset: 159599},
 							name: "CMD_SPATH",
 						},
 						&labeledExpr{
-							pos:   position{line: 5163, col: 30, offset: 157090},
+							pos:   position{line: 5237, col: 30, offset: 159609},
 							label: "spathExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5163, col: 40, offset: 157100},
+								pos: position{line: 5237, col: 40, offset: 159619},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5163, col: 40, offset: 157100},
+									pos:  position{line: 5237, col: 40, offset: 159619},
 									name: "SPathArgumentsList",
 								},
 							},
@@ -12603,39 +12842,39 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgumentsList",
-			pos:  position{line: 5170, col: 1, offset: 157226},
+			pos:  position{line: 5244, col: 1, offset: 159745},
 			expr: &actionExpr{
-				pos: position{line: 5170, col: 23, offset: 157248},
+				pos: position{line: 5244, col: 23, offset: 159767},
 				run: (*parser).callonSPathArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5170, col: 23, offset: 157248},
+					pos: position{line: 5244, col: 23, offset: 159767},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5170, col: 23, offset: 157248},
+							pos:  position{line: 5244, col: 23, offset: 159767},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5170, col: 29, offset: 157254},
+							pos:   position{line: 5244, col: 29, offset: 159773},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5170, col: 35, offset: 157260},
+								pos:  position{line: 5244, col: 35, offset: 159779},
 								name: "SPathArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5170, col: 49, offset: 157274},
+							pos:   position{line: 5244, col: 49, offset: 159793},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5170, col: 54, offset: 157279},
+								pos: position{line: 5244, col: 54, offset: 159798},
 								expr: &seqExpr{
-									pos: position{line: 5170, col: 55, offset: 157280},
+									pos: position{line: 5244, col: 55, offset: 159799},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5170, col: 55, offset: 157280},
+											pos:  position{line: 5244, col: 55, offset: 159799},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5170, col: 61, offset: 157286},
+											pos:  position{line: 5244, col: 61, offset: 159805},
 											name: "SPathArgument",
 										},
 									},
@@ -12648,26 +12887,26 @@ var g = &grammar{
 		},
 		{
 			name: "SPathArgument",
-			pos:  position{line: 5202, col: 1, offset: 158179},
+			pos:  position{line: 5276, col: 1, offset: 160698},
 			expr: &actionExpr{
-				pos: position{line: 5202, col: 18, offset: 158196},
+				pos: position{line: 5276, col: 18, offset: 160715},
 				run: (*parser).callonSPathArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5202, col: 18, offset: 158196},
+					pos:   position{line: 5276, col: 18, offset: 160715},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5202, col: 23, offset: 158201},
+						pos: position{line: 5276, col: 23, offset: 160720},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 23, offset: 158201},
+								pos:  position{line: 5276, col: 23, offset: 160720},
 								name: "InputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 36, offset: 158214},
+								pos:  position{line: 5276, col: 36, offset: 160733},
 								name: "OutputField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5202, col: 50, offset: 158228},
+								pos:  position{line: 5276, col: 50, offset: 160747},
 								name: "PathField",
 							},
 						},
@@ -12677,28 +12916,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputField",
-			pos:  position{line: 5206, col: 1, offset: 158264},
+			pos:  position{line: 5280, col: 1, offset: 160783},
 			expr: &actionExpr{
-				pos: position{line: 5206, col: 15, offset: 158278},
+				pos: position{line: 5280, col: 15, offset: 160797},
 				run: (*parser).callonInputField1,
 				expr: &seqExpr{
-					pos: position{line: 5206, col: 15, offset: 158278},
+					pos: position{line: 5280, col: 15, offset: 160797},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5206, col: 15, offset: 158278},
+							pos:        position{line: 5280, col: 15, offset: 160797},
 							val:        "input",
 							ignoreCase: false,
 							want:       "\"input\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5206, col: 23, offset: 158286},
+							pos:  position{line: 5280, col: 23, offset: 160805},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5206, col: 29, offset: 158292},
+							pos:   position{line: 5280, col: 29, offset: 160811},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5206, col: 35, offset: 158298},
+								pos:  position{line: 5280, col: 35, offset: 160817},
 								name: "FieldName",
 							},
 						},
@@ -12708,28 +12947,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputField",
-			pos:  position{line: 5209, col: 1, offset: 158354},
+			pos:  position{line: 5283, col: 1, offset: 160873},
 			expr: &actionExpr{
-				pos: position{line: 5209, col: 16, offset: 158369},
+				pos: position{line: 5283, col: 16, offset: 160888},
 				run: (*parser).callonOutputField1,
 				expr: &seqExpr{
-					pos: position{line: 5209, col: 16, offset: 158369},
+					pos: position{line: 5283, col: 16, offset: 160888},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5209, col: 16, offset: 158369},
+							pos:        position{line: 5283, col: 16, offset: 160888},
 							val:        "output",
 							ignoreCase: false,
 							want:       "\"output\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5209, col: 25, offset: 158378},
+							pos:  position{line: 5283, col: 25, offset: 160897},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5209, col: 31, offset: 158384},
+							pos:   position{line: 5283, col: 31, offset: 160903},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5209, col: 37, offset: 158390},
+								pos:  position{line: 5283, col: 37, offset: 160909},
 								name: "FieldName",
 							},
 						},
@@ -12739,34 +12978,34 @@ var g = &grammar{
 		},
 		{
 			name: "PathField",
-			pos:  position{line: 5212, col: 1, offset: 158447},
+			pos:  position{line: 5286, col: 1, offset: 160966},
 			expr: &actionExpr{
-				pos: position{line: 5212, col: 14, offset: 158460},
+				pos: position{line: 5286, col: 14, offset: 160979},
 				run: (*parser).callonPathField1,
 				expr: &choiceExpr{
-					pos: position{line: 5212, col: 15, offset: 158461},
+					pos: position{line: 5286, col: 15, offset: 160980},
 					alternatives: []any{
 						&seqExpr{
-							pos: position{line: 5212, col: 15, offset: 158461},
+							pos: position{line: 5286, col: 15, offset: 160980},
 							exprs: []any{
 								&litMatcher{
-									pos:        position{line: 5212, col: 15, offset: 158461},
+									pos:        position{line: 5286, col: 15, offset: 160980},
 									val:        "path",
 									ignoreCase: false,
 									want:       "\"path\"",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5212, col: 22, offset: 158468},
+									pos:  position{line: 5286, col: 22, offset: 160987},
 									name: "EQUAL",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 5212, col: 28, offset: 158474},
+									pos:  position{line: 5286, col: 28, offset: 160993},
 									name: "SPathFieldString",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5212, col: 47, offset: 158493},
+							pos:  position{line: 5286, col: 47, offset: 161012},
 							name: "SPathFieldString",
 						},
 					},
@@ -12775,16 +13014,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPathFieldString",
-			pos:  position{line: 5224, col: 1, offset: 158905},
+			pos:  position{line: 5298, col: 1, offset: 161424},
 			expr: &choiceExpr{
-				pos: position{line: 5224, col: 21, offset: 158925},
+				pos: position{line: 5298, col: 21, offset: 161444},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5224, col: 21, offset: 158925},
+						pos:  position{line: 5298, col: 21, offset: 161444},
 						name: "QuotedString",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5224, col: 36, offset: 158940},
+						pos:  position{line: 5298, col: 36, offset: 161459},
 						name: "UnquotedStringWithTemplateWildCard",
 					},
 				},
@@ -12792,28 +13031,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatBlock",
-			pos:  position{line: 5227, col: 1, offset: 159013},
+			pos:  position{line: 5301, col: 1, offset: 161532},
 			expr: &actionExpr{
-				pos: position{line: 5227, col: 16, offset: 159028},
+				pos: position{line: 5301, col: 16, offset: 161547},
 				run: (*parser).callonFormatBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5227, col: 16, offset: 159028},
+					pos: position{line: 5301, col: 16, offset: 161547},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5227, col: 16, offset: 159028},
+							pos:  position{line: 5301, col: 16, offset: 161547},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5227, col: 21, offset: 159033},
+							pos:  position{line: 5301, col: 21, offset: 161552},
 							name: "CMD_FORMAT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5227, col: 32, offset: 159044},
+							pos:   position{line: 5301, col: 32, offset: 161563},
 							label: "formatArgExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5227, col: 46, offset: 159058},
+								pos: position{line: 5301, col: 46, offset: 161577},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5227, col: 46, offset: 159058},
+									pos:  position{line: 5301, col: 46, offset: 161577},
 									name: "FormatArgumentsList",
 								},
 							},
@@ -12824,39 +13063,39 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgumentsList",
-			pos:  position{line: 5249, col: 1, offset: 159667},
+			pos:  position{line: 5323, col: 1, offset: 162186},
 			expr: &actionExpr{
-				pos: position{line: 5249, col: 24, offset: 159690},
+				pos: position{line: 5323, col: 24, offset: 162209},
 				run: (*parser).callonFormatArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5249, col: 24, offset: 159690},
+					pos: position{line: 5323, col: 24, offset: 162209},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5249, col: 24, offset: 159690},
+							pos:  position{line: 5323, col: 24, offset: 162209},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5249, col: 30, offset: 159696},
+							pos:   position{line: 5323, col: 30, offset: 162215},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5249, col: 37, offset: 159703},
+								pos:  position{line: 5323, col: 37, offset: 162222},
 								name: "FormatArgument",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5249, col: 52, offset: 159718},
+							pos:   position{line: 5323, col: 52, offset: 162237},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5249, col: 57, offset: 159723},
+								pos: position{line: 5323, col: 57, offset: 162242},
 								expr: &seqExpr{
-									pos: position{line: 5249, col: 58, offset: 159724},
+									pos: position{line: 5323, col: 58, offset: 162243},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5249, col: 58, offset: 159724},
+											pos:  position{line: 5323, col: 58, offset: 162243},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5249, col: 64, offset: 159730},
+											pos:  position{line: 5323, col: 64, offset: 162249},
 											name: "FormatArgument",
 										},
 									},
@@ -12869,30 +13108,30 @@ var g = &grammar{
 		},
 		{
 			name: "FormatArgument",
-			pos:  position{line: 5283, col: 1, offset: 160919},
+			pos:  position{line: 5357, col: 1, offset: 163438},
 			expr: &actionExpr{
-				pos: position{line: 5283, col: 19, offset: 160937},
+				pos: position{line: 5357, col: 19, offset: 163456},
 				run: (*parser).callonFormatArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5283, col: 19, offset: 160937},
+					pos:   position{line: 5357, col: 19, offset: 163456},
 					label: "argExpr",
 					expr: &choiceExpr{
-						pos: position{line: 5283, col: 28, offset: 160946},
+						pos: position{line: 5357, col: 28, offset: 163465},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5283, col: 28, offset: 160946},
+								pos:  position{line: 5357, col: 28, offset: 163465},
 								name: "FormatSeparator",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5283, col: 46, offset: 160964},
+								pos:  position{line: 5357, col: 46, offset: 163483},
 								name: "FormatMaxResults",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5283, col: 65, offset: 160983},
+								pos:  position{line: 5357, col: 65, offset: 163502},
 								name: "FormatEmptyStr",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5283, col: 82, offset: 161000},
+								pos:  position{line: 5357, col: 82, offset: 163519},
 								name: "FormatRowColOptions",
 							},
 						},
@@ -12902,28 +13141,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatSeparator",
-			pos:  position{line: 5287, col: 1, offset: 161050},
+			pos:  position{line: 5361, col: 1, offset: 163569},
 			expr: &actionExpr{
-				pos: position{line: 5287, col: 20, offset: 161069},
+				pos: position{line: 5361, col: 20, offset: 163588},
 				run: (*parser).callonFormatSeparator1,
 				expr: &seqExpr{
-					pos: position{line: 5287, col: 20, offset: 161069},
+					pos: position{line: 5361, col: 20, offset: 163588},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5287, col: 20, offset: 161069},
+							pos:        position{line: 5361, col: 20, offset: 163588},
 							val:        "mvsep",
 							ignoreCase: false,
 							want:       "\"mvsep\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5287, col: 28, offset: 161077},
+							pos:  position{line: 5361, col: 28, offset: 163596},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5287, col: 34, offset: 161083},
+							pos:   position{line: 5361, col: 34, offset: 163602},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5287, col: 38, offset: 161087},
+								pos:  position{line: 5361, col: 38, offset: 163606},
 								name: "QuotedString",
 							},
 						},
@@ -12933,28 +13172,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatMaxResults",
-			pos:  position{line: 5296, col: 1, offset: 161299},
+			pos:  position{line: 5370, col: 1, offset: 163818},
 			expr: &actionExpr{
-				pos: position{line: 5296, col: 21, offset: 161319},
+				pos: position{line: 5370, col: 21, offset: 163838},
 				run: (*parser).callonFormatMaxResults1,
 				expr: &seqExpr{
-					pos: position{line: 5296, col: 21, offset: 161319},
+					pos: position{line: 5370, col: 21, offset: 163838},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5296, col: 21, offset: 161319},
+							pos:        position{line: 5370, col: 21, offset: 163838},
 							val:        "maxresults",
 							ignoreCase: false,
 							want:       "\"maxresults\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5296, col: 34, offset: 161332},
+							pos:  position{line: 5370, col: 34, offset: 163851},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5296, col: 40, offset: 161338},
+							pos:   position{line: 5370, col: 40, offset: 163857},
 							label: "numStr",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5296, col: 47, offset: 161345},
+								pos:  position{line: 5370, col: 47, offset: 163864},
 								name: "IntegerAsString",
 							},
 						},
@@ -12964,28 +13203,28 @@ var g = &grammar{
 		},
 		{
 			name: "FormatEmptyStr",
-			pos:  position{line: 5309, col: 1, offset: 161751},
+			pos:  position{line: 5383, col: 1, offset: 164270},
 			expr: &actionExpr{
-				pos: position{line: 5309, col: 19, offset: 161769},
+				pos: position{line: 5383, col: 19, offset: 164288},
 				run: (*parser).callonFormatEmptyStr1,
 				expr: &seqExpr{
-					pos: position{line: 5309, col: 19, offset: 161769},
+					pos: position{line: 5383, col: 19, offset: 164288},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5309, col: 19, offset: 161769},
+							pos:        position{line: 5383, col: 19, offset: 164288},
 							val:        "emptystr",
 							ignoreCase: false,
 							want:       "\"emptystr\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5309, col: 30, offset: 161780},
+							pos:  position{line: 5383, col: 30, offset: 164299},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5309, col: 36, offset: 161786},
+							pos:   position{line: 5383, col: 36, offset: 164305},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5309, col: 40, offset: 161790},
+								pos:  position{line: 5383, col: 40, offset: 164309},
 								name: "QuotedString",
 							},
 						},
@@ -12995,78 +13234,78 @@ var g = &grammar{
 		},
 		{
 			name: "FormatRowColOptions",
-			pos:  position{line: 5318, col: 1, offset: 162005},
+			pos:  position{line: 5392, col: 1, offset: 164524},
 			expr: &actionExpr{
-				pos: position{line: 5318, col: 24, offset: 162028},
+				pos: position{line: 5392, col: 24, offset: 164547},
 				run: (*parser).callonFormatRowColOptions1,
 				expr: &seqExpr{
-					pos: position{line: 5318, col: 24, offset: 162028},
+					pos: position{line: 5392, col: 24, offset: 164547},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5318, col: 24, offset: 162028},
+							pos:   position{line: 5392, col: 24, offset: 164547},
 							label: "rowPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 34, offset: 162038},
+								pos:  position{line: 5392, col: 34, offset: 164557},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 47, offset: 162051},
+							pos:  position{line: 5392, col: 47, offset: 164570},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 53, offset: 162057},
+							pos:   position{line: 5392, col: 53, offset: 164576},
 							label: "colPrefix",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 63, offset: 162067},
+								pos:  position{line: 5392, col: 63, offset: 164586},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 76, offset: 162080},
+							pos:  position{line: 5392, col: 76, offset: 164599},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 82, offset: 162086},
+							pos:   position{line: 5392, col: 82, offset: 164605},
 							label: "colSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 95, offset: 162099},
+								pos:  position{line: 5392, col: 95, offset: 164618},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 108, offset: 162112},
+							pos:  position{line: 5392, col: 108, offset: 164631},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 114, offset: 162118},
+							pos:   position{line: 5392, col: 114, offset: 164637},
 							label: "colEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 121, offset: 162125},
+								pos:  position{line: 5392, col: 121, offset: 164644},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 134, offset: 162138},
+							pos:  position{line: 5392, col: 134, offset: 164657},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 140, offset: 162144},
+							pos:   position{line: 5392, col: 140, offset: 164663},
 							label: "rowSeparator",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 153, offset: 162157},
+								pos:  position{line: 5392, col: 153, offset: 164676},
 								name: "QuotedString",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5318, col: 166, offset: 162170},
+							pos:  position{line: 5392, col: 166, offset: 164689},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5318, col: 172, offset: 162176},
+							pos:   position{line: 5392, col: 172, offset: 164695},
 							label: "rowEnd",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5318, col: 179, offset: 162183},
+								pos:  position{line: 5392, col: 179, offset: 164702},
 								name: "QuotedString",
 							},
 						},
@@ -13076,28 +13315,28 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountBlock",
-			pos:  position{line: 5336, col: 1, offset: 162759},
+			pos:  position{line: 5410, col: 1, offset: 165278},
 			expr: &actionExpr{
-				pos: position{line: 5336, col: 20, offset: 162778},
+				pos: position{line: 5410, col: 20, offset: 165297},
 				run: (*parser).callonEventCountBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5336, col: 20, offset: 162778},
+					pos: position{line: 5410, col: 20, offset: 165297},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5336, col: 20, offset: 162778},
+							pos:  position{line: 5410, col: 20, offset: 165297},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5336, col: 25, offset: 162783},
+							pos:  position{line: 5410, col: 25, offset: 165302},
 							name: "CMD_EVENTCOUNT",
 						},
 						&labeledExpr{
-							pos:   position{line: 5336, col: 40, offset: 162798},
+							pos:   position{line: 5410, col: 40, offset: 165317},
 							label: "eventCountExpr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5336, col: 55, offset: 162813},
+								pos: position{line: 5410, col: 55, offset: 165332},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5336, col: 55, offset: 162813},
+									pos:  position{line: 5410, col: 55, offset: 165332},
 									name: "EventCountArgumentsList",
 								},
 							},
@@ -13108,42 +13347,42 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgumentsList",
-			pos:  position{line: 5343, col: 1, offset: 162966},
+			pos:  position{line: 5417, col: 1, offset: 165485},
 			expr: &actionExpr{
-				pos: position{line: 5343, col: 28, offset: 162993},
+				pos: position{line: 5417, col: 28, offset: 165512},
 				run: (*parser).callonEventCountArgumentsList1,
 				expr: &seqExpr{
-					pos: position{line: 5343, col: 28, offset: 162993},
+					pos: position{line: 5417, col: 28, offset: 165512},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5343, col: 28, offset: 162993},
+							pos:  position{line: 5417, col: 28, offset: 165512},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5343, col: 34, offset: 162999},
+							pos:   position{line: 5417, col: 34, offset: 165518},
 							label: "first",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5343, col: 40, offset: 163005},
+								pos: position{line: 5417, col: 40, offset: 165524},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5343, col: 40, offset: 163005},
+									pos:  position{line: 5417, col: 40, offset: 165524},
 									name: "EventCountArgument",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5343, col: 60, offset: 163025},
+							pos:   position{line: 5417, col: 60, offset: 165544},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5343, col: 65, offset: 163030},
+								pos: position{line: 5417, col: 65, offset: 165549},
 								expr: &seqExpr{
-									pos: position{line: 5343, col: 66, offset: 163031},
+									pos: position{line: 5417, col: 66, offset: 165550},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5343, col: 66, offset: 163031},
+											pos:  position{line: 5417, col: 66, offset: 165550},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5343, col: 72, offset: 163037},
+											pos:  position{line: 5417, col: 72, offset: 165556},
 											name: "EventCountArgument",
 										},
 									},
@@ -13156,30 +13395,30 @@ var g = &grammar{
 		},
 		{
 			name: "EventCountArgument",
-			pos:  position{line: 5399, col: 1, offset: 164914},
+			pos:  position{line: 5473, col: 1, offset: 167433},
 			expr: &actionExpr{
-				pos: position{line: 5399, col: 23, offset: 164936},
+				pos: position{line: 5473, col: 23, offset: 167455},
 				run: (*parser).callonEventCountArgument1,
 				expr: &labeledExpr{
-					pos:   position{line: 5399, col: 23, offset: 164936},
+					pos:   position{line: 5473, col: 23, offset: 167455},
 					label: "arg",
 					expr: &choiceExpr{
-						pos: position{line: 5399, col: 28, offset: 164941},
+						pos: position{line: 5473, col: 28, offset: 167460},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5399, col: 28, offset: 164941},
+								pos:  position{line: 5473, col: 28, offset: 167460},
 								name: "IndexField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5399, col: 41, offset: 164954},
+								pos:  position{line: 5473, col: 41, offset: 167473},
 								name: "SummarizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5399, col: 58, offset: 164971},
+								pos:  position{line: 5473, col: 58, offset: 167490},
 								name: "ReportSizeField",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5399, col: 76, offset: 164989},
+								pos:  position{line: 5473, col: 76, offset: 167508},
 								name: "ListVixField",
 							},
 						},
@@ -13189,28 +13428,28 @@ var g = &grammar{
 		},
 		{
 			name: "IndexField",
-			pos:  position{line: 5403, col: 1, offset: 165028},
+			pos:  position{line: 5477, col: 1, offset: 167547},
 			expr: &actionExpr{
-				pos: position{line: 5403, col: 15, offset: 165042},
+				pos: position{line: 5477, col: 15, offset: 167561},
 				run: (*parser).callonIndexField1,
 				expr: &seqExpr{
-					pos: position{line: 5403, col: 15, offset: 165042},
+					pos: position{line: 5477, col: 15, offset: 167561},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5403, col: 15, offset: 165042},
+							pos:        position{line: 5477, col: 15, offset: 167561},
 							val:        "index",
 							ignoreCase: false,
 							want:       "\"index\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5403, col: 23, offset: 165050},
+							pos:  position{line: 5477, col: 23, offset: 167569},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5403, col: 29, offset: 165056},
+							pos:   position{line: 5477, col: 29, offset: 167575},
 							label: "index",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5403, col: 35, offset: 165062},
+								pos:  position{line: 5477, col: 35, offset: 167581},
 								name: "IndexName",
 							},
 						},
@@ -13220,28 +13459,28 @@ var g = &grammar{
 		},
 		{
 			name: "SummarizeField",
-			pos:  position{line: 5406, col: 1, offset: 165118},
+			pos:  position{line: 5480, col: 1, offset: 167637},
 			expr: &actionExpr{
-				pos: position{line: 5406, col: 19, offset: 165136},
+				pos: position{line: 5480, col: 19, offset: 167655},
 				run: (*parser).callonSummarizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5406, col: 19, offset: 165136},
+					pos: position{line: 5480, col: 19, offset: 167655},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5406, col: 19, offset: 165136},
+							pos:        position{line: 5480, col: 19, offset: 167655},
 							val:        "summarize",
 							ignoreCase: false,
 							want:       "\"summarize\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5406, col: 31, offset: 165148},
+							pos:  position{line: 5480, col: 31, offset: 167667},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5406, col: 37, offset: 165154},
+							pos:   position{line: 5480, col: 37, offset: 167673},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5406, col: 43, offset: 165160},
+								pos:  position{line: 5480, col: 43, offset: 167679},
 								name: "Boolean",
 							},
 						},
@@ -13251,28 +13490,28 @@ var g = &grammar{
 		},
 		{
 			name: "ReportSizeField",
-			pos:  position{line: 5409, col: 1, offset: 165236},
+			pos:  position{line: 5483, col: 1, offset: 167755},
 			expr: &actionExpr{
-				pos: position{line: 5409, col: 20, offset: 165255},
+				pos: position{line: 5483, col: 20, offset: 167774},
 				run: (*parser).callonReportSizeField1,
 				expr: &seqExpr{
-					pos: position{line: 5409, col: 20, offset: 165255},
+					pos: position{line: 5483, col: 20, offset: 167774},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5409, col: 20, offset: 165255},
+							pos:        position{line: 5483, col: 20, offset: 167774},
 							val:        "report_size",
 							ignoreCase: false,
 							want:       "\"report_size\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5409, col: 34, offset: 165269},
+							pos:  position{line: 5483, col: 34, offset: 167788},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5409, col: 40, offset: 165275},
+							pos:   position{line: 5483, col: 40, offset: 167794},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5409, col: 46, offset: 165281},
+								pos:  position{line: 5483, col: 46, offset: 167800},
 								name: "Boolean",
 							},
 						},
@@ -13282,28 +13521,28 @@ var g = &grammar{
 		},
 		{
 			name: "ListVixField",
-			pos:  position{line: 5412, col: 1, offset: 165359},
+			pos:  position{line: 5486, col: 1, offset: 167878},
 			expr: &actionExpr{
-				pos: position{line: 5412, col: 17, offset: 165375},
+				pos: position{line: 5486, col: 17, offset: 167894},
 				run: (*parser).callonListVixField1,
 				expr: &seqExpr{
-					pos: position{line: 5412, col: 17, offset: 165375},
+					pos: position{line: 5486, col: 17, offset: 167894},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5412, col: 17, offset: 165375},
+							pos:        position{line: 5486, col: 17, offset: 167894},
 							val:        "list_vix",
 							ignoreCase: false,
 							want:       "\"list_vix\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5412, col: 28, offset: 165386},
+							pos:  position{line: 5486, col: 28, offset: 167905},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5412, col: 34, offset: 165392},
+							pos:   position{line: 5486, col: 34, offset: 167911},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5412, col: 40, offset: 165398},
+								pos:  position{line: 5486, col: 40, offset: 167917},
 								name: "Boolean",
 							},
 						},
@@ -13313,24 +13552,24 @@ var g = &grammar{
 		},
 		{
 			name: "IndexName",
-			pos:  position{line: 5416, col: 1, offset: 165474},
+			pos:  position{line: 5490, col: 1, offset: 167993},
 			expr: &actionExpr{
-				pos: position{line: 5416, col: 14, offset: 165487},
+				pos: position{line: 5490, col: 14, offset: 168006},
 				run: (*parser).callonIndexName1,
 				expr: &oneOrMoreExpr{
-					pos: position{line: 5416, col: 14, offset: 165487},
+					pos: position{line: 5490, col: 14, offset: 168006},
 					expr: &seqExpr{
-						pos: position{line: 5416, col: 15, offset: 165488},
+						pos: position{line: 5490, col: 15, offset: 168007},
 						exprs: []any{
 							&notExpr{
-								pos: position{line: 5416, col: 15, offset: 165488},
+								pos: position{line: 5490, col: 15, offset: 168007},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5416, col: 16, offset: 165489},
+									pos:  position{line: 5490, col: 16, offset: 168008},
 									name: "SPACE",
 								},
 							},
 							&anyMatcher{
-								line: 5416, col: 22, offset: 165495,
+								line: 5490, col: 22, offset: 168014,
 							},
 						},
 					},
@@ -13339,39 +13578,39 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullBlock",
-			pos:  position{line: 5421, col: 1, offset: 165568},
+			pos:  position{line: 5495, col: 1, offset: 168087},
 			expr: &actionExpr{
-				pos: position{line: 5421, col: 18, offset: 165585},
+				pos: position{line: 5495, col: 18, offset: 168104},
 				run: (*parser).callonFillNullBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5421, col: 18, offset: 165585},
+					pos: position{line: 5495, col: 18, offset: 168104},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5421, col: 18, offset: 165585},
+							pos:  position{line: 5495, col: 18, offset: 168104},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5421, col: 23, offset: 165590},
+							pos:  position{line: 5495, col: 23, offset: 168109},
 							name: "CMD_FILLNULL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5421, col: 36, offset: 165603},
+							pos:   position{line: 5495, col: 36, offset: 168122},
 							label: "valueOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5421, col: 49, offset: 165616},
+								pos: position{line: 5495, col: 49, offset: 168135},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5421, col: 49, offset: 165616},
+									pos:  position{line: 5495, col: 49, offset: 168135},
 									name: "FillNullValueOption",
 								},
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5421, col: 70, offset: 165637},
+							pos:   position{line: 5495, col: 70, offset: 168156},
 							label: "fields",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5421, col: 77, offset: 165644},
+								pos: position{line: 5495, col: 77, offset: 168163},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5421, col: 77, offset: 165644},
+									pos:  position{line: 5495, col: 77, offset: 168163},
 									name: "FillNullFieldList",
 								},
 							},
@@ -13382,32 +13621,32 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullValueOption",
-			pos:  position{line: 5451, col: 1, offset: 166407},
+			pos:  position{line: 5525, col: 1, offset: 168926},
 			expr: &actionExpr{
-				pos: position{line: 5451, col: 24, offset: 166430},
+				pos: position{line: 5525, col: 24, offset: 168949},
 				run: (*parser).callonFillNullValueOption1,
 				expr: &seqExpr{
-					pos: position{line: 5451, col: 24, offset: 166430},
+					pos: position{line: 5525, col: 24, offset: 168949},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5451, col: 24, offset: 166430},
+							pos:  position{line: 5525, col: 24, offset: 168949},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5451, col: 30, offset: 166436},
+							pos:        position{line: 5525, col: 30, offset: 168955},
 							val:        "value",
 							ignoreCase: false,
 							want:       "\"value\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5451, col: 38, offset: 166444},
+							pos:  position{line: 5525, col: 38, offset: 168963},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5451, col: 44, offset: 166450},
+							pos:   position{line: 5525, col: 44, offset: 168969},
 							label: "str",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5451, col: 48, offset: 166454},
+								pos:  position{line: 5525, col: 48, offset: 168973},
 								name: "String",
 							},
 						},
@@ -13417,22 +13656,22 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullFieldList",
-			pos:  position{line: 5455, col: 1, offset: 166500},
+			pos:  position{line: 5529, col: 1, offset: 169019},
 			expr: &actionExpr{
-				pos: position{line: 5455, col: 22, offset: 166521},
+				pos: position{line: 5529, col: 22, offset: 169040},
 				run: (*parser).callonFillNullFieldList1,
 				expr: &seqExpr{
-					pos: position{line: 5455, col: 22, offset: 166521},
+					pos: position{line: 5529, col: 22, offset: 169040},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5455, col: 22, offset: 166521},
+							pos:  position{line: 5529, col: 22, offset: 169040},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5455, col: 28, offset: 166527},
+							pos:   position{line: 5529, col: 28, offset: 169046},
 							label: "fieldList",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5455, col: 38, offset: 166537},
+								pos:  position{line: 5529, col: 38, offset: 169056},
 								name: "SpaceSeparatedFieldNameList",
 							},
 						},
@@ -13442,36 +13681,36 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandBlock",
-			pos:  position{line: 5459, col: 1, offset: 166596},
+			pos:  position{line: 5533, col: 1, offset: 169115},
 			expr: &actionExpr{
-				pos: position{line: 5459, col: 18, offset: 166613},
+				pos: position{line: 5533, col: 18, offset: 169132},
 				run: (*parser).callonMvexpandBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5459, col: 18, offset: 166613},
+					pos: position{line: 5533, col: 18, offset: 169132},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5459, col: 18, offset: 166613},
+							pos:  position{line: 5533, col: 18, offset: 169132},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5459, col: 23, offset: 166618},
+							pos:  position{line: 5533, col: 23, offset: 169137},
 							name: "CMD_MVEXPAND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5459, col: 36, offset: 166631},
+							pos:   position{line: 5533, col: 36, offset: 169150},
 							label: "field",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5459, col: 42, offset: 166637},
+								pos:  position{line: 5533, col: 42, offset: 169156},
 								name: "MvexpandField",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5459, col: 56, offset: 166651},
+							pos:   position{line: 5533, col: 56, offset: 169170},
 							label: "limitStr",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5459, col: 65, offset: 166660},
+								pos: position{line: 5533, col: 65, offset: 169179},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5459, col: 65, offset: 166660},
+									pos:  position{line: 5533, col: 65, offset: 169179},
 									name: "MvexpandLimit",
 								},
 							},
@@ -13482,22 +13721,22 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandField",
-			pos:  position{line: 5488, col: 1, offset: 167436},
+			pos:  position{line: 5562, col: 1, offset: 169955},
 			expr: &actionExpr{
-				pos: position{line: 5488, col: 18, offset: 167453},
+				pos: position{line: 5562, col: 18, offset: 169972},
 				run: (*parser).callonMvexpandField1,
 				expr: &seqExpr{
-					pos: position{line: 5488, col: 18, offset: 167453},
+					pos: position{line: 5562, col: 18, offset: 169972},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5488, col: 18, offset: 167453},
+							pos:  position{line: 5562, col: 18, offset: 169972},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5488, col: 24, offset: 167459},
+							pos:   position{line: 5562, col: 24, offset: 169978},
 							label: "fieldName",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5488, col: 34, offset: 167469},
+								pos:  position{line: 5562, col: 34, offset: 169988},
 								name: "FieldName",
 							},
 						},
@@ -13507,32 +13746,32 @@ var g = &grammar{
 		},
 		{
 			name: "MvexpandLimit",
-			pos:  position{line: 5492, col: 1, offset: 167510},
+			pos:  position{line: 5566, col: 1, offset: 170029},
 			expr: &actionExpr{
-				pos: position{line: 5492, col: 18, offset: 167527},
+				pos: position{line: 5566, col: 18, offset: 170046},
 				run: (*parser).callonMvexpandLimit1,
 				expr: &seqExpr{
-					pos: position{line: 5492, col: 18, offset: 167527},
+					pos: position{line: 5566, col: 18, offset: 170046},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5492, col: 18, offset: 167527},
+							pos:  position{line: 5566, col: 18, offset: 170046},
 							name: "SPACE",
 						},
 						&litMatcher{
-							pos:        position{line: 5492, col: 24, offset: 167533},
+							pos:        position{line: 5566, col: 24, offset: 170052},
 							val:        "limit",
 							ignoreCase: false,
 							want:       "\"limit\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5492, col: 32, offset: 167541},
+							pos:  position{line: 5566, col: 32, offset: 170060},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5492, col: 38, offset: 167547},
+							pos:   position{line: 5566, col: 38, offset: 170066},
 							label: "intValue",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5492, col: 47, offset: 167556},
+								pos:  position{line: 5566, col: 47, offset: 170075},
 								name: "IntegerAsString",
 							},
 						},
@@ -13542,26 +13781,26 @@ var g = &grammar{
 		},
 		{
 			name: "WhereClause",
-			pos:  position{line: 5496, col: 1, offset: 167602},
+			pos:  position{line: 5570, col: 1, offset: 170121},
 			expr: &actionExpr{
-				pos: position{line: 5496, col: 16, offset: 167617},
+				pos: position{line: 5570, col: 16, offset: 170136},
 				run: (*parser).callonWhereClause1,
 				expr: &seqExpr{
-					pos: position{line: 5496, col: 16, offset: 167617},
+					pos: position{line: 5570, col: 16, offset: 170136},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5496, col: 16, offset: 167617},
+							pos:  position{line: 5570, col: 16, offset: 170136},
 							name: "SPACE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5496, col: 22, offset: 167623},
+							pos:  position{line: 5570, col: 22, offset: 170142},
 							name: "CMD_WHERE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5496, col: 32, offset: 167633},
+							pos:   position{line: 5570, col: 32, offset: 170152},
 							label: "condition",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5496, col: 42, offset: 167643},
+								pos:  position{line: 5570, col: 42, offset: 170162},
 								name: "BoolExpr",
 							},
 						},
@@ -13571,28 +13810,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionAppend",
-			pos:  position{line: 5500, col: 1, offset: 167703},
+			pos:  position{line: 5574, col: 1, offset: 170222},
 			expr: &actionExpr{
-				pos: position{line: 5500, col: 28, offset: 167730},
+				pos: position{line: 5574, col: 28, offset: 170249},
 				run: (*parser).callonInputLookupOptionAppend1,
 				expr: &seqExpr{
-					pos: position{line: 5500, col: 28, offset: 167730},
+					pos: position{line: 5574, col: 28, offset: 170249},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5500, col: 28, offset: 167730},
+							pos:        position{line: 5574, col: 28, offset: 170249},
 							val:        "append",
 							ignoreCase: false,
 							want:       "\"append\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5500, col: 37, offset: 167739},
+							pos:  position{line: 5574, col: 37, offset: 170258},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5500, col: 43, offset: 167745},
+							pos:   position{line: 5574, col: 43, offset: 170264},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5500, col: 51, offset: 167753},
+								pos:  position{line: 5574, col: 51, offset: 170272},
 								name: "Boolean",
 							},
 						},
@@ -13602,28 +13841,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStrict",
-			pos:  position{line: 5509, col: 1, offset: 167937},
+			pos:  position{line: 5583, col: 1, offset: 170456},
 			expr: &actionExpr{
-				pos: position{line: 5509, col: 28, offset: 167964},
+				pos: position{line: 5583, col: 28, offset: 170483},
 				run: (*parser).callonInputLookupOptionStrict1,
 				expr: &seqExpr{
-					pos: position{line: 5509, col: 28, offset: 167964},
+					pos: position{line: 5583, col: 28, offset: 170483},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5509, col: 28, offset: 167964},
+							pos:        position{line: 5583, col: 28, offset: 170483},
 							val:        "strict",
 							ignoreCase: false,
 							want:       "\"strict\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5509, col: 37, offset: 167973},
+							pos:  position{line: 5583, col: 37, offset: 170492},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5509, col: 43, offset: 167979},
+							pos:   position{line: 5583, col: 43, offset: 170498},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5509, col: 51, offset: 167987},
+								pos:  position{line: 5583, col: 51, offset: 170506},
 								name: "Boolean",
 							},
 						},
@@ -13633,28 +13872,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionStart",
-			pos:  position{line: 5518, col: 1, offset: 168171},
+			pos:  position{line: 5592, col: 1, offset: 170690},
 			expr: &actionExpr{
-				pos: position{line: 5518, col: 27, offset: 168197},
+				pos: position{line: 5592, col: 27, offset: 170716},
 				run: (*parser).callonInputLookupOptionStart1,
 				expr: &seqExpr{
-					pos: position{line: 5518, col: 27, offset: 168197},
+					pos: position{line: 5592, col: 27, offset: 170716},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5518, col: 27, offset: 168197},
+							pos:        position{line: 5592, col: 27, offset: 170716},
 							val:        "start",
 							ignoreCase: false,
 							want:       "\"start\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5518, col: 35, offset: 168205},
+							pos:  position{line: 5592, col: 35, offset: 170724},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5518, col: 41, offset: 168211},
+							pos:   position{line: 5592, col: 41, offset: 170730},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5518, col: 48, offset: 168218},
+								pos:  position{line: 5592, col: 48, offset: 170737},
 								name: "PositiveInteger",
 							},
 						},
@@ -13664,28 +13903,28 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionMax",
-			pos:  position{line: 5527, col: 1, offset: 168409},
+			pos:  position{line: 5601, col: 1, offset: 170928},
 			expr: &actionExpr{
-				pos: position{line: 5527, col: 25, offset: 168433},
+				pos: position{line: 5601, col: 25, offset: 170952},
 				run: (*parser).callonInputLookupOptionMax1,
 				expr: &seqExpr{
-					pos: position{line: 5527, col: 25, offset: 168433},
+					pos: position{line: 5601, col: 25, offset: 170952},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5527, col: 25, offset: 168433},
+							pos:        position{line: 5601, col: 25, offset: 170952},
 							val:        "max",
 							ignoreCase: false,
 							want:       "\"max\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5527, col: 31, offset: 168439},
+							pos:  position{line: 5601, col: 31, offset: 170958},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5527, col: 37, offset: 168445},
+							pos:   position{line: 5601, col: 37, offset: 170964},
 							label: "posInt",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5527, col: 44, offset: 168452},
+								pos:  position{line: 5601, col: 44, offset: 170971},
 								name: "PositiveInteger",
 							},
 						},
@@ -13695,30 +13934,30 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOption",
-			pos:  position{line: 5536, col: 1, offset: 168639},
+			pos:  position{line: 5610, col: 1, offset: 171158},
 			expr: &actionExpr{
-				pos: position{line: 5536, col: 22, offset: 168660},
+				pos: position{line: 5610, col: 22, offset: 171179},
 				run: (*parser).callonInputLookupOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5536, col: 22, offset: 168660},
+					pos:   position{line: 5610, col: 22, offset: 171179},
 					label: "inputLookupOption",
 					expr: &choiceExpr{
-						pos: position{line: 5536, col: 41, offset: 168679},
+						pos: position{line: 5610, col: 41, offset: 171198},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5536, col: 41, offset: 168679},
+								pos:  position{line: 5610, col: 41, offset: 171198},
 								name: "InputLookupOptionAppend",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5536, col: 67, offset: 168705},
+								pos:  position{line: 5610, col: 67, offset: 171224},
 								name: "InputLookupOptionStrict",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5536, col: 93, offset: 168731},
+								pos:  position{line: 5610, col: 93, offset: 171250},
 								name: "InputLookupOptionStart",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5536, col: 118, offset: 168756},
+								pos:  position{line: 5610, col: 118, offset: 171275},
 								name: "InputLookupOptionMax",
 							},
 						},
@@ -13728,35 +13967,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupOptionList",
-			pos:  position{line: 5540, col: 1, offset: 168817},
+			pos:  position{line: 5614, col: 1, offset: 171336},
 			expr: &actionExpr{
-				pos: position{line: 5540, col: 26, offset: 168842},
+				pos: position{line: 5614, col: 26, offset: 171361},
 				run: (*parser).callonInputLookupOptionList1,
 				expr: &seqExpr{
-					pos: position{line: 5540, col: 26, offset: 168842},
+					pos: position{line: 5614, col: 26, offset: 171361},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5540, col: 26, offset: 168842},
+							pos:   position{line: 5614, col: 26, offset: 171361},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5540, col: 34, offset: 168850},
+								pos:  position{line: 5614, col: 34, offset: 171369},
 								name: "InputLookupOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5540, col: 53, offset: 168869},
+							pos:   position{line: 5614, col: 53, offset: 171388},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5540, col: 58, offset: 168874},
+								pos: position{line: 5614, col: 58, offset: 171393},
 								expr: &seqExpr{
-									pos: position{line: 5540, col: 59, offset: 168875},
+									pos: position{line: 5614, col: 59, offset: 171394},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5540, col: 59, offset: 168875},
+											pos:  position{line: 5614, col: 59, offset: 171394},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5540, col: 65, offset: 168881},
+											pos:  position{line: 5614, col: 65, offset: 171400},
 											name: "InputLookupOption",
 										},
 									},
@@ -13769,35 +14008,35 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupBlock",
-			pos:  position{line: 5582, col: 1, offset: 170327},
+			pos:  position{line: 5656, col: 1, offset: 172846},
 			expr: &actionExpr{
-				pos: position{line: 5582, col: 21, offset: 170347},
+				pos: position{line: 5656, col: 21, offset: 172866},
 				run: (*parser).callonInputLookupBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5582, col: 21, offset: 170347},
+					pos: position{line: 5656, col: 21, offset: 172866},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5582, col: 21, offset: 170347},
+							pos:  position{line: 5656, col: 21, offset: 172866},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5582, col: 26, offset: 170352},
+							pos:  position{line: 5656, col: 26, offset: 172871},
 							name: "CMD_INPUTLOOKUP",
 						},
 						&labeledExpr{
-							pos:   position{line: 5582, col: 42, offset: 170368},
+							pos:   position{line: 5656, col: 42, offset: 172887},
 							label: "inputLookupOption",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5582, col: 60, offset: 170386},
+								pos: position{line: 5656, col: 60, offset: 172905},
 								expr: &seqExpr{
-									pos: position{line: 5582, col: 61, offset: 170387},
+									pos: position{line: 5656, col: 61, offset: 172906},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5582, col: 61, offset: 170387},
+											pos:  position{line: 5656, col: 61, offset: 172906},
 											name: "InputLookupOptionList",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5582, col: 83, offset: 170409},
+											pos:  position{line: 5656, col: 83, offset: 172928},
 											name: "SPACE",
 										},
 									},
@@ -13805,20 +14044,20 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5582, col: 91, offset: 170417},
+							pos:   position{line: 5656, col: 91, offset: 172936},
 							label: "filename",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5582, col: 101, offset: 170427},
+								pos:  position{line: 5656, col: 101, offset: 172946},
 								name: "String",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5582, col: 109, offset: 170435},
+							pos:   position{line: 5656, col: 109, offset: 172954},
 							label: "whereClause",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 5582, col: 121, offset: 170447},
+								pos: position{line: 5656, col: 121, offset: 172966},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5582, col: 122, offset: 170448},
+									pos:  position{line: 5656, col: 122, offset: 172967},
 									name: "WhereClause",
 								},
 							},
@@ -13829,15 +14068,15 @@ var g = &grammar{
 		},
 		{
 			name: "InputLookupAggBlock",
-			pos:  position{line: 5605, col: 1, offset: 171136},
+			pos:  position{line: 5679, col: 1, offset: 173655},
 			expr: &actionExpr{
-				pos: position{line: 5605, col: 24, offset: 171159},
+				pos: position{line: 5679, col: 24, offset: 173678},
 				run: (*parser).callonInputLookupAggBlock1,
 				expr: &labeledExpr{
-					pos:   position{line: 5605, col: 24, offset: 171159},
+					pos:   position{line: 5679, col: 24, offset: 173678},
 					label: "inputLookupBlock",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5605, col: 41, offset: 171176},
+						pos:  position{line: 5679, col: 41, offset: 173695},
 						name: "InputLookupBlock",
 					},
 				},
@@ -13845,26 +14084,26 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOption",
-			pos:  position{line: 5616, col: 1, offset: 171575},
+			pos:  position{line: 5690, col: 1, offset: 174094},
 			expr: &actionExpr{
-				pos: position{line: 5616, col: 20, offset: 171594},
+				pos: position{line: 5690, col: 20, offset: 174113},
 				run: (*parser).callonAppendCmdOption1,
 				expr: &labeledExpr{
-					pos:   position{line: 5616, col: 20, offset: 171594},
+					pos:   position{line: 5690, col: 20, offset: 174113},
 					label: "option",
 					expr: &choiceExpr{
-						pos: position{line: 5616, col: 28, offset: 171602},
+						pos: position{line: 5690, col: 28, offset: 174121},
 						alternatives: []any{
 							&ruleRefExpr{
-								pos:  position{line: 5616, col: 28, offset: 171602},
+								pos:  position{line: 5690, col: 28, offset: 174121},
 								name: "ExtendTimeRangeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5616, col: 52, offset: 171626},
+								pos:  position{line: 5690, col: 52, offset: 174145},
 								name: "MaxTimeOption",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5616, col: 68, offset: 171642},
+								pos:  position{line: 5690, col: 68, offset: 174161},
 								name: "MaxOutOption",
 							},
 						},
@@ -13874,28 +14113,28 @@ var g = &grammar{
 		},
 		{
 			name: "ExtendTimeRangeOption",
-			pos:  position{line: 5621, col: 1, offset: 171740},
+			pos:  position{line: 5695, col: 1, offset: 174259},
 			expr: &actionExpr{
-				pos: position{line: 5621, col: 26, offset: 171765},
+				pos: position{line: 5695, col: 26, offset: 174284},
 				run: (*parser).callonExtendTimeRangeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5621, col: 26, offset: 171765},
+					pos: position{line: 5695, col: 26, offset: 174284},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5621, col: 26, offset: 171765},
+							pos:        position{line: 5695, col: 26, offset: 174284},
 							val:        "extendtimerange",
 							ignoreCase: false,
 							want:       "\"extendtimerange\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5621, col: 44, offset: 171783},
+							pos:  position{line: 5695, col: 44, offset: 174302},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5621, col: 50, offset: 171789},
+							pos:   position{line: 5695, col: 50, offset: 174308},
 							label: "boolean",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5621, col: 58, offset: 171797},
+								pos:  position{line: 5695, col: 58, offset: 174316},
 								name: "Boolean",
 							},
 						},
@@ -13905,28 +14144,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxTimeOption",
-			pos:  position{line: 5628, col: 1, offset: 171936},
+			pos:  position{line: 5702, col: 1, offset: 174455},
 			expr: &actionExpr{
-				pos: position{line: 5628, col: 18, offset: 171953},
+				pos: position{line: 5702, col: 18, offset: 174472},
 				run: (*parser).callonMaxTimeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5628, col: 18, offset: 171953},
+					pos: position{line: 5702, col: 18, offset: 174472},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5628, col: 18, offset: 171953},
+							pos:        position{line: 5702, col: 18, offset: 174472},
 							val:        "maxtime",
 							ignoreCase: false,
 							want:       "\"maxtime\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5628, col: 28, offset: 171963},
+							pos:  position{line: 5702, col: 28, offset: 174482},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5628, col: 34, offset: 171969},
+							pos:   position{line: 5702, col: 34, offset: 174488},
 							label: "time",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5628, col: 39, offset: 171974},
+								pos:  position{line: 5702, col: 39, offset: 174493},
 								name: "IntegerAsString",
 							},
 						},
@@ -13936,28 +14175,28 @@ var g = &grammar{
 		},
 		{
 			name: "MaxOutOption",
-			pos:  position{line: 5639, col: 1, offset: 172275},
+			pos:  position{line: 5713, col: 1, offset: 174794},
 			expr: &actionExpr{
-				pos: position{line: 5639, col: 17, offset: 172291},
+				pos: position{line: 5713, col: 17, offset: 174810},
 				run: (*parser).callonMaxOutOption1,
 				expr: &seqExpr{
-					pos: position{line: 5639, col: 17, offset: 172291},
+					pos: position{line: 5713, col: 17, offset: 174810},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5639, col: 17, offset: 172291},
+							pos:        position{line: 5713, col: 17, offset: 174810},
 							val:        "maxout",
 							ignoreCase: false,
 							want:       "\"maxout\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5639, col: 26, offset: 172300},
+							pos:  position{line: 5713, col: 26, offset: 174819},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5639, col: 32, offset: 172306},
+							pos:   position{line: 5713, col: 32, offset: 174825},
 							label: "max",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5639, col: 36, offset: 172310},
+								pos:  position{line: 5713, col: 36, offset: 174829},
 								name: "IntegerAsString",
 							},
 						},
@@ -13967,43 +14206,43 @@ var g = &grammar{
 		},
 		{
 			name: "Subsearch",
-			pos:  position{line: 5651, col: 1, offset: 172665},
+			pos:  position{line: 5725, col: 1, offset: 175184},
 			expr: &actionExpr{
-				pos: position{line: 5651, col: 14, offset: 172678},
+				pos: position{line: 5725, col: 14, offset: 175197},
 				run: (*parser).callonSubsearch1,
 				expr: &seqExpr{
-					pos: position{line: 5651, col: 14, offset: 172678},
+					pos: position{line: 5725, col: 14, offset: 175197},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5651, col: 14, offset: 172678},
+							pos:        position{line: 5725, col: 14, offset: 175197},
 							val:        "[",
 							ignoreCase: false,
 							want:       "\"[\"",
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5651, col: 18, offset: 172682},
+							pos: position{line: 5725, col: 18, offset: 175201},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5651, col: 18, offset: 172682},
+								pos:  position{line: 5725, col: 18, offset: 175201},
 								name: "SPACE",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5651, col: 25, offset: 172689},
+							pos:   position{line: 5725, col: 25, offset: 175208},
 							label: "search",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5651, col: 32, offset: 172696},
+								pos:  position{line: 5725, col: 32, offset: 175215},
 								name: "SearchBlock",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 5651, col: 44, offset: 172708},
+							pos: position{line: 5725, col: 44, offset: 175227},
 							expr: &ruleRefExpr{
-								pos:  position{line: 5651, col: 44, offset: 172708},
+								pos:  position{line: 5725, col: 44, offset: 175227},
 								name: "SPACE",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 5651, col: 51, offset: 172715},
+							pos:        position{line: 5725, col: 51, offset: 175234},
 							val:        "]",
 							ignoreCase: false,
 							want:       "\"]\"",
@@ -14014,35 +14253,35 @@ var g = &grammar{
 		},
 		{
 			name: "AppendCmdOptionsList",
-			pos:  position{line: 5656, col: 1, offset: 172804},
+			pos:  position{line: 5730, col: 1, offset: 175323},
 			expr: &actionExpr{
-				pos: position{line: 5656, col: 25, offset: 172828},
+				pos: position{line: 5730, col: 25, offset: 175347},
 				run: (*parser).callonAppendCmdOptionsList1,
 				expr: &seqExpr{
-					pos: position{line: 5656, col: 25, offset: 172828},
+					pos: position{line: 5730, col: 25, offset: 175347},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5656, col: 25, offset: 172828},
+							pos:   position{line: 5730, col: 25, offset: 175347},
 							label: "first",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5656, col: 31, offset: 172834},
+								pos:  position{line: 5730, col: 31, offset: 175353},
 								name: "AppendCmdOption",
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5656, col: 47, offset: 172850},
+							pos:   position{line: 5730, col: 47, offset: 175369},
 							label: "rest",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5656, col: 52, offset: 172855},
+								pos: position{line: 5730, col: 52, offset: 175374},
 								expr: &seqExpr{
-									pos: position{line: 5656, col: 53, offset: 172856},
+									pos: position{line: 5730, col: 53, offset: 175375},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5656, col: 53, offset: 172856},
+											pos:  position{line: 5730, col: 53, offset: 175375},
 											name: "SPACE",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 5656, col: 59, offset: 172862},
+											pos:  position{line: 5730, col: 59, offset: 175381},
 											name: "AppendCmdOption",
 										},
 									},
@@ -14055,37 +14294,37 @@ var g = &grammar{
 		},
 		{
 			name: "AppendBlock",
-			pos:  position{line: 5683, col: 1, offset: 173672},
+			pos:  position{line: 5757, col: 1, offset: 176191},
 			expr: &actionExpr{
-				pos: position{line: 5683, col: 16, offset: 173687},
+				pos: position{line: 5757, col: 16, offset: 176206},
 				run: (*parser).callonAppendBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5683, col: 16, offset: 173687},
+					pos: position{line: 5757, col: 16, offset: 176206},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5683, col: 16, offset: 173687},
+							pos:  position{line: 5757, col: 16, offset: 176206},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5683, col: 21, offset: 173692},
+							pos:  position{line: 5757, col: 21, offset: 176211},
 							name: "CMD_APPEND",
 						},
 						&labeledExpr{
-							pos:   position{line: 5683, col: 32, offset: 173703},
+							pos:   position{line: 5757, col: 32, offset: 176222},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5683, col: 40, offset: 173711},
+								pos: position{line: 5757, col: 40, offset: 176230},
 								expr: &seqExpr{
-									pos: position{line: 5683, col: 41, offset: 173712},
+									pos: position{line: 5757, col: 41, offset: 176231},
 									exprs: []any{
 										&ruleRefExpr{
-											pos:  position{line: 5683, col: 41, offset: 173712},
+											pos:  position{line: 5757, col: 41, offset: 176231},
 											name: "AppendCmdOption",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 5683, col: 57, offset: 173728},
+											pos: position{line: 5757, col: 57, offset: 176247},
 											expr: &ruleRefExpr{
-												pos:  position{line: 5683, col: 57, offset: 173728},
+												pos:  position{line: 5757, col: 57, offset: 176247},
 												name: "SPACE",
 											},
 										},
@@ -14094,10 +14333,10 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 5683, col: 66, offset: 173737},
+							pos:   position{line: 5757, col: 66, offset: 176256},
 							label: "subsearch",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5683, col: 76, offset: 173747},
+								pos:  position{line: 5757, col: 76, offset: 176266},
 								name: "Subsearch",
 							},
 						},
@@ -14107,45 +14346,45 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonOption",
-			pos:  position{line: 5725, col: 1, offset: 175284},
+			pos:  position{line: 5799, col: 1, offset: 177803},
 			expr: &actionExpr{
-				pos: position{line: 5725, col: 17, offset: 175300},
+				pos: position{line: 5799, col: 17, offset: 177819},
 				run: (*parser).callonToJsonOption1,
 				expr: &seqExpr{
-					pos: position{line: 5725, col: 17, offset: 175300},
+					pos: position{line: 5799, col: 17, offset: 177819},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5725, col: 17, offset: 175300},
+							pos:  position{line: 5799, col: 17, offset: 177819},
 							name: "SPACE",
 						},
 						&labeledExpr{
-							pos:   position{line: 5725, col: 23, offset: 175306},
+							pos:   position{line: 5799, col: 23, offset: 177825},
 							label: "option",
 							expr: &choiceExpr{
-								pos: position{line: 5725, col: 31, offset: 175314},
+								pos: position{line: 5799, col: 31, offset: 177833},
 								alternatives: []any{
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 31, offset: 175314},
+										pos:  position{line: 5799, col: 31, offset: 177833},
 										name: "ToJsonFunctionOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 54, offset: 175337},
+										pos:  position{line: 5799, col: 54, offset: 177856},
 										name: "DefaultTypeOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 74, offset: 175357},
+										pos:  position{line: 5799, col: 74, offset: 177876},
 										name: "FillNullOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 91, offset: 175374},
+										pos:  position{line: 5799, col: 91, offset: 177893},
 										name: "IncludeInternalOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 115, offset: 175398},
+										pos:  position{line: 5799, col: 115, offset: 177917},
 										name: "OutputFieldOption",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 5725, col: 135, offset: 175418},
+										pos:  position{line: 5799, col: 135, offset: 177937},
 										name: "ToJsonFunctionPostProcess",
 									},
 								},
@@ -14157,51 +14396,51 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionOption",
-			pos:  position{line: 5729, col: 1, offset: 175473},
+			pos:  position{line: 5803, col: 1, offset: 177992},
 			expr: &actionExpr{
-				pos: position{line: 5729, col: 25, offset: 175497},
+				pos: position{line: 5803, col: 25, offset: 178016},
 				run: (*parser).callonToJsonFunctionOption1,
 				expr: &seqExpr{
-					pos: position{line: 5729, col: 26, offset: 175498},
+					pos: position{line: 5803, col: 26, offset: 178017},
 					exprs: []any{
 						&labeledExpr{
-							pos:   position{line: 5729, col: 26, offset: 175498},
+							pos:   position{line: 5803, col: 26, offset: 178017},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5729, col: 33, offset: 175505},
+								pos: position{line: 5803, col: 33, offset: 178024},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5729, col: 33, offset: 175505},
+										pos:        position{line: 5803, col: 33, offset: 178024},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5729, col: 42, offset: 175514},
+										pos:        position{line: 5803, col: 42, offset: 178033},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5729, col: 51, offset: 175523},
+										pos:        position{line: 5803, col: 51, offset: 178042},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5729, col: 60, offset: 175532},
+										pos:        position{line: 5803, col: 60, offset: 178051},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5729, col: 68, offset: 175540},
+										pos:        position{line: 5803, col: 68, offset: 178059},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5729, col: 76, offset: 175548},
+										pos:        position{line: 5803, col: 76, offset: 178067},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14210,19 +14449,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5729, col: 84, offset: 175556},
+							pos:  position{line: 5803, col: 84, offset: 178075},
 							name: "L_PAREN",
 						},
 						&labeledExpr{
-							pos:   position{line: 5729, col: 92, offset: 175564},
+							pos:   position{line: 5803, col: 92, offset: 178083},
 							label: "regexPattern",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5729, col: 105, offset: 175577},
+								pos:  position{line: 5803, col: 105, offset: 178096},
 								name: "StringExpr",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5729, col: 116, offset: 175588},
+							pos:  position{line: 5803, col: 116, offset: 178107},
 							name: "R_PAREN",
 						},
 					},
@@ -14231,15 +14470,15 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonFunctionPostProcess",
-			pos:  position{line: 5755, col: 1, offset: 176346},
+			pos:  position{line: 5829, col: 1, offset: 178865},
 			expr: &actionExpr{
-				pos: position{line: 5755, col: 30, offset: 176375},
+				pos: position{line: 5829, col: 30, offset: 178894},
 				run: (*parser).callonToJsonFunctionPostProcess1,
 				expr: &labeledExpr{
-					pos:   position{line: 5755, col: 30, offset: 176375},
+					pos:   position{line: 5829, col: 30, offset: 178894},
 					label: "regexPattern",
 					expr: &ruleRefExpr{
-						pos:  position{line: 5755, col: 43, offset: 176388},
+						pos:  position{line: 5829, col: 43, offset: 178907},
 						name: "StringExpr",
 					},
 				},
@@ -14247,61 +14486,61 @@ var g = &grammar{
 		},
 		{
 			name: "DefaultTypeOption",
-			pos:  position{line: 5780, col: 1, offset: 177096},
+			pos:  position{line: 5854, col: 1, offset: 179615},
 			expr: &actionExpr{
-				pos: position{line: 5780, col: 22, offset: 177117},
+				pos: position{line: 5854, col: 22, offset: 179636},
 				run: (*parser).callonDefaultTypeOption1,
 				expr: &seqExpr{
-					pos: position{line: 5780, col: 22, offset: 177117},
+					pos: position{line: 5854, col: 22, offset: 179636},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5780, col: 22, offset: 177117},
+							pos:        position{line: 5854, col: 22, offset: 179636},
 							val:        "default_type",
 							ignoreCase: false,
 							want:       "\"default_type\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5780, col: 37, offset: 177132},
+							pos:  position{line: 5854, col: 37, offset: 179651},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5780, col: 43, offset: 177138},
+							pos:   position{line: 5854, col: 43, offset: 179657},
 							label: "dtype",
 							expr: &choiceExpr{
-								pos: position{line: 5780, col: 50, offset: 177145},
+								pos: position{line: 5854, col: 50, offset: 179664},
 								alternatives: []any{
 									&litMatcher{
-										pos:        position{line: 5780, col: 50, offset: 177145},
+										pos:        position{line: 5854, col: 50, offset: 179664},
 										val:        "auto",
 										ignoreCase: false,
 										want:       "\"auto\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5780, col: 59, offset: 177154},
+										pos:        position{line: 5854, col: 59, offset: 179673},
 										val:        "bool",
 										ignoreCase: false,
 										want:       "\"bool\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5780, col: 68, offset: 177163},
+										pos:        position{line: 5854, col: 68, offset: 179682},
 										val:        "json",
 										ignoreCase: false,
 										want:       "\"json\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5780, col: 77, offset: 177172},
+										pos:        position{line: 5854, col: 77, offset: 179691},
 										val:        "num",
 										ignoreCase: false,
 										want:       "\"num\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5780, col: 85, offset: 177180},
+										pos:        position{line: 5854, col: 85, offset: 179699},
 										val:        "str",
 										ignoreCase: false,
 										want:       "\"str\"",
 									},
 									&litMatcher{
-										pos:        position{line: 5780, col: 93, offset: 177188},
+										pos:        position{line: 5854, col: 93, offset: 179707},
 										val:        "none",
 										ignoreCase: false,
 										want:       "\"none\"",
@@ -14315,28 +14554,28 @@ var g = &grammar{
 		},
 		{
 			name: "FillNullOption",
-			pos:  position{line: 5793, col: 1, offset: 177517},
+			pos:  position{line: 5867, col: 1, offset: 180036},
 			expr: &actionExpr{
-				pos: position{line: 5793, col: 19, offset: 177535},
+				pos: position{line: 5867, col: 19, offset: 180054},
 				run: (*parser).callonFillNullOption1,
 				expr: &seqExpr{
-					pos: position{line: 5793, col: 19, offset: 177535},
+					pos: position{line: 5867, col: 19, offset: 180054},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5793, col: 19, offset: 177535},
+							pos:        position{line: 5867, col: 19, offset: 180054},
 							val:        "fill_null",
 							ignoreCase: false,
 							want:       "\"fill_null\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5793, col: 31, offset: 177547},
+							pos:  position{line: 5867, col: 31, offset: 180066},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5793, col: 37, offset: 177553},
+							pos:   position{line: 5867, col: 37, offset: 180072},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5793, col: 45, offset: 177561},
+								pos:  position{line: 5867, col: 45, offset: 180080},
 								name: "Boolean",
 							},
 						},
@@ -14346,28 +14585,28 @@ var g = &grammar{
 		},
 		{
 			name: "IncludeInternalOption",
-			pos:  position{line: 5800, col: 1, offset: 177684},
+			pos:  position{line: 5874, col: 1, offset: 180203},
 			expr: &actionExpr{
-				pos: position{line: 5800, col: 26, offset: 177709},
+				pos: position{line: 5874, col: 26, offset: 180228},
 				run: (*parser).callonIncludeInternalOption1,
 				expr: &seqExpr{
-					pos: position{line: 5800, col: 26, offset: 177709},
+					pos: position{line: 5874, col: 26, offset: 180228},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5800, col: 26, offset: 177709},
+							pos:        position{line: 5874, col: 26, offset: 180228},
 							val:        "include_internal",
 							ignoreCase: false,
 							want:       "\"include_internal\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5800, col: 45, offset: 177728},
+							pos:  position{line: 5874, col: 45, offset: 180247},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5800, col: 51, offset: 177734},
+							pos:   position{line: 5874, col: 51, offset: 180253},
 							label: "boolVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5800, col: 59, offset: 177742},
+								pos:  position{line: 5874, col: 59, offset: 180261},
 								name: "Boolean",
 							},
 						},
@@ -14377,28 +14616,28 @@ var g = &grammar{
 		},
 		{
 			name: "OutputFieldOption",
-			pos:  position{line: 5807, col: 1, offset: 177872},
+			pos:  position{line: 5881, col: 1, offset: 180391},
 			expr: &actionExpr{
-				pos: position{line: 5807, col: 22, offset: 177893},
+				pos: position{line: 5881, col: 22, offset: 180412},
 				run: (*parser).callonOutputFieldOption1,
 				expr: &seqExpr{
-					pos: position{line: 5807, col: 22, offset: 177893},
+					pos: position{line: 5881, col: 22, offset: 180412},
 					exprs: []any{
 						&litMatcher{
-							pos:        position{line: 5807, col: 22, offset: 177893},
+							pos:        position{line: 5881, col: 22, offset: 180412},
 							val:        "output_field",
 							ignoreCase: false,
 							want:       "\"output_field\"",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5807, col: 37, offset: 177908},
+							pos:  position{line: 5881, col: 37, offset: 180427},
 							name: "EQUAL",
 						},
 						&labeledExpr{
-							pos:   position{line: 5807, col: 43, offset: 177914},
+							pos:   position{line: 5881, col: 43, offset: 180433},
 							label: "strVal",
 							expr: &ruleRefExpr{
-								pos:  position{line: 5807, col: 50, offset: 177921},
+								pos:  position{line: 5881, col: 50, offset: 180440},
 								name: "String",
 							},
 						},
@@ -14408,28 +14647,28 @@ var g = &grammar{
 		},
 		{
 			name: "ToJsonBlock",
-			pos:  position{line: 5814, col: 1, offset: 178047},
+			pos:  position{line: 5888, col: 1, offset: 180566},
 			expr: &actionExpr{
-				pos: position{line: 5814, col: 16, offset: 178062},
+				pos: position{line: 5888, col: 16, offset: 180581},
 				run: (*parser).callonToJsonBlock1,
 				expr: &seqExpr{
-					pos: position{line: 5814, col: 16, offset: 178062},
+					pos: position{line: 5888, col: 16, offset: 180581},
 					exprs: []any{
 						&ruleRefExpr{
-							pos:  position{line: 5814, col: 16, offset: 178062},
+							pos:  position{line: 5888, col: 16, offset: 180581},
 							name: "PIPE",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 5814, col: 21, offset: 178067},
+							pos:  position{line: 5888, col: 21, offset: 180586},
 							name: "CMD_TOJSON",
 						},
 						&labeledExpr{
-							pos:   position{line: 5814, col: 32, offset: 178078},
+							pos:   position{line: 5888, col: 32, offset: 180597},
 							label: "options",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 5814, col: 40, offset: 178086},
+								pos: position{line: 5888, col: 40, offset: 180605},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5814, col: 41, offset: 178087},
+									pos:  position{line: 5888, col: 41, offset: 180606},
 									name: "ToJsonOption",
 								},
 							},
@@ -14440,132 +14679,132 @@ var g = &grammar{
 		},
 		{
 			name: "ALLCMD",
-			pos:  position{line: 5867, col: 1, offset: 180169},
+			pos:  position{line: 5941, col: 1, offset: 182688},
 			expr: &choiceExpr{
-				pos: position{line: 5867, col: 12, offset: 180180},
+				pos: position{line: 5941, col: 12, offset: 182699},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 12, offset: 180180},
+						pos:  position{line: 5941, col: 12, offset: 182699},
 						name: "CMD_REGEX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 24, offset: 180192},
+						pos:  position{line: 5941, col: 24, offset: 182711},
 						name: "CMD_STATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 36, offset: 180204},
+						pos:  position{line: 5941, col: 36, offset: 182723},
 						name: "CMD_FIELDS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 49, offset: 180217},
+						pos:  position{line: 5941, col: 49, offset: 182736},
 						name: "CMD_WHERE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 61, offset: 180229},
+						pos:  position{line: 5941, col: 61, offset: 182748},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 81, offset: 180249},
+						pos:  position{line: 5941, col: 81, offset: 182768},
 						name: "CMD_HEAD",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 92, offset: 180260},
+						pos:  position{line: 5941, col: 92, offset: 182779},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 112, offset: 180280},
+						pos:  position{line: 5941, col: 112, offset: 182799},
 						name: "CMD_TAIL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 123, offset: 180291},
+						pos:  position{line: 5941, col: 123, offset: 182810},
 						name: "CMD_EVAL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 134, offset: 180302},
+						pos:  position{line: 5941, col: 134, offset: 182821},
 						name: "CMD_REX",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 144, offset: 180312},
+						pos:  position{line: 5941, col: 144, offset: 182831},
 						name: "CMD_TOP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 154, offset: 180322},
+						pos:  position{line: 5941, col: 154, offset: 182841},
 						name: "CMD_RARE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 165, offset: 180333},
+						pos:  position{line: 5941, col: 165, offset: 182852},
 						name: "CMD_RENAME",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 178, offset: 180346},
+						pos:  position{line: 5941, col: 178, offset: 182865},
 						name: "CMD_TIMECHART",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 194, offset: 180362},
+						pos:  position{line: 5941, col: 194, offset: 182881},
 						name: "CMD_TRANSACTION",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 212, offset: 180380},
+						pos:  position{line: 5941, col: 212, offset: 182899},
 						name: "CMD_DEDUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 224, offset: 180392},
+						pos:  position{line: 5941, col: 224, offset: 182911},
 						name: "CMD_SORT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 235, offset: 180403},
+						pos:  position{line: 5941, col: 235, offset: 182922},
 						name: "CMD_MAKEMV",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 248, offset: 180416},
+						pos:  position{line: 5941, col: 248, offset: 182935},
 						name: "CMD_SPATH",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 260, offset: 180428},
+						pos:  position{line: 5941, col: 260, offset: 182947},
 						name: "CMD_FORMAT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 273, offset: 180441},
+						pos:  position{line: 5941, col: 273, offset: 182960},
 						name: "CMD_EARLIEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 288, offset: 180456},
+						pos:  position{line: 5941, col: 288, offset: 182975},
 						name: "CMD_LATEST",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 301, offset: 180469},
+						pos:  position{line: 5941, col: 301, offset: 182988},
 						name: "CMD_EVENTCOUNT",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 318, offset: 180486},
+						pos:  position{line: 5941, col: 318, offset: 183005},
 						name: "CMD_BIN",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 328, offset: 180496},
+						pos:  position{line: 5941, col: 328, offset: 183015},
 						name: "CMD_STREAMSTATS",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 346, offset: 180514},
+						pos:  position{line: 5941, col: 346, offset: 183033},
 						name: "CMD_FILLNULL",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 361, offset: 180529},
+						pos:  position{line: 5941, col: 361, offset: 183048},
 						name: "CMD_MVEXPAND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 376, offset: 180544},
+						pos:  position{line: 5941, col: 376, offset: 183063},
 						name: "CMD_GENTIMES",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 391, offset: 180559},
+						pos:  position{line: 5941, col: 391, offset: 183078},
 						name: "CMD_INPUTLOOKUP",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 409, offset: 180577},
+						pos:  position{line: 5941, col: 409, offset: 183096},
 						name: "CMD_APPEND",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5867, col: 422, offset: 180590},
+						pos:  position{line: 5941, col: 422, offset: 183109},
 						name: "CMD_TOJSON",
 					},
 				},
@@ -14573,18 +14812,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SEARCH",
-			pos:  position{line: 5868, col: 1, offset: 180602},
+			pos:  position{line: 5942, col: 1, offset: 183121},
 			expr: &seqExpr{
-				pos: position{line: 5868, col: 15, offset: 180616},
+				pos: position{line: 5942, col: 15, offset: 183135},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5868, col: 15, offset: 180616},
+						pos:        position{line: 5942, col: 15, offset: 183135},
 						val:        "search",
 						ignoreCase: false,
 						want:       "\"search\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5868, col: 24, offset: 180625},
+						pos:  position{line: 5942, col: 24, offset: 183144},
 						name: "SPACE",
 					},
 				},
@@ -14592,18 +14831,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REGEX",
-			pos:  position{line: 5869, col: 1, offset: 180631},
+			pos:  position{line: 5943, col: 1, offset: 183150},
 			expr: &seqExpr{
-				pos: position{line: 5869, col: 14, offset: 180644},
+				pos: position{line: 5943, col: 14, offset: 183163},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5869, col: 14, offset: 180644},
+						pos:        position{line: 5943, col: 14, offset: 183163},
 						val:        "regex",
 						ignoreCase: false,
 						want:       "\"regex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5869, col: 22, offset: 180652},
+						pos:  position{line: 5943, col: 22, offset: 183171},
 						name: "SPACE",
 					},
 				},
@@ -14611,18 +14850,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STATS",
-			pos:  position{line: 5870, col: 1, offset: 180658},
+			pos:  position{line: 5944, col: 1, offset: 183177},
 			expr: &seqExpr{
-				pos: position{line: 5870, col: 14, offset: 180671},
+				pos: position{line: 5944, col: 14, offset: 183190},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5870, col: 14, offset: 180671},
+						pos:        position{line: 5944, col: 14, offset: 183190},
 						val:        "stats",
 						ignoreCase: false,
 						want:       "\"stats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5870, col: 22, offset: 180679},
+						pos:  position{line: 5944, col: 22, offset: 183198},
 						name: "SPACE",
 					},
 				},
@@ -14630,18 +14869,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_STREAMSTATS",
-			pos:  position{line: 5871, col: 1, offset: 180685},
+			pos:  position{line: 5945, col: 1, offset: 183204},
 			expr: &seqExpr{
-				pos: position{line: 5871, col: 20, offset: 180704},
+				pos: position{line: 5945, col: 20, offset: 183223},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5871, col: 20, offset: 180704},
+						pos:        position{line: 5945, col: 20, offset: 183223},
 						val:        "streamstats",
 						ignoreCase: false,
 						want:       "\"streamstats\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5871, col: 34, offset: 180718},
+						pos:  position{line: 5945, col: 34, offset: 183237},
 						name: "SPACE",
 					},
 				},
@@ -14649,18 +14888,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FIELDS",
-			pos:  position{line: 5872, col: 1, offset: 180724},
+			pos:  position{line: 5946, col: 1, offset: 183243},
 			expr: &seqExpr{
-				pos: position{line: 5872, col: 15, offset: 180738},
+				pos: position{line: 5946, col: 15, offset: 183257},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5872, col: 15, offset: 180738},
+						pos:        position{line: 5946, col: 15, offset: 183257},
 						val:        "fields",
 						ignoreCase: false,
 						want:       "\"fields\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5872, col: 24, offset: 180747},
+						pos:  position{line: 5946, col: 24, offset: 183266},
 						name: "SPACE",
 					},
 				},
@@ -14668,18 +14907,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_WHERE",
-			pos:  position{line: 5873, col: 1, offset: 180753},
+			pos:  position{line: 5947, col: 1, offset: 183272},
 			expr: &seqExpr{
-				pos: position{line: 5873, col: 14, offset: 180766},
+				pos: position{line: 5947, col: 14, offset: 183285},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5873, col: 14, offset: 180766},
+						pos:        position{line: 5947, col: 14, offset: 183285},
 						val:        "where",
 						ignoreCase: false,
 						want:       "\"where\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5873, col: 22, offset: 180774},
+						pos:  position{line: 5947, col: 22, offset: 183293},
 						name: "SPACE",
 					},
 				},
@@ -14687,9 +14926,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD_NO_SPACE",
-			pos:  position{line: 5874, col: 1, offset: 180780},
+			pos:  position{line: 5948, col: 1, offset: 183299},
 			expr: &litMatcher{
-				pos:        position{line: 5874, col: 22, offset: 180801},
+				pos:        position{line: 5948, col: 22, offset: 183320},
 				val:        "head",
 				ignoreCase: false,
 				want:       "\"head\"",
@@ -14697,16 +14936,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_HEAD",
-			pos:  position{line: 5875, col: 1, offset: 180808},
+			pos:  position{line: 5949, col: 1, offset: 183327},
 			expr: &seqExpr{
-				pos: position{line: 5875, col: 13, offset: 180820},
+				pos: position{line: 5949, col: 13, offset: 183339},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5875, col: 13, offset: 180820},
+						pos:  position{line: 5949, col: 13, offset: 183339},
 						name: "CMD_HEAD_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5875, col: 31, offset: 180838},
+						pos:  position{line: 5949, col: 31, offset: 183357},
 						name: "SPACE",
 					},
 				},
@@ -14714,9 +14953,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL_NO_SPACE",
-			pos:  position{line: 5876, col: 1, offset: 180844},
+			pos:  position{line: 5950, col: 1, offset: 183363},
 			expr: &litMatcher{
-				pos:        position{line: 5876, col: 22, offset: 180865},
+				pos:        position{line: 5950, col: 22, offset: 183384},
 				val:        "tail",
 				ignoreCase: false,
 				want:       "\"tail\"",
@@ -14724,16 +14963,16 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TAIL",
-			pos:  position{line: 5877, col: 1, offset: 180872},
+			pos:  position{line: 5951, col: 1, offset: 183391},
 			expr: &seqExpr{
-				pos: position{line: 5877, col: 13, offset: 180884},
+				pos: position{line: 5951, col: 13, offset: 183403},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5877, col: 13, offset: 180884},
+						pos:  position{line: 5951, col: 13, offset: 183403},
 						name: "CMD_TAIL_NO_SPACE",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5877, col: 31, offset: 180902},
+						pos:  position{line: 5951, col: 31, offset: 183421},
 						name: "SPACE",
 					},
 				},
@@ -14741,18 +14980,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVAL",
-			pos:  position{line: 5878, col: 1, offset: 180908},
+			pos:  position{line: 5952, col: 1, offset: 183427},
 			expr: &seqExpr{
-				pos: position{line: 5878, col: 13, offset: 180920},
+				pos: position{line: 5952, col: 13, offset: 183439},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5878, col: 13, offset: 180920},
+						pos:        position{line: 5952, col: 13, offset: 183439},
 						val:        "eval",
 						ignoreCase: false,
 						want:       "\"eval\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5878, col: 20, offset: 180927},
+						pos:  position{line: 5952, col: 20, offset: 183446},
 						name: "SPACE",
 					},
 				},
@@ -14760,18 +14999,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_REX",
-			pos:  position{line: 5879, col: 1, offset: 180933},
+			pos:  position{line: 5953, col: 1, offset: 183452},
 			expr: &seqExpr{
-				pos: position{line: 5879, col: 12, offset: 180944},
+				pos: position{line: 5953, col: 12, offset: 183463},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5879, col: 12, offset: 180944},
+						pos:        position{line: 5953, col: 12, offset: 183463},
 						val:        "rex",
 						ignoreCase: false,
 						want:       "\"rex\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5879, col: 18, offset: 180950},
+						pos:  position{line: 5953, col: 18, offset: 183469},
 						name: "SPACE",
 					},
 				},
@@ -14779,18 +15018,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SORT",
-			pos:  position{line: 5880, col: 1, offset: 180956},
+			pos:  position{line: 5954, col: 1, offset: 183475},
 			expr: &seqExpr{
-				pos: position{line: 5880, col: 13, offset: 180968},
+				pos: position{line: 5954, col: 13, offset: 183487},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5880, col: 13, offset: 180968},
+						pos:        position{line: 5954, col: 13, offset: 183487},
 						val:        "sort",
 						ignoreCase: false,
 						want:       "\"sort\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5880, col: 20, offset: 180975},
+						pos:  position{line: 5954, col: 20, offset: 183494},
 						name: "SPACE",
 					},
 				},
@@ -14798,9 +15037,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOP",
-			pos:  position{line: 5881, col: 1, offset: 180981},
+			pos:  position{line: 5955, col: 1, offset: 183500},
 			expr: &litMatcher{
-				pos:        position{line: 5881, col: 12, offset: 180992},
+				pos:        position{line: 5955, col: 12, offset: 183511},
 				val:        "top",
 				ignoreCase: false,
 				want:       "\"top\"",
@@ -14808,9 +15047,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RARE",
-			pos:  position{line: 5882, col: 1, offset: 180998},
+			pos:  position{line: 5956, col: 1, offset: 183517},
 			expr: &litMatcher{
-				pos:        position{line: 5882, col: 13, offset: 181010},
+				pos:        position{line: 5956, col: 13, offset: 183529},
 				val:        "rare",
 				ignoreCase: false,
 				want:       "\"rare\"",
@@ -14818,18 +15057,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_RENAME",
-			pos:  position{line: 5883, col: 1, offset: 181017},
+			pos:  position{line: 5957, col: 1, offset: 183536},
 			expr: &seqExpr{
-				pos: position{line: 5883, col: 15, offset: 181031},
+				pos: position{line: 5957, col: 15, offset: 183550},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5883, col: 15, offset: 181031},
+						pos:        position{line: 5957, col: 15, offset: 183550},
 						val:        "rename",
 						ignoreCase: false,
 						want:       "\"rename\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5883, col: 24, offset: 181040},
+						pos:  position{line: 5957, col: 24, offset: 183559},
 						name: "SPACE",
 					},
 				},
@@ -14837,18 +15076,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TIMECHART",
-			pos:  position{line: 5884, col: 1, offset: 181046},
+			pos:  position{line: 5958, col: 1, offset: 183565},
 			expr: &seqExpr{
-				pos: position{line: 5884, col: 18, offset: 181063},
+				pos: position{line: 5958, col: 18, offset: 183582},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5884, col: 18, offset: 181063},
+						pos:        position{line: 5958, col: 18, offset: 183582},
 						val:        "timechart",
 						ignoreCase: false,
 						want:       "\"timechart\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5884, col: 30, offset: 181075},
+						pos:  position{line: 5958, col: 30, offset: 183594},
 						name: "SPACE",
 					},
 				},
@@ -14856,18 +15095,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_BIN",
-			pos:  position{line: 5885, col: 1, offset: 181081},
+			pos:  position{line: 5959, col: 1, offset: 183600},
 			expr: &seqExpr{
-				pos: position{line: 5885, col: 12, offset: 181092},
+				pos: position{line: 5959, col: 12, offset: 183611},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5885, col: 12, offset: 181092},
+						pos:        position{line: 5959, col: 12, offset: 183611},
 						val:        "bin",
 						ignoreCase: false,
 						want:       "\"bin\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5885, col: 18, offset: 181098},
+						pos:  position{line: 5959, col: 18, offset: 183617},
 						name: "SPACE",
 					},
 				},
@@ -14875,9 +15114,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPAN",
-			pos:  position{line: 5886, col: 1, offset: 181104},
+			pos:  position{line: 5960, col: 1, offset: 183623},
 			expr: &litMatcher{
-				pos:        position{line: 5886, col: 13, offset: 181116},
+				pos:        position{line: 5960, col: 13, offset: 183635},
 				val:        "span",
 				ignoreCase: false,
 				want:       "\"span\"",
@@ -14885,18 +15124,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TRANSACTION",
-			pos:  position{line: 5887, col: 1, offset: 181123},
+			pos:  position{line: 5961, col: 1, offset: 183642},
 			expr: &seqExpr{
-				pos: position{line: 5887, col: 20, offset: 181142},
+				pos: position{line: 5961, col: 20, offset: 183661},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5887, col: 20, offset: 181142},
+						pos:        position{line: 5961, col: 20, offset: 183661},
 						val:        "transaction",
 						ignoreCase: false,
 						want:       "\"transaction\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5887, col: 34, offset: 181156},
+						pos:  position{line: 5961, col: 34, offset: 183675},
 						name: "SPACE",
 					},
 				},
@@ -14904,9 +15143,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP",
-			pos:  position{line: 5888, col: 1, offset: 181162},
+			pos:  position{line: 5962, col: 1, offset: 183681},
 			expr: &litMatcher{
-				pos:        position{line: 5888, col: 14, offset: 181175},
+				pos:        position{line: 5962, col: 14, offset: 183694},
 				val:        "dedup",
 				ignoreCase: false,
 				want:       "\"dedup\"",
@@ -14914,22 +15153,22 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_DEDUP_SORTBY",
-			pos:  position{line: 5889, col: 1, offset: 181183},
+			pos:  position{line: 5963, col: 1, offset: 183702},
 			expr: &seqExpr{
-				pos: position{line: 5889, col: 21, offset: 181203},
+				pos: position{line: 5963, col: 21, offset: 183722},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 21, offset: 181203},
+						pos:  position{line: 5963, col: 21, offset: 183722},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5889, col: 27, offset: 181209},
+						pos:        position{line: 5963, col: 27, offset: 183728},
 						val:        "sortby",
 						ignoreCase: false,
 						want:       "\"sortby\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5889, col: 36, offset: 181218},
+						pos:  position{line: 5963, col: 36, offset: 183737},
 						name: "SPACE",
 					},
 				},
@@ -14937,9 +15176,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MAKEMV",
-			pos:  position{line: 5890, col: 1, offset: 181224},
+			pos:  position{line: 5964, col: 1, offset: 183743},
 			expr: &litMatcher{
-				pos:        position{line: 5890, col: 15, offset: 181238},
+				pos:        position{line: 5964, col: 15, offset: 183757},
 				val:        "makemv",
 				ignoreCase: false,
 				want:       "\"makemv\"",
@@ -14947,9 +15186,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_SPATH",
-			pos:  position{line: 5891, col: 1, offset: 181247},
+			pos:  position{line: 5965, col: 1, offset: 183766},
 			expr: &litMatcher{
-				pos:        position{line: 5891, col: 14, offset: 181260},
+				pos:        position{line: 5965, col: 14, offset: 183779},
 				val:        "spath",
 				ignoreCase: false,
 				want:       "\"spath\"",
@@ -14957,9 +15196,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FORMAT",
-			pos:  position{line: 5892, col: 1, offset: 181268},
+			pos:  position{line: 5966, col: 1, offset: 183787},
 			expr: &litMatcher{
-				pos:        position{line: 5892, col: 15, offset: 181282},
+				pos:        position{line: 5966, col: 15, offset: 183801},
 				val:        "format",
 				ignoreCase: false,
 				want:       "\"format\"",
@@ -14967,9 +15206,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EARLIEST",
-			pos:  position{line: 5893, col: 1, offset: 181291},
+			pos:  position{line: 5967, col: 1, offset: 183810},
 			expr: &litMatcher{
-				pos:        position{line: 5893, col: 17, offset: 181307},
+				pos:        position{line: 5967, col: 17, offset: 183826},
 				val:        "earliest",
 				ignoreCase: false,
 				want:       "\"earliest\"",
@@ -14977,9 +15216,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_LATEST",
-			pos:  position{line: 5894, col: 1, offset: 181318},
+			pos:  position{line: 5968, col: 1, offset: 183837},
 			expr: &litMatcher{
-				pos:        position{line: 5894, col: 15, offset: 181332},
+				pos:        position{line: 5968, col: 15, offset: 183851},
 				val:        "latest",
 				ignoreCase: false,
 				want:       "\"latest\"",
@@ -14987,9 +15226,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_EVENTCOUNT",
-			pos:  position{line: 5895, col: 1, offset: 181341},
+			pos:  position{line: 5969, col: 1, offset: 183860},
 			expr: &litMatcher{
-				pos:        position{line: 5895, col: 19, offset: 181359},
+				pos:        position{line: 5969, col: 19, offset: 183878},
 				val:        "eventcount",
 				ignoreCase: false,
 				want:       "\"eventcount\"",
@@ -14997,9 +15236,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_FILLNULL",
-			pos:  position{line: 5896, col: 1, offset: 181372},
+			pos:  position{line: 5970, col: 1, offset: 183891},
 			expr: &litMatcher{
-				pos:        position{line: 5896, col: 17, offset: 181388},
+				pos:        position{line: 5970, col: 17, offset: 183907},
 				val:        "fillnull",
 				ignoreCase: false,
 				want:       "\"fillnull\"",
@@ -15007,9 +15246,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_GENTIMES",
-			pos:  position{line: 5897, col: 1, offset: 181399},
+			pos:  position{line: 5971, col: 1, offset: 183918},
 			expr: &litMatcher{
-				pos:        position{line: 5897, col: 17, offset: 181415},
+				pos:        position{line: 5971, col: 17, offset: 183934},
 				val:        "gentimes",
 				ignoreCase: false,
 				want:       "\"gentimes\"",
@@ -15017,18 +15256,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_INPUTLOOKUP",
-			pos:  position{line: 5898, col: 1, offset: 181426},
+			pos:  position{line: 5972, col: 1, offset: 183945},
 			expr: &seqExpr{
-				pos: position{line: 5898, col: 20, offset: 181445},
+				pos: position{line: 5972, col: 20, offset: 183964},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5898, col: 20, offset: 181445},
+						pos:        position{line: 5972, col: 20, offset: 183964},
 						val:        "inputlookup",
 						ignoreCase: false,
 						want:       "\"inputlookup\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5898, col: 34, offset: 181459},
+						pos:  position{line: 5972, col: 34, offset: 183978},
 						name: "SPACE",
 					},
 				},
@@ -15036,28 +15275,28 @@ var g = &grammar{
 		},
 		{
 			name: "EVAL_CONCAT",
-			pos:  position{line: 5899, col: 1, offset: 181465},
+			pos:  position{line: 5973, col: 1, offset: 183984},
 			expr: &seqExpr{
-				pos: position{line: 5899, col: 16, offset: 181480},
+				pos: position{line: 5973, col: 16, offset: 183999},
 				exprs: []any{
 					&zeroOrOneExpr{
-						pos: position{line: 5899, col: 16, offset: 181480},
+						pos: position{line: 5973, col: 16, offset: 183999},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5899, col: 16, offset: 181480},
+							pos:  position{line: 5973, col: 16, offset: 183999},
 							name: "SPACE",
 						},
 					},
 					&choiceExpr{
-						pos: position{line: 5899, col: 24, offset: 181488},
+						pos: position{line: 5973, col: 24, offset: 184007},
 						alternatives: []any{
 							&litMatcher{
-								pos:        position{line: 5899, col: 24, offset: 181488},
+								pos:        position{line: 5973, col: 24, offset: 184007},
 								val:        ".",
 								ignoreCase: false,
 								want:       "\".\"",
 							},
 							&litMatcher{
-								pos:        position{line: 5899, col: 30, offset: 181494},
+								pos:        position{line: 5973, col: 30, offset: 184013},
 								val:        "+",
 								ignoreCase: false,
 								want:       "\"+\"",
@@ -15065,9 +15304,9 @@ var g = &grammar{
 						},
 					},
 					&zeroOrOneExpr{
-						pos: position{line: 5899, col: 35, offset: 181499},
+						pos: position{line: 5973, col: 35, offset: 184018},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5899, col: 35, offset: 181499},
+							pos:  position{line: 5973, col: 35, offset: 184018},
 							name: "SPACE",
 						},
 					},
@@ -15076,9 +15315,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_MVEXPAND",
-			pos:  position{line: 5900, col: 1, offset: 181506},
+			pos:  position{line: 5974, col: 1, offset: 184025},
 			expr: &litMatcher{
-				pos:        position{line: 5900, col: 17, offset: 181522},
+				pos:        position{line: 5974, col: 17, offset: 184041},
 				val:        "mvexpand",
 				ignoreCase: false,
 				want:       "\"mvexpand\"",
@@ -15086,18 +15325,18 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_APPEND",
-			pos:  position{line: 5901, col: 1, offset: 181533},
+			pos:  position{line: 5975, col: 1, offset: 184052},
 			expr: &seqExpr{
-				pos: position{line: 5901, col: 15, offset: 181547},
+				pos: position{line: 5975, col: 15, offset: 184066},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5901, col: 15, offset: 181547},
+						pos:        position{line: 5975, col: 15, offset: 184066},
 						val:        "append",
 						ignoreCase: false,
 						want:       "\"append\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5901, col: 24, offset: 181556},
+						pos:  position{line: 5975, col: 24, offset: 184075},
 						name: "SPACE",
 					},
 				},
@@ -15105,9 +15344,9 @@ var g = &grammar{
 		},
 		{
 			name: "CMD_TOJSON",
-			pos:  position{line: 5902, col: 1, offset: 181562},
+			pos:  position{line: 5976, col: 1, offset: 184081},
 			expr: &litMatcher{
-				pos:        position{line: 5902, col: 15, offset: 181576},
+				pos:        position{line: 5976, col: 15, offset: 184095},
 				val:        "tojson",
 				ignoreCase: false,
 				want:       "\"tojson\"",
@@ -15115,115 +15354,115 @@ var g = &grammar{
 		},
 		{
 			name: "MAJOR_BREAK",
-			pos:  position{line: 5905, col: 1, offset: 181689},
+			pos:  position{line: 5979, col: 1, offset: 184208},
 			expr: &choiceExpr{
-				pos: position{line: 5905, col: 16, offset: 181704},
+				pos: position{line: 5979, col: 16, offset: 184223},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5905, col: 16, offset: 181704},
+						pos:        position{line: 5979, col: 16, offset: 184223},
 						val:        "[[\\]<>(){}|!;,'\"*\\n\\r \\t&?+]",
 						chars:      []rune{'[', ']', '<', '>', '(', ')', '{', '}', '|', '!', ';', ',', '\'', '"', '*', '\n', '\r', ' ', '\t', '&', '?', '+'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5905, col: 47, offset: 181735},
+						pos:        position{line: 5979, col: 47, offset: 184254},
 						val:        "%21",
 						ignoreCase: false,
 						want:       "\"%21\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5905, col: 55, offset: 181743},
+						pos:        position{line: 5979, col: 55, offset: 184262},
 						val:        "%26",
 						ignoreCase: false,
 						want:       "\"%26\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 16, offset: 181766},
+						pos:        position{line: 5980, col: 16, offset: 184285},
 						val:        "%2526",
 						ignoreCase: false,
 						want:       "\"%2526\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 26, offset: 181776},
+						pos:        position{line: 5980, col: 26, offset: 184295},
 						val:        "%3B",
 						ignoreCase: false,
 						want:       "\"%3B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 34, offset: 181784},
+						pos:        position{line: 5980, col: 34, offset: 184303},
 						val:        "%7C",
 						ignoreCase: false,
 						want:       "\"%7C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 42, offset: 181792},
+						pos:        position{line: 5980, col: 42, offset: 184311},
 						val:        "%20",
 						ignoreCase: false,
 						want:       "\"%20\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 50, offset: 181800},
+						pos:        position{line: 5980, col: 50, offset: 184319},
 						val:        "%2B",
 						ignoreCase: false,
 						want:       "\"%2B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 58, offset: 181808},
+						pos:        position{line: 5980, col: 58, offset: 184327},
 						val:        "%3D",
 						ignoreCase: false,
 						want:       "\"%3D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5906, col: 66, offset: 181816},
+						pos:        position{line: 5980, col: 66, offset: 184335},
 						val:        "--",
 						ignoreCase: false,
 						want:       "\"--\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 16, offset: 181838},
+						pos:        position{line: 5981, col: 16, offset: 184357},
 						val:        "%2520",
 						ignoreCase: false,
 						want:       "\"%2520\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 26, offset: 181848},
+						pos:        position{line: 5981, col: 26, offset: 184367},
 						val:        "%5D",
 						ignoreCase: false,
 						want:       "\"%5D\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 34, offset: 181856},
+						pos:        position{line: 5981, col: 34, offset: 184375},
 						val:        "%5B",
 						ignoreCase: false,
 						want:       "\"%5B\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 42, offset: 181864},
+						pos:        position{line: 5981, col: 42, offset: 184383},
 						val:        "%3A",
 						ignoreCase: false,
 						want:       "\"%3A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 50, offset: 181872},
+						pos:        position{line: 5981, col: 50, offset: 184391},
 						val:        "%0A",
 						ignoreCase: false,
 						want:       "\"%0A\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 58, offset: 181880},
+						pos:        position{line: 5981, col: 58, offset: 184399},
 						val:        "%2C",
 						ignoreCase: false,
 						want:       "\"%2C\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 66, offset: 181888},
+						pos:        position{line: 5981, col: 66, offset: 184407},
 						val:        "%28",
 						ignoreCase: false,
 						want:       "\"%28\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5907, col: 74, offset: 181896},
+						pos:        position{line: 5981, col: 74, offset: 184415},
 						val:        "%29",
 						ignoreCase: false,
 						want:       "\"%29\"",
@@ -15233,25 +15472,25 @@ var g = &grammar{
 		},
 		{
 			name: "MINOR_BREAK",
-			pos:  position{line: 5908, col: 1, offset: 181902},
+			pos:  position{line: 5982, col: 1, offset: 184421},
 			expr: &choiceExpr{
-				pos: position{line: 5908, col: 16, offset: 181917},
+				pos: position{line: 5982, col: 16, offset: 184436},
 				alternatives: []any{
 					&charClassMatcher{
-						pos:        position{line: 5908, col: 16, offset: 181917},
+						pos:        position{line: 5982, col: 16, offset: 184436},
 						val:        "[/:=@.$#%_]",
 						chars:      []rune{'/', ':', '=', '@', '.', '$', '#', '%', '_'},
 						ignoreCase: false,
 						inverted:   false,
 					},
 					&litMatcher{
-						pos:        position{line: 5908, col: 30, offset: 181931},
+						pos:        position{line: 5982, col: 30, offset: 184450},
 						val:        "-",
 						ignoreCase: false,
 						want:       "\"-\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5908, col: 36, offset: 181937},
+						pos:        position{line: 5982, col: 36, offset: 184456},
 						val:        "\\",
 						ignoreCase: false,
 						want:       "\"\\\\\"",
@@ -15261,18 +15500,18 @@ var g = &grammar{
 		},
 		{
 			name: "NOT",
-			pos:  position{line: 5912, col: 1, offset: 182093},
+			pos:  position{line: 5986, col: 1, offset: 184612},
 			expr: &seqExpr{
-				pos: position{line: 5912, col: 8, offset: 182100},
+				pos: position{line: 5986, col: 8, offset: 184619},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5912, col: 8, offset: 182100},
+						pos:        position{line: 5986, col: 8, offset: 184619},
 						val:        "NOT",
 						ignoreCase: false,
 						want:       "\"NOT\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5912, col: 14, offset: 182106},
+						pos:  position{line: 5986, col: 14, offset: 184625},
 						name: "SPACE",
 					},
 				},
@@ -15280,22 +15519,22 @@ var g = &grammar{
 		},
 		{
 			name: "OR",
-			pos:  position{line: 5913, col: 1, offset: 182112},
+			pos:  position{line: 5987, col: 1, offset: 184631},
 			expr: &seqExpr{
-				pos: position{line: 5913, col: 7, offset: 182118},
+				pos: position{line: 5987, col: 7, offset: 184637},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5913, col: 7, offset: 182118},
+						pos:  position{line: 5987, col: 7, offset: 184637},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5913, col: 13, offset: 182124},
+						pos:        position{line: 5987, col: 13, offset: 184643},
 						val:        "OR",
 						ignoreCase: false,
 						want:       "\"OR\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5913, col: 18, offset: 182129},
+						pos:  position{line: 5987, col: 18, offset: 184648},
 						name: "SPACE",
 					},
 				},
@@ -15303,22 +15542,22 @@ var g = &grammar{
 		},
 		{
 			name: "AND",
-			pos:  position{line: 5914, col: 1, offset: 182135},
+			pos:  position{line: 5988, col: 1, offset: 184654},
 			expr: &seqExpr{
-				pos: position{line: 5914, col: 8, offset: 182142},
+				pos: position{line: 5988, col: 8, offset: 184661},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5914, col: 8, offset: 182142},
+						pos:  position{line: 5988, col: 8, offset: 184661},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5914, col: 14, offset: 182148},
+						pos:        position{line: 5988, col: 14, offset: 184667},
 						val:        "AND",
 						ignoreCase: false,
 						want:       "\"AND\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5914, col: 20, offset: 182154},
+						pos:  position{line: 5988, col: 20, offset: 184673},
 						name: "SPACE",
 					},
 				},
@@ -15326,22 +15565,22 @@ var g = &grammar{
 		},
 		{
 			name: "PIPE",
-			pos:  position{line: 5915, col: 1, offset: 182160},
+			pos:  position{line: 5989, col: 1, offset: 184679},
 			expr: &seqExpr{
-				pos: position{line: 5915, col: 9, offset: 182168},
+				pos: position{line: 5989, col: 9, offset: 184687},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5915, col: 9, offset: 182168},
+						pos:  position{line: 5989, col: 9, offset: 184687},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5915, col: 24, offset: 182183},
+						pos:        position{line: 5989, col: 24, offset: 184702},
 						val:        "|",
 						ignoreCase: false,
 						want:       "\"|\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5915, col: 28, offset: 182187},
+						pos:  position{line: 5989, col: 28, offset: 184706},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15349,22 +15588,22 @@ var g = &grammar{
 		},
 		{
 			name: "AS",
-			pos:  position{line: 5916, col: 1, offset: 182202},
+			pos:  position{line: 5990, col: 1, offset: 184721},
 			expr: &seqExpr{
-				pos: position{line: 5916, col: 7, offset: 182208},
+				pos: position{line: 5990, col: 7, offset: 184727},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5916, col: 7, offset: 182208},
+						pos:  position{line: 5990, col: 7, offset: 184727},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5916, col: 13, offset: 182214},
+						pos:        position{line: 5990, col: 13, offset: 184733},
 						val:        "as",
 						ignoreCase: true,
 						want:       "\"AS\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5916, col: 19, offset: 182220},
+						pos:  position{line: 5990, col: 19, offset: 184739},
 						name: "SPACE",
 					},
 				},
@@ -15372,22 +15611,22 @@ var g = &grammar{
 		},
 		{
 			name: "BY",
-			pos:  position{line: 5917, col: 1, offset: 182246},
+			pos:  position{line: 5991, col: 1, offset: 184765},
 			expr: &seqExpr{
-				pos: position{line: 5917, col: 7, offset: 182252},
+				pos: position{line: 5991, col: 7, offset: 184771},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5917, col: 7, offset: 182252},
+						pos:  position{line: 5991, col: 7, offset: 184771},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5917, col: 13, offset: 182258},
+						pos:        position{line: 5991, col: 13, offset: 184777},
 						val:        "by",
 						ignoreCase: true,
 						want:       "\"BY\"i",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5917, col: 19, offset: 182264},
+						pos:  position{line: 5991, col: 19, offset: 184783},
 						name: "SPACE",
 					},
 				},
@@ -15395,22 +15634,22 @@ var g = &grammar{
 		},
 		{
 			name: "EQUAL",
-			pos:  position{line: 5919, col: 1, offset: 182291},
+			pos:  position{line: 5993, col: 1, offset: 184810},
 			expr: &seqExpr{
-				pos: position{line: 5919, col: 10, offset: 182300},
+				pos: position{line: 5993, col: 10, offset: 184819},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5919, col: 10, offset: 182300},
+						pos:  position{line: 5993, col: 10, offset: 184819},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5919, col: 25, offset: 182315},
+						pos:        position{line: 5993, col: 25, offset: 184834},
 						val:        "=",
 						ignoreCase: false,
 						want:       "\"=\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5919, col: 29, offset: 182319},
+						pos:  position{line: 5993, col: 29, offset: 184838},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15418,22 +15657,22 @@ var g = &grammar{
 		},
 		{
 			name: "COMMA",
-			pos:  position{line: 5920, col: 1, offset: 182334},
+			pos:  position{line: 5994, col: 1, offset: 184853},
 			expr: &seqExpr{
-				pos: position{line: 5920, col: 10, offset: 182343},
+				pos: position{line: 5994, col: 10, offset: 184862},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5920, col: 10, offset: 182343},
+						pos:  position{line: 5994, col: 10, offset: 184862},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5920, col: 25, offset: 182358},
+						pos:        position{line: 5994, col: 25, offset: 184877},
 						val:        ",",
 						ignoreCase: false,
 						want:       "\",\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5920, col: 29, offset: 182362},
+						pos:  position{line: 5994, col: 29, offset: 184881},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15441,9 +15680,9 @@ var g = &grammar{
 		},
 		{
 			name: "QUOTE",
-			pos:  position{line: 5921, col: 1, offset: 182377},
+			pos:  position{line: 5995, col: 1, offset: 184896},
 			expr: &litMatcher{
-				pos:        position{line: 5921, col: 10, offset: 182386},
+				pos:        position{line: 5995, col: 10, offset: 184905},
 				val:        "\"",
 				ignoreCase: false,
 				want:       "\"\\\"\"",
@@ -15451,18 +15690,18 @@ var g = &grammar{
 		},
 		{
 			name: "L_PAREN",
-			pos:  position{line: 5922, col: 1, offset: 182390},
+			pos:  position{line: 5996, col: 1, offset: 184909},
 			expr: &seqExpr{
-				pos: position{line: 5922, col: 12, offset: 182401},
+				pos: position{line: 5996, col: 12, offset: 184920},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5922, col: 12, offset: 182401},
+						pos:        position{line: 5996, col: 12, offset: 184920},
 						val:        "(",
 						ignoreCase: false,
 						want:       "\"(\"",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5922, col: 16, offset: 182405},
+						pos:  position{line: 5996, col: 16, offset: 184924},
 						name: "EMPTY_OR_SPACE",
 					},
 				},
@@ -15470,16 +15709,16 @@ var g = &grammar{
 		},
 		{
 			name: "R_PAREN",
-			pos:  position{line: 5923, col: 1, offset: 182420},
+			pos:  position{line: 5997, col: 1, offset: 184939},
 			expr: &seqExpr{
-				pos: position{line: 5923, col: 12, offset: 182431},
+				pos: position{line: 5997, col: 12, offset: 184950},
 				exprs: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5923, col: 12, offset: 182431},
+						pos:  position{line: 5997, col: 12, offset: 184950},
 						name: "EMPTY_OR_SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5923, col: 27, offset: 182446},
+						pos:        position{line: 5997, col: 27, offset: 184965},
 						val:        ")",
 						ignoreCase: false,
 						want:       "\")\"",
@@ -15489,40 +15728,40 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 5925, col: 1, offset: 182451},
+			pos:  position{line: 5999, col: 1, offset: 184970},
 			expr: &notExpr{
-				pos: position{line: 5925, col: 8, offset: 182458},
+				pos: position{line: 5999, col: 8, offset: 184977},
 				expr: &anyMatcher{
-					line: 5925, col: 9, offset: 182459,
+					line: 5999, col: 9, offset: 184978,
 				},
 			},
 		},
 		{
 			name: "WHITESPACE",
-			pos:  position{line: 5926, col: 1, offset: 182461},
+			pos:  position{line: 6000, col: 1, offset: 184980},
 			expr: &choiceExpr{
-				pos: position{line: 5926, col: 15, offset: 182475},
+				pos: position{line: 6000, col: 15, offset: 184994},
 				alternatives: []any{
 					&litMatcher{
-						pos:        position{line: 5926, col: 15, offset: 182475},
+						pos:        position{line: 6000, col: 15, offset: 184994},
 						val:        " ",
 						ignoreCase: false,
 						want:       "\" \"",
 					},
 					&litMatcher{
-						pos:        position{line: 5926, col: 21, offset: 182481},
+						pos:        position{line: 6000, col: 21, offset: 185000},
 						val:        "\t",
 						ignoreCase: false,
 						want:       "\"\\t\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5926, col: 28, offset: 182488},
+						pos:        position{line: 6000, col: 28, offset: 185007},
 						val:        "\n",
 						ignoreCase: false,
 						want:       "\"\\n\"",
 					},
 					&litMatcher{
-						pos:        position{line: 5926, col: 35, offset: 182495},
+						pos:        position{line: 6000, col: 35, offset: 185014},
 						val:        "\r",
 						ignoreCase: false,
 						want:       "\"\\r\"",
@@ -15532,37 +15771,37 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE",
-			pos:  position{line: 5927, col: 1, offset: 182500},
+			pos:  position{line: 6001, col: 1, offset: 185019},
 			expr: &choiceExpr{
-				pos: position{line: 5927, col: 10, offset: 182509},
+				pos: position{line: 6001, col: 10, offset: 185028},
 				alternatives: []any{
 					&seqExpr{
-						pos: position{line: 5927, col: 11, offset: 182510},
+						pos: position{line: 6001, col: 11, offset: 185029},
 						exprs: []any{
 							&zeroOrOneExpr{
-								pos: position{line: 5927, col: 11, offset: 182510},
+								pos: position{line: 6001, col: 11, offset: 185029},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5927, col: 11, offset: 182510},
+									pos:  position{line: 6001, col: 11, offset: 185029},
 									name: "WHITESPACE",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 5927, col: 23, offset: 182522},
+								pos:  position{line: 6001, col: 23, offset: 185041},
 								name: "COMMENT",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 5927, col: 31, offset: 182530},
+								pos: position{line: 6001, col: 31, offset: 185049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 5927, col: 31, offset: 182530},
+									pos:  position{line: 6001, col: 31, offset: 185049},
 									name: "WHITESPACE",
 								},
 							},
 						},
 					},
 					&oneOrMoreExpr{
-						pos: position{line: 5927, col: 46, offset: 182545},
+						pos: position{line: 6001, col: 46, offset: 185064},
 						expr: &ruleRefExpr{
-							pos:  position{line: 5927, col: 46, offset: 182545},
+							pos:  position{line: 6001, col: 46, offset: 185064},
 							name: "WHITESPACE",
 						},
 					},
@@ -15571,38 +15810,38 @@ var g = &grammar{
 		},
 		{
 			name: "COMMENT",
-			pos:  position{line: 5928, col: 1, offset: 182557},
+			pos:  position{line: 6002, col: 1, offset: 185076},
 			expr: &seqExpr{
-				pos: position{line: 5928, col: 12, offset: 182568},
+				pos: position{line: 6002, col: 12, offset: 185087},
 				exprs: []any{
 					&litMatcher{
-						pos:        position{line: 5928, col: 12, offset: 182568},
+						pos:        position{line: 6002, col: 12, offset: 185087},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 5928, col: 18, offset: 182574},
+						pos: position{line: 6002, col: 18, offset: 185093},
 						expr: &seqExpr{
-							pos: position{line: 5928, col: 19, offset: 182575},
+							pos: position{line: 6002, col: 19, offset: 185094},
 							exprs: []any{
 								&notExpr{
-									pos: position{line: 5928, col: 19, offset: 182575},
+									pos: position{line: 6002, col: 19, offset: 185094},
 									expr: &litMatcher{
-										pos:        position{line: 5928, col: 21, offset: 182577},
+										pos:        position{line: 6002, col: 21, offset: 185096},
 										val:        "```",
 										ignoreCase: false,
 										want:       "\"```\"",
 									},
 								},
 								&anyMatcher{
-									line: 5928, col: 28, offset: 182584,
+									line: 6002, col: 28, offset: 185103,
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 5928, col: 32, offset: 182588},
+						pos:        position{line: 6002, col: 32, offset: 185107},
 						val:        "```",
 						ignoreCase: false,
 						want:       "\"```\"",
@@ -15612,16 +15851,16 @@ var g = &grammar{
 		},
 		{
 			name: "EMPTY_OR_SPACE",
-			pos:  position{line: 5929, col: 1, offset: 182594},
+			pos:  position{line: 6003, col: 1, offset: 185113},
 			expr: &choiceExpr{
-				pos: position{line: 5929, col: 20, offset: 182613},
+				pos: position{line: 6003, col: 20, offset: 185132},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5929, col: 20, offset: 182613},
+						pos:  position{line: 6003, col: 20, offset: 185132},
 						name: "SPACE",
 					},
 					&litMatcher{
-						pos:        position{line: 5929, col: 28, offset: 182621},
+						pos:        position{line: 6003, col: 28, offset: 185140},
 						val:        "",
 						ignoreCase: false,
 						want:       "\"\"",
@@ -15631,16 +15870,16 @@ var g = &grammar{
 		},
 		{
 			name: "SPACE_OR_COMMA",
-			pos:  position{line: 5930, col: 1, offset: 182624},
+			pos:  position{line: 6004, col: 1, offset: 185143},
 			expr: &choiceExpr{
-				pos: position{line: 5930, col: 19, offset: 182642},
+				pos: position{line: 6004, col: 19, offset: 185161},
 				alternatives: []any{
 					&ruleRefExpr{
-						pos:  position{line: 5930, col: 19, offset: 182642},
+						pos:  position{line: 6004, col: 19, offset: 185161},
 						name: "COMMA",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 5930, col: 27, offset: 182650},
+						pos:  position{line: 6004, col: 27, offset: 185169},
 						name: "SPACE",
 					},
 				},
@@ -20155,103 +20394,79 @@ func (p *parser) callonJsonExprLevel126() (any, error) {
 	return p.cur.onJsonExprLevel126(stack["value"])
 }
 
-func (c *current) onJsonExpr1(firstKey, firstValue, rest any) (any, error) {
-	isValidJsonObjectKey := func(key *structs.JsonExpr) error {
-		// key can only be a string => either a field or a StringExpr
-		// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
-		if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
-			return fmt.Errorf("spl peg: key in json_object can only be a string")
-		}
-		return nil
-	}
-
-	astDs := make([]*structs.JsonExpr, 1, 5)
-	keyToIdxMap := make(map[string]int)
-
-	key, ok := firstKey.(*structs.JsonExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the first argument of the function")
-	}
-
-	err := isValidJsonObjectKey(key)
+func (c *current) onJsonExpr2(firstKey, firstValue, rest any) (any, error) {
+	result, err := createJsonExprKeyValueAst("json_object", firstKey, firstValue, rest)
 	if err != nil {
 		return nil, err
-	}
-
-	var value *structs.JsonExpr
-	value, ok = firstValue.(*structs.JsonExpr)
-	if !ok {
-		return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
-	}
-
-	rawKey := getRawValJsonObjectKey(key)
-
-	keyToIdxMap[rawKey] = 0
-
-	astDs[0] = &structs.JsonExpr{
-		JsonExprMode: structs.JEMKeyVal,
-		IsTerminal:   value.JsonExprMode != structs.JEMExpr,
-		Key:          key,
-		Value:        value,
-	}
-
-	var restKey *structs.JsonExpr
-	var restValue *structs.JsonExpr
-
-	if rest != nil {
-		for idx, arg := range rest.([]any) {
-			// Each item in rest is [",", Key, ",", Value]
-			restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
-			if !ok {
-				return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
-			}
-
-			err := isValidJsonObjectKey(restKey)
-			if err != nil {
-				return nil, err
-			}
-
-			restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
-			if !ok {
-				return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
-			}
-
-			rawKey = getRawValJsonObjectKey(restKey)
-
-			keyValueStruct := &structs.JsonExpr{
-				JsonExprMode: structs.JEMKeyVal,
-				IsTerminal:   restValue.JsonExprMode != structs.JEMExpr,
-				Key:          restKey,
-				Value:        restValue,
-			}
-
-			var v int
-			if v, ok = keyToIdxMap[rawKey]; ok {
-				astDs[v] = keyValueStruct
-			} else {
-				keyToIdxMap[rawKey] = len(astDs)
-				astDs = append(astDs, keyValueStruct)
-			}
-		}
-	}
-
-	// build ast tree
-	result := astDs[0]
-	for i := 1; i < len(astDs); i++ {
-		var err error
-		result, err = createJsonExprAst("json_object", result, astDs[i], structs.JEMExpr)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return result, nil
 }
 
-func (p *parser) callonJsonExpr1() (any, error) {
+func (p *parser) callonJsonExpr2() (any, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onJsonExpr1(stack["firstKey"], stack["firstValue"], stack["rest"])
+	return p.cur.onJsonExpr2(stack["firstKey"], stack["firstValue"], stack["rest"])
+}
+
+func (c *current) onJsonExpr19(opName, value any) (any, error) {
+	opNameStr, err := transferUint8ToString(opName)
+	if err != nil {
+		return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+	}
+
+	leftJsonExpr, ok := value.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert expr as *structs.JsonExpr")
+	}
+
+	node, err := createJsonExprAst(opNameStr, leftJsonExpr, nil, structs.JEMExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func (p *parser) callonJsonExpr19() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr19(stack["opName"], stack["value"])
+}
+
+func (c *current) onJsonExpr27(opName, json, path, value, rest any) (any, error) {
+	// json can only be a field that references a json object
+	// https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title4
+	// words from documentation - <json> (the name of a valid JSON document such as a JSON object)
+
+	castedJson, ok := json.(*structs.JsonExpr)
+	if !ok {
+		return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr")
+	}
+
+	// change this condition to allow other dtypes if splunk allows them since it is not stated in the documentation
+	if castedJson.JsonExprMode != structs.JEMField {
+		return nil, fmt.Errorf("spl peg: json field can only be a field")
+	}
+
+	result, err := createJsonExprKeyValueAst("json_append", path, value, rest)
+	if err != nil {
+		return nil, err
+	}
+
+	// JsonExpr.Right will contain the field that may be pointing to a json object
+	result, err = createJsonExprAst("json_append", result, castedJson, structs.JEMExpr)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (p *parser) callonJsonExpr27() (any, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onJsonExpr27(stack["opName"], stack["json"], stack["path"], stack["value"], stack["rest"])
 }
 
 func (c *current) onLenExpr2(str any) (any, error) {

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -76,6 +76,11 @@ const (
     TJ_CMD_OUTPUT_FIELD
 )
 
+type JsonExprAstStruct struct {
+    Key   *structs.JsonExpr
+    Value *structs.JsonExpr
+}
+
 func CalculateRelativeTime(timeModifier ast.TimeModifier, currTime time.Time) (int64, error) {
     var epoch int64 = 0
     var err error
@@ -278,6 +283,16 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
         Left: leftNumericExpr,
         Right: rightNumericExpr,
         NumericExprMode: numericExprMode,
+    }, nil
+}
+
+func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+    return &structs.JsonExpr{
+        IsTerminal: false,
+        Op: op,
+        Left: leftExpr,
+        Right: rightExpr,
+        JsonExprMode: mode,
     }, nil
 }
 
@@ -3305,6 +3320,14 @@ ValueExpr <- condition:ConditionExpr {
 
     return expr, nil
 }
+/ jsonExpr:JsonExpr {
+    expr := &structs.ValueExpr {
+        ValueExprMode: structs.VEMJsonExpr,
+        JsonExpr: jsonExpr.(*structs.JsonExpr),
+    }
+
+    return expr, nil
+}
 
 StringExpr <- text:TextExpr !(EVAL_CONCAT) {
     expr := &structs.StringExpr {
@@ -3569,11 +3592,11 @@ NumericEvalExpr <- (opName:("abs" / "ceil" / "ceiling" / "sqrt" / "exact" / "exp
     var ok bool
     args[0], ok = firstArg.(*structs.NumericExpr)
     if !ok {
-        return nil, fmt.Errorf("Failed to assert exprr as *structs.NumericExpr")
+        return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
     }
     args[1], ok = secondArg.(*structs.NumericExpr)
     if !ok {
-        return nil, fmt.Errorf("Failed to assert exprr as *structs.NumericExpr")
+        return nil, fmt.Errorf("Failed to assert expr as *structs.NumericExpr")
     }
     
     if rest != nil {
@@ -3584,10 +3607,6 @@ NumericEvalExpr <- (opName:("abs" / "ceil" / "ceiling" / "sqrt" / "exact" / "exp
         }
     }
     
-    if len(args) == 1 {
-        return args[0], nil
-    }
-
     // build the ast tree 
     result := args[0]
     for i := 1; i < len(args); i++ {
@@ -3704,6 +3723,178 @@ NumericEvalExpr <- (opName:("abs" / "ceil" / "ceiling" / "sqrt" / "exact" / "exp
     }
     node.RelativeTime = relTimeSpecifier
     return node, nil
+}
+
+JsonExprLevel1 <- jsonExpr:JsonExpr {
+    return jsonExpr, nil
+}
+/ field:EvalFieldToRead {
+    fieldStr, ok := field.(string)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: unable to assert EvalFieldToRead as string")
+    }
+    expr := &structs.JsonExpr {
+        JsonExprMode: structs.JEMField,
+        IsTerminal: true,
+        ValueIsField: true,
+        FieldValue: fieldStr,
+    }
+
+    return expr, nil
+}
+/ value:NumericEvalExpr {
+    numExpr, ok := value.(*structs.NumericExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMNumber,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputNumber: numExpr,
+    }
+
+    return expr, nil
+}
+/ value:NumericExprLevel3 {
+    numExpr, ok := value.(*structs.NumericExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.NumericExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMNumber,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputNumber: numExpr,
+    }
+
+    return expr, nil
+}
+/ value:MultiValueExpr {
+    multiExpr, ok := value.(*structs.MultiValueExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.MultiValueExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMMultiVal,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputMultiVal: multiExpr,
+    }
+
+    return expr, nil
+}
+/ value:BoolExpr {
+    boolExpr, ok := value.(*structs.BoolExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.BoolExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMBoolean,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputBoolean: boolExpr,
+    }
+
+    return expr, nil
+}
+/ value:("null" L_PAREN R_PAREN) {
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMNull,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputIsNull: true,
+    }
+
+    return expr, nil
+}
+/ value:StringExpr {
+    stringExpr, ok := value.(*structs.StringExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert string as *structs.StringExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMString,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputString: stringExpr,
+    }
+
+    return expr, nil
+}
+
+JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(JsonExprLevel1) rest:(COMMA String COMMA JsonExprLevel1)* R_PAREN {
+    isValidJsonObjectKey := func(key *structs.JsonExpr) error {
+        // key can only be a string => either a field or a StringExpr
+        // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
+        if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+            return fmt.Errorf("spl peg: key in json_object can only be a string")
+        }
+        return nil
+    }
+    
+    astDs := make([]*structs.JsonExpr, 1, 5)
+
+    key, ok := firstKey.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the first argument of the function")
+    }
+
+    err := isValidJsonObjectKey(key)
+    if err != nil {
+        return nil, err
+    }
+    
+    var value *structs.JsonExpr
+    value, ok = firstValue.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
+    }
+
+    astDs[0] = &structs.JsonExpr{
+        JsonExprMode: structs.JEMKeyVal,
+        Key: key,
+        Value: value,
+    }
+
+    var restKey *structs.JsonExpr
+    var restValue *structs.JsonExpr
+    if rest != nil {
+        for idx, arg := range rest.([]any) {
+            // Each item in rest is [",", Key, ",", Value]
+            restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
+            }
+
+            err := isValidJsonObjectKey(key)
+            if err != nil {
+                return nil, err
+            }
+
+            restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+            }
+            astDs = append(astDs, &structs.JsonExpr{
+                JsonExprMode: structs.JEMKeyVal,
+                Key: restKey,
+                Value: restValue,
+            })
+        }
+    }
+
+    // build ast tree
+    result := astDs[0]
+    for i := 1; i < len(astDs); i++ {
+        var err error
+        result, err = createJsonExprAst("json_object", result, astDs[i], structs.JEMExpr)
+        if err != nil {
+            return nil, err
+        }
+    }    
+
+    return result, nil
 }
 
 LenExpr <- str:QuotedString !(EVAL_CONCAT) {

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -296,6 +296,14 @@ func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs
     }, nil
 }
 
+func getRawValJsonObjectKey(key *structs.JsonExpr) string {
+    if key.JsonExprMode == structs.JEMField {
+        return key.FieldValue
+    } else {
+        return key.InputString.RawString 
+    }
+}
+
 func transferUint8ToString(opName interface{}) (string, error){
     strData, ok := opName.([]byte)
     if !ok {
@@ -3834,6 +3842,7 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
     }
     
     astDs := make([]*structs.JsonExpr, 1, 5)
+    keyToIdxMap := make(map[string]int)
 
     key, ok := firstKey.(*structs.JsonExpr)
     if !ok {
@@ -3851,15 +3860,20 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
         return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
     }
 
+    rawKey := getRawValJsonObjectKey(key)
+
+    keyToIdxMap[rawKey] = 0
+
     astDs[0] = &structs.JsonExpr{
         JsonExprMode: structs.JEMKeyVal,
-        IsTerminal: true,
+        IsTerminal: value.JsonExprMode != structs.JEMExpr,
         Key: key,
         Value: value,
     }
 
     var restKey *structs.JsonExpr
     var restValue *structs.JsonExpr
+
     if rest != nil {
         for idx, arg := range rest.([]any) {
             // Each item in rest is [",", Key, ",", Value]
@@ -3877,12 +3891,23 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
             if !ok {
                 return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
             }
-            astDs = append(astDs, &structs.JsonExpr{
+
+            rawKey = getRawValJsonObjectKey(restKey)
+
+            keyValueStruct := &structs.JsonExpr{
                 JsonExprMode: structs.JEMKeyVal,
-                IsTerminal: true,
+                IsTerminal: restValue.JsonExprMode != structs.JEMExpr,
                 Key: restKey,
                 Value: restValue,
-            })
+            }
+
+            var v int
+            if v, ok = keyToIdxMap[rawKey]; ok {
+                astDs[v] = keyValueStruct
+            } else {
+                keyToIdxMap[rawKey] = len(astDs)
+                astDs = append(astDs, keyValueStruct)
+            }
         }
     }
 

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -3823,7 +3823,7 @@ JsonExprLevel1 <- jsonExpr:JsonExpr {
     return expr, nil
 }
 
-JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(JsonExprLevel1) rest:(COMMA String COMMA JsonExprLevel1)* R_PAREN {
+JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(JsonExprLevel1) rest:(COMMA JsonExprLevel1 COMMA JsonExprLevel1)* R_PAREN {
     isValidJsonObjectKey := func(key *structs.JsonExpr) error {
         // key can only be a string => either a field or a StringExpr
         // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
@@ -3853,6 +3853,7 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
 
     astDs[0] = &structs.JsonExpr{
         JsonExprMode: structs.JEMKeyVal,
+        IsTerminal: true,
         Key: key,
         Value: value,
     }
@@ -3867,7 +3868,7 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
                 return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
             }
 
-            err := isValidJsonObjectKey(key)
+            err := isValidJsonObjectKey(restKey)
             if err != nil {
                 return nil, err
             }
@@ -3878,6 +3879,7 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
             }
             astDs = append(astDs, &structs.JsonExpr{
                 JsonExprMode: structs.JEMKeyVal,
+                IsTerminal: true,
                 Key: restKey,
                 Value: restValue,
             })

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -317,7 +317,7 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
     isValidKey := func(key *structs.JsonExpr) error {
         // key can only be a string => either a field or a StringExpr
         // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
-        if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+        if !(key.JsonExprMode == structs.JEMString || key.JsonExprMode == structs.JEMField) {
             return fmt.Errorf("spl peg: key can only be a string")
         }
         return nil
@@ -3902,6 +3902,33 @@ NumericEvalExpr <- (opName:("abs" / "ceil" / "ceiling" / "sqrt" / "exact" / "exp
 JsonExprLevel1 <- jsonExpr:JsonExpr {
     return jsonExpr, nil
 }
+/ value:BoolExpr {
+    boolExpr, ok := value.(*structs.BoolExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.BoolExpr")
+    }
+    expr := &structs.JsonExpr{
+        JsonExprMode: structs.JEMBoolean,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputBoolean: boolExpr,
+    }
+
+    return expr, nil
+}
+/ value:("true" / "false") L_PAREN R_PAREN {
+    boolValue, err := transferUint8ToString(value)
+    if err != nil {
+        return nil, fmt.Errorf("spl peg: failed to convert literal true to string")
+    }
+    expr := &structs.JsonExpr {
+        JsonExprMode: structs.JEMBoolean,
+        IsTerminal: true,
+        ValueIsField: false,
+        InputBooleanValue: boolValue == "true",
+    }
+    return expr, nil
+}
 / field:EvalFieldToRead {
     fieldStr, ok := field.(string)
     if !ok {
@@ -3958,20 +3985,6 @@ JsonExprLevel1 <- jsonExpr:JsonExpr {
 
     return expr, nil
 }
-/ value:BoolExpr {
-    boolExpr, ok := value.(*structs.BoolExpr)
-    if !ok {
-        return nil, fmt.Errorf("spl peg: failed to assert value as *structs.BoolExpr")
-    }
-    expr := &structs.JsonExpr{
-        JsonExprMode: structs.JEMBoolean,
-        IsTerminal: true,
-        ValueIsField: false,
-        InputBoolean: boolExpr,
-    }
-
-    return expr, nil
-}
 / value:("null" L_PAREN R_PAREN) {
     expr := &structs.JsonExpr{
         JsonExprMode: structs.JEMNull,
@@ -4017,7 +4030,7 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
     }
 
     if opNameStr == "json_entries" || opNameStr == "json_keys" {
-        if leftJsonExpr.JsonExprMode != structs.JEMString || leftJsonExpr.JsonExprMode != structs.JEMField {
+        if !(leftJsonExpr.JsonExprMode == structs.JEMString || leftJsonExpr.JsonExprMode == structs.JEMField) {
             // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/evaluation-functions/json-functions#e1d0bff6_e301_4880_8e8d_daf710234e07__json_delete.28.26lt.3Bobject.26gt.3B.2C.26lt.3Bkeys.26gt.3B.29
             // text from documentation - The <value> argument can be a valid JSON object or the name of a field that contains a valid JSON object.
             return nil, fmt.Errorf("spl peg: value argument can only take a json string or a field")
@@ -4111,16 +4124,18 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
     if paths != nil {
         // paths structure - [",", pathValue]
         // if length is greater than 2 that means there are more than one paths
-        if len(paths.([]any)) > 2 {
-            // firstValue = first path value (i.e. value at index 1)
-            // rest of the values including commas are from index 2
-            result, err = createJsonExprAst(opNameStr, paths.([]any)[1], paths.([]any)[2:], 1)
-        } else {
-            // rest is nil here
-            result, err = createJsonExprAst(opNameStr, paths.([]any)[1], nil, 1)
-        }
-        if err != nil {
-            return nil, err
+        for _, pathArg := range paths.([]any) {
+            if len(paths.([]any)) > 2 {
+                // firstValue = first path value (i.e. value at index 1)
+                // rest of the values including commas are from index 2
+                result, err = createJsonExprAst(opNameStr, pathArg.([]any)[1], paths.([]any)[2:], 1)
+            } else {
+                // rest is nil here
+                result, err = createJsonExprAst(opNameStr, pathArg.([]any)[1], nil, 1)
+            }
+            if err != nil {
+                return nil, err
+            }
         }
     }
 

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -287,6 +287,12 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
 }
 
 func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+    if leftExpr.Op == "" {
+        leftExpr.Op = op
+    }
+    if rightExpr.Op == "" {
+        rightExpr.Op = op
+    }
     return &structs.JsonExpr{
         IsTerminal: false,
         Op: op,
@@ -298,10 +304,116 @@ func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs
 
 func getRawValJsonObjectKey(key *structs.JsonExpr) string {
     if key.JsonExprMode == structs.JEMField {
-        return key.FieldValue
+        return "__" + key.FieldValue + "__"
     } else {
         return key.InputString.RawString 
     }
+}
+
+func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, rest any) (*structs.JsonExpr, error) {
+    isValidKey := func(key *structs.JsonExpr) error {
+        // key can only be a string => either a field or a StringExpr
+        // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
+        if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
+            return fmt.Errorf("spl peg: key in json_object can only be a string")
+        }
+        return nil
+    }
+
+    astDs := make([]*structs.JsonExpr, 1, 5)
+    keyToIdxMap := make(map[string]int)
+
+    key, ok := firstKey.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert key/path as *structs.JsonExpr; Check the first key/path of the function")
+    }
+
+    err := isValidKey(key)
+    if err != nil {
+        return nil, err
+    }
+    if key.Op == "" {
+        key.Op = opNameStr
+    }
+    
+    var value *structs.JsonExpr
+    value, ok = firstValue.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert value argument as *structs.JsonExpr; Check the first value of the function")
+    }
+    if value.Op == "" {
+        value.Op = opNameStr
+    }
+
+    rawKey := getRawValJsonObjectKey(key)
+
+    keyToIdxMap[rawKey] = 0
+
+    astDs[0] = &structs.JsonExpr{
+        Op: opNameStr,
+        JsonExprMode: structs.JEMKeyVal,
+        IsTerminal: value.JsonExprMode != structs.JEMExpr,
+        Key: key,
+        Value: value,
+    }
+
+    if rest != nil {
+        var restKey *structs.JsonExpr
+        var restValue *structs.JsonExpr
+        for idx, arg := range rest.([]any) {
+            // Each item in rest is [",", Key, ",", Value]
+            restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert key as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+            }
+            if restKey.Op == "" {
+                restKey.Op = opNameStr
+            }
+
+            err := isValidKey(restKey)
+            if err != nil {
+                return nil, err
+            }
+
+            restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+            }
+            if restValue.Op == "" {
+                restValue.Op = opNameStr
+            }
+
+            rawKey = getRawValJsonObjectKey(restKey)
+
+            keyValueStruct := &structs.JsonExpr{
+                Op: opNameStr,
+                JsonExprMode: structs.JEMKeyVal,
+                IsTerminal: restValue.JsonExprMode != structs.JEMExpr,
+                Key: restKey,
+                Value: restValue,
+            }
+
+            var v int
+            if v, ok = keyToIdxMap[rawKey]; ok {
+                astDs[v] = keyValueStruct
+            } else {
+                keyToIdxMap[rawKey] = len(astDs)
+                astDs = append(astDs, keyValueStruct)
+            }
+        }
+    }
+
+    // build ast tree
+    result := astDs[0]
+    for i := 1; i < len(astDs); i++ {
+        var err error
+        result, err = createJsonExprAst(opNameStr, result, astDs[i], structs.JEMExpr)
+        if err != nil {
+            return nil, err
+        }
+    }    
+
+    return result, nil
 }
 
 func transferUint8ToString(opName interface{}) (string, error){
@@ -3832,94 +3944,56 @@ JsonExprLevel1 <- jsonExpr:JsonExpr {
 }
 
 JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(JsonExprLevel1) rest:(COMMA JsonExprLevel1 COMMA JsonExprLevel1)* R_PAREN {
-    isValidJsonObjectKey := func(key *structs.JsonExpr) error {
-        // key can only be a string => either a field or a StringExpr
-        // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
-        if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
-            return fmt.Errorf("spl peg: key in json_object can only be a string")
-        }
-        return nil
-    }
-    
-    astDs := make([]*structs.JsonExpr, 1, 5)
-    keyToIdxMap := make(map[string]int)
-
-    key, ok := firstKey.(*structs.JsonExpr)
-    if !ok {
-        return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the first argument of the function")
-    }
-
-    err := isValidJsonObjectKey(key)
+    result, err := createJsonExprKeyValueAst("json_object", firstKey, firstValue, rest)
     if err != nil {
         return nil, err
     }
     
-    var value *structs.JsonExpr
-    value, ok = firstValue.(*structs.JsonExpr)
+    return result, nil
+}
+/ opName:"json" L_PAREN value:JsonExprLevel1 R_PAREN {
+    opNameStr, err := transferUint8ToString(opName)
+    if err != nil {
+        return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+    }
+
+    leftJsonExpr, ok := value.(*structs.JsonExpr)
     if !ok {
-        return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the second argument of the function")
+        return nil, fmt.Errorf("failed to assert expr as *structs.JsonExpr")
     }
 
-    rawKey := getRawValJsonObjectKey(key)
+    node, err := createJsonExprAst(opNameStr, leftJsonExpr, nil, structs.JEMExpr)
+    if err != nil {
+        return nil, err
+    }
+    
+    return node, nil
+}
+/ opName:"json_append" L_PAREN json:JsonExprLevel1 COMMA path:JsonExprLevel1 COMMA value:JsonExprLevel1 rest:(COMMA JsonExprLevel1 COMMA JsonExprLevel1)* R_PAREN {
+    // json can only be a field that references a json object
+    // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title4
+    // words from documentation - <json> (the name of a valid JSON document such as a JSON object)
 
-    keyToIdxMap[rawKey] = 0
-
-    astDs[0] = &structs.JsonExpr{
-        JsonExprMode: structs.JEMKeyVal,
-        IsTerminal: value.JsonExprMode != structs.JEMExpr,
-        Key: key,
-        Value: value,
+    castedJson, ok := json.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr")
     }
 
-    var restKey *structs.JsonExpr
-    var restValue *structs.JsonExpr
-
-    if rest != nil {
-        for idx, arg := range rest.([]any) {
-            // Each item in rest is [",", Key, ",", Value]
-            restKey, ok = arg.([]any)[1].(*structs.JsonExpr)
-            if !ok {
-                return nil, fmt.Errorf("spl peg: failed to assert firstKey as string; Check the %v argument of the function", idx+1)
-            }
-
-            err := isValidJsonObjectKey(restKey)
-            if err != nil {
-                return nil, err
-            }
-
-            restValue, ok = arg.([]any)[3].(*structs.JsonExpr)
-            if !ok {
-                return nil, fmt.Errorf("spl peg: failed to assert firstValue as *structs.JsonExpr; Check the %v argument of the function", idx+1)
-            }
-
-            rawKey = getRawValJsonObjectKey(restKey)
-
-            keyValueStruct := &structs.JsonExpr{
-                JsonExprMode: structs.JEMKeyVal,
-                IsTerminal: restValue.JsonExprMode != structs.JEMExpr,
-                Key: restKey,
-                Value: restValue,
-            }
-
-            var v int
-            if v, ok = keyToIdxMap[rawKey]; ok {
-                astDs[v] = keyValueStruct
-            } else {
-                keyToIdxMap[rawKey] = len(astDs)
-                astDs = append(astDs, keyValueStruct)
-            }
-        }
+    // change this condition to allow other dtypes if splunk allows them since it is not stated in the documentation
+    if castedJson.JsonExprMode != structs.JEMField {
+        return nil, fmt.Errorf("spl peg: json field can only be a field")
     }
 
-    // build ast tree
-    result := astDs[0]
-    for i := 1; i < len(astDs); i++ {
-        var err error
-        result, err = createJsonExprAst("json_object", result, astDs[i], structs.JEMExpr)
-        if err != nil {
-            return nil, err
-        }
-    }    
+    result, err := createJsonExprKeyValueAst("json_append", path, value, rest)
+    if err != nil {
+        return nil, err
+    }
+
+    // JsonExpr.Right will contain the field that may be pointing to a json object
+    result, err = createJsonExprAst("json_append", result, castedJson, structs.JEMExpr)
+    if err != nil {
+        return nil, err
+    }
 
     return result, nil
 }

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -3997,6 +3997,45 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
 
     return result, nil
 }
+/ "json_array" L_PAREN value:JsonExprLevel1 rest:(COMMA JsonExprLevel1)* R_PAREN {
+    castedValue, ok := value.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
+    }
+
+    args := make([]*structs.JsonExpr, 1, 5)
+    args[0] = castedValue
+
+    if rest != nil {
+        var restValue *structs.JsonExpr
+        for idx, arg := range rest.([]any) {
+            restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
+            }
+            args = append(args, restValue)
+        }
+    }
+
+    var result *structs.JsonExpr
+    var err error
+    if len(args) == 1 {
+        result, err = createJsonExprAst("json_array", args[0], nil, structs.JEMExpr)
+        if err != nil {
+            return nil, err
+        }
+    } else {
+        result = args[0]
+        for i := 1; i < len(args); i++ {
+            result, err = createJsonExprAst("json_array", result, args[i], structs.JEMExpr)
+            if err != nil {
+                return nil, err
+            }
+        }
+    }
+
+    return result, nil
+}
 
 LenExpr <- str:QuotedString !(EVAL_CONCAT) {
 

--- a/pkg/ast/spl/spl.peg
+++ b/pkg/ast/spl/spl.peg
@@ -286,11 +286,14 @@ func createNumericExpr(op string, leftNumericExpr *structs.NumericExpr, rightNum
     }, nil
 }
 
-func createJsonExprAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
-    if leftExpr.Op == "" {
+func createJsonExprSingleNodeAst(op string, leftExpr *structs.JsonExpr, rightExpr *structs.JsonExpr, mode structs.JsonExprMode) (*structs.JsonExpr, error) {
+    if leftExpr == nil && rightExpr == nil {
+        return nil, fmt.Errorf("spl peg: both left and right expressions can not be nil at the same time; %v", op)
+    }
+    if leftExpr != nil && leftExpr.Op == "" {
         leftExpr.Op = op
     }
-    if rightExpr.Op == "" {
+    if rightExpr != nil && rightExpr.Op == "" {
         rightExpr.Op = op
     }
     return &structs.JsonExpr{
@@ -315,12 +318,19 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
         // key can only be a string => either a field or a StringExpr
         // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title2
         if key.JsonExprMode != structs.JEMString && key.JsonExprMode != structs.JEMField {
-            return fmt.Errorf("spl peg: key in json_object can only be a string")
+            return fmt.Errorf("spl peg: key can only be a string")
         }
         return nil
     }
 
-    astDs := make([]*structs.JsonExpr, 1, 5)
+    var capacityOfAstDs int = 1
+    if rest != nil {
+        // each key value pair in rest is accompanied by two commas
+        // [",", "key", ",", "value"]
+        // therefore we divide by 4 to get the actual length. (key+value = 1 node)
+        capacityOfAstDs = len(rest.([]any)) / 4 + 1
+    }
+    astDs := make([]*structs.JsonExpr, 1, capacityOfAstDs)
     keyToIdxMap := make(map[string]int)
 
     key, ok := firstKey.(*structs.JsonExpr)
@@ -349,6 +359,7 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
 
     keyToIdxMap[rawKey] = 0
 
+    // the node is not a terminal node if the JsonExpr is a nested Expr
     astDs[0] = &structs.JsonExpr{
         Op: opNameStr,
         JsonExprMode: structs.JEMKeyVal,
@@ -393,9 +404,10 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
                 Value: restValue,
             }
 
-            var v int
-            if v, ok = keyToIdxMap[rawKey]; ok {
-                astDs[v] = keyValueStruct
+            // deduplication of keys, last/latest key overwrites the previous key if exists
+            var indexInStructure int
+            if indexInStructure, ok = keyToIdxMap[rawKey]; ok {
+                astDs[indexInStructure] = keyValueStruct
             } else {
                 keyToIdxMap[rawKey] = len(astDs)
                 astDs = append(astDs, keyValueStruct)
@@ -407,11 +419,53 @@ func createJsonExprKeyValueAst(opNameStr string, firstKey any, firstValue any, r
     result := astDs[0]
     for i := 1; i < len(astDs); i++ {
         var err error
-        result, err = createJsonExprAst(opNameStr, result, astDs[i], structs.JEMExpr)
+        result, err = createJsonExprSingleNodeAst(opNameStr, result, astDs[i], structs.JEMExpr)
         if err != nil {
             return nil, err
         }
     }    
+
+    return result, nil
+}
+
+func createJsonExprAst(opNameStr string, firstValue any, rest any, argumentOffset int) (*structs.JsonExpr, error) {
+    castedValue, ok := firstValue.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
+    }
+
+    var capacityArgs int = 1
+    if rest != nil {
+        // each value in rest is of the type - [",", "value"]
+        // therefore we divide by two to get the actual length.
+        // + 1 is for firstValue
+        capacityArgs = len(rest.([]any)) / 2 + 1
+    }
+
+    args := make([]*structs.JsonExpr, 1, capacityArgs)
+    args[0] = castedValue
+
+    if rest != nil {
+        var restValue *structs.JsonExpr
+        for idx, arg := range rest.([]any) {
+            restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
+            if !ok {
+                return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1+argumentOffset)
+            }
+            args = append(args, restValue)
+        }
+    }
+
+    var result *structs.JsonExpr
+    var err error
+
+    result = args[0]
+    for i := 1; i < len(args); i++ {
+        result, err = createJsonExprSingleNodeAst(opNameStr, result, args[i], structs.JEMExpr)
+        if err != nil {
+            return nil, err
+        }
+    }
 
     return result, nil
 }
@@ -3951,46 +4005,65 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
     
     return result, nil
 }
-/ opName:"json" L_PAREN value:JsonExprLevel1 R_PAREN {
+/ opName:("json" / "json_entries" / "json_keys" / "json_valid") L_PAREN value:JsonExprLevel1 R_PAREN {
     opNameStr, err := transferUint8ToString(opName)
     if err != nil {
         return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
-    }
+    } 
 
     leftJsonExpr, ok := value.(*structs.JsonExpr)
     if !ok {
-        return nil, fmt.Errorf("failed to assert expr as *structs.JsonExpr")
+        return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr; Check the argument of the function")
     }
 
-    node, err := createJsonExprAst(opNameStr, leftJsonExpr, nil, structs.JEMExpr)
+    if opNameStr == "json_entries" || opNameStr == "json_keys" {
+        if leftJsonExpr.JsonExprMode != structs.JEMString || leftJsonExpr.JsonExprMode != structs.JEMField {
+            // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.4/evaluation-functions/json-functions#e1d0bff6_e301_4880_8e8d_daf710234e07__json_delete.28.26lt.3Bobject.26gt.3B.2C.26lt.3Bkeys.26gt.3B.29
+            // text from documentation - The <value> argument can be a valid JSON object or the name of a field that contains a valid JSON object.
+            return nil, fmt.Errorf("spl peg: value argument can only take a json string or a field")
+        }
+    }
+
+    node, err := createJsonExprSingleNodeAst("json", leftJsonExpr, nil, structs.JEMExpr)
     if err != nil {
         return nil, err
     }
     
     return node, nil
 }
-/ opName:"json_append" L_PAREN json:JsonExprLevel1 COMMA path:JsonExprLevel1 COMMA value:JsonExprLevel1 rest:(COMMA JsonExprLevel1 COMMA JsonExprLevel1)* R_PAREN {
+/ opName:("json_append" / "json_extend" / "json_set" / "json_set_exact") L_PAREN json:JsonExprLevel1 COMMA path:JsonExprLevel1 COMMA value:JsonExprLevel1 rest:(COMMA JsonExprLevel1 COMMA JsonExprLevel1)* R_PAREN {
     // json can only be a field that references a json object
     // https://help.splunk.com/en/splunk-enterprise/search/spl-search-reference/9.3/evaluation-functions/json-functions#ariaid-title4
     // words from documentation - <json> (the name of a valid JSON document such as a JSON object)
 
+    opNameStr, err := transferUint8ToString(opName)
+    if err != nil {
+        return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+    }
+
     castedJson, ok := json.(*structs.JsonExpr)
     if !ok {
-        return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr")
+        return nil, fmt.Errorf("spl peg: failed to assert expr as *structs.JsonExpr; Check the json argument of the function")
     }
 
     // change this condition to allow other dtypes if splunk allows them since it is not stated in the documentation
     if castedJson.JsonExprMode != structs.JEMField {
-        return nil, fmt.Errorf("spl peg: json field can only be a field")
+        if opNameStr == "json_append" {
+            return nil, fmt.Errorf("spl peg: json argument can only be a field")
+        // not explicitly stated for json_extend/json_set/json_set_exact
+        } else if castedJson.JsonExprMode != structs.JEMString {
+            return nil, fmt.Errorf("spl peg: json argument can only be a field or a json string")
+        }
     }
 
-    result, err := createJsonExprKeyValueAst("json_append", path, value, rest)
+    var result *structs.JsonExpr
+    result, err = createJsonExprKeyValueAst(opNameStr, path, value, rest)
     if err != nil {
         return nil, err
     }
 
     // JsonExpr.Right will contain the field that may be pointing to a json object
-    result, err = createJsonExprAst("json_append", result, castedJson, structs.JEMExpr)
+    result, err = createJsonExprSingleNodeAst(opNameStr, result, castedJson, structs.JEMExpr)
     if err != nil {
         return nil, err
     }
@@ -3998,40 +4071,90 @@ JsonExpr <- "json_object" L_PAREN firstKey:(JsonExprLevel1) COMMA firstValue:(Js
     return result, nil
 }
 / "json_array" L_PAREN value:JsonExprLevel1 rest:(COMMA JsonExprLevel1)* R_PAREN {
-    castedValue, ok := value.(*structs.JsonExpr)
+    result, err := createJsonExprAst("json_array", value, rest, 0)
+    if err != nil {
+        return nil, err
+    }
+
+    return result, nil
+}
+/ "json_delete" L_PAREN object:JsonExprLevel1 COMMA "[" SPACE? firstKey:JsonExprLevel1 rest:(COMMA JsonExprLevel1)* SPACE? "]" R_PAREN {
+    castedJson, ok := object.(*structs.JsonExpr)
     if !ok {
-        return nil, fmt.Errorf("spl peg: failed to assert first value as *structs.JsonExpr")
+        return nil, fmt.Errorf("spl peg: failed to assert object argument as *structs.JsonExpr")
     }
 
-    args := make([]*structs.JsonExpr, 1, 5)
-    args[0] = castedValue
-
-    if rest != nil {
-        var restValue *structs.JsonExpr
-        for idx, arg := range rest.([]any) {
-            restValue, ok = arg.([]any)[1].(*structs.JsonExpr)
-            if !ok {
-                return nil, fmt.Errorf("spl peg: failed to assert value as *structs.JsonExpr; Check the %v argument of the function", idx+1)
-            }
-            args = append(args, restValue)
-        }
+    result, err := createJsonExprAst("json_delete", firstKey, rest, 1)
+    if err != nil {
+        return nil, err
     }
 
+    result, err = createJsonExprSingleNodeAst("json_delete", result, castedJson, structs.JEMExpr)
+    if err != nil {
+        return nil, err
+    }
+
+    return result, nil
+}
+/ opName:("json_extract" / "json_extract_exact") L_PAREN json:JsonExprLevel1 paths:(COMMA JsonExprLevel1)* R_PAREN {
+    opNameStr, err := transferUint8ToString(opName)
+    if err != nil {
+        return nil, fmt.Errorf("spl peg: error in converting opName to str; err: %v", err)
+    }
+
+    castedJson, ok := json.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert json argument as *structs.JsonExpr")
+    }
+    
     var result *structs.JsonExpr
-    var err error
-    if len(args) == 1 {
-        result, err = createJsonExprAst("json_array", args[0], nil, structs.JEMExpr)
+    if paths != nil {
+        // paths structure - [",", pathValue]
+        // if length is greater than 2 that means there are more than one paths
+        if len(paths.([]any)) > 2 {
+            // firstValue = first path value (i.e. value at index 1)
+            // rest of the values including commas are from index 2
+            result, err = createJsonExprAst(opNameStr, paths.([]any)[1], paths.([]any)[2:], 1)
+        } else {
+            // rest is nil here
+            result, err = createJsonExprAst(opNameStr, paths.([]any)[1], nil, 1)
+        }
         if err != nil {
             return nil, err
         }
-    } else {
-        result = args[0]
-        for i := 1; i < len(args); i++ {
-            result, err = createJsonExprAst("json_array", result, args[i], structs.JEMExpr)
-            if err != nil {
-                return nil, err
-            }
-        }
+    }
+
+    result, err = createJsonExprSingleNodeAst(opNameStr, result, castedJson, structs.JEMExpr)
+    if err != nil {
+        return nil, err
+    }
+
+    return result, nil
+}
+/ "json_has_key_exact" L_PAREN object:JsonExprLevel1 key:JsonExprLevel1 R_PAREN {
+    isValid := func (value *structs.JsonExpr) bool {
+        return value.JsonExprMode == structs.JEMField || value.JsonExprMode == structs.JEMString
+    }
+
+    castedObject, ok := object.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert object argument to *structs.JsonExpr")
+    }
+    if !isValid(castedObject) {
+        return nil, fmt.Errorf("spl peg: object argument of json_has_key_exact can only accept a field or a json string")
+    }
+
+    castedKey, ok := object.(*structs.JsonExpr)
+    if !ok {
+        return nil, fmt.Errorf("spl peg: failed to assert key argument to *structs.JsonExpr")
+    }
+    if !isValid(castedKey) {
+        return nil, fmt.Errorf("spl peg: key argument of json_has_key_exact can onlyy accept a field or a json string")
+    }
+
+    result, err := createJsonExprSingleNodeAst("json_has_key_exact", castedKey, castedObject, structs.JEMExpr)
+    if err != nil {
+        return nil, err
     }
 
     return result, nil

--- a/pkg/ast/spl/tests/splParser_test.go
+++ b/pkg/ast/spl/tests/splParser_test.go
@@ -5008,6 +5008,234 @@ func Test_evalFunctionsLog(t *testing.T) {
 	assert.Equal(t, aggregator.Next.Next.OutputTransforms.LetColumns.NewColName, "newField")
 }
 
+func Test_evalJSONFunctions_json_object(t *testing.T) {
+	tests := []struct {
+		expr    string
+		wantErr bool
+		check   func(e *structs.JsonExpr)
+	}{
+		{
+			`json_object("foo","bar")`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				kv := collectKeyVals(e)[0]
+
+				keyV, err := kv.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				valV, err := kv.Value.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "foo", keyV)
+				assert.Equal(t, "bar", valV)
+			},
+		},
+		{
+			`json_object("num", 123)`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				kv := collectKeyVals(e)[0]
+
+				k, err := kv.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v, err := kv.Value.InputNumber.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "num", k)
+				assert.Equal(t, float64(123), v)
+			},
+		},
+		{
+			`json_object("flag", true(), "f2", false(), "z", null())`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				kvs := collectKeyVals(e)
+
+				k0, err := kvs[0].Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v0 := kvs[0].Value.InputBooleanValue
+
+				k1, err := kvs[1].Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v1 := kvs[1].Value.InputBooleanValue
+
+				k2, err := kvs[2].Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v2 := kvs[2].Value.InputIsNull
+
+				assert.Equal(t, "flag", k0)
+				assert.Equal(t, true, v0)
+				assert.Equal(t, "f2", k1)
+				assert.Equal(t, false, v1)
+				assert.Equal(t, "z", k2)
+				assert.True(t, v2)
+			},
+		},
+		{
+			`json_object("f", myField)`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := map[string]sutils.CValueEnclosure{"myField": sutils.CValueEnclosure{CVal: 123, Dtype: sutils.SS_DT_SIGNED_NUM}}
+				kv := collectKeyVals(e)[0]
+
+				k, err := kv.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v := kv.Value.FieldValue
+
+				assert.Equal(t, "f", k)
+				assert.Equal(t, "myField", v)
+			},
+		},
+		{
+			`json_object("a",1, "a",2)`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				kv := collectKeyVals(e)[0]
+
+				k, err := kv.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				v, err := kv.Value.InputNumber.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "a", k)
+				assert.Equal(t, float64(2), v)
+			},
+		},
+		{
+			`json_object("o", json_object("i", 10))`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				outer := collectKeyVals(e)[0]
+
+				ok, err := outer.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "o", ok)
+
+				inner := outer.Value
+				innerKV := collectKeyVals(inner)[0]
+
+				ik, err := innerKV.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				iv, err := innerKV.Value.InputNumber.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+
+				assert.Equal(t, "i", ik)
+				assert.Equal(t, float64(iv), iv)
+			},
+		},
+		{
+			`json_object("a", json_array(json_object("b", 2), json_object("c",3)))`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				outer := collectKeyVals(e)[0]
+				arr := outer.Value
+				args := collectJsonArguments(arr)
+
+				keys := []string{}
+				for _, el := range args {
+					k, err := el.Key.InputString.Evaluate(fieldToValue)
+					assert.NoError(t, err)
+					keys = append(keys, k)
+				}
+
+				assert.ElementsMatch(t, []string{"b", "c"}, keys)
+			},
+		},
+		{
+			`json_object("e", json_extract(json_object("x","y"), "$.x"))`, false,
+			func(e *structs.JsonExpr) {
+				fieldToValue := make(map[string]sutils.CValueEnclosure)
+				outer := collectKeyVals(e)[0]
+
+				ek, err := outer.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "e", ek)
+
+				ext := outer.Value
+				assert.Equal(t, "json_extract", ext.Op)
+
+				base := ext.Left
+				bk, err := base.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "$.x", bk)
+
+				p, err := ext.Right.Key.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "x", p)
+
+				v, err := ext.Right.Value.InputString.Evaluate(fieldToValue)
+				assert.NoError(t, err)
+				assert.Equal(t, "y", v)
+			},
+		},
+		{
+			`json_object(123, "v")`, true, nil,
+		},
+	}
+
+	for _, tt := range tests {
+		q := fmt.Sprintf(`city=Test | eval x=%s`, tt.expr)
+		res, err := spl.Parse("", []byte(q))
+		if tt.wantErr {
+			assert.Error(t, err, "expected error: %s", tt.expr)
+			continue
+		}
+		assert.NoError(t, err, "unexpected error: %s", tt.expr)
+		jsonExpr := findJsonObjectExpr(res)
+		assert.NotNil(t, jsonExpr, "missing JsonExpr: %s", tt.expr)
+		tt.check(jsonExpr)
+	}
+}
+
+// collectKeyVals flattens chained KeyVal nodes into a slice
+func collectKeyVals(root *structs.JsonExpr) []*structs.JsonExpr {
+	var out []*structs.JsonExpr
+	var visit func(n *structs.JsonExpr)
+	visit = func(n *structs.JsonExpr) {
+		if n.JsonExprMode == structs.JEMKeyVal {
+			out = append(out, n)
+		}
+		if n.Left != nil {
+			visit(n.Left)
+		}
+		if n.Right != nil {
+			visit(n.Right)
+		}
+	}
+	visit(root)
+	return out
+}
+
+// collectJsonArguments for array nodes: returns slice of JsonExpr args
+func collectJsonArguments(arr *structs.JsonExpr) []*structs.JsonExpr {
+	var out []*structs.JsonExpr
+	var visit func(n *structs.JsonExpr)
+	visit = func(n *structs.JsonExpr) {
+		if n.Op == "json_array" && n.JsonExprMode == structs.JEMExpr {
+			if n.Left != nil {
+				out = append(out, n.Left)
+			}
+			if n.Right != nil {
+				// if Right is another array, recurse
+				if n.Right.Op == "json_array" && n.Right.JsonExprMode == structs.JEMExpr {
+					visit(n.Right)
+				} else {
+					// terminal element — append directly
+					out = append(out, n.Right)
+				}
+			}
+		}
+	}
+	visit(arr)
+	return out
+}
+
+func findJsonObjectExpr(q interface{}) *structs.JsonExpr {
+	qs, ok := q.(ast.QueryStruct)
+	if !ok {
+		return nil
+	}
+	pipe := qs.PipeCommands.EvalExpr.ValueExpr.JsonExpr
+	return pipe
+}
+
 func Test_evalFunctionsPower(t *testing.T) {
 	query := []byte(`city=Boston | stats count AS Count BY http_status | eval newField=pow(http_status, 2)`)
 	res, err := spl.Parse("", query)

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -208,6 +208,7 @@ type ValueExpr struct {
 	ConditionExpr  *ConditionExpr
 	BooleanExpr    *BoolExpr
 	MultiValueExpr *MultiValueExpr
+	JsonExpr       *JsonExpr
 }
 
 type ConcatExpr struct {
@@ -230,6 +231,23 @@ type MultiValueExpr struct {
 	ValueExprParams      []*ValueExpr
 	InferTypes           bool // To specify that the mv_to_json_array function should attempt to infer JSON data types when it converts field values into array elements.
 	FieldName            string
+}
+
+type JsonExpr struct {
+	JsonExprMode  JsonExprMode
+	Op            string
+	IsTerminal    bool
+	InputIsNull   bool
+	ValueIsField  bool
+	FieldValue    string
+	InputString   *StringExpr
+	InputNumber   *NumericExpr
+	InputBoolean  *BoolExpr
+	InputMultiVal *MultiValueExpr
+	Left          *JsonExpr
+	Right         *JsonExpr
+	Key           *JsonExpr
+	Value         *JsonExpr
 }
 
 type NumericExpr struct {
@@ -444,6 +462,7 @@ const (
 	VEMConditionExpr         // Only ConditionExpr is valud
 	VEMBooleanExpr           // Only BooleanExpr is valid
 	VEMMultiValueExpr        // Only MultiValueExpr is valid
+	VEMJsonExpr
 )
 
 type StringExprMode uint8
@@ -472,6 +491,19 @@ type MultiValueExprMode uint8
 const (
 	MVEMMultiValueExpr = iota // only used when mode is a MultiValueExpr
 	MVEMField
+)
+
+type JsonExprMode uint8
+
+const (
+	JEMExpr = iota
+	JEMField
+	JEMString
+	JEMNumber
+	JEMBoolean
+	JEMMultiVal
+	JEMNull
+	JEMKeyVal
 )
 
 var timeFormatReplacements = []struct {

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -234,20 +234,21 @@ type MultiValueExpr struct {
 }
 
 type JsonExpr struct {
-	JsonExprMode  JsonExprMode
-	Op            string
-	IsTerminal    bool
-	InputIsNull   bool
-	ValueIsField  bool
-	FieldValue    string
-	InputString   *StringExpr
-	InputNumber   *NumericExpr
-	InputBoolean  *BoolExpr
-	InputMultiVal *MultiValueExpr
-	Left          *JsonExpr
-	Right         *JsonExpr
-	Key           *JsonExpr
-	Value         *JsonExpr
+	JsonExprMode      JsonExprMode
+	Op                string
+	IsTerminal        bool
+	InputIsNull       bool
+	ValueIsField      bool
+	FieldValue        string
+	InputString       *StringExpr
+	InputNumber       *NumericExpr
+	InputBoolean      *BoolExpr
+	InputBooleanValue bool
+	InputMultiVal     *MultiValueExpr
+	Left              *JsonExpr
+	Right             *JsonExpr
+	Key               *JsonExpr
+	Value             *JsonExpr
 }
 
 type NumericExpr struct {


### PR DESCRIPTION
# Description
Implemented peg grammar for eval json functions
This pr will only contain the grammar changes with splParser unit tests.

## Work Completed -
1. json_object
2. json
3. json_append
4. json_array
5. json_delete
6. json_entries
7. json_extend
8. json_extract
9. json_extract_exact
10. json_has_key_exact
11. json_keys
12. json_set
13. json_set_exact
14. json_valid

## Work left -
parser tests
