### PR TITLE
Improve perf by moving slice from heap to stack

### DIFF
--- a/pkg/segment/results/blockresults/runningstats.go
+++ b/pkg/segment/results/blockresults/runningstats.go
@@ -1132,11 +1132,17 @@ func hllAddRawCval(hll *utils.GobbableHll, cval *sutils.CValueEnclosure) error {
 			hll.AddRaw(2) // cannot use AddRaw(0), 0 is not a valid value for AddRaw(). See: Hll.AddRaw()
 		}
 	case sutils.SS_DT_UNSIGNED_NUM:
-		hll.AddRaw(xxhash.Sum64(utils.Uint64ToBytesLittleEndian(cval.CVal.(uint64))))
+		bytes := [8]byte{}
+		utils.Uint64ToBytesLittleEndianInplace(cval.CVal.(uint64), bytes[:])
+		hll.AddRaw(xxhash.Sum64(bytes[:]))
 	case sutils.SS_DT_SIGNED_NUM:
-		hll.AddRaw(xxhash.Sum64(utils.Int64ToBytesLittleEndian(cval.CVal.(int64))))
+		bytes := [8]byte{}
+		utils.Int64ToBytesLittleEndianInplace(cval.CVal.(int64), bytes[:])
+		hll.AddRaw(xxhash.Sum64(bytes[:]))
 	case sutils.SS_DT_FLOAT:
-		hll.AddRaw(xxhash.Sum64(utils.Float64ToBytesLittleEndian(cval.CVal.(float64))))
+		bytes := [8]byte{}
+		utils.Float64ToBytesLittleEndianInplace(cval.CVal.(float64), bytes[:])
+		hll.AddRaw(xxhash.Sum64(bytes[:]))
 	case sutils.SS_DT_BACKFILL:
 		return utils.NewErrorWithCode(utils.NIL_VALUE_ERR, fmt.Errorf("CValueEnclosure GetString: nil value"))
 	default:


### PR DESCRIPTION
# Description
Summarize the change. Link to an issue like "Fixes #{issue-number}" if applicable.

# Testing
On 100 million records, ran this query:
```splunk
* | stats dc(UserID) as u BY RegionID | sort 10 -u
```

This PR reduced the query time from 4.3 seconds to 2.7, and reduced the total allocations from 13 GB to 1.9 GB.