### PR TITLE
Revert for GH user glanzz #2262: Refactor NodeResult Struct by cleaning up the RecsAggs Fields

### DIFF
--- a/pkg/segment/aggregations/segaggs.go
+++ b/pkg/segment/aggregations/segaggs.go
@@ -113,7 +113,7 @@ func PostQueryBucketCleaning(nodeResult *structs.NodeResult, post *structs.Query
 
 	if post.GroupByRequest != nil {
 		nodeResult.GroupByCols = post.GroupByRequest.GroupByColumns
-		nodeResult.RecsAggregator.GroupByRequest = post.GroupByRequest
+		nodeResult.GroupByRequest = post.GroupByRequest
 	}
 
 	if post.TransactionArguments != nil && len(recs) == 0 {
@@ -139,10 +139,10 @@ func PostQueryBucketCleaning(nodeResult *structs.NodeResult, post *structs.Query
 		err := performAggOnResult(nodeResult, agg, recs, recordIndexInFinal, finalCols, numTotalSegments, finishesSegment, hasSort, timeSort, timeSortAsc)
 
 		if len(nodeResult.TransactionEventRecords) > 0 {
-			nodeResult.RecsAggregator.NextQueryAgg = agg
+			nodeResult.NextQueryAgg = agg
 			return nodeResult
-		} else if nodeResult.RecsAggregator.PerformAggsOnRecs && recs != nil {
-			nodeResult.RecsAggregator.NextQueryAgg = agg
+		} else if nodeResult.PerformAggsOnRecs && recs != nil {
+			nodeResult.NextQueryAgg = agg
 			return nodeResult
 		}
 
@@ -230,14 +230,14 @@ func performAggOnResult(nodeResult *structs.NodeResult, agg *structs.QueryAggreg
 			}
 		}
 	case structs.GroupByType:
-		nodeResult.RecsAggregator.PerformAggsOnRecs = true
-		nodeResult.RecsAggregator.RecsAggsType = structs.GroupByType
+		nodeResult.PerformAggsOnRecs = true
+		nodeResult.RecsAggsType = structs.GroupByType
 		nodeResult.GroupByCols = agg.GroupByRequest.GroupByColumns
-		nodeResult.RecsAggregator.GroupByRequest = agg.GroupByRequest
+		nodeResult.GroupByRequest = agg.GroupByRequest
 	case structs.MeasureAggsType:
-		nodeResult.RecsAggregator.PerformAggsOnRecs = true
-		nodeResult.RecsAggregator.RecsAggsType = structs.MeasureAggsType
-		nodeResult.RecsAggregator.MeasureOperations = agg.MeasureOperations
+		nodeResult.PerformAggsOnRecs = true
+		nodeResult.RecsAggsType = structs.MeasureAggsType
+		nodeResult.MeasureOperations = agg.MeasureOperations
 	case structs.TransactionType:
 		performTransactionCommandRequest(nodeResult, agg, recs, finalCols, numTotalSegments, finishesSegment)
 	default:
@@ -913,11 +913,11 @@ RenamingLoop:
 	}
 
 	if colReq.ExcludeColumns != nil {
-		if nodeResult.RecsAggregator.GroupByRequest == nil {
+		if nodeResult.GroupByRequest == nil {
 			return errors.New("performColumnsRequest: expected non-nil GroupByRequest while handling ExcludeColumns")
 		}
 
-		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.RecsAggregator.GroupByRequest.GroupByColumns, colReq.ExcludeColumns, false)
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByRequest.GroupByColumns, colReq.ExcludeColumns, false)
 		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.ExcludeColumns, false)
 
 		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
