### PR TITLE
Align "Time Picker" button to the right in metric-summary header

### DIFF
--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -635,3 +635,10 @@ input:checked+.slider:before {
     background-color: var(--input-box-bg-color);
     color: var(--text-color);
 }
+
+.metrics-js-textarea {
+    border: 1px solid var(--search-input-border);
+    font-size: 12px;
+    background-color: var(--input-box-bg-color);
+    border-radius: 0;
+}

--- a/static/css/metrics-explorer.css
+++ b/static/css/metrics-explorer.css
@@ -634,11 +634,6 @@ input:checked+.slider:before {
     font-size: 11px;
     background-color: var(--input-box-bg-color);
     color: var(--text-color);
-}
-
-.metrics-js-textarea {
-    border: 1px solid var(--search-input-border);
-    font-size: 12px;
-    background-color: var(--input-box-bg-color);
     border-radius: 0;
 }
+

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1294,7 +1294,6 @@ textarea {
     border: 1px solid var(--search-input-border);
     background: var(--search-bar-bg);
     font-size: 12px;
-    border-radius: 5px;
     padding: 8px;
 }
 

--- a/static/css/siglens.css
+++ b/static/css/siglens.css
@@ -1294,6 +1294,7 @@ textarea {
     border: 1px solid var(--search-input-border);
     background: var(--search-bar-bg);
     font-size: 12px;
+    border-radius: 5px;
     padding: 8px;
 }
 

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -732,7 +732,8 @@ function createQueryElementTemplate(queryName) {
                 </div>
             </div>
             <div class="raw-query" style="display: none;">
-                <textarea class="raw-query-input" placeholder="Enter your query here"></textarea><button class="btn run-filter-btn" id="run-filter-btn" title="Run your search" type="button"> </button>
+                <textarea class="raw-query-input metrics-js-textarea" placeholder="Enter your query here"></textarea>
+                <button class="btn run-filter-btn" id="run-filter-btn" title="Run your search" type="button"> </button>
             </div>
         </div>
         <div>

--- a/static/js/metrics-explorer.js
+++ b/static/js/metrics-explorer.js
@@ -732,7 +732,7 @@ function createQueryElementTemplate(queryName) {
                 </div>
             </div>
             <div class="raw-query" style="display: none;">
-                <textarea class="raw-query-input metrics-js-textarea" placeholder="Enter your query here"></textarea>
+                <textarea class="raw-query-input" placeholder="Enter your query here"></textarea>
                 <button class="btn run-filter-btn" id="run-filter-btn" title="Run your search" type="button"> </button>
             </div>
         </div>

--- a/static/metric-summary.html
+++ b/static/metric-summary.html
@@ -60,7 +60,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <div id="dashboard">
             <div>
                 <div class="metric-summary" style="height:100vh; width: 100vw; padding:16px">
-                    <div style="display: flex; align-items: center;" class="metric-summary-head">
+                    <div style="display: flex; align-items: center; justify-content: space-between;" class="metric-summary-head">
                         <h5 style="margin-right: 10px; font-size:16px" class="mb-0">
                             All metrics reporting across your infrastructure in the past
                         </h5>


### PR DESCRIPTION
# Description
Updated the flex container inside .metric-summary-head to use justify-content: space-between for left-right alignment.