### PR TITLE
Fix loki ingestion carry-over for optional fields

### DIFF
--- a/pkg/integrations/loki/loki.go
+++ b/pkg/integrations/loki/loki.go
@@ -280,6 +280,13 @@ func processJsonLogs(ctx *fasthttp.RequestCtx, myid int64) {
 		}
 
 		for _, value := range stream.Values {
+			// Clear leftover fields from previous iterations
+			for key := range allIngestData {
+				if _, ok := stream.Stream[key]; !ok && key != "timestamp" && key != "line" {
+					delete(allIngestData, key)
+				}
+			}
+
 			if len(value) < 2 {
 				utils.SendError(ctx, "Invalid log entry format", "", nil)
 				return


### PR DESCRIPTION
# Description
When ingesting logs into the loki endpoint, if a single batch contained logs with and without a certain optional field, logs without that field would erroneously get ingested with the previous value for that field. This PR fixes that.

So if log 1 had a field `foo` with value 42, and log 2 didn't have `foo`, log 2 would still get ingested with `foo=42`.

# Testing
Used this python script to ingest two logs with disjoint optional fields, and then ran a match-all query. With this PR, the query shows both records have the expected fields.
```python
#!/usr/bin/env python3

import requests
import json
import time

def main():
    # Loki endpoint - adjust as needed
    loki_url = "http://localhost:8081/loki/api/v1/push"
    
    # Create timestamp in nanoseconds
    now = time.time_ns()
    
    # Create payload that demonstrates the contamination bug
    payload = {
        "streams": [
            {
                "stream": {
                    "job": "test",
                    "instance": "localhost"
                },
                "values": [
                    # Entry 1: has trace_id only
                    [
                        str(now),
                        "First log entry",
                        {"trace_id": "abc123"}
                    ],
                    # Entry 2: has user_id only (but will get contaminated with trace_id)
                    [
                        str(now + 1_000_000),  # 1ms later
                        "Second log entry",
                        {"user_id": "user456"}
                    ]
                ]
            }
        ]
    }
    
    print("Sending payload:")
    print(json.dumps(payload, indent=2))
    print()
    
    # Send to Loki
    try:
        response = requests.post(loki_url, json=payload, headers={"Content-Type": "application/json"})
        print(f"Response Status: {response.status_code}")
        print(f"Response Body: {response.text}")
    except requests.exceptions.RequestException as e:
        print(f"Error sending request: {e}")
        return
    
if __name__ == "__main__":
    main()
```