### PR TITLE
Set elapsed time on API query response

### DIFF
--- a/pkg/segment/query/processor/queryprocessor.go
+++ b/pkg/segment/query/processor/queryprocessor.go
@@ -598,7 +598,9 @@ func (qp *QueryProcessor) GetFullResult() (*structs.PipeSearchResponseOuter, err
 		return nil, utils.TeeErrorf("GetFullResult: failed to get result; err=%v", err)
 	}
 
-	qp.querySummary.UpdateQueryTotalTime(time.Since(qp.startTime), response.BucketCount)
+	queryDuration := time.Since(qp.startTime)
+	qp.querySummary.UpdateQueryTotalTime(queryDuration, response.BucketCount)
+	response.ElapsedTimeMS = queryDuration.Milliseconds()
 
 	canScrollMore, relation, _, err := qp.getStatusParams(uint64(totalRecords))
 	if err != nil {

--- a/pkg/segment/structs/resultStructs.go
+++ b/pkg/segment/structs/resultStructs.go
@@ -20,7 +20,7 @@ package structs
 type PipeSearchResponseOuter struct {
 	Hits                   PipeSearchResponse            `json:"hits"`
 	Aggs                   map[string]AggregationResults `json:"aggregations"`
-	ElapedTimeMS           int64                         `json:"elapedTimeMS"`
+	ElapsedTimeMS          int64                         `json:"elapsedTimeMS"`
 	AllPossibleColumns     []string                      `json:"allColumns"`
 	Errors                 []string                      `json:"errors,omitempty"`
 	MeasureFunctions       []string                      `json:"measureFunctions,omitempty"`


### PR DESCRIPTION
# Description
Summarize the change. Link to an issue like "Fixes #{issue-number}" if applicable.

# Testing
Ran
```
curl -X POST -d '{ "searchText": "* | stats count", "indexName": "*", "startEpoch": "now-30d", "endEpoch": "now", "queryLanguage": "Splunk QL" }' http://localhost:5122/api/search | jq
```
Now it shows a line like
```
  "elapsedTimeMS": 14,
```
instead of
```
  "elapedTimeMS": 0,
```
