### PR TITLE
Fix: Handle Long Descriptions in Saved Queries Table

### DIFF
--- a/static/js/saved-query.js
+++ b/static/js/saved-query.js
@@ -176,11 +176,11 @@ class linkCellRenderer {
         this.eGui = document.createElement('span');
         let href;
         if (params.data.dataSource === 'metrics') {
-            let href = 'metrics-explorer.html?queryString=' + encodeURIComponent(params.data.metricsQueryParams);
-            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block;">' + params.data.qname + '</a>';
+            href = 'metrics-explorer.html?queryString=' + encodeURIComponent(params.data.metricsQueryParams);
+            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block; width:100%; height:100%;">' + params.data.qname + '</a>';
         } else {
             href = 'index.html?searchText=' + encodeURIComponent(params.data.searchText) + '&startEpoch=' + encodeURIComponent(params.data.startTime) + '&endEpoch=' + encodeURIComponent(params.data.endTime) + '&indexName=' + encodeURIComponent(params.data.indexName) + '&filterTab=' + encodeURIComponent(params.data.filterTab) + '&queryLanguage=' + encodeURIComponent(params.data.queryLanguage);
-            this.eGui.innerHTML = '<a class="query-link" href=' + href + '" title="' + params.data.description + '"style="display:block;">' + params.data.qname + '</a>';
+            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block; width:100%; height:100%;">' + params.data.qname + '</a>';
         }
     }
 
