### PR TITLE
Improve performance of time formatting

### DIFF
--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -3421,35 +3421,30 @@ func handleTrimFunctions(op string, value string, trim_chars string) string {
 
 // formatTime formats a time.Time object into a string based on the provided format string, using mappings from Go's time package and strftime.net.
 func formatTime(t time.Time, format string) string {
-	preReplacements := map[string]string{
-		"%e": "_2",
-		"%a": "Mon",
-		"%A": "Monday",
-		"%d": "02",
-		"%b": "Jan",
-		"%B": "January",
-		"%m": "01",
-		"%y": "06",
-		"%Y": "2006",
-		"%H": "15",
-		"%I": "03",
-		"%p": "PM",
-		"%M": "04",
-		"%S": "05",
-		"%f": ".000000",
-		"%z": "-0700",
-		"%Z": "MST",
-		"%c": "Mon Jan 2 15:04:05 2006",
-		"%x": "01/02/06",
-		"%X": "15:04:05",
-		"%%": "%",
-		"%k": "_15",
-		"%T": "15:04:05",
-		"%F": "2006-01-02", // The ISO 8601 date format
-	}
-	for k, v := range preReplacements {
-		format = strings.ReplaceAll(format, k, v)
-	}
+	format = strings.ReplaceAll(format, "%e", "_2")
+	format = strings.ReplaceAll(format, "%a", "Mon")
+	format = strings.ReplaceAll(format, "%A", "Monday")
+	format = strings.ReplaceAll(format, "%d", "02")
+	format = strings.ReplaceAll(format, "%b", "Jan")
+	format = strings.ReplaceAll(format, "%B", "January")
+	format = strings.ReplaceAll(format, "%m", "01")
+	format = strings.ReplaceAll(format, "%y", "06")
+	format = strings.ReplaceAll(format, "%Y", "2006")
+	format = strings.ReplaceAll(format, "%H", "15")
+	format = strings.ReplaceAll(format, "%I", "03")
+	format = strings.ReplaceAll(format, "%p", "PM")
+	format = strings.ReplaceAll(format, "%M", "04")
+	format = strings.ReplaceAll(format, "%S", "05")
+	format = strings.ReplaceAll(format, "%f", ".000000")
+	format = strings.ReplaceAll(format, "%z", "-0700")
+	format = strings.ReplaceAll(format, "%Z", "MST")
+	format = strings.ReplaceAll(format, "%c", "Mon Jan 2 15:04:05 2006")
+	format = strings.ReplaceAll(format, "%x", "01/02/06")
+	format = strings.ReplaceAll(format, "%X", "15:04:05")
+	format = strings.ReplaceAll(format, "%%", "%")
+	format = strings.ReplaceAll(format, "%k", "_15")
+	format = strings.ReplaceAll(format, "%T", "15:04:05")
+	format = strings.ReplaceAll(format, "%F", "2006-01-02") // The ISO 8601 date format
 
 	timeStr := t.Format(format)
 

--- a/pkg/segment/structs/evaluationstructs.go
+++ b/pkg/segment/structs/evaluationstructs.go
@@ -3453,20 +3453,38 @@ func formatTime(t time.Time, format string) string {
 	offsetHours := offset / 3600
 	offsetMinutes := (offset % 3600) / 60
 	formattedOffset := fmt.Sprintf("%+03d:%02d", offsetHours, offsetMinutes)
-	postReplacements := map[string]string{
-		"%w":  strconv.Itoa(int(t.Weekday())),                         // weekday as a decimal number
-		"%j":  strconv.Itoa(t.YearDay()),                              // day of the year as a decimal number
-		"%U":  strconv.Itoa(t.YearDay() / 7),                          // week number of the year (Sunday as the first day of the week)
-		"%W":  strconv.Itoa((int(t.Weekday()) - 1 + t.YearDay()) / 7), // week number of the year (Monday as the first day of the week)
-		"%V":  strconv.Itoa(week),                                     // ISO week number
-		"%+":  t.Format("Mon Jan 2 15:04:05 MST 2006"),                // date and time with timezone
-		"%N":  fmt.Sprintf("%09d", t.Nanosecond()),                    // nanoseconds
-		"%Q":  strconv.Itoa(t.Nanosecond() / 1e6),                     // milliseconds
-		"%Ez": formattedOffset,                                        // timezone offset
-		"%s":  strconv.FormatInt(t.Unix(), 10),                        // Unix Epoch Time timestamp
+
+	// In the hot path the timeStr won't include all of these. So avoid
+	// creating the replacement string if the thing to replace isn't present.
+	if strings.Contains(timeStr, "%w") { // weekday as a decimal number
+		timeStr = strings.ReplaceAll(timeStr, "%w", strconv.Itoa(int(t.Weekday())))
 	}
-	for k, v := range postReplacements {
-		timeStr = strings.ReplaceAll(timeStr, k, v)
+	if strings.Contains(timeStr, "%j") { // day of the year as a decimal number
+		timeStr = strings.ReplaceAll(timeStr, "%j", strconv.Itoa(t.YearDay()))
+	}
+	if strings.Contains(timeStr, "%U") { // week number of the year (Sunday as the first day of the week)
+		timeStr = strings.ReplaceAll(timeStr, "%U", strconv.Itoa(t.YearDay()/7))
+	}
+	if strings.Contains(timeStr, "%W") { // week number of the year (Monday as the first day of the week)
+		timeStr = strings.ReplaceAll(timeStr, "%W", strconv.Itoa((int(t.Weekday())-1+t.YearDay())/7))
+	}
+	if strings.Contains(timeStr, "%V") { // ISO week number
+		timeStr = strings.ReplaceAll(timeStr, "%V", strconv.Itoa(week))
+	}
+	if strings.Contains(timeStr, "%+") { // date and time with timezone
+		timeStr = strings.ReplaceAll(timeStr, "%+", t.Format("Mon Jan 2 15:04:05 MST 2006"))
+	}
+	if strings.Contains(timeStr, "%N") { // nanoseconds
+		timeStr = strings.ReplaceAll(timeStr, "%N", fmt.Sprintf("%09d", t.Nanosecond()))
+	}
+	if strings.Contains(timeStr, "%Q") { // milliseconds
+		timeStr = strings.ReplaceAll(timeStr, "%Q", strconv.Itoa(t.Nanosecond()/1e6))
+	}
+	if strings.Contains(timeStr, "%Ez") { // timezone offset
+		timeStr = strings.ReplaceAll(timeStr, "%Ez", formattedOffset)
+	}
+	if strings.Contains(timeStr, "%s") { // Unix Epoch Time timestamp
+		timeStr = strings.ReplaceAll(timeStr, "%s", strconv.FormatInt(t.Unix(), 10))
 	}
 
 	return timeStr


### PR DESCRIPTION
# Description
This is a performance improvement that shouldn't change any behavior.

1. Avoid repeated map creation, which was giving GC more work
2. Avoid map iteration, which used more CPU
3. Avoid creating strings that won't be used, which was giving GC more work

# Testing
Reduced the query time by about 25% for this query:
```
CounterID=62 DontCountHits = 0 IsRefresh = 0 
| eval ptime = strptime(EventDate,"%Y-%m-%d") 
| where ptime >= strptime("2013-07-01", "%Y-%m-%d") AND ptime <= strptime("2013-07-31", "%Y-%m-%d") 
| eval truncTime = strftime(tonumber(strptime(EventTime, "%Y-%m-%d %H:%M:%S")), "%Y-%m-%d %H:%M:00") 
| stats count as PageViews by truncTime 
| sort 1010 -truncTime 
| tail 10 
```