@@ -926,13 +926,13 @@ RenamingLoop:
 		}
 	}
 	if colReq.IncludeColumns != nil {
-		if nodeResult.RecsAggregator.GroupByRequest == nil {
+		if nodeResult.GroupByRequest == nil {
 			return errors.New("performColumnsRequest: expected non-nil GroupByRequest while handling IncludeColumns")
 		}
 
-		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.RecsAggregator.GroupByRequest.GroupByColumns, colReq.IncludeColumns, true)
+		groupByColIndicesToKeep, groupByColNamesToKeep, _ := getColumnsToKeepAndRemove(nodeResult.GroupByRequest.GroupByColumns, colReq.IncludeColumns, true)
 		_, _, measureColNamesToRemove := getColumnsToKeepAndRemove(nodeResult.MeasureFunctions, colReq.IncludeColumns, true)
-		nodeResult.ColumnsOrder = getColumnsInOrder(nodeResult.RecsAggregator.GroupByRequest.GroupByColumns, nodeResult.MeasureFunctions, colReq.IncludeColumns)
+		nodeResult.ColumnsOrder = getColumnsInOrder(nodeResult.GroupByRequest.GroupByColumns, nodeResult.MeasureFunctions, colReq.IncludeColumns)
 
 		err := removeAggColumns(nodeResult, groupByColIndicesToKeep, groupByColNamesToKeep, measureColNamesToRemove)
 		if err != nil {
@@ -1064,10 +1064,10 @@ func removeAggColumns(nodeResult *structs.NodeResult, groupByColIndicesToKeep []
 		}
 	}
 
-	if nodeResult.RecsAggregator.GroupByRequest == nil {
+	if nodeResult.GroupByRequest == nil {
 		return fmt.Errorf("removeAggColumns: expected non-nil GroupByRequest")
 	} else {
-		nodeResult.RecsAggregator.GroupByRequest.GroupByColumns = groupByColNamesToKeep
+		nodeResult.GroupByRequest.GroupByColumns = groupByColNamesToKeep
 	}
 
 	return nil
@@ -3870,7 +3870,7 @@ func performTransactionCommandRequest(nodeResult *structs.NodeResult, aggs *stru
 		var err error
 
 		if finishesSegment {
-			nodeResult.RecsAggResults.RecsAggsProcessedSegments++
+			nodeResult.RecsAggsProcessedSegments++
 
 			// Sort the records by timestamp. The records in the segment may not be sorted. We need to sort them before processing.
 			// This method also assumes that all records in the segment will come before the records in the next segment(Segments are Sorted).
@@ -3878,7 +3878,7 @@ func performTransactionCommandRequest(nodeResult *structs.NodeResult, aggs *stru
 				return aggs.TransactionArguments.SortedRecordsSlice[i]["timestamp"].(uint64) < aggs.TransactionArguments.SortedRecordsSlice[j]["timestamp"].(uint64)
 			})
 
-			cols, err = processTransactionsOnRecords(nodeResult.TransactionEventRecords, nodeResult.TransactionsProcessed, nil, aggs.TransactionArguments, nodeResult.RecsAggResults.RecsAggsProcessedSegments == numTotalSegments)
+			cols, err = processTransactionsOnRecords(nodeResult.TransactionEventRecords, nodeResult.TransactionsProcessed, nil, aggs.TransactionArguments, nodeResult.RecsAggsProcessedSegments == numTotalSegments)
 			if err != nil {
 				log.Errorf("performTransactionCommandRequest: %v", err)
 				return
@@ -3889,12 +3889,12 @@ func performTransactionCommandRequest(nodeResult *structs.NodeResult, aggs *stru
 
 			// Creating a single Map after processing the segment.
 			// This tells the PostQueryBucketCleaning function to return to the rrcreader.go to process the further segments.
-			nodeResult.TransactionEventRecords["PROCESSED_SEGMENT_"+fmt.Sprint(nodeResult.RecsAggResults.RecsAggsProcessedSegments)] = make(map[string]interface{})
+			nodeResult.TransactionEventRecords["PROCESSED_SEGMENT_"+fmt.Sprint(nodeResult.RecsAggsProcessedSegments)] = make(map[string]interface{})
 
 			aggs.TransactionArguments.SortedRecordsSlice = nil // Clear the sorted records slice.
 		}
 
-		if nodeResult.RecsAggResults.RecsAggsProcessedSegments == numTotalSegments {
+		if nodeResult.RecsAggsProcessedSegments == numTotalSegments {
 			nodeResult.TransactionEventRecords = nil
 			nodeResult.TransactionEventRecords = make(map[string]map[string]interface{})
 			nodeResult.TransactionEventRecords["CHECK_NEXT_AGG"] = make(map[string]interface{}) // All segments have been processed. Check the next aggregation.

--- a/pkg/segment/reader/record/rrcreader.go
+++ b/pkg/segment/reader/record/rrcreader.go
@@ -292,21 +292,21 @@ func GetJsonFromAllRrcOldPipeline(allrrc []*sutils.RecordResultContainer, esResp
 					if exists {
 						// Reset the TransactionEventRecords and update aggs with NextQueryAgg to loop for next Aggs processing.
 						delete(nodeRes.TransactionEventRecords, "CHECK_NEXT_AGG")
-						aggs = &structs.QueryAggregators{Next: nodeRes.RecsAggregator.NextQueryAgg.Next}
+						aggs = &structs.QueryAggregators{Next: nodeRes.NextQueryAgg.Next}
 						nodeRes.CurrentSearchResultCount = len(recs)
 					} else {
 						break // Break out of the loop to process next segment.
 					}
-				} else if nodeRes.RecsAggregator.PerformAggsOnRecs {
+				} else if nodeRes.PerformAggsOnRecs {
 					resultRecMap = search.PerformAggsOnRecs(nodeRes, aggs, recs, finalCols, numTotalSegments, finishesSegment, qid)
 					// By default reset PerformAggsOnRecs flag, otherwise the execution will immediately return here from PostQueryBucketCleaning;
 					// Without performing the aggs from the start for the next segment or next bulk.
-					nodeRes.RecsAggregator.PerformAggsOnRecs = false
+					nodeRes.PerformAggsOnRecs = false
 					if len(resultRecMap) > 0 {
 						boolVal, exists := resultRecMap["CHECK_NEXT_AGG"]
 						if exists && boolVal {
 							// Update aggs with NextQueryAgg to loop for additional cleaning.
-							aggs = nodeRes.RecsAggregator.NextQueryAgg
+							aggs = nodeRes.NextQueryAgg
 							nodeRes.CurrentSearchResultCount = len(recs)
 						} else {
 							break

--- a/pkg/segment/search/searchaggs.go
+++ b/pkg/segment/search/searchaggs.go
@@ -374,17 +374,17 @@ func addRecordToAggregations(grpReq *structs.GroupByRequest, timeHistogram *stru
 func PerformAggsOnRecs(nodeResult *structs.NodeResult, aggs *structs.QueryAggregators, recs map[string]map[string]interface{},
 	finalCols map[string]bool, numTotalSegments uint64, finishesSegment bool, qid uint64) map[string]bool {
 
-	if !nodeResult.RecsAggregator.PerformAggsOnRecs {
+	if !nodeResult.PerformAggsOnRecs {
 		return nil
 	}
 
 	if finishesSegment {
-		nodeResult.RecsAggResults.RecsAggsProcessedSegments++
+		nodeResult.RecsAggsProcessedSegments++
 	}
 
-	if nodeResult.RecsAggregator.RecsAggsType == structs.GroupByType {
+	if nodeResult.RecsAggsType == structs.GroupByType {
 		return PerformGroupByRequestAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments, uint64(aggs.Limit))
-	} else if nodeResult.RecsAggregator.RecsAggsType == structs.MeasureAggsType {
+	} else if nodeResult.RecsAggsType == structs.MeasureAggsType {
 		return PerformMeasureAggsOnRecs(nodeResult, recs, finalCols, qid, numTotalSegments, uint64(aggs.Limit))
 	}
 
@@ -393,9 +393,9 @@ func PerformAggsOnRecs(nodeResult *structs.NodeResult, aggs *structs.QueryAggreg
 
 func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64, sizeLimit uint64) map[string]bool {
 
-	nodeResult.RecsAggregator.GroupByRequest.BucketCount = 3000
+	nodeResult.GroupByRequest.BucketCount = 3000
 
-	blockRes, err := blockresults.InitBlockResults(uint64(len(recs)), &structs.QueryAggregators{GroupByRequest: nodeResult.RecsAggregator.GroupByRequest}, qid)
+	blockRes, err := blockresults.InitBlockResults(uint64(len(recs)), &structs.QueryAggregators{GroupByRequest: nodeResult.GroupByRequest}, qid)
 	if err != nil {
 		log.Errorf("PerformGroupByRequestAggsOnRecs: failed to initialize block results reader. Err: %v", err)
 		return nil
@@ -403,8 +403,8 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 
 	measureInfo, internalMops := blockRes.GetConvertedMeasureInfo()
 
-	if nodeResult.RecsAggregator.GroupByRequest != nil && nodeResult.RecsAggregator.GroupByRequest.MeasureOperations != nil {
-		for _, mOp := range nodeResult.RecsAggregator.GroupByRequest.MeasureOperations {
+	if nodeResult.GroupByRequest != nil && nodeResult.GroupByRequest.MeasureOperations != nil {
+		for _, mOp := range nodeResult.GroupByRequest.MeasureOperations {
 			if mOp.MeasureFunc == sutils.Count {
 				internalMops = append(internalMops, mOp)
 			}
@@ -474,25 +474,25 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 		blockRes.AddMeasureResultsToKey(currKey.Bytes(), measureResults, "", false, qid, unsetRecord)
 	}
 
-	if nodeResult.RecsAggResults.RecsAggsBlockResults == nil {
-		nodeResult.RecsAggResults.RecsAggsBlockResults = blockRes
+	if nodeResult.RecsAggsBlockResults == nil {
+		nodeResult.RecsAggsBlockResults = blockRes
 	} else {
-		recAggsBlockresults := nodeResult.RecsAggResults.RecsAggsBlockResults.(*blockresults.BlockResults)
+		recAggsBlockresults := nodeResult.RecsAggsBlockResults.(*blockresults.BlockResults)
 		recAggsBlockresults.MergeBuckets(blockRes)
 	}
 
 	nodeResult.TotalRRCCount += uint64(len(recs))
 
-	if (nodeResult.RecsAggResults.RecsAggsProcessedSegments < numTotalSegments) && (sizeLimit == 0 || nodeResult.TotalRRCCount < sizeLimit) {
+	if (nodeResult.RecsAggsProcessedSegments < numTotalSegments) && (sizeLimit == 0 || nodeResult.TotalRRCCount < sizeLimit) {
 		for k := range recs {
 			delete(recs, k)
 		}
 		return nil
 	} else {
-		blockRes = nodeResult.RecsAggResults.RecsAggsBlockResults.(*blockresults.BlockResults)
+		blockRes = nodeResult.RecsAggsBlockResults.(*blockresults.BlockResults)
 		if sizeLimit > 0 && nodeResult.TotalRRCCount >= sizeLimit {
 			log.Info("PerformGroupByRequestAggsOnRecs: Reached size limit, Returning the Bucket Results.")
-			nodeResult.RecsAggResults.RecsAggsProcessedSegments = numTotalSegments
+			nodeResult.RecsAggsProcessedSegments = numTotalSegments
 		}
 	}
 
@@ -557,18 +557,18 @@ func PerformGroupByRequestAggsOnRecs(nodeResult *structs.NodeResult, recs map[st
 
 func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]map[string]interface{}, finalCols map[string]bool, qid uint64, numTotalSegments uint64, sizeLimit uint64) map[string]bool {
 
-	searchResults, err := segresults.InitSearchResults(uint64(len(recs)), &structs.QueryAggregators{MeasureOperations: nodeResult.RecsAggregator.MeasureOperations}, structs.SegmentStatsCmd, qid)
+	searchResults, err := segresults.InitSearchResults(uint64(len(recs)), &structs.QueryAggregators{MeasureOperations: nodeResult.MeasureOperations}, structs.SegmentStatsCmd, qid)
 	if err != nil {
 		log.Errorf("PerformMeasureAggsOnRecs: failed to initialize search results. Err: %v", err)
 		return nil
 	}
 
-	searchResults.InitSegmentStatsResults(nodeResult.RecsAggregator.MeasureOperations)
+	searchResults.InitSegmentStatsResults(nodeResult.MeasureOperations)
 
 	anyCountStat := -1
 	lenRecords := len(recs)
 
-	for idx, mOp := range nodeResult.RecsAggregator.MeasureOperations {
+	for idx, mOp := range nodeResult.MeasureOperations {
 		if mOp.String() == "count(*)" {
 			anyCountStat = idx
 			break
@@ -585,7 +585,7 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 	for recInden, record := range recs {
 		sstMap := make(map[string]*structs.SegStats, 0)
 
-		for _, mOp := range nodeResult.RecsAggregator.MeasureOperations {
+		for _, mOp := range nodeResult.MeasureOperations {
 			dtypeVal, err := sutils.CreateDtypeEnclosure(record[mOp.MeasureCol], qid)
 			if err != nil {
 				log.Errorf("PerformMeasureAggsOnRecs: failed to create Dtype Value from rec: %v", err)
@@ -640,7 +640,7 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 			sstMap[mOp.MeasureCol] = segStat
 		}
 
-		err := searchResults.UpdateSegmentStats(sstMap, nodeResult.RecsAggregator.MeasureOperations)
+		err := searchResults.UpdateSegmentStats(sstMap, nodeResult.MeasureOperations)
 		if err != nil {
 			log.Errorf("PerformMeasureAggsOnRecs: failed to update segment stats: %v", err)
 		}
@@ -648,21 +648,21 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 		delete(recs, recInden)
 	}
 
-	if nodeResult.RecsAggResults.RecsRunningSegStats == nil {
-		nodeResult.RecsAggResults.RecsRunningSegStats = searchResults.GetSegmentRunningStats()
+	if nodeResult.RecsRunningSegStats == nil {
+		nodeResult.RecsRunningSegStats = searchResults.GetSegmentRunningStats()
 	} else {
 		sstMap := make(map[string]*structs.SegStats, 0)
 
-		for idx, mOp := range nodeResult.RecsAggregator.MeasureOperations {
-			sstMap[mOp.MeasureCol] = nodeResult.RecsAggResults.RecsRunningSegStats[idx]
+		for idx, mOp := range nodeResult.MeasureOperations {
+			sstMap[mOp.MeasureCol] = nodeResult.RecsRunningSegStats[idx]
 		}
 
-		err := searchResults.UpdateSegmentStats(sstMap, nodeResult.RecsAggregator.MeasureOperations)
+		err := searchResults.UpdateSegmentStats(sstMap, nodeResult.MeasureOperations)
 		if err != nil {
 			log.Errorf("PerformMeasureAggsOnRecs: failed to update segment stats: %v", err)
 		}
 
-		nodeResult.RecsAggResults.RecsRunningSegStats = searchResults.GetSegmentRunningStats()
+		nodeResult.RecsRunningSegStats = searchResults.GetSegmentRunningStats()
 	}
 
 	nodeResult.TotalRRCCount += uint64(lenRecords)
@@ -675,8 +675,8 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 		finalSegment := make(map[string]interface{}, 0)
 
 		if anyCountStat > -1 {
-			finalCols[nodeResult.RecsAggregator.MeasureOperations[anyCountStat].String()] = true
-			finalSegment[nodeResult.RecsAggregator.MeasureOperations[anyCountStat].String()] = humanize.Comma(int64(nodeResult.TotalRRCCount))
+			finalCols[nodeResult.MeasureOperations[anyCountStat].String()] = true
+			finalSegment[nodeResult.MeasureOperations[anyCountStat].String()] = humanize.Comma(int64(nodeResult.TotalRRCCount))
 		}
 
 		for colName, value := range searchResults.GetSegmentStatsMeasureResults() {
@@ -709,9 +709,9 @@ func PerformMeasureAggsOnRecs(nodeResult *structs.NodeResult, recs map[string]ma
 
 	if sizeLimit > 0 && nodeResult.TotalRRCCount >= sizeLimit {
 		log.Info("PerformMeasureAggsOnRecs: Reached size limit, processing final segment.")
-		nodeResult.RecsAggResults.RecsAggsProcessedSegments = numTotalSegments
+		nodeResult.RecsAggsProcessedSegments = numTotalSegments
 		processFinalSegement()
-	} else if nodeResult.RecsAggResults.RecsAggsProcessedSegments < numTotalSegments {
+	} else if nodeResult.RecsAggsProcessedSegments < numTotalSegments {
 		return nil
 	} else {
 		processFinalSegement()

--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -68,7 +68,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "*",
-				MeasureFunc: utils.Count,
+				MeasureFunc: sutils.Count,
 				StrEnc:      "count(*)",
 			},
 		}}
@@ -107,7 +107,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "*",
-				MeasureFunc: utils.Count,
+				MeasureFunc: sutils.Count,
 				StrEnc:      "count(*)",
 			},
 		}}
@@ -140,7 +140,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "*",
-				MeasureFunc: utils.Count,
+				MeasureFunc: sutils.Count,
 				StrEnc:      "count(*)",
 			},
 		}}
@@ -183,7 +183,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testi
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "*",
-				MeasureFunc: utils.Count,
+				MeasureFunc: sutils.Count,
 				StrEnc:      "count(*)",
 			},
 		}}
@@ -223,7 +223,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.
 			MeasureOperations: []*structs.MeasureAggregator{
 				{
 					MeasureCol:  "*",
-					MeasureFunc: utils.Count,
+					MeasureFunc: sutils.Count,
 					StrEnc:      "count(*)",
 				},
 			},
@@ -267,7 +267,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *t
 			MeasureOperations: []*structs.MeasureAggregator{
 				{
 					MeasureCol:  "*",
-					MeasureFunc: utils.Count,
+					MeasureFunc: sutils.Count,
 					StrEnc:      "count(*)",
 				},
 			},
@@ -306,7 +306,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *te
 			MeasureOperations: []*structs.MeasureAggregator{
 				{
 					MeasureCol:  "*",
-					MeasureFunc: utils.Count,
+					MeasureFunc: sutils.Count,
 					StrEnc:      "count(*)",
 				},
 			},
@@ -364,7 +364,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t
 			MeasureOperations: []*structs.MeasureAggregator{
 				{
 					MeasureCol:  "*",
-					MeasureFunc: utils.Count,
+					MeasureFunc: sutils.Count,
 					StrEnc:      "count(*)",
 				},
 			},

--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/siglens/siglens/pkg/segment/structs"
+	"github.com/siglens/siglens/pkg/segment/utils"
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -63,18 +64,14 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
 	sizeLimit := 0
 	recsSize := 100
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "*",
-					MeasureFunc: sutils.Count,
-					StrEnc:      "count(*)",
-				},
+		PerformAggsOnRecs: true, RecsAggsType: structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "*",
+				MeasureFunc: utils.Count,
+				StrEnc:      "count(*)",
 			},
-		},
-	}
+		}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
 	for i := 0; i < numSegments; i++ {
@@ -83,7 +80,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_Zero_MultiSegments(t *testing.T) {
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
@@ -105,15 +102,13 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.
 	numSegments := 2
 	sizeLimit := 99
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "*",
-					MeasureFunc: sutils.Count,
-					StrEnc:      "count(*)",
-				},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "*",
+				MeasureFunc: utils.Count,
+				StrEnc:      "count(*)",
 			},
 		}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
@@ -122,7 +117,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *testing.
 
 	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
 
 	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
 	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
@@ -140,15 +135,13 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T
 	recsSize := 100
 	sizeLimit := 180
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "*",
-					MeasureFunc: sutils.Count,
-					StrEnc:      "count(*)",
-				},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "*",
+				MeasureFunc: utils.Count,
+				StrEnc:      "count(*)",
 			},
 		}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
@@ -162,7 +155,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *testing.T
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
@@ -185,15 +178,13 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testi
 	recsSize := 100
 	sizeLimit := 250
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "*",
-					MeasureFunc: sutils.Count,
-					StrEnc:      "count(*)",
-				},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "*",
+				MeasureFunc: utils.Count,
+				StrEnc:      "count(*)",
 			},
 		}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
@@ -203,7 +194,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t *testi
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
@@ -225,22 +216,20 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.
 	sizeLimit := 0
 	recsSize := 100
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.GroupByType,
-			GroupByRequest: &structs.GroupByRequest{
-				MeasureOperations: []*structs.MeasureAggregator{
-					{
-						MeasureCol:  "*",
-						MeasureFunc: sutils.Count,
-						StrEnc:      "count(*)",
-					},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
 				},
-				GroupByColumns: []string{"measure3"},
-				BucketCount:    3000,
 			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
 		},
-		GroupByCols: []string{"measure3"},
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
@@ -249,7 +238,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_Zero_MultiSegment(t *testing.
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
@@ -271,22 +260,20 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *t
 	numSegments := 2
 	sizeLimit := 99
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.GroupByType,
-			GroupByRequest: &structs.GroupByRequest{
-				MeasureOperations: []*structs.MeasureAggregator{
-					{
-						MeasureCol:  "*",
-						MeasureFunc: sutils.Count,
-						StrEnc:      "count(*)",
-					},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
 				},
-				GroupByColumns: []string{"measure3"},
-				BucketCount:    3000,
 			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
 		},
-		GroupByCols: []string{"measure3"},
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
@@ -294,7 +281,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_LessThanSegments(t *t
 
 	resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
+	assert.Equal(t, uint64(numSegments), nodeResult.RecsAggsProcessedSegments, "The number of Segments processed should be equal to the total number of segments")
 
 	assert.Equal(t, 1, len(resultMap), "The resultMap should have a single key")
 	assert.True(t, resultMap["CHECK_NEXT_AGG"], "The resultMap should have a key CHECK_NEXT_AGG set to true")
@@ -312,22 +299,20 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *te
 	recsSize := 100
 	sizeLimit := 180
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.GroupByType,
-			GroupByRequest: &structs.GroupByRequest{
-				MeasureOperations: []*structs.MeasureAggregator{
-					{
-						MeasureCol:  "*",
-						MeasureFunc: sutils.Count,
-						StrEnc:      "count(*)",
-					},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
 				},
-				GroupByColumns: []string{"measure3"},
-				BucketCount:    3000,
 			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
 		},
-		GroupByCols: []string{"measure3"},
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
@@ -340,7 +325,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_EqualToSegments(t *te
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
@@ -372,22 +357,20 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t
 	recsSize := 100
 	sizeLimit := 250
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.GroupByType,
-			GroupByRequest: &structs.GroupByRequest{
-				MeasureOperations: []*structs.MeasureAggregator{
-					{
-						MeasureCol:  "*",
-						MeasureFunc: sutils.Count,
-						StrEnc:      "count(*)",
-					},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByCols:       []string{"measure3"},
+		GroupByRequest: &structs.GroupByRequest{
+			MeasureOperations: []*structs.MeasureAggregator{
+				{
+					MeasureCol:  "*",
+					MeasureFunc: utils.Count,
+					StrEnc:      "count(*)",
 				},
-				GroupByColumns: []string{"measure3"},
-				BucketCount:    3000,
 			},
+			GroupByColumns: []string{"measure3"},
+			BucketCount:    3000,
 		},
-		GroupByCols: []string{"measure3"},
 	}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 
@@ -396,7 +379,7 @@ func Test_PerformGroupByRequestAggsOnRecsSizeLimit_NonZero_GreaterThanSegments(t
 
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The Processed Segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The Last Segment should return a resultMap with a single key.")
@@ -417,24 +400,21 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_WithList(t *testing.T) {
 	sizeLimit := 0
 	recsSize := sutils.MAX_SPL_LIST_SIZE * 2
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "measure1",
-					MeasureFunc: sutils.List,
-					StrEnc:      "list(measure1)",
-				},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "measure1",
+				MeasureFunc: utils.List,
+				StrEnc:      "list(measure1)",
 			},
-		},
-	}
+		}}
 	aggs := &structs.QueryAggregators{Limit: sizeLimit}
 	for i := 0; i < numSegments; i++ {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
@@ -456,15 +436,13 @@ func Test_PerformMeasureAggsOnRecs_WithList(t *testing.T) {
 	sizeLimit := 0
 	recsSize := 20
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.MeasureAggsType,
-			MeasureOperations: []*structs.MeasureAggregator{
-				{
-					MeasureCol:  "measure1",
-					MeasureFunc: sutils.List,
-					StrEnc:      "list(measure1)",
-				},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.MeasureAggsType,
+		MeasureOperations: []*structs.MeasureAggregator{
+			{
+				MeasureCol:  "measure1",
+				MeasureFunc: utils.List,
+				StrEnc:      "list(measure1)",
 			},
 		},
 	}
@@ -473,7 +451,7 @@ func Test_PerformMeasureAggsOnRecs_WithList(t *testing.T) {
 		recs, finalCols := getMockRecsAndFinalCols(uint64(recsSize))
 		resultMap := PerformAggsOnRecs(nodeResult, aggs, recs, finalCols, uint64(numSegments), true, 1)
 
-		assert.Equal(t, uint64(i+1), nodeResult.RecsAggResults.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
+		assert.Equal(t, uint64(i+1), nodeResult.RecsAggsProcessedSegments, "The processed segments count should be incremented for each Segment that is processed completely.")
 
 		if i == numSegments-1 {
 			assert.Equal(t, 1, len(resultMap), "The last Segment should return a resultMap with a single key.")
@@ -517,22 +495,20 @@ func Test_PerformGroupByAggsWithRexColumns(t *testing.T) {
 	}
 
 	nodeResult := &structs.NodeResult{
-		RecsAggregator: structs.RecsAggregator{
-			PerformAggsOnRecs: true,
-			RecsAggsType:      structs.GroupByType,
-			GroupByRequest: &structs.GroupByRequest{
-				GroupByColumns: []string{"rex_field"},
-				MeasureOperations: []*structs.MeasureAggregator{{
-					MeasureCol:  "*",
-					MeasureFunc: sutils.Count,
-					StrEnc:      "count(*)",
-					ValueColRequest: &structs.ValueExpr{
-						ValueExprMode:  structs.VEMMultiValueExpr,
-						MultiValueExpr: &structs.MultiValueExpr{FieldName: "rex_field"},
-					},
-				}},
-				BucketCount: 3000,
-			},
+		PerformAggsOnRecs: true,
+		RecsAggsType:      structs.GroupByType,
+		GroupByRequest: &structs.GroupByRequest{
+			GroupByColumns: []string{"rex_field"},
+			MeasureOperations: []*structs.MeasureAggregator{{
+				MeasureCol:  "*",
+				MeasureFunc: sutils.Count,
+				StrEnc:      "count(*)",
+				ValueColRequest: &structs.ValueExpr{
+					ValueExprMode:  structs.VEMMultiValueExpr,
+					MultiValueExpr: &structs.MultiValueExpr{FieldName: "rex_field"},
+				},
+			}},
+			BucketCount: 3000,
 		},
 		GroupByCols:    []string{"rex_field"},
 		FinalColumns:   finalCols,

--- a/pkg/segment/search/searchaggs_test.go
+++ b/pkg/segment/search/searchaggs_test.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/siglens/siglens/pkg/segment/structs"
-	"github.com/siglens/siglens/pkg/segment/utils"
 	sutils "github.com/siglens/siglens/pkg/segment/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -405,7 +404,7 @@ func Test_PerformMeasureAggsOnRecsSizeLimit_WithList(t *testing.T) {
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "measure1",
-				MeasureFunc: utils.List,
+				MeasureFunc: sutils.List,
 				StrEnc:      "list(measure1)",
 			},
 		}}
@@ -441,7 +440,7 @@ func Test_PerformMeasureAggsOnRecs_WithList(t *testing.T) {
 		MeasureOperations: []*structs.MeasureAggregator{
 			{
 				MeasureCol:  "measure1",
-				MeasureFunc: utils.List,
+				MeasureFunc: sutils.List,
 				StrEnc:      "list(measure1)",
 			},
 		},

--- a/pkg/segment/structs/segstructs.go
+++ b/pkg/segment/structs/segstructs.go
@@ -495,20 +495,6 @@ type Progress struct {
 	TotalRecords    uint64
 }
 
-type RecsAggregator struct {
-	PerformAggsOnRecs bool            // if true, perform aggregations on records that are returned from rrcreader.go
-	RecsAggsType      PipeCommandType // To determine Whether it is GroupByType or MeasureAggsType
-	GroupByRequest    *GroupByRequest
-	MeasureOperations []*MeasureAggregator
-	NextQueryAgg      *QueryAggregators
-}
-
-type RecsAggResults struct {
-	RecsAggsBlockResults      interface{} // Evaluates to *blockresults.BlockResults
-	RecsAggsProcessedSegments uint64
-	RecsRunningSegStats       []*SegStats
-}
-
 // A helper struct to keep track of errors and results together
 // In cases of partial failures, both logLines and errList can be defined
 type NodeResult struct {
@@ -528,11 +514,17 @@ type NodeResult struct {
 	Qtype                       string          `json:"qtype,omitempty"`
 	BucketCount                 int             `json:"bucketCount,omitempty"`
 	SegStatsMap                 map[string]*SegStats
-	GroupByBuckets              interface{} // *blockresults.GroupByBuckets
-	TimeBuckets                 interface{} // *blockresults.TimeBuckets
-	RecsAggregator              RecsAggregator
-	RecsAggResults              RecsAggResults
+	GroupByBuckets              interface{}     // *blockresults.GroupByBuckets
+	TimeBuckets                 interface{}     // *blockresults.TimeBuckets
+	PerformAggsOnRecs           bool            // if true, perform aggregations on records that are returned from rrcreader.go
+	RecsAggsType                PipeCommandType // To determine Whether it is GroupByType or MeasureAggsType
+	GroupByRequest              *GroupByRequest
+	MeasureOperations           []*MeasureAggregator
+	NextQueryAgg                *QueryAggregators
+	RecsAggsBlockResults        interface{}              // Evaluates to *blockresults.BlockResults
 	RecsAggsColumnKeysMap       map[string][]interface{} // map of column name to column keys for GroupBy Recs
+	RecsAggsProcessedSegments   uint64
+	RecsRunningSegStats         []*SegStats
 	TransactionEventRecords     map[string]map[string]interface{}
 	TransactionsProcessed       map[string]map[string]interface{}
 	ColumnsOrder                map[string]int


### PR DESCRIPTION
# Description
Revert for GH user glanzz #2262: Refactor NodeResult Struct by cleaning up the RecsAggs Fields