@@ -198,13 +198,14 @@ class btnCellRenderer {
         this.eGui = document.createElement('div');
         this.eGui.innerHTML = `
         <div id="alert-grid-btn">
-            <input type="button" class="btn-simple" id="delbutton"  />
+            <input type="button" class="btn-simple" id="delbutton" style="cursor:pointer;" />
         </div>`;
 
         // get references to the elements we want
         this.eButton = this.eGui.querySelector('.btn-simple');
-        this.eventListener = () => {
-            $('.popupOverlay, .popupContent').addClass('active');
+        this.eventListener = (e) => {
+            e.stopPropagation(); // Stop event from bubbling up
+            $('.popupOverlay, .popupContent:first').addClass('active');
             $('#delete-btn').data('params', params);
         };
         this.eButton.addEventListener('click', this.eventListener);
@@ -228,51 +229,47 @@ class btnCellRenderer {
     }
 }
 
-// Delete confirmation popup
-$(document).ready(function () {
-    var currentPage = window.location.pathname;
-    if (currentPage.startsWith('/metrics-explorer.html')) {
-        //eslint-disable-next-line no-undef
-        isMetricsScreen = true;
+// Fix the description cell renderer class
+class descriptionCellRenderer {
+    init(params) {
+        this.eGui = document.createElement('div');
+        this.eGui.style.width = "100%";
+        this.eGui.style.height = "100%";
+        
+        // Get description value or use empty string if undefined
+        const description = params.value || '';
+        const truncatedDesc = description.length > 100 ? description.substring(0, 100) + '...' : description;
+        
+        // Create a div with truncated text and proper styling
+        this.eGui.innerHTML = `<div class="description-cell" style="cursor:pointer; width:100%; height:100%; display:block;" data-full-description="${encodeURIComponent(description)}">${truncatedDesc}</div>`;
+        
+        // Store a reference to the cell element and add click handler directly
+        this.eGui.onclick = (e) => {
+            e.stopPropagation();
+            // Display the full description in the popup
+            document.getElementById('description-content').textContent = description;
+            
+            // Show the popup - make sure we're selecting the right popup (second one)
+            $('.popupOverlay').addClass('active');
+            $('.popupContent:eq(1)').addClass('active');
+        };
     }
-    $('#cancel-btn, .popupOverlay, #delete-btn').click(function () {
-        $('.popupOverlay, .popupContent').removeClass('active');
-    });
 
-    // delete function
-    $('#delete-btn').click(function () {
-        let params = $('#delete-btn').data('params');
-        $.ajax({
-            method: 'get',
-            url: 'api/usersavedqueries/deleteone/' + params.data.qname,
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-                Accept: '*/*',
-            },
-            crossDomain: true,
-        }).then(function () {
-            let deletedRowID = params.data.rowId;
-            sqgridOptions.api.applyTransaction({
-                remove: [{ rowId: deletedRowID }],
-            });
-        });
-    });
+    getGui() {
+        return this.eGui;
+    }
 
-    $(document).on('keydown', (event) => {
-        if (event.key === 'Escape') {
-            $('.popupOverlay, .popupContent').removeClass('active');
+    destroy() {
+        // Clean up by removing the click handler
+        if (this.eGui) {
+            this.eGui.onclick = null;
         }
-    });
+    }
 
-    $('#sq-filter-input').keyup(function (event) {
-        if (event.keyCode == '13') {
-            searchSavedQueryHandler(event);
-        } else {
-            displayOriginalSavedQueries();
-        }
-    });
-    $('#sq-filter-input').on('input', searchSavedQueryHandler);
-});
+    refresh() {
+        return false;
+    }
+}
 
 let queriesColumnDefs = [
     {
@@ -288,6 +285,8 @@ let queriesColumnDefs = [
     {
         field: 'qdescription',
         headerName: 'Description',
+        cellRenderer: descriptionCellRenderer,
+        cellClass: 'truncate-cell', // Add this class for styling
         resizable: true,
     },
     {
@@ -474,3 +473,62 @@ function getSearchedQuery() {
             el.show();
         });
 }
+
+// Delete confirmation popup
+$(document).ready(function () {
+    var currentPage = window.location.pathname;
+    if (currentPage.startsWith('/saved-queries.html')) {
+        //eslint-disable-next-line no-undef
+        isMetricsScreen = true;
+    }
+    $('#cancel-btn, .popupOverlay, #delete-btn').click(function () {
+        $('.popupOverlay, .popupContent').removeClass('active');
+    });
+
+    // delete function
+    $('#delete-btn').click(function () {
+        let params = $('#delete-btn').data('params');
+        $.ajax({
+            method: 'get',
+            url: 'api/usersavedqueries/deleteone/' + params.data.qname,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                Accept: '*/*',
+            },
+            crossDomain: true,
+        }).then(function () {
+            let deletedRowID = params.data.rowId;
+            sqgridOptions.api.applyTransaction({
+                remove: [{ rowId: deletedRowID }],
+            });
+        });
+    });
+
+    // Close description popup when close button is clicked
+    $('#close-desc-btn').click(function() {
+        $('.popupOverlay').removeClass('active');
+        $('.popupContent:eq(1)').removeClass('active');
+    });
+
+    // Update the escape key handler to close both popups
+    $(document).on('keydown', function(event) {
+        if (event.key === 'Escape') {
+            $('.popupOverlay, .popupContent').removeClass('active');
+        }
+    });
+
+    $('#sq-filter-input').keyup(function (event) {
+        if (event.keyCode == '13') {
+            searchSavedQueryHandler(event);
+        } else {
+            displayOriginalSavedQueries();
+        }
+    });
+    $('#sq-filter-input').on('input', searchSavedQueryHandler);
+
+    // Make sure clicking on the overlay closes both popups
+    $('.popupOverlay').click(function() {
+        $('.popupOverlay, .popupContent').removeClass('active');
+    });
+});
+

--- a/static/js/saved-query.js
+++ b/static/js/saved-query.js
@@ -176,11 +176,11 @@ class linkCellRenderer {
         this.eGui = document.createElement('span');
         let href;
         if (params.data.dataSource === 'metrics') {
-            href = 'metrics-explorer.html?queryString=' + encodeURIComponent(params.data.metricsQueryParams);
-            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block; width:100%; height:100%;">' + params.data.qname + '</a>';
+            let href = 'metrics-explorer.html?queryString=' + encodeURIComponent(params.data.metricsQueryParams);
+            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block;">' + params.data.qname + '</a>';
         } else {
             href = 'index.html?searchText=' + encodeURIComponent(params.data.searchText) + '&startEpoch=' + encodeURIComponent(params.data.startTime) + '&endEpoch=' + encodeURIComponent(params.data.endTime) + '&indexName=' + encodeURIComponent(params.data.indexName) + '&filterTab=' + encodeURIComponent(params.data.filterTab) + '&queryLanguage=' + encodeURIComponent(params.data.queryLanguage);
-            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block; width:100%; height:100%;">' + params.data.qname + '</a>';
+            this.eGui.innerHTML = '<a class="query-link" href=' + href + '" title="' + params.data.description + '"style="display:block;">' + params.data.qname + '</a>';
         }
     }
 
@@ -198,14 +198,13 @@ class btnCellRenderer {
         this.eGui = document.createElement('div');
         this.eGui.innerHTML = `
         <div id="alert-grid-btn">
-            <input type="button" class="btn-simple" id="delbutton" style="cursor:pointer;" />
+            <input type="button" class="btn-simple" id="delbutton"  />
         </div>`;
 
         // get references to the elements we want
         this.eButton = this.eGui.querySelector('.btn-simple');
-        this.eventListener = (e) => {
-            e.stopPropagation(); // Stop event from bubbling up
-            $('.popupOverlay, .popupContent:first').addClass('active');
+        this.eventListener = () => {
+            $('.popupOverlay, .popupContent').addClass('active');
             $('#delete-btn').data('params', params);
         };
         this.eButton.addEventListener('click', this.eventListener);
@@ -229,47 +228,51 @@ class btnCellRenderer {
     }
 }
 
-// Fix the description cell renderer class
-class descriptionCellRenderer {
-    init(params) {
-        this.eGui = document.createElement('div');
-        this.eGui.style.width = "100%";
-        this.eGui.style.height = "100%";
-        
-        // Get description value or use empty string if undefined
-        const description = params.value || '';
-        const truncatedDesc = description.length > 100 ? description.substring(0, 100) + '...' : description;
-        
-        // Create a div with truncated text and proper styling
-        this.eGui.innerHTML = `<div class="description-cell" style="cursor:pointer; width:100%; height:100%; display:block;" data-full-description="${encodeURIComponent(description)}">${truncatedDesc}</div>`;
-        
-        // Store a reference to the cell element and add click handler directly
-        this.eGui.onclick = (e) => {
-            e.stopPropagation();
-            // Display the full description in the popup
-            document.getElementById('description-content').textContent = description;
-            
-            // Show the popup - make sure we're selecting the right popup (second one)
-            $('.popupOverlay').addClass('active');
-            $('.popupContent:eq(1)').addClass('active');
-        };
+// Delete confirmation popup
+$(document).ready(function () {
+    var currentPage = window.location.pathname;
+    if (currentPage.startsWith('/metrics-explorer.html')) {
+        //eslint-disable-next-line no-undef
+        isMetricsScreen = true;
     }
+    $('#cancel-btn, .popupOverlay, #delete-btn').click(function () {
+        $('.popupOverlay, .popupContent').removeClass('active');
+    });
 
-    getGui() {
-        return this.eGui;
-    }
+    // delete function
+    $('#delete-btn').click(function () {
+        let params = $('#delete-btn').data('params');
+        $.ajax({
+            method: 'get',
+            url: 'api/usersavedqueries/deleteone/' + params.data.qname,
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                Accept: '*/*',
+            },
+            crossDomain: true,
+        }).then(function () {
+            let deletedRowID = params.data.rowId;
+            sqgridOptions.api.applyTransaction({
+                remove: [{ rowId: deletedRowID }],
+            });
+        });
+    });
 
-    destroy() {
-        // Clean up by removing the click handler
-        if (this.eGui) {
-            this.eGui.onclick = null;
+    $(document).on('keydown', (event) => {
+        if (event.key === 'Escape') {
+            $('.popupOverlay, .popupContent').removeClass('active');
         }
-    }
+    });
 
-    refresh() {
-        return false;
-    }
-}
+    $('#sq-filter-input').keyup(function (event) {
+        if (event.keyCode == '13') {
+            searchSavedQueryHandler(event);
+        } else {
+            displayOriginalSavedQueries();
+        }
+    });
+    $('#sq-filter-input').on('input', searchSavedQueryHandler);
+});
 
 let queriesColumnDefs = [
     {
@@ -285,8 +288,6 @@ let queriesColumnDefs = [
     {
         field: 'qdescription',
         headerName: 'Description',
-        cellRenderer: descriptionCellRenderer,
-        cellClass: 'truncate-cell', // Add this class for styling
         resizable: true,
     },
     {
@@ -473,62 +474,3 @@ function getSearchedQuery() {
             el.show();
         });
 }
-
-// Delete confirmation popup
-$(document).ready(function () {
-    var currentPage = window.location.pathname;
-    if (currentPage.startsWith('/saved-queries.html')) {
-        //eslint-disable-next-line no-undef
-        isMetricsScreen = true;
-    }
-    $('#cancel-btn, .popupOverlay, #delete-btn').click(function () {
-        $('.popupOverlay, .popupContent').removeClass('active');
-    });
-
-    // delete function
-    $('#delete-btn').click(function () {
-        let params = $('#delete-btn').data('params');
-        $.ajax({
-            method: 'get',
-            url: 'api/usersavedqueries/deleteone/' + params.data.qname,
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-                Accept: '*/*',
-            },
-            crossDomain: true,
-        }).then(function () {
-            let deletedRowID = params.data.rowId;
-            sqgridOptions.api.applyTransaction({
-                remove: [{ rowId: deletedRowID }],
-            });
-        });
-    });
-
-    // Close description popup when close button is clicked
-    $('#close-desc-btn').click(function() {
-        $('.popupOverlay').removeClass('active');
-        $('.popupContent:eq(1)').removeClass('active');
-    });
-
-    // Update the escape key handler to close both popups
-    $(document).on('keydown', function(event) {
-        if (event.key === 'Escape') {
-            $('.popupOverlay, .popupContent').removeClass('active');
-        }
-    });
-
-    $('#sq-filter-input').keyup(function (event) {
-        if (event.keyCode == '13') {
-            searchSavedQueryHandler(event);
-        } else {
-            displayOriginalSavedQueries();
-        }
-    });
-    $('#sq-filter-input').on('input', searchSavedQueryHandler);
-
-    // Make sure clicking on the overlay closes both popups
-    $('.popupOverlay').click(function() {
-        $('.popupOverlay, .popupContent').removeClass('active');
-    });
-});
-

--- a/static/js/saved-query.js
+++ b/static/js/saved-query.js
@@ -177,10 +177,10 @@ class linkCellRenderer {
         let href;
         if (params.data.dataSource === 'metrics') {
             let href = 'metrics-explorer.html?queryString=' + encodeURIComponent(params.data.metricsQueryParams);
-            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" title="' + params.data.description + '" style="display:block;">' + params.data.qname + '</a>';
+            this.eGui.innerHTML = '<a class="query-link" href="' + href + '" style="display:block;">' + params.data.qname + '</a>';
         } else {
             href = 'index.html?searchText=' + encodeURIComponent(params.data.searchText) + '&startEpoch=' + encodeURIComponent(params.data.startTime) + '&endEpoch=' + encodeURIComponent(params.data.endTime) + '&indexName=' + encodeURIComponent(params.data.indexName) + '&filterTab=' + encodeURIComponent(params.data.filterTab) + '&queryLanguage=' + encodeURIComponent(params.data.queryLanguage);
-            this.eGui.innerHTML = '<a class="query-link" href=' + href + '" title="' + params.data.description + '"style="display:block;">' + params.data.qname + '</a>';
+            this.eGui.innerHTML = '<a class="query-link" href=' + href + '" style="display:block;">' + params.data.qname + '</a>';
         }
     }
 
@@ -289,6 +289,13 @@ let queriesColumnDefs = [
         field: 'qdescription',
         headerName: 'Description',
         resizable: true,
+        cellStyle: {
+            'white-space': 'nowrap',
+            'overflow': 'hidden',
+            'text-overflow': 'ellipsis',
+            'max-width': '100%',
+            'display': 'block'
+        },
     },
     {
         field: 'type',
@@ -336,6 +343,7 @@ const sqgridOptions = {
         cellClass: 'align-center-grid',
         resizable: true,
         sortable: true,
+        suppressSizeToFit: false,
     },
     enableCellTextSelection: true,
     suppressScrollOnNewData: true,

--- a/static/saved-queries.html
+++ b/static/saved-queries.html
@@ -85,7 +85,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <button type="button" id="delete-btn" class="btn btn-secondary">Delete</button>
                 </div>
             </div>
-        </div>
+            <div class="popupContent">
+                <h3 class="header">Description</h3>
+                <div id="description-content"></div>
+                <div class="btncontainer">
+                    <button type="button" id="close-desc-btn" class="btn btn-primary">Close</button>
+                </div>
+            </div>
+            </div>
         <div id="app-footer">
         </div>
     </div>

--- a/static/saved-queries.html
+++ b/static/saved-queries.html
@@ -85,14 +85,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <button type="button" id="delete-btn" class="btn btn-secondary">Delete</button>
                 </div>
             </div>
-            <div class="popupContent">
-                <h3 class="header">Description</h3>
-                <div id="description-content"></div>
-                <div class="btncontainer">
-                    <button type="button" id="close-desc-btn" class="btn btn-primary">Close</button>
-                </div>
-            </div>
-            </div>
+        </div>
         <div id="app-footer">
         </div>
     </div>


### PR DESCRIPTION
Long descriptions in the Description column were breaking the table layout.

BEFORE 
<img width="1914" height="914" alt="Screenshot 2025-07-16 115907" src="https://github.com/user-attachments/assets/e61b3d24-a6c4-4c6c-981c-97c467432edf" />

AFTER
<img width="1918" height="909" alt="Screenshot 2025-07-16 174716" src="https://github.com/user-attachments/assets/2f614eea-b278-4037-9b1c-a276e06f5bd5" />